### PR TITLE
linalg.eig and beta09 related changes

### DIFF
--- a/dpnp/backend/backend_iface.hpp
+++ b/dpnp/backend/backend_iface.hpp
@@ -46,11 +46,6 @@
 #define INP_DLLEXPORT
 #endif
 
-// for beta08/beta09 compatibility
-namespace oneapi
-{
-}
-
 /**
  * @defgroup BACKEND_API Backend C++ library interface API
  * @{

--- a/dpnp/backend/backend_iface.hpp
+++ b/dpnp/backend/backend_iface.hpp
@@ -46,6 +46,11 @@
 #define INP_DLLEXPORT
 #endif
 
+// for beta08/beta09 compatibility
+namespace oneapi
+{
+}
+
 /**
  * @defgroup BACKEND_API Backend C++ library interface API
  * @{

--- a/dpnp/backend/mkl_wrap_blas1.cpp
+++ b/dpnp/backend/mkl_wrap_blas1.cpp
@@ -30,6 +30,10 @@
 #include <backend/backend_iface.hpp>
 #include "queue_sycl.hpp"
 
+// for beta08/beta09 compatibility
+#include <oneapi/dpl/algorithm>
+using namespace oneapi;
+
 template <typename _DataType>
 void mkl_blas_dot_c(void* array1_in, void* array2_in, void* result1, size_t size)
 {
@@ -41,13 +45,13 @@ void mkl_blas_dot_c(void* array1_in, void* array2_in, void* result1, size_t size
 
     try
     {
-        status = oneapi::mkl::blas::dot(DPNP_QUEUE,
-                                        size,
-                                        array_1,
-                                        1, // array_1 stride
-                                        array_2,
-                                        1, // array_2 stride
-                                        result);
+        status = mkl::blas::dot(DPNP_QUEUE,
+                                size,
+                                array_1,
+                                1, // array_1 stride
+                                array_2,
+                                1, // array_2 stride
+                                result);
     }
     catch (cl::sycl::exception const& e)
     {

--- a/dpnp/backend/mkl_wrap_blas1.cpp
+++ b/dpnp/backend/mkl_wrap_blas1.cpp
@@ -30,8 +30,7 @@
 #include <backend/backend_iface.hpp>
 #include "queue_sycl.hpp"
 
-// for beta08/beta09 compatibility
-using namespace oneapi;
+namespace mkl_blas = oneapi::mkl::blas;
 
 template <typename _DataType>
 void mkl_blas_dot_c(void* array1_in, void* array2_in, void* result1, size_t size)
@@ -44,13 +43,13 @@ void mkl_blas_dot_c(void* array1_in, void* array2_in, void* result1, size_t size
 
     try
     {
-        status = mkl::blas::dot(DPNP_QUEUE,
-                                size,
-                                array_1,
-                                1, // array_1 stride
-                                array_2,
-                                1, // array_2 stride
-                                result);
+        status = mkl_blas::dot(DPNP_QUEUE,
+                               size,
+                               array_1,
+                               1, // array_1 stride
+                               array_2,
+                               1, // array_2 stride
+                               result);
     }
     catch (cl::sycl::exception const& e)
     {

--- a/dpnp/backend/mkl_wrap_blas1.cpp
+++ b/dpnp/backend/mkl_wrap_blas1.cpp
@@ -41,13 +41,13 @@ void mkl_blas_dot_c(void* array1_in, void* array2_in, void* result1, size_t size
 
     try
     {
-        status = mkl::blas::dot(DPNP_QUEUE,
-                                size,
-                                array_1,
-                                1, // array_1 stride
-                                array_2,
-                                1, // array_2 stride
-                                result);
+        status = oneapi::mkl::blas::dot(DPNP_QUEUE,
+                                        size,
+                                        array_1,
+                                        1, // array_1 stride
+                                        array_2,
+                                        1, // array_2 stride
+                                        result);
     }
     catch (cl::sycl::exception const& e)
     {

--- a/dpnp/backend/mkl_wrap_blas1.cpp
+++ b/dpnp/backend/mkl_wrap_blas1.cpp
@@ -31,7 +31,6 @@
 #include "queue_sycl.hpp"
 
 // for beta08/beta09 compatibility
-#include <oneapi/dpl/algorithm>
 using namespace oneapi;
 
 template <typename _DataType>

--- a/dpnp/backend/mkl_wrap_blas3.cpp
+++ b/dpnp/backend/mkl_wrap_blas3.cpp
@@ -30,8 +30,7 @@
 #include <backend/backend_iface.hpp>
 #include "queue_sycl.hpp"
 
-// for beta08/beta09 compatibility
-using namespace oneapi;
+namespace mkl_blas = oneapi::mkl::blas;
 
 template <typename _DataType>
 void dpnp_blas_gemm_c(void* array1_in, void* array2_in, void* result1, size_t size_m, size_t size_n, size_t size_k)
@@ -92,20 +91,20 @@ void dpnp_blas_gemm_c(void* array1_in, void* array2_in, void* result1, size_t si
 #endif
     try
     {
-        status = mkl::blas::gemm(DPNP_QUEUE,
-                                 mkl::transpose::nontrans,
-                                 mkl::transpose::nontrans,
-                                 size_n,
-                                 size_m,
-                                 size_k,
-                                 _DataType(1),
-                                 array_2,
-                                 ldb,
-                                 array_1,
-                                 lda,
-                                 _DataType(0),
-                                 result,
-                                 ldc);
+        status = mkl_blas::gemm(DPNP_QUEUE,
+                                oneapi::mkl::transpose::nontrans,
+                                oneapi::mkl::transpose::nontrans,
+                                size_n,
+                                size_m,
+                                size_k,
+                                _DataType(1),
+                                array_2,
+                                ldb,
+                                array_1,
+                                lda,
+                                _DataType(0),
+                                result,
+                                ldc);
     }
     catch (cl::sycl::exception const& e)
     {

--- a/dpnp/backend/mkl_wrap_blas3.cpp
+++ b/dpnp/backend/mkl_wrap_blas3.cpp
@@ -89,20 +89,20 @@ void dpnp_blas_gemm_c(void* array1_in, void* array2_in, void* result1, size_t si
 #endif
     try
     {
-        status = mkl::blas::gemm(DPNP_QUEUE,
-                                 mkl::transpose::nontrans,
-                                 mkl::transpose::nontrans,
-                                 size_n,
-                                 size_m,
-                                 size_k,
-                                 _DataType(1),
-                                 array_2,
-                                 ldb,
-                                 array_1,
-                                 lda,
-                                 _DataType(0),
-                                 result,
-                                 ldc);
+        status = oneapi::mkl::blas::gemm(DPNP_QUEUE,
+                                         oneapi::mkl::transpose::nontrans,
+                                         oneapi::mkl::transpose::nontrans,
+                                         size_n,
+                                         size_m,
+                                         size_k,
+                                         _DataType(1),
+                                         array_2,
+                                         ldb,
+                                         array_1,
+                                         lda,
+                                         _DataType(0),
+                                         result,
+                                         ldc);
     }
     catch (cl::sycl::exception const& e)
     {

--- a/dpnp/backend/mkl_wrap_blas3.cpp
+++ b/dpnp/backend/mkl_wrap_blas3.cpp
@@ -31,7 +31,6 @@
 #include "queue_sycl.hpp"
 
 // for beta08/beta09 compatibility
-#include <oneapi/dpl/algorithm>
 using namespace oneapi;
 
 template <typename _DataType>

--- a/dpnp/backend/mkl_wrap_blas3.cpp
+++ b/dpnp/backend/mkl_wrap_blas3.cpp
@@ -30,6 +30,10 @@
 #include <backend/backend_iface.hpp>
 #include "queue_sycl.hpp"
 
+// for beta08/beta09 compatibility
+#include <oneapi/dpl/algorithm>
+using namespace oneapi;
+
 template <typename _DataType>
 void dpnp_blas_gemm_c(void* array1_in, void* array2_in, void* result1, size_t size_m, size_t size_n, size_t size_k)
 {
@@ -89,20 +93,20 @@ void dpnp_blas_gemm_c(void* array1_in, void* array2_in, void* result1, size_t si
 #endif
     try
     {
-        status = oneapi::mkl::blas::gemm(DPNP_QUEUE,
-                                         oneapi::mkl::transpose::nontrans,
-                                         oneapi::mkl::transpose::nontrans,
-                                         size_n,
-                                         size_m,
-                                         size_k,
-                                         _DataType(1),
-                                         array_2,
-                                         ldb,
-                                         array_1,
-                                         lda,
-                                         _DataType(0),
-                                         result,
-                                         ldc);
+        status = mkl::blas::gemm(DPNP_QUEUE,
+                                 mkl::transpose::nontrans,
+                                 mkl::transpose::nontrans,
+                                 size_n,
+                                 size_m,
+                                 size_k,
+                                 _DataType(1),
+                                 array_2,
+                                 ldb,
+                                 array_1,
+                                 lda,
+                                 _DataType(0),
+                                 result,
+                                 ldc);
     }
     catch (cl::sycl::exception const& e)
     {

--- a/dpnp/backend/mkl_wrap_lapack.cpp
+++ b/dpnp/backend/mkl_wrap_lapack.cpp
@@ -30,6 +30,10 @@
 #include <backend/backend_iface.hpp>
 #include "queue_sycl.hpp"
 
+// for beta08/beta09 compatibility
+#include <oneapi/dpl/algorithm>
+using namespace oneapi;
+
 template <typename _DataType>
 void mkl_lapack_syevd_c(void* array_in, void* result1, size_t size)
 {
@@ -42,20 +46,20 @@ void mkl_lapack_syevd_c(void* array_in, void* result1, size_t size)
 
     auto queue = DPNP_QUEUE;
 
-    const std::int64_t scratchpad_size = oneapi::mkl::lapack::syevd_scratchpad_size<_DataType>(
-        queue, oneapi::mkl::job::vec, oneapi::mkl::uplo::upper, size, lda);
+    const std::int64_t scratchpad_size =
+        mkl::lapack::syevd_scratchpad_size<_DataType>(queue, mkl::job::vec, mkl::uplo::upper, size, lda);
 
     _DataType* scratchpad = reinterpret_cast<_DataType*>(dpnp_memory_alloc_c(scratchpad_size * sizeof(_DataType)));
 
-    status = oneapi::mkl::lapack::syevd(queue,                    // queue
-                                        oneapi::mkl::job::vec,    // jobz
-                                        oneapi::mkl::uplo::upper, // uplo
-                                        size,                     // The order of the matrix A (0≤n)
-                                        array,                    // will be overwritten with eigenvectors
-                                        lda,
-                                        result,
-                                        scratchpad,
-                                        scratchpad_size);
+    status = mkl::lapack::syevd(queue,            // queue
+                                mkl::job::vec,    // jobz
+                                mkl::uplo::upper, // uplo
+                                size,             // The order of the matrix A (0≤n)
+                                array,            // will be overwritten with eigenvectors
+                                lda,
+                                result,
+                                scratchpad,
+                                scratchpad_size);
 
     status.wait();
 

--- a/dpnp/backend/mkl_wrap_lapack.cpp
+++ b/dpnp/backend/mkl_wrap_lapack.cpp
@@ -30,8 +30,7 @@
 #include <backend/backend_iface.hpp>
 #include "queue_sycl.hpp"
 
-// for beta08/beta09 compatibility
-using namespace oneapi;
+namespace mkl_lapack = oneapi::mkl::lapack;
 
 template <typename _DataType>
 void mkl_lapack_syevd_c(void* array_in, void* result1, size_t size)
@@ -46,20 +45,20 @@ void mkl_lapack_syevd_c(void* array_in, void* result1, size_t size)
 
     const std::int64_t lda = std::max<size_t>(1UL, size);
 
-    const std::int64_t scratchpad_size =
-        mkl::lapack::syevd_scratchpad_size<_DataType>(DPNP_QUEUE, mkl::job::vec, mkl::uplo::upper, size, lda);
+    const std::int64_t scratchpad_size = mkl_lapack::syevd_scratchpad_size<_DataType>(
+        DPNP_QUEUE, oneapi::mkl::job::vec, oneapi::mkl::uplo::upper, size, lda);
 
     _DataType* scratchpad = reinterpret_cast<_DataType*>(dpnp_memory_alloc_c(scratchpad_size * sizeof(_DataType)));
 
-    status = mkl::lapack::syevd(DPNP_QUEUE,       // queue
-                                mkl::job::vec,    // jobz
-                                mkl::uplo::upper, // uplo
-                                size,             // The order of the matrix A (0≤n)
-                                syevd_array,      // will be overwritten with eigenvectors
-                                lda,
-                                result,
-                                scratchpad,
-                                scratchpad_size);
+    status = mkl_lapack::syevd(DPNP_QUEUE,               // queue
+                               oneapi::mkl::job::vec,    // jobz
+                               oneapi::mkl::uplo::upper, // uplo
+                               size,                     // The order of the matrix A (0≤n)
+                               syevd_array,              // will be overwritten with eigenvectors
+                               lda,
+                               result,
+                               scratchpad,
+                               scratchpad_size);
     status.wait();
 
     dpnp_memory_free_c(scratchpad);

--- a/dpnp/backend/mkl_wrap_lapack.cpp
+++ b/dpnp/backend/mkl_wrap_lapack.cpp
@@ -31,7 +31,6 @@
 #include "queue_sycl.hpp"
 
 // for beta08/beta09 compatibility
-#include <oneapi/dpl/algorithm>
 using namespace oneapi;
 
 template <typename _DataType>

--- a/dpnp/backend/mkl_wrap_rng.cpp
+++ b/dpnp/backend/mkl_wrap_rng.cpp
@@ -33,6 +33,10 @@
 #include "backend_utils.hpp"
 #include "queue_sycl.hpp"
 
+// for beta08/beta09 compatibility
+#include <oneapi/dpl/algorithm>
+using namespace oneapi;
+
 template <typename _DataType>
 void mkl_rng_gaussian(void* result, size_t size)
 {
@@ -42,16 +46,16 @@ void mkl_rng_gaussian(void* result, size_t size)
     // choose engine as is in numpy
     // seed number
     size_t seed = std::time(nullptr);
-    oneapi::mkl::rng::philox4x32x10 engine(DPNP_QUEUE, seed);
+    mkl::rng::philox4x32x10 engine(DPNP_QUEUE, seed);
 
     const _DataType mean = _DataType(0.0);
     const _DataType stddev = _DataType(1.0);
 
-    oneapi::mkl::rng::gaussian<_DataType> distribution(mean, stddev);
+    mkl::rng::gaussian<_DataType> distribution(mean, stddev);
     try
     {
         // perform generation
-        oneapi::mkl::rng::generate(distribution, engine, size, result1);
+        mkl::rng::generate(distribution, engine, size, result1);
         DPNP_QUEUE.wait_and_throw();
     }
     catch (cl::sycl::exception const& e)
@@ -70,16 +74,16 @@ void mkl_rng_uniform(void* result, size_t size)
     // choose engine as is in numpy
     // seed number
     size_t seed = std::time(nullptr);
-    oneapi::mkl::rng::philox4x32x10 engine(DPNP_QUEUE, seed);
+    mkl::rng::philox4x32x10 engine(DPNP_QUEUE, seed);
 
     const _DataType a = (_DataType(0.0));
     const _DataType b = (_DataType(1.0));
 
-    oneapi::mkl::rng::uniform<_DataType> distribution(a, b);
+    mkl::rng::uniform<_DataType> distribution(a, b);
     try
     {
         // perform generation
-        oneapi::mkl::rng::generate(distribution, engine, size, result1);
+        mkl::rng::generate(distribution, engine, size, result1);
         DPNP_QUEUE.wait_and_throw();
     }
     catch (cl::sycl::exception const& e)
@@ -98,18 +102,18 @@ void mkl_rng_uniform_mt19937(void* result, long low, long high, size_t size)
     // choose engine as is in numpy
     // seed number
     size_t seed = std::time(nullptr);
-    oneapi::mkl::rng::mt19937 engine(DPNP_QUEUE, seed);
+    mkl::rng::mt19937 engine(DPNP_QUEUE, seed);
 
     // set left bound of distribution
     const _DataType a = (_DataType(low));
     // set right bound of distribution
     const _DataType b = (_DataType(high));
 
-    oneapi::mkl::rng::uniform<_DataType> distribution(a, b);
+    mkl::rng::uniform<_DataType> distribution(a, b);
     try
     {
         // perform generation
-        oneapi::mkl::rng::generate(distribution, engine, size, result1);
+        mkl::rng::generate(distribution, engine, size, result1);
         DPNP_QUEUE.wait_and_throw();
     }
     catch (cl::sycl::exception const& e)

--- a/dpnp/backend/mkl_wrap_rng.cpp
+++ b/dpnp/backend/mkl_wrap_rng.cpp
@@ -34,7 +34,6 @@
 #include "queue_sycl.hpp"
 
 // for beta08/beta09 compatibility
-#include <oneapi/dpl/algorithm>
 using namespace oneapi;
 
 template <typename _DataType>

--- a/dpnp/backend/mkl_wrap_rng.cpp
+++ b/dpnp/backend/mkl_wrap_rng.cpp
@@ -33,8 +33,7 @@
 #include "backend_utils.hpp"
 #include "queue_sycl.hpp"
 
-// for beta08/beta09 compatibility
-using namespace oneapi;
+namespace mkl_rng = oneapi::mkl::rng;
 
 template <typename _DataType>
 void mkl_rng_gaussian(void* result, size_t size)
@@ -45,16 +44,16 @@ void mkl_rng_gaussian(void* result, size_t size)
     // choose engine as is in numpy
     // seed number
     size_t seed = std::time(nullptr);
-    mkl::rng::philox4x32x10 engine(DPNP_QUEUE, seed);
+    mkl_rng::philox4x32x10 engine(DPNP_QUEUE, seed);
 
     const _DataType mean = _DataType(0.0);
     const _DataType stddev = _DataType(1.0);
 
-    mkl::rng::gaussian<_DataType> distribution(mean, stddev);
+    mkl_rng::gaussian<_DataType> distribution(mean, stddev);
     try
     {
         // perform generation
-        mkl::rng::generate(distribution, engine, size, result1);
+        mkl_rng::generate(distribution, engine, size, result1);
         DPNP_QUEUE.wait_and_throw();
     }
     catch (cl::sycl::exception const& e)
@@ -73,16 +72,16 @@ void mkl_rng_uniform(void* result, size_t size)
     // choose engine as is in numpy
     // seed number
     size_t seed = std::time(nullptr);
-    mkl::rng::philox4x32x10 engine(DPNP_QUEUE, seed);
+    mkl_rng::philox4x32x10 engine(DPNP_QUEUE, seed);
 
     const _DataType a = (_DataType(0.0));
     const _DataType b = (_DataType(1.0));
 
-    mkl::rng::uniform<_DataType> distribution(a, b);
+    mkl_rng::uniform<_DataType> distribution(a, b);
     try
     {
         // perform generation
-        mkl::rng::generate(distribution, engine, size, result1);
+        mkl_rng::generate(distribution, engine, size, result1);
         DPNP_QUEUE.wait_and_throw();
     }
     catch (cl::sycl::exception const& e)
@@ -101,18 +100,18 @@ void mkl_rng_uniform_mt19937(void* result, long low, long high, size_t size)
     // choose engine as is in numpy
     // seed number
     size_t seed = std::time(nullptr);
-    mkl::rng::mt19937 engine(DPNP_QUEUE, seed);
+    mkl_rng::mt19937 engine(DPNP_QUEUE, seed);
 
     // set left bound of distribution
     const _DataType a = (_DataType(low));
     // set right bound of distribution
     const _DataType b = (_DataType(high));
 
-    mkl::rng::uniform<_DataType> distribution(a, b);
+    mkl_rng::uniform<_DataType> distribution(a, b);
     try
     {
         // perform generation
-        mkl::rng::generate(distribution, engine, size, result1);
+        mkl_rng::generate(distribution, engine, size, result1);
         DPNP_QUEUE.wait_and_throw();
     }
     catch (cl::sycl::exception const& e)

--- a/dpnp/backend/mkl_wrap_rng.cpp
+++ b/dpnp/backend/mkl_wrap_rng.cpp
@@ -42,16 +42,16 @@ void mkl_rng_gaussian(void* result, size_t size)
     // choose engine as is in numpy
     // seed number
     size_t seed = std::time(nullptr);
-    mkl::rng::philox4x32x10 engine(DPNP_QUEUE, seed);
+    oneapi::mkl::rng::philox4x32x10 engine(DPNP_QUEUE, seed);
 
     const _DataType mean = _DataType(0.0);
     const _DataType stddev = _DataType(1.0);
 
-    mkl::rng::gaussian<_DataType> distribution(mean, stddev);
+    oneapi::mkl::rng::gaussian<_DataType> distribution(mean, stddev);
     try
     {
         // perform generation
-        mkl::rng::generate(distribution, engine, size, result1);
+        oneapi::mkl::rng::generate(distribution, engine, size, result1);
         DPNP_QUEUE.wait_and_throw();
     }
     catch (cl::sycl::exception const& e)
@@ -70,16 +70,16 @@ void mkl_rng_uniform(void* result, size_t size)
     // choose engine as is in numpy
     // seed number
     size_t seed = std::time(nullptr);
-    mkl::rng::philox4x32x10 engine(DPNP_QUEUE, seed);
+    oneapi::mkl::rng::philox4x32x10 engine(DPNP_QUEUE, seed);
 
     const _DataType a = (_DataType(0.0));
     const _DataType b = (_DataType(1.0));
 
-    mkl::rng::uniform<_DataType> distribution(a, b);
+    oneapi::mkl::rng::uniform<_DataType> distribution(a, b);
     try
     {
         // perform generation
-        mkl::rng::generate(distribution, engine, size, result1);
+        oneapi::mkl::rng::generate(distribution, engine, size, result1);
         DPNP_QUEUE.wait_and_throw();
     }
     catch (cl::sycl::exception const& e)
@@ -98,18 +98,18 @@ void mkl_rng_uniform_mt19937(void* result, long low, long high, size_t size)
     // choose engine as is in numpy
     // seed number
     size_t seed = std::time(nullptr);
-    mkl::rng::mt19937 engine(DPNP_QUEUE, seed);
+    oneapi::mkl::rng::mt19937 engine(DPNP_QUEUE, seed);
 
     // set left bound of distribution
     const _DataType a = (_DataType(low));
     // set right bound of distribution
     const _DataType b = (_DataType(high));
 
-    mkl::rng::uniform<_DataType> distribution(a, b);
+    oneapi::mkl::rng::uniform<_DataType> distribution(a, b);
     try
     {
         // perform generation
-        mkl::rng::generate(distribution, engine, size, result1);
+        oneapi::mkl::rng::generate(distribution, engine, size, result1);
         DPNP_QUEUE.wait_and_throw();
     }
     catch (cl::sycl::exception const& e)

--- a/dpnp/linalg/linalg.pyx
+++ b/dpnp/linalg/linalg.pyx
@@ -45,23 +45,26 @@ __all__ = [
 ]
 
 
-cpdef dparray dpnp_eig(dparray in_array1):
-    cdef vector[Py_ssize_t] shape1 = in_array1.shape
+cpdef tuple dpnp_eig(dparray in_array1):
+    cdef dparray_shape_type shape1 = in_array1.shape
 
     call_type = in_array1.dtype
+    res_type = call_type
+    if res_type != numpy.float32:
+        res_type = numpy.float64
 
     cdef size_t size1 = 0
     if not shape1.empty():
         size1 = shape1.front()
 
-    cdef dparray res_val = dparray((size1,), dtype=call_type)
+    cdef dparray res_val = dparray((size1,), dtype=res_type)
 
     # this array is used as input for MKL and will be overwritten with eigen vectors
-    cdef dparray res_vec = dparray(shape1, dtype=call_type)
+    cdef dparray res_vec = dparray(shape1, dtype=res_type)
     for i in range(in_array1.size):
         res_vec[i] = in_array1[i]
 
-    if call_type == numpy.float64:
+    if call_type in [numpy.float64, numpy.int32, numpy.int64]:
         mkl_lapack_syevd_c[double](res_vec.get_data(), res_val.get_data(), size1)
     elif call_type == numpy.float32:
         mkl_lapack_syevd_c[float](res_vec.get_data(), res_val.get_data(), size1)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -4,9 +4,6 @@ import dpnp as inp
 
 import numpy
 
-import sys
-numpy.set_printoptions(threshold=sys.maxsize)
-
 
 def vvsort(val, vec, size):
     for i in range(size):
@@ -31,14 +28,12 @@ def vvsort(val, vec, size):
 @pytest.mark.parametrize("size",
                          [2, 4, 8, 16, 300])
 def test_eig_arange(type, size):
-    a = (numpy.arange(size * size, dtype=type) + 1).reshape((size, size))
-    symm = numpy.tril(a) + numpy.tril(a, -1).T
-    isymm = inp.array(a)
+    a = numpy.arange(size * size, dtype=type).reshape((size, size))
+    symm = numpy.tril(a) + numpy.tril(a, -1).T + numpy.diag(numpy.full((size,), size * size, dtype=type))
+    isymm = inp.array(symm)
 
     dpnp_val, dpnp_vec = inp.linalg.eig(isymm)
     np_val, np_vec = numpy.linalg.eig(symm)
-
-    dpnp_vec = dpnp_vec.T
 
     # DPNP sort val/vec by abs value
     vvsort(dpnp_val, dpnp_vec, size)
@@ -51,15 +46,5 @@ def test_eig_arange(type, size):
         if np_vec[0, i] * dpnp_vec[0, i] < 0:
             np_vec[:, i] = -np_vec[:, i]
 
-    # print("----------------------------------")
-    # print("dpnp_val", numpy.array(dpnp_val))
-    # print("----------------------------------")
-    # print("np_val", np_val)
-    # print("----------------------------------")
-    # print("dpnp_vec", numpy.array(dpnp_vec))
-    # print("----------------------------------")
-    # print("np_vec", np_vec)
-    # print("----------------------------------")
-
-    numpy.testing.assert_allclose(dpnp_val, np_val)
-    numpy.testing.assert_allclose(dpnp_vec, np_vec)
+    numpy.testing.assert_allclose(dpnp_val, np_val, rtol=1e-05, atol=1e-05)
+    numpy.testing.assert_allclose(dpnp_vec, np_vec, rtol=1e-05, atol=1e-05)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -1,0 +1,65 @@
+import pytest
+
+import dpnp as inp
+
+import numpy
+
+import sys
+numpy.set_printoptions(threshold=sys.maxsize)
+
+
+def vvsort(val, vec, size):
+    for i in range(size):
+        imax = i
+        for j in range(i + 1, size):
+            if numpy.abs(val[imax]) < numpy.abs(val[j]):
+                imax = j
+
+        temp = val[i]
+        val[i] = val[imax]
+        val[imax] = temp
+
+        for k in range(size):
+            temp = vec[k, i]
+            vec[k, i] = vec[k, imax]
+            vec[k, imax] = temp
+
+
+@pytest.mark.parametrize("type",
+                         [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
+                         ids=['float64', 'float32', 'int64', 'int32'])
+@pytest.mark.parametrize("size",
+                         [2, 4, 8, 16, 300])
+def test_eig_arange(type, size):
+    a = (numpy.arange(size * size, dtype=type) + 1).reshape((size, size))
+    symm = numpy.tril(a) + numpy.tril(a, -1).T
+    isymm = inp.array(a)
+
+    dpnp_val, dpnp_vec = inp.linalg.eig(isymm)
+    np_val, np_vec = numpy.linalg.eig(symm)
+
+    dpnp_vec = dpnp_vec.T
+
+    # DPNP sort val/vec by abs value
+    vvsort(dpnp_val, dpnp_vec, size)
+
+    # NP sort val/vec by abs value
+    vvsort(np_val, np_vec, size)
+
+    # NP change sign of vectors
+    for i in range(np_vec.shape[1]):
+        if np_vec[0, i] * dpnp_vec[0, i] < 0:
+            np_vec[:, i] = -np_vec[:, i]
+
+    # print("----------------------------------")
+    # print("dpnp_val", numpy.array(dpnp_val))
+    # print("----------------------------------")
+    # print("np_val", np_val)
+    # print("----------------------------------")
+    # print("dpnp_vec", numpy.array(dpnp_vec))
+    # print("----------------------------------")
+    # print("np_vec", np_vec)
+    # print("----------------------------------")
+
+    numpy.testing.assert_allclose(dpnp_val, np_val)
+    numpy.testing.assert_allclose(dpnp_vec, np_vec)


### PR DESCRIPTION
I missed this PR
https://github.com/IntelPython/dpnp/pull/5
beta9 is required for work with linalg.eig in any case.

Test shows issues and difference between current (mkl::lapack::syevd) and original implementations. 
tests/test_linalg.py::test_eig_arange[2-float64] PASSED[  5%]
tests/test_linalg.py::test_eig_arange[2-float32] PASSED[ 10%]
tests/test_linalg.py::test_eig_arange[2-int64] PASSED[ 15%]
tests/test_linalg.py::test_eig_arange[2-int32] PASSED[ 20%]
tests/test_linalg.py::test_eig_arange[4-float64] PASSED[ 25%]
tests/test_linalg.py::test_eig_arange[4-float32] FAILED[ 30%]
tests/test_linalg.py::test_eig_arange[4-int64] PASSED[ 35%]
tests/test_linalg.py::test_eig_arange[4-int32] PASSED[ 40%]
tests/test_linalg.py::test_eig_arange[8-float64] PASSED[ 45%]
tests/test_linalg.py::test_eig_arange[8-float32] FAILED[ 50%]
tests/test_linalg.py::test_eig_arange[8-int64] PASSED[ 55%]
tests/test_linalg.py::test_eig_arange[8-int32] PASSED[ 60%]
tests/test_linalg.py::test_eig_arange[16-float64] PASSED[ 65%]
tests/test_linalg.py::test_eig_arange[16-float32] FAILED[ 70%]
tests/test_linalg.py::test_eig_arange[16-int64] PASSED[ 75%]
tests/test_linalg.py::test_eig_arange[16-int32] PASSED[ 80%]
tests/test_linalg.py::test_eig_arange[300-float64] FAILED[ 85%]
tests/test_linalg.py::test_eig_arange[300-float32] FAILED[ 90%]
tests/test_linalg.py::test_eig_arange[300-int64] FAILED[ 95%]
tests/test_linalg.py::test_eig_arange[300-int32] FAILED[100%]