### PR TITLE
Add methods flatten and ravel + cupy tests

### DIFF
--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -52,6 +52,7 @@ from dpnp.dpnp_utils import (checker_throw_value_error, use_origin_backend, norm
 
 __all__ = [
     "moveaxis",
+    "ravel",
     "repeat",
     "rollaxis",
     "swapaxes",
@@ -100,6 +101,36 @@ def moveaxis(x1, source, destination):
         input_permute.insert(destination_id, source_id)
 
     return transpose(x1, axes=input_permute)
+
+
+def ravel(a, order='C'):
+    """
+    Return a contiguous flattened array.
+
+    Parameters
+    ----------
+    a: array_like
+        Input array.
+    order: {'C', 'F', 'A', 'K'}, optional
+        The elements of a are read using this index order.
+
+    Returns
+    -------
+    out: ndarray
+        Output array.
+
+    See Also
+    --------
+    flat, flatten, reshape
+
+    """
+
+    if not use_origin_backend(a) and isinstance(a, dparray):
+        return a.ravel(order=order)
+
+    result = numpy.rollaxis(dp2nd_array(a), order=order)
+
+    return nd2dp_array(result)
 
 
 def repeat(x1, repeats, axis=None):

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -19,13 +19,11 @@ tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAn
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_diagonal1
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_diagonal2
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_fill_with_numpy_nonscalar_ndarray
-tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_flatten
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_flatten_copied
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_isinstance_numpy_copy
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_isinstance_numpy_copy_not_slice
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_isinstance_numpy_copy_wrong_dtype
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_isinstance_numpy_copy_wrong_shape
-tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_transposed_flatten
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_view
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_view_0d
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_view_0d_raise
@@ -374,6 +372,59 @@ tests/third_party/cupy/logic_tests/test_comparison.py::TestComparisonOperator::t
 tests/third_party/cupy/logic_tests/test_comparison.py::TestComparisonOperator::test_binary_array_pyscalar
 tests/third_party/cupy/logic_tests/test_comparison.py::TestComparisonOperator::test_binary_npscalar_array
 tests/third_party/cupy/logic_tests/test_comparison.py::TestComparisonOperator::test_binary_pyscalar_array
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshape::test_external_reshape
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshape::test_nocopy_reshape
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshape::test_nocopy_reshape_with_order
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshape::test_reshape2
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshape::test_reshape_invalid_order
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshape::test_reshape_strides
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshape::test_reshape_with_changed_arraysize
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshape::test_reshape_with_multiple_unknown_dimensions
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshape::test_reshape_with_unknown_dimension
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshape::test_transposed_reshape2
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestRavel::test_ravel3
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestShape_param_0_{shape=(2, 3)}::test_shape
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestShape_param_0_{shape=(2, 3)}::test_shape_list
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestShape_param_1_{shape=()}::test_shape
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestShape_param_1_{shape=()}::test_shape_list
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestShape_param_2_{shape=(4,)}::test_shape
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestShape_param_2_{shape=(4,)}::test_shape_list
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_0_{order_init='C', order_reshape='C', shape_in_out=((2, 3), (1, 6, 1))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_1_{order_init='C', order_reshape='C', shape_in_out=((6,), (2, 3))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_2_{order_init='C', order_reshape='C', shape_in_out=((3, 3, 3), (9, 3))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_3_{order_init='C', order_reshape='F', shape_in_out=((2, 3), (1, 6, 1))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_4_{order_init='C', order_reshape='F', shape_in_out=((6,), (2, 3))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_5_{order_init='C', order_reshape='F', shape_in_out=((3, 3, 3), (9, 3))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_6_{order_init='C', order_reshape='A', shape_in_out=((2, 3), (1, 6, 1))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_7_{order_init='C', order_reshape='A', shape_in_out=((6,), (2, 3))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_8_{order_init='C', order_reshape='A', shape_in_out=((3, 3, 3), (9, 3))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_9_{order_init='C', order_reshape='c', shape_in_out=((2, 3), (1, 6, 1))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_10_{order_init='C', order_reshape='c', shape_in_out=((6,), (2, 3))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_11_{order_init='C', order_reshape='c', shape_in_out=((3, 3, 3), (9, 3))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_12_{order_init='C', order_reshape='f', shape_in_out=((2, 3), (1, 6, 1))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_13_{order_init='C', order_reshape='f', shape_in_out=((6,), (2, 3))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_14_{order_init='C', order_reshape='f', shape_in_out=((3, 3, 3), (9, 3))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_15_{order_init='C', order_reshape='a', shape_in_out=((2, 3), (1, 6, 1))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_16_{order_init='C', order_reshape='a', shape_in_out=((6,), (2, 3))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_17_{order_init='C', order_reshape='a', shape_in_out=((3, 3, 3), (9, 3))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_18_{order_init='F', order_reshape='C', shape_in_out=((2, 3), (1, 6, 1))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_19_{order_init='F', order_reshape='C', shape_in_out=((6,), (2, 3))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_20_{order_init='F', order_reshape='C', shape_in_out=((3, 3, 3), (9, 3))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_21_{order_init='F', order_reshape='F', shape_in_out=((2, 3), (1, 6, 1))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_22_{order_init='F', order_reshape='F', shape_in_out=((6,), (2, 3))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_23_{order_init='F', order_reshape='F', shape_in_out=((3, 3, 3), (9, 3))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_24_{order_init='F', order_reshape='A', shape_in_out=((2, 3), (1, 6, 1))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_25_{order_init='F', order_reshape='A', shape_in_out=((6,), (2, 3))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_26_{order_init='F', order_reshape='A', shape_in_out=((3, 3, 3), (9, 3))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_27_{order_init='F', order_reshape='c', shape_in_out=((2, 3), (1, 6, 1))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_28_{order_init='F', order_reshape='c', shape_in_out=((6,), (2, 3))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_29_{order_init='F', order_reshape='c', shape_in_out=((3, 3, 3), (9, 3))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_30_{order_init='F', order_reshape='f', shape_in_out=((2, 3), (1, 6, 1))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_31_{order_init='F', order_reshape='f', shape_in_out=((6,), (2, 3))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_32_{order_init='F', order_reshape='f', shape_in_out=((3, 3, 3), (9, 3))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_33_{order_init='F', order_reshape='a', shape_in_out=((2, 3), (1, 6, 1))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_34_{order_init='F', order_reshape='a', shape_in_out=((6,), (2, 3))}::test_reshape_contiguity
+tests/third_party/cupy/manipulation_tests/test_shape.py::TestReshapeOrder_param_35_{order_init='F', order_reshape='a', shape_in_out=((3, 3, 3), (9, 3))}::test_reshape_contiguity
 tests/third_party/cupy/manipulation_tests/test_tiling.py::TestRepeat1D_param_3_{axis=None, repeats=[1, 2, 3, 4]}::test_array_repeat
 tests/third_party/cupy/manipulation_tests/test_tiling.py::TestRepeat1D_param_4_{axis=0, repeats=[1, 2, 3, 4]}::test_array_repeat
 tests/third_party/cupy/manipulation_tests/test_tiling.py::TestRepeatRepeatsNdarray::test_func

--- a/tests/third_party/cupy/manipulation_tests/test_shape.py
+++ b/tests/third_party/cupy/manipulation_tests/test_shape.py
@@ -1,0 +1,165 @@
+import unittest
+
+import numpy
+import pytest
+
+import dpnp as cupy
+from tests.third_party.cupy import testing
+
+
+@testing.parameterize(*testing.product({
+    'shape': [(2, 3), (), (4,)],
+}))
+@testing.gpu
+class TestShape(unittest.TestCase):
+
+    def test_shape(self):
+        shape = self.shape
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange(shape, xp)
+            assert cupy.shape(a) == shape
+
+    def test_shape_list(self):
+        shape = self.shape
+        a = testing.shaped_arange(shape, numpy)
+        a = a.tolist()
+        assert cupy.shape(a) == shape
+
+
+@testing.gpu
+class TestReshape(unittest.TestCase):
+
+    def test_reshape_strides(self):
+        def func(xp):
+            a = testing.shaped_arange((1, 1, 1, 2, 2), xp)
+            return a.strides
+        self.assertEqual(func(numpy), func(cupy))
+
+    def test_reshape2(self):
+        def func(xp):
+            a = xp.zeros((8,), dtype=xp.float32)
+            return a.reshape((1, 1, 1, 4, 1, 2)).strides
+        self.assertEqual(func(numpy), func(cupy))
+
+    @testing.for_orders('CFA')
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_nocopy_reshape(self, xp, dtype, order):
+        a = xp.zeros((2, 3, 4), dtype=dtype)
+        b = a.reshape(4, 3, 2, order=order)
+        b[1] = 1
+        return a
+
+    @testing.for_orders('CFA')
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_nocopy_reshape_with_order(self, xp, dtype, order):
+        a = xp.zeros((2, 3, 4), dtype=dtype)
+        b = a.reshape(4, 3, 2, order=order)
+        b[1] = 1
+        return a
+
+    @testing.for_orders('CFA')
+    @testing.numpy_cupy_array_equal()
+    def test_transposed_reshape2(self, xp, order):
+        a = testing.shaped_arange((2, 3, 4), xp).transpose(2, 0, 1)
+        return a.reshape(2, 3, 4, order=order)
+
+    @testing.for_orders('CFA')
+    @testing.numpy_cupy_array_equal()
+    def test_reshape_with_unknown_dimension(self, xp, order):
+        a = testing.shaped_arange((2, 3, 4), xp)
+        return a.reshape(3, -1, order=order)
+
+    def test_reshape_with_multiple_unknown_dimensions(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(ValueError):
+                a.reshape(3, -1, -1)
+
+    def test_reshape_with_changed_arraysize(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(ValueError):
+                a.reshape(2, 4, 4)
+
+    def test_reshape_invalid_order(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(ValueError):
+                a.reshape(2, 4, 4, order='K')
+
+    def test_reshape_zerosize_invalid(self):
+        for xp in (numpy, cupy):
+            a = xp.zeros((0,))
+            with pytest.raises(ValueError):
+                a.reshape(())
+
+    @testing.numpy_cupy_array_equal()
+    def test_reshape_zerosize(self, xp):
+        a = xp.zeros((0,))
+        return a.reshape((0,))
+
+    @testing.for_orders('CFA')
+    @testing.numpy_cupy_array_equal()
+    def test_external_reshape(self, xp, order):
+        a = xp.zeros((8,), dtype=xp.float32)
+        return xp.reshape(a, (1, 1, 1, 4, 1, 2), order=order)
+
+
+@testing.gpu
+class TestRavel(unittest.TestCase):
+
+    @testing.for_orders('CFA')
+    @testing.numpy_cupy_array_equal()
+    def test_ravel(self, xp, order):
+        a = testing.shaped_arange((2, 3, 4), xp)
+        a = a.transpose(2, 0, 1)
+        return a.ravel(order)
+
+    @testing.for_orders('CFA')
+    @testing.numpy_cupy_array_equal()
+    def test_ravel2(self, xp, order):
+        a = testing.shaped_arange((2, 3, 4), xp)
+        return a.ravel(order)
+
+    @testing.for_orders('CFA')
+    @testing.numpy_cupy_array_equal()
+    def test_ravel3(self, xp, order):
+        a = testing.shaped_arange((2, 3, 4), xp)
+        a = xp.asfortranarray(a)
+        return a.ravel(order)
+
+    @testing.numpy_cupy_array_equal()
+    def test_external_ravel(self, xp):
+        a = testing.shaped_arange((2, 3, 4), xp)
+        a = a.transpose(2, 0, 1)
+        return xp.ravel(a)
+
+
+@testing.parameterize(*testing.product({
+    'order_init': ['C', 'F'],
+    'order_reshape': ['C', 'F', 'A', 'c', 'f', 'a'],
+    'shape_in_out': [((2, 3), (1, 6, 1)),  # (shape_init, shape_final)
+                     ((6,), (2, 3)),
+                     ((3, 3, 3), (9, 3))],
+}))
+@testing.gpu
+class TestReshapeOrder(unittest.TestCase):
+
+    def test_reshape_contiguity(self):
+        shape_init, shape_final = self.shape_in_out
+
+        a_cupy = testing.shaped_arange(shape_init, xp=cupy)
+        a_cupy = cupy.asarray(a_cupy, order=self.order_init)
+        b_cupy = a_cupy.reshape(shape_final, order=self.order_reshape)
+
+        a_numpy = testing.shaped_arange(shape_init, xp=numpy)
+        a_numpy = numpy.asarray(a_numpy, order=self.order_init)
+        b_numpy = a_numpy.reshape(shape_final, order=self.order_reshape)
+
+        assert b_cupy.flags.f_contiguous == b_numpy.flags.f_contiguous
+        assert b_cupy.flags.c_contiguous == b_numpy.flags.c_contiguous
+
+        testing.assert_array_equal(b_cupy.strides, b_numpy.strides)
+        testing.assert_array_equal(b_cupy, b_numpy)


### PR DESCRIPTION
Current implementation of `dparray.ravel` just calls `dparray.flatten()` that returns copy of the input array.