### PR TITLE
try to use AOT for kernels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,8 @@ Set compiler for the project
 # default variables (for Linux)
 _project_compiler = "clang++"
 _project_linker = "clang++"
-_project_cmplr_flag_sycl = ["-fsycl"]
+_project_cmplr_aot_flag_sycl = ["-fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice"] #,spir64_gen-unknown-unknown-sycldevice"]
+_project_cmplr_flag_sycl = ["-fsycl"] + _project_cmplr_aot_flag_sycl
 _project_cmplr_flag_compatibility = ["-Wl,--enable-new-dtags", "-fPIC"]
 _project_cmplr_flag_lib = []
 _project_cmplr_macro = []


### PR DESCRIPTION
It loook like AOT is usable for development only.

AOT reduces the module loading time from 21sec to 0.5sec.
if use CPU only option, it compiles successfully and run on CPU but failed with GPU run
```
terminate called after throwing an instance of 'cl::sycl::runtime_error'
  what():  Native API failed. Native API returns: -42 (CL_INVALID_BINARY) -42 (CL_INVALID_BINARY)

```
if use both options:
```
Platform name: Intel(R) OpenCL
Device name: Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz
Driver version: 2020.11.8.0.27
OpenCL program was successfully created from SPIR-V file /tmp/backend_iface_fptr-ec9979.spv
Using build options:  -I "/tmp"
Compilation started
Compilation done
Linking started
Linking done
Device build started
Options used by backend compiler:
Device build done
Kernel <_ZTS25custom_blas_gemm_c_kernelIlE> was successfully vectorized (8)
Kernel <_ZTS25custom_blas_gemm_c_kernelIiE> was successfully vectorized (8)
Kernel <_ZTS24custom_blas_dot_c_kernelIlE> was successfully vectorized (8)
Kernel <_ZTS24custom_blas_dot_c_kernelIiE> was successfully vectorized (8)
Kernel <_ZTSN6oneapi3dpl20__par_backend_hetero24__parallel_sort_kernel_1IJ23custom_argsort_c_kernelIdlEEEE> was successfully vectorized (8)
Kernel <_ZTSN6oneapi3dpl20__par_backend_hetero24__parallel_sort_kernel_2IJ23custom_argsort_c_kernelIdlEEEE> was successfully vectorized (8)
...
Kernel <_ZTSN6oneapi3dpl20__par_backend_hetero26__parallel_reduce_kernel_1IJ19custom_sum_c_kernelIiEEEE> was successfully vectorized (8)
Kernel <_ZTSN6oneapi3dpl20__par_backend_hetero26__parallel_reduce_kernel_2IJ19custom_sum_c_kernelIiEEEE> was successfully vectorized (8)
Done.
OpenCL program binary file was successfully created: /tmp/backend_iface_fptr-5230b0.out
Error: Device name missing.
clang++: error: gen compiler command failed with exit code 226 (use -v to see invocation)
error: command 'clang++' failed with exit status 226
```