### PR TITLE
Move trigonometric functions to new FPRT structure

### DIFF
--- a/dpnp/backend.pxd
+++ b/dpnp/backend.pxd
@@ -32,29 +32,54 @@ from dpnp.dparray cimport dparray, dparray_shape_type
 cdef extern from "backend/backend_iface_fptr.hpp" namespace "DPNPFuncName":  # need this namespace for Enum import
     cdef enum DPNPFuncName "DPNPFuncName":
         DPNP_FN_ADD
+        DPNP_FN_ARCCOS
+        DPNP_FN_ARCCOSH
+        DPNP_FN_ARCSIN
+        DPNP_FN_ARCSINH
+        DPNP_FN_ARCTAN
         DPNP_FN_ARCTAN2
+        DPNP_FN_ARCTANH
         DPNP_FN_ARGMAX
         DPNP_FN_ARGMIN
         DPNP_FN_ARGSORT
+        DPNP_FN_CBRT
         DPNP_FN_CEIL
+        DPNP_FN_COS
+        DPNP_FN_COSH
         DPNP_FN_COV
+        DPNP_FN_DEGREES
         DPNP_FN_DIVIDE
         DPNP_FN_DOT
         DPNP_FN_EIG
+        DPNP_FN_EXP
+        DPNP_FN_EXP2
+        DPNP_FN_EXPM1
         DPNP_FN_FABS
         DPNP_FN_FLOOR
         DPNP_FN_FMOD
         DPNP_FN_HYPOT
+        DPNP_FN_LOG
+        DPNP_FN_LOG10
+        DPNP_FN_LOG1P
+        DPNP_FN_LOG2
         DPNP_FN_MATMUL
         DPNP_FN_MAXIMUM
         DPNP_FN_MINIMUM
         DPNP_FN_MULTIPLY
         DPNP_FN_POWER
         DPNP_FN_PROD
+        DPNP_FN_RADIANS
         DPNP_FN_RAND
+        DPNP_FN_RECIP
         DPNP_FN_SIGN
+        DPNP_FN_SIN
+        DPNP_FN_SINH
+        DPNP_FN_SQRT
+        DPNP_FN_SQUARE
         DPNP_FN_SUBTRACT
         DPNP_FN_SUM
+        DPNP_FN_TAN
+        DPNP_FN_TANH
         DPNP_FN_TRUNC
 
 cdef extern from "backend/backend_iface_fptr.hpp" namespace "DPNPFuncType":  # need this namespace for Enum import
@@ -93,33 +118,6 @@ cdef extern from "backend/backend_iface.hpp":
     void mkl_blas_dot_c[_DataType](void * array1, void * array2, void * result1, size_t size)
     void mkl_lapack_syevd_c[_DataType](void * array1, void * result1, size_t size)
 
-    # Trigonometric part
-    void custom_elemwise_acos_c[_DataType_input, _DataType_output](void * array1, void * result1, size_t size)
-    void custom_elemwise_acosh_c[_DataType_input, _DataType_output](void * array1, void * result1, size_t size)
-    void custom_elemwise_asin_c[_DataType_input, _DataType_output](void * array1, void * result1, size_t size)
-    void custom_elemwise_asinh_c[_DataType_input, _DataType_output](void * array1, void * result1, size_t size)
-    void custom_elemwise_atan_c[_DataType_input, _DataType_output](void * array1, void * result1, size_t size)
-    void custom_elemwise_atanh_c[_DataType_input, _DataType_output](void * array1, void * result1, size_t size)
-    void custom_elemwise_cbrt_c[_DataType_input, _DataType_output](void * array1, void * result1, size_t size)
-    void custom_elemwise_cos_c[_DataType_input, _DataType_output](void * array1, void * result1, size_t size)
-    void custom_elemwise_cosh_c[_DataType_input, _DataType_output](void * array1, void * result1, size_t size)
-    void custom_elemwise_degrees_c[_DataType_input, _DataType_output](void * array1, void * result1, size_t size)
-    void custom_elemwise_exp2_c[_DataType_input, _DataType_output](void * array1, void * result1, size_t size)
-    void custom_elemwise_exp_c[_DataType_input, _DataType_output](void * array1, void * result1, size_t size)
-    void custom_elemwise_expm1_c[_DataType_input, _DataType_output](void * array1, void * result1, size_t size)
-    void custom_elemwise_log10_c[_DataType_input, _DataType_output](void * array1, void * result1, size_t size)
-    void custom_elemwise_log1p_c[_DataType_input, _DataType_output](void * array1, void * result1, size_t size)
-    void custom_elemwise_log2_c[_DataType_input, _DataType_output](void * array1, void * result1, size_t size)
-    void custom_elemwise_log_c[_DataType_input, _DataType_output](void * array1, void * result1, size_t size)
-    void custom_elemwise_radians_c[_DataType_input, _DataType_output](void * array1, void * result1, size_t size)
-    void custom_elemwise_recip_c[_DataType](void * array1, void * result1, size_t size)
-    void custom_elemwise_sin_c[_DataType_input, _DataType_output](void * array1, void * result1, size_t size)
-    void custom_elemwise_sinh_c[_DataType_input, _DataType_output](void * array1, void * result1, size_t size)
-    void custom_elemwise_sqrt_c[_DataType_input, _DataType_output](void * array1, void * result1, size_t size)
-    void custom_elemwise_square_c[_DataType](void * array1, void * result1, size_t size)
-    void custom_elemwise_tan_c[_DataType_input, _DataType_output](void * array1, void * result1, size_t size)
-    void custom_elemwise_tanh_c[_DataType_input, _DataType_output](void * array1, void * result1, size_t size)
-
     # array manipulation routines
     void custom_elemwise_transpose_c[_DataType](void * array1_in, dparray_shape_type & input_shape, dparray_shape_type & result_shape, dparray_shape_type & permute_axes, void * result1, size_t size)
 
@@ -138,6 +136,15 @@ cdef extern from "backend/backend_iface.hpp":
     # Sorting routines
     void custom_argmax_c[_DataType, _idx_DataType](void * array, void * result, size_t size)
     void custom_argmin_c[_DataType, _idx_DataType](void * array, void * result, size_t size)
+
+
+# C function pointer to the C library template functions
+ctypedef void(*fptr_1in_1out_t)(void *, void * , size_t)
+ctypedef void(*fptr_2in_1out_t)(void *, void*, void*, size_t)
+
+cdef dparray call_fptr_1in_1out(DPNPFuncName fptr_name, dparray x1, dparray_shape_type result_shape)
+cdef dparray call_fptr_2in_1out(DPNPFuncName fptr_name, dparray x1, dparray x2, dparray_shape_type result_shape)
+
 
 cpdef dparray dpnp_remainder(dparray array1, int scalar)
 cpdef dparray dpnp_astype(dparray array1, dtype_target)
@@ -223,3 +230,32 @@ Searching functions
 """
 cpdef dparray dpnp_argmax(dparray array1)
 cpdef dparray dpnp_argmin(dparray array1)
+
+"""
+Trigonometric functions
+"""
+cpdef dparray dpnp_arccos(dparray array1)
+cpdef dparray dpnp_arccosh(dparray array1)
+cpdef dparray dpnp_arcsin(dparray array1)
+cpdef dparray dpnp_arcsinh(dparray array1)
+cpdef dparray dpnp_arctan(dparray array1)
+cpdef dparray dpnp_arctanh(dparray array1)
+cpdef dparray dpnp_cbrt(dparray array1)
+cpdef dparray dpnp_cos(dparray array1)
+cpdef dparray dpnp_cosh(dparray array1)
+cpdef dparray dpnp_degrees(dparray array1)
+cpdef dparray dpnp_exp(dparray array1)
+cpdef dparray dpnp_exp2(dparray array1)
+cpdef dparray dpnp_expm1(dparray array1)
+cpdef dparray dpnp_log(dparray array1)
+cpdef dparray dpnp_log10(dparray array1)
+cpdef dparray dpnp_log1p(dparray array1)
+cpdef dparray dpnp_log2(dparray array1)
+cpdef dparray dpnp_radians(dparray array1)
+cpdef dparray dpnp_recip(dparray array1)
+cpdef dparray dpnp_sin(dparray array1)
+cpdef dparray dpnp_sinh(dparray array1)
+cpdef dparray dpnp_sqrt(dparray array1)
+cpdef dparray dpnp_square(dparray array1)
+cpdef dparray dpnp_tan(dparray array1)
+cpdef dparray dpnp_tanh(dparray array1)

--- a/dpnp/backend.pyx
+++ b/dpnp/backend.pyx
@@ -254,3 +254,42 @@ cpdef dpnp_DPNPFuncType_to_dtype(size_t type):
         return numpy.int32
     else:
         checker_throw_type_error("dpnp_DPNPFuncType_to_dtype", type)
+
+
+cdef dparray call_fptr_1in_1out(DPNPFuncName fptr_name, dparray x1, dparray_shape_type result_shape):
+
+    """ Convert string type names (dparray.dtype) to C enum DPNPFuncType """
+    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(x1.dtype)
+
+    """ get the FPTR data structure """
+    cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(fptr_name, param1_type, param1_type)
+
+    result_type = dpnp_DPNPFuncType_to_dtype( < size_t > kernel_data.return_type)
+    """ Create result array with type given by FPTR data """
+    cdef dparray result = dparray(result_shape, dtype=result_type)
+
+    cdef fptr_1in_1out_t func = <fptr_1in_1out_t > kernel_data.ptr
+    """ Call FPTR function """
+    func(x1.get_data(), result.get_data(), x1.size)
+
+    return result
+
+
+cdef dparray call_fptr_2in_1out(DPNPFuncName fptr_name, dparray x1, dparray x2, dparray_shape_type result_shape):
+
+    """ Convert string type names (dparray.dtype) to C enum DPNPFuncType """
+    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(x1.dtype)
+    cdef DPNPFuncType param2_type = dpnp_dtype_to_DPNPFuncType(x2.dtype)
+
+    """ get the FPTR data structure """
+    cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(fptr_name, param1_type, param2_type)
+
+    result_type = dpnp_DPNPFuncType_to_dtype( < size_t > kernel_data.return_type)
+    """ Create result array with type given by FPTR data """
+    cdef dparray result = dparray(result_shape, dtype=result_type)
+
+    cdef fptr_2in_1out_t func = <fptr_2in_1out_t > kernel_data.ptr
+    """ Call FPTR function """
+    func(x1.get_data(), x2.get_data(), result.get_data(), x1.size)
+
+    return result

--- a/dpnp/backend/backend_iface_fptr.cpp
+++ b/dpnp/backend/backend_iface_fptr.cpp
@@ -160,6 +160,31 @@ static func_map_t func_map_init()
     fmap[DPNPFuncName::DPNP_FN_ADD][eft_DBL][eft_FLT] = {eft_DBL, (void*)custom_elemwise_add_c<double, float, double>};
     fmap[DPNPFuncName::DPNP_FN_ADD][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_add_c<double, double, double>};
 
+    fmap[DPNPFuncName::DPNP_FN_ARCCOS][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_acos_c<int, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCCOS][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_acos_c<long, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCCOS][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_acos_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCCOS][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_acos_c<double, double>};
+
+    fmap[DPNPFuncName::DPNP_FN_ARCCOSH][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_acosh_c<int, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCCOSH][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_acosh_c<long, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCCOSH][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_acosh_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCCOSH][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_acosh_c<double, double>};
+
+    fmap[DPNPFuncName::DPNP_FN_ARCSIN][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_asin_c<int, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCSIN][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_asin_c<long, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCSIN][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_asin_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCSIN][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_asin_c<double, double>};
+
+    fmap[DPNPFuncName::DPNP_FN_ARCSINH][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_asinh_c<int, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCSINH][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_asinh_c<long, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCSINH][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_asinh_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCSINH][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_asinh_c<double, double>};
+
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_atan_c<int, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_atan_c<long, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_atan_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_atan_c<double, double>};
+
     fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_INT][eft_INT] = {eft_DBL,
                                                              (void*)custom_elemwise_arctan2_c<int, int, double>};
     fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_INT][eft_LNG] = {eft_DBL,
@@ -193,6 +218,11 @@ static func_map_t func_map_init()
     fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_DBL][eft_DBL] = {eft_DBL,
                                                              (void*)custom_elemwise_arctan2_c<double, double, double>};
 
+    fmap[DPNPFuncName::DPNP_FN_ARCTANH][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_atanh_c<int, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTANH][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_atanh_c<long, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTANH][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_atanh_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTANH][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_atanh_c<double, double>};
+
     fmap[DPNPFuncName::DPNP_FN_ARGMAX][eft_INT][eft_INT] = {eft_INT, (void*)custom_argmax_c<int, int>};
     fmap[DPNPFuncName::DPNP_FN_ARGMAX][eft_INT][eft_LNG] = {eft_LNG, (void*)custom_argmax_c<int, long>};
     fmap[DPNPFuncName::DPNP_FN_ARGMAX][eft_LNG][eft_INT] = {eft_INT, (void*)custom_argmax_c<long, int>};
@@ -220,12 +250,32 @@ static func_map_t func_map_init()
     fmap[DPNPFuncName::DPNP_FN_ARGSORT][eft_DBL][eft_INT] = {eft_INT, (void*)custom_argsort_c<double, int>};
     fmap[DPNPFuncName::DPNP_FN_ARGSORT][eft_DBL][eft_LNG] = {eft_LNG, (void*)custom_argsort_c<double, long>};
 
+    fmap[DPNPFuncName::DPNP_FN_CBRT][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_cbrt_c<int, double>};
+    fmap[DPNPFuncName::DPNP_FN_CBRT][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_cbrt_c<long, double>};
+    fmap[DPNPFuncName::DPNP_FN_CBRT][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_cbrt_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_CBRT][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_cbrt_c<double, double>};
+
     fmap[DPNPFuncName::DPNP_FN_CEIL][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_ceil_c<int, double>};
     fmap[DPNPFuncName::DPNP_FN_CEIL][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_ceil_c<long, double>};
     fmap[DPNPFuncName::DPNP_FN_CEIL][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_ceil_c<float, float>};
     fmap[DPNPFuncName::DPNP_FN_CEIL][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_ceil_c<double, double>};
 
+    fmap[DPNPFuncName::DPNP_FN_COS][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_cos_c<int, double>};
+    fmap[DPNPFuncName::DPNP_FN_COS][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_cos_c<long, double>};
+    fmap[DPNPFuncName::DPNP_FN_COS][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_cos_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_COS][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_cos_c<double, double>};
+
+    fmap[DPNPFuncName::DPNP_FN_COSH][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_cosh_c<int, double>};
+    fmap[DPNPFuncName::DPNP_FN_COSH][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_cosh_c<long, double>};
+    fmap[DPNPFuncName::DPNP_FN_COSH][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_cosh_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_COSH][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_cosh_c<double, double>};
+
     fmap[DPNPFuncName::DPNP_FN_COV][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_cov_c<double>};
+
+    fmap[DPNPFuncName::DPNP_FN_DEGREES][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_degrees_c<int, double>};
+    fmap[DPNPFuncName::DPNP_FN_DEGREES][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_degrees_c<long, double>};
+    fmap[DPNPFuncName::DPNP_FN_DEGREES][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_degrees_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_DEGREES][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_degrees_c<double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_INT][eft_INT] = {eft_INT, (void*)custom_elemwise_divide_c<int, int, int>};
     fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_INT][eft_LNG] = {eft_LNG, (void*)custom_elemwise_divide_c<int, long, long>};
@@ -263,6 +313,21 @@ static func_map_t func_map_init()
 
     fmap[DPNPFuncName::DPNP_FN_EIG][eft_FLT][eft_FLT] = {eft_FLT, (void*)mkl_lapack_syevd_c<float>};
     fmap[DPNPFuncName::DPNP_FN_EIG][eft_DBL][eft_DBL] = {eft_DBL, (void*)mkl_lapack_syevd_c<double>};
+
+    fmap[DPNPFuncName::DPNP_FN_EXP][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_exp_c<int, double>};
+    fmap[DPNPFuncName::DPNP_FN_EXP][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_exp_c<long, double>};
+    fmap[DPNPFuncName::DPNP_FN_EXP][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_exp_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_EXP][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_exp_c<double, double>};
+
+    fmap[DPNPFuncName::DPNP_FN_EXP2][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_exp2_c<int, double>};
+    fmap[DPNPFuncName::DPNP_FN_EXP2][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_exp2_c<long, double>};
+    fmap[DPNPFuncName::DPNP_FN_EXP2][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_exp2_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_EXP2][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_exp2_c<double, double>};
+
+    fmap[DPNPFuncName::DPNP_FN_EXPM1][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_expm1_c<int, double>};
+    fmap[DPNPFuncName::DPNP_FN_EXPM1][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_expm1_c<long, double>};
+    fmap[DPNPFuncName::DPNP_FN_EXPM1][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_expm1_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_EXPM1][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_expm1_c<double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_FABS][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_fabs_c<int, double>};
     fmap[DPNPFuncName::DPNP_FN_FABS][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_fabs_c<long, double>};
@@ -320,6 +385,26 @@ static func_map_t func_map_init()
                                                            (void*)custom_elemwise_hypot_c<double, float, double>};
     fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_DBL][eft_DBL] = {eft_DBL,
                                                            (void*)custom_elemwise_hypot_c<double, double, double>};
+
+    fmap[DPNPFuncName::DPNP_FN_LOG][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_log_c<int, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_log_c<long, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_log_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_LOG][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_log_c<double, double>};
+
+    fmap[DPNPFuncName::DPNP_FN_LOG10][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_log10_c<int, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG10][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_log10_c<long, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG10][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_log10_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_LOG10][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_log10_c<double, double>};
+
+    fmap[DPNPFuncName::DPNP_FN_LOG1P][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_log1p_c<int, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG1P][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_log1p_c<long, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG1P][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_log1p_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_LOG1P][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_log1p_c<double, double>};
+
+    fmap[DPNPFuncName::DPNP_FN_LOG2][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_log2_c<int, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG2][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_log2_c<long, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG2][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_log2_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_LOG2][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_log2_c<double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_MATMUL][eft_INT][eft_INT] = {eft_INT, (void*)custom_blas_gemm_c<int>};
     fmap[DPNPFuncName::DPNP_FN_MATMUL][eft_LNG][eft_LNG] = {eft_LNG, (void*)custom_blas_gemm_c<long>};
@@ -455,6 +540,14 @@ static func_map_t func_map_init()
     fmap[DPNPFuncName::DPNP_FN_PROD][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_prod_c<float>};
     fmap[DPNPFuncName::DPNP_FN_PROD][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_prod_c<double>};
 
+    fmap[DPNPFuncName::DPNP_FN_RADIANS][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_radians_c<int, double>};
+    fmap[DPNPFuncName::DPNP_FN_RADIANS][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_radians_c<long, double>};
+    fmap[DPNPFuncName::DPNP_FN_RADIANS][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_radians_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_RADIANS][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_radians_c<double, double>};
+
+    fmap[DPNPFuncName::DPNP_FN_RECIP][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_recip_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_RECIP][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_recip_c<double>};
+
     fmap[DPNPFuncName::DPNP_FN_RAND][eft_FLT][eft_FLT] = {eft_FLT, (void*)mkl_rng_uniform<float>};
     fmap[DPNPFuncName::DPNP_FN_RAND][eft_DBL][eft_DBL] = {eft_DBL, (void*)mkl_rng_uniform<double>};
 
@@ -462,6 +555,26 @@ static func_map_t func_map_init()
     fmap[DPNPFuncName::DPNP_FN_SIGN][eft_LNG][eft_LNG] = {eft_LNG, (void*)custom_elemwise_sign_c<long>};
     fmap[DPNPFuncName::DPNP_FN_SIGN][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_sign_c<float>};
     fmap[DPNPFuncName::DPNP_FN_SIGN][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_sign_c<double>};
+
+    fmap[DPNPFuncName::DPNP_FN_SIN][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_sin_c<int, double>};
+    fmap[DPNPFuncName::DPNP_FN_SIN][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_sin_c<long, double>};
+    fmap[DPNPFuncName::DPNP_FN_SIN][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_sin_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_SIN][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_sin_c<double, double>};
+
+    fmap[DPNPFuncName::DPNP_FN_SINH][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_sinh_c<int, double>};
+    fmap[DPNPFuncName::DPNP_FN_SINH][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_sinh_c<long, double>};
+    fmap[DPNPFuncName::DPNP_FN_SINH][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_sinh_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_SINH][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_sinh_c<double, double>};
+
+    fmap[DPNPFuncName::DPNP_FN_SQRT][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_sqrt_c<int, double>};
+    fmap[DPNPFuncName::DPNP_FN_SQRT][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_sqrt_c<long, double>};
+    fmap[DPNPFuncName::DPNP_FN_SQRT][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_sqrt_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_SQRT][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_sqrt_c<double, double>};
+
+    fmap[DPNPFuncName::DPNP_FN_SQUARE][eft_INT][eft_INT] = {eft_INT, (void*)custom_elemwise_square_c<int>};
+    fmap[DPNPFuncName::DPNP_FN_SQUARE][eft_LNG][eft_LNG] = {eft_LNG, (void*)custom_elemwise_square_c<long>};
+    fmap[DPNPFuncName::DPNP_FN_SQUARE][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_square_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_SQUARE][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_square_c<double>};
 
     fmap[DPNPFuncName::DPNP_FN_SUBTRACT][eft_INT][eft_INT] = {eft_INT,
                                                               (void*)custom_elemwise_subtract_c<int, int, int>};
@@ -500,6 +613,16 @@ static func_map_t func_map_init()
     fmap[DPNPFuncName::DPNP_FN_SUM][eft_LNG][eft_LNG] = {eft_LNG, (void*)custom_sum_c<long>};
     fmap[DPNPFuncName::DPNP_FN_SUM][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_sum_c<float>};
     fmap[DPNPFuncName::DPNP_FN_SUM][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_sum_c<double>};
+
+    fmap[DPNPFuncName::DPNP_FN_TAN][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_tan_c<int, double>};
+    fmap[DPNPFuncName::DPNP_FN_TAN][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_tan_c<long, double>};
+    fmap[DPNPFuncName::DPNP_FN_TAN][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_tan_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_TAN][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_tan_c<double, double>};
+
+    fmap[DPNPFuncName::DPNP_FN_TANH][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_tanh_c<int, double>};
+    fmap[DPNPFuncName::DPNP_FN_TANH][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_tanh_c<long, double>};
+    fmap[DPNPFuncName::DPNP_FN_TANH][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_elemwise_tanh_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_TANH][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_elemwise_tanh_c<double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_TRUNC][eft_INT][eft_INT] = {eft_DBL, (void*)custom_elemwise_trunc_c<int, double>};
     fmap[DPNPFuncName::DPNP_FN_TRUNC][eft_LNG][eft_LNG] = {eft_DBL, (void*)custom_elemwise_trunc_c<long, double>};

--- a/dpnp/backend/backend_iface_fptr.hpp
+++ b/dpnp/backend/backend_iface_fptr.hpp
@@ -61,29 +61,54 @@ enum class DPNPFuncName : size_t
 {
     DPNP_FN_NONE,     /**< Very first element of the enumeration */
     DPNP_FN_ADD,      /**< Used in numpy.add() implementation  */
+    DPNP_FN_ARCCOS,   /**< Used in numpy.arccos() implementation  */
+    DPNP_FN_ARCCOSH,  /**< Used in numpy.arccosh() implementation  */
+    DPNP_FN_ARCSIN,   /**< Used in numpy.arcsin() implementation  */
+    DPNP_FN_ARCSINH,  /**< Used in numpy.arcsinh() implementation  */
+    DPNP_FN_ARCTAN,   /**< Used in numpy.arctan() implementation  */
     DPNP_FN_ARCTAN2,  /**< Used in numpy.arctan2() implementation  */
+    DPNP_FN_ARCTANH,  /**< Used in numpy.arctanh() implementation  */
     DPNP_FN_ARGMAX,   /**< Used in numpy.argmax() implementation  */
     DPNP_FN_ARGMIN,   /**< Used in numpy.argmin() implementation  */
     DPNP_FN_ARGSORT,  /**< Used in numpy.argsort() implementation  */
+    DPNP_FN_CBRT,     /**< Used in numpy.cbrt() implementation  */
     DPNP_FN_CEIL,     /**< Used in numpy.ceil() implementation  */
+    DPNP_FN_COS,      /**< Used in numpy.cos() implementation  */
+    DPNP_FN_COSH,     /**< Used in numpy.cosh() implementation  */
     DPNP_FN_COV,      /**< Used in numpy.cov() implementation  */
+    DPNP_FN_DEGREES,  /**< Used in numpy.degrees() implementation  */
     DPNP_FN_DIVIDE,   /**< Used in numpy.divide() implementation  */
     DPNP_FN_DOT,      /**< Used in numpy.dot() implementation  */
     DPNP_FN_EIG,      /**< Used in numpy.linalg.eig() implementation  */
+    DPNP_FN_EXP,      /**< Used in numpy.exp() implementation  */
+    DPNP_FN_EXP2,     /**< Used in numpy.exp2() implementation  */
+    DPNP_FN_EXPM1,    /**< Used in numpy.expm1() implementation  */
     DPNP_FN_FABS,     /**< Used in numpy.fabs() implementation  */
     DPNP_FN_FLOOR,    /**< Used in numpy.floor() implementation  */
     DPNP_FN_FMOD,     /**< Used in numpy.fmod() implementation  */
     DPNP_FN_HYPOT,    /**< Used in numpy.hypot() implementation  */
+    DPNP_FN_LOG,      /**< Used in numpy.log() implementation  */
+    DPNP_FN_LOG10,    /**< Used in numpy.log10() implementation  */
+    DPNP_FN_LOG2,     /**< Used in numpy.log2() implementation  */
+    DPNP_FN_LOG1P,    /**< Used in numpy.log1p() implementation  */
     DPNP_FN_MATMUL,   /**< Used in numpy.matmul() implementation  */
     DPNP_FN_MAXIMUM,  /**< Used in numpy.maximum() implementation  */
     DPNP_FN_MINIMUM,  /**< Used in numpy.minimum() implementation  */
     DPNP_FN_MULTIPLY, /**< Used in numpy.multiply() implementation  */
     DPNP_FN_POWER,    /**< Used in numpy.random.power() implementation  */
     DPNP_FN_PROD,     /**< Used in numpy.prod() implementation  */
+    DPNP_FN_RADIANS,  /**< Used in numpy.radians() implementation  */
+    DPNP_FN_RECIP,    /**< Used in numpy.recip() implementation  */
     DPNP_FN_RAND,     /**< Used in numpy.random.rand() implementation  */
     DPNP_FN_SIGN,     /**< Used in numpy.sign() implementation  */
+    DPNP_FN_SIN,      /**< Used in numpy.sin() implementation  */
+    DPNP_FN_SINH,     /**< Used in numpy.sinh() implementation  */
+    DPNP_FN_SQRT,     /**< Used in numpy.sqrt() implementation  */
+    DPNP_FN_SQUARE,    /**< Used in numpy.square() implementation  */
     DPNP_FN_SUBTRACT, /**< Used in numpy.subtract() implementation  */
     DPNP_FN_SUM,      /**< Used in numpy.sum() implementation  */
+    DPNP_FN_TAN,      /**< Used in numpy.tan() implementation  */
+    DPNP_FN_TANH,      /**< Used in numpy.tanh() implementation  */
     DPNP_FN_TRUNC,    /**< Used in numpy.trunc() implementation  */
     DPNP_FN_LAST      /**< The latest element of the enumeration */
 };

--- a/dpnp/backend_mathematical.pyx
+++ b/dpnp/backend_mathematical.pyx
@@ -63,52 +63,6 @@ __all__ += [
 ]
 
 
-# C function pointer to the C library template functions
-# TODO later move to PXD
-ctypedef void(*fptr_1in_1out_t)(void *, void * , size_t)
-ctypedef void(*fptr_2in_1out_t)(void *, void*, void*, size_t)
-
-# TODO later move to PXD
-cdef dparray call_fptr_1in_1out(DPNPFuncName fptr_name, dparray x1, dparray_shape_type result_shape):
-
-    """ Convert string type names (dparray.dtype) to C enum DPNPFuncType """
-    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(x1.dtype)
-
-    """ get the FPTR data structure """
-    cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(fptr_name, param1_type, param1_type)
-
-    result_type = dpnp_DPNPFuncType_to_dtype( < size_t > kernel_data.return_type)
-    """ Create result array with type given by FPTR data """
-    cdef dparray result = dparray(result_shape, dtype=result_type)
-
-    cdef fptr_1in_1out_t func = <fptr_1in_1out_t > kernel_data.ptr
-    """ Call FPTR function """
-    func(x1.get_data(), result.get_data(), x1.size)
-
-    return result
-
-
-# TODO later move to PXD
-cdef dparray call_fptr_2in_1out(DPNPFuncName fptr_name, dparray x1, dparray x2, dparray_shape_type result_shape):
-
-    """ Convert string type names (dparray.dtype) to C enum DPNPFuncType """
-    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(x1.dtype)
-    cdef DPNPFuncType param2_type = dpnp_dtype_to_DPNPFuncType(x2.dtype)
-
-    """ get the FPTR data structure """
-    cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(fptr_name, param1_type, param2_type)
-
-    result_type = dpnp_DPNPFuncType_to_dtype( < size_t > kernel_data.return_type)
-    """ Create result array with type given by FPTR data """
-    cdef dparray result = dparray(result_shape, dtype=result_type)
-
-    cdef fptr_2in_1out_t func = <fptr_2in_1out_t > kernel_data.ptr
-    """ Call FPTR function """
-    func(x1.get_data(), x2.get_data(), result.get_data(), x1.size)
-
-    return result
-
-
 cpdef dparray dpnp_absolute(dparray input):
     cdef dparray_shape_type shape_input = input.shape
     cdef long size_input = input.size

--- a/dpnp/backend_trigonometric.pyx
+++ b/dpnp/backend_trigonometric.pyx
@@ -66,590 +66,104 @@ __all__ += [
 ]
 
 
-cpdef dparray dpnp_arccos(dparray array1):
-    cdef dparray result
-    cdef size_t size = array1.size
-    call_type = array1.dtype
-
-    if call_type == numpy.float32:
-        result = dparray(array1.shape, dtype=call_type)
-    else:
-        result = dparray(array1.shape)
-
-    if call_type == numpy.float64:
-        custom_elemwise_acos_c[double, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.float32:
-        custom_elemwise_acos_c[float, float](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int64:
-        custom_elemwise_acos_c[long, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int32:
-        custom_elemwise_acos_c[int, double](array1.get_data(), result.get_data(), size)
-    else:
-        checker_throw_type_error("dpnp_arccos", call_type)
-
-    return result
-
-
-cpdef dparray dpnp_arccosh(dparray array1):
-    cdef dparray result
-    cdef size_t size = array1.size
-    call_type = array1.dtype
-
-    if call_type == numpy.float32:
-        result = dparray(array1.shape, dtype=call_type)
-    else:
-        result = dparray(array1.shape)
-
-    if call_type == numpy.float64:
-        custom_elemwise_acosh_c[double, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.float32:
-        custom_elemwise_acosh_c[float, float](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int64:
-        custom_elemwise_acosh_c[long, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int32:
-        custom_elemwise_acosh_c[int, double](array1.get_data(), result.get_data(), size)
-    else:
-        checker_throw_type_error("dpnp_arccosh", call_type)
-
-    return result
-
-
-cpdef dparray dpnp_arcsin(dparray array1):
-    cdef dparray result
-    cdef size_t size = array1.size
-    call_type = array1.dtype
-
-    if call_type == numpy.float32:
-        result = dparray(array1.shape, dtype=call_type)
-    else:
-        result = dparray(array1.shape)
-
-    if call_type == numpy.float64:
-        custom_elemwise_asin_c[double, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.float32:
-        custom_elemwise_asin_c[float, float](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int64:
-        custom_elemwise_asin_c[long, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int32:
-        custom_elemwise_asin_c[int, double](array1.get_data(), result.get_data(), size)
-    else:
-        checker_throw_type_error("dpnp_arcsin", call_type)
-
-    return result
-
-
-cpdef dparray dpnp_arcsinh(dparray array1):
-    cdef dparray result
-    cdef size_t size = array1.size
-    call_type = array1.dtype
-
-    if call_type == numpy.float32:
-        result = dparray(array1.shape, dtype=call_type)
-    else:
-        result = dparray(array1.shape)
-
-    if call_type == numpy.float64:
-        custom_elemwise_asinh_c[double, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.float32:
-        custom_elemwise_asinh_c[float, float](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int64:
-        custom_elemwise_asinh_c[long, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int32:
-        custom_elemwise_asinh_c[int, double](array1.get_data(), result.get_data(), size)
-    else:
-        checker_throw_type_error("dpnp_arcsinh", call_type)
-
-    return result
-
-
-cpdef dparray dpnp_arctan(dparray array1):
-    cdef dparray result
-    cdef size_t size = array1.size
-    call_type = array1.dtype
-
-    if call_type == numpy.float32:
-        result = dparray(array1.shape, dtype=call_type)
-    else:
-        result = dparray(array1.shape)
-
-    if call_type == numpy.float64:
-        custom_elemwise_atan_c[double, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.float32:
-        custom_elemwise_atan_c[float, float](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int64:
-        custom_elemwise_atan_c[long, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int32:
-        custom_elemwise_atan_c[int, double](array1.get_data(), result.get_data(), size)
-    else:
-        checker_throw_type_error("dpnp_arctan", call_type)
-
-    return result
-
-
-cpdef dparray dpnp_arctanh(dparray array1):
-    cdef dparray result
-    cdef size_t size = array1.size
-    call_type = array1.dtype
-
-    if call_type == numpy.float32:
-        result = dparray(array1.shape, dtype=call_type)
-    else:
-        result = dparray(array1.shape)
-
-    if call_type == numpy.float64:
-        custom_elemwise_atanh_c[double, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.float32:
-        custom_elemwise_atanh_c[float, float](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int64:
-        custom_elemwise_atanh_c[long, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int32:
-        custom_elemwise_atanh_c[int, double](array1.get_data(), result.get_data(), size)
-    else:
-        checker_throw_type_error("dpnp_arctanh", call_type)
-
-    return result
-
-
-cpdef dparray dpnp_cbrt(dparray array1):
-    cdef dparray result
-    cdef size_t size = array1.size
-    call_type = array1.dtype
-
-    if call_type == numpy.float32:
-        result = dparray(array1.shape, dtype=call_type)
-    else:
-        result = dparray(array1.shape)
-
-    if call_type == numpy.float64:
-        custom_elemwise_cbrt_c[double, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.float32:
-        custom_elemwise_cbrt_c[float, float](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int64:
-        custom_elemwise_cbrt_c[long, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int32:
-        custom_elemwise_cbrt_c[int, double](array1.get_data(), result.get_data(), size)
-    else:
-        checker_throw_type_error("dpnp_cbrt", call_type)
-
-    return result
-
-
-cpdef dparray dpnp_cos(dparray array1):
-    cdef dparray result
-    cdef size_t size = array1.size
-    call_type = array1.dtype
-
-    if call_type == numpy.float32:
-        result = dparray(array1.shape, dtype=call_type)
-    else:
-        result = dparray(array1.shape)
-
-    if call_type == numpy.float64:
-        custom_elemwise_cos_c[double, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.float32:
-        custom_elemwise_cos_c[float, float](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int64:
-        custom_elemwise_cos_c[long, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int32:
-        custom_elemwise_cos_c[int, double](array1.get_data(), result.get_data(), size)
-    else:
-        checker_throw_type_error("dpnp_cos", call_type)
-
-    return result
-
-
-cpdef dparray dpnp_cosh(dparray array1):
-    cdef dparray result
-    cdef size_t size = array1.size
-    call_type = array1.dtype
-
-    if call_type == numpy.float32:
-        result = dparray(array1.shape, dtype=call_type)
-    else:
-        result = dparray(array1.shape)
-
-    if call_type == numpy.float64:
-        custom_elemwise_cosh_c[double, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.float32:
-        custom_elemwise_cosh_c[float, float](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int64:
-        custom_elemwise_cosh_c[long, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int32:
-        custom_elemwise_cosh_c[int, double](array1.get_data(), result.get_data(), size)
-    else:
-        checker_throw_type_error("dpnp_cosh", call_type)
-
-    return result
-
-
-cpdef dparray dpnp_degrees(dparray array1):
-    cdef dparray result
-    cdef size_t size = array1.size
-    call_type = array1.dtype
-
-    if call_type == numpy.float32:
-        result = dparray(array1.shape, dtype=call_type)
-    else:
-        result = dparray(array1.shape)
-
-    if call_type == numpy.float64:
-        custom_elemwise_degrees_c[double, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.float32:
-        custom_elemwise_degrees_c[float, float](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int64:
-        custom_elemwise_degrees_c[long, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int32:
-        custom_elemwise_degrees_c[int, double](array1.get_data(), result.get_data(), size)
-    else:
-        checker_throw_type_error("dpnp_degrees", call_type)
-
-    return result
-
-
-cpdef dparray dpnp_exp(dparray array1):
-    cdef dparray result
-    cdef size_t size = array1.size
-    call_type = array1.dtype
-
-    if call_type == numpy.float32:
-        result = dparray(array1.shape, dtype=call_type)
-    else:
-        result = dparray(array1.shape)
-
-    if call_type == numpy.float64:
-        custom_elemwise_exp_c[double, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.float32:
-        custom_elemwise_exp_c[float, float](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int64:
-        custom_elemwise_exp_c[long, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int32:
-        custom_elemwise_exp_c[int, double](array1.get_data(), result.get_data(), size)
-    else:
-        checker_throw_type_error("dpnp_exp", call_type)
-
-    return result
-
-
-cpdef dparray dpnp_exp2(dparray array1):
-    cdef dparray result
-    cdef size_t size = array1.size
-    call_type = array1.dtype
-
-    if call_type == numpy.float32:
-        result = dparray(array1.shape, dtype=call_type)
-    else:
-        result = dparray(array1.shape)
-
-    if call_type == numpy.float64:
-        custom_elemwise_exp2_c[double, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.float32:
-        custom_elemwise_exp2_c[float, float](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int64:
-        custom_elemwise_exp2_c[long, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int32:
-        custom_elemwise_exp2_c[int, double](array1.get_data(), result.get_data(), size)
-    else:
-        checker_throw_type_error("dpnp_exp2", call_type)
-
-    return result
-
-
-cpdef dparray dpnp_expm1(dparray array1):
-    cdef dparray result
-    cdef size_t size = array1.size
-    call_type = array1.dtype
-
-    if call_type == numpy.float32:
-        result = dparray(array1.shape, dtype=call_type)
-    else:
-        result = dparray(array1.shape)
-
-    if call_type == numpy.float64:
-        custom_elemwise_expm1_c[double, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.float32:
-        custom_elemwise_expm1_c[float, float](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int64:
-        custom_elemwise_expm1_c[long, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int32:
-        custom_elemwise_expm1_c[int, double](array1.get_data(), result.get_data(), size)
-    else:
-        checker_throw_type_error("dpnp_expm1", call_type)
-
-    return result
-
-
-cpdef dparray dpnp_log(dparray array1):
-    cdef dparray result
-    cdef size_t size = array1.size
-    call_type = array1.dtype
-
-    if call_type == numpy.float32:
-        result = dparray(array1.shape, dtype=call_type)
-    else:
-        result = dparray(array1.shape)
-
-    if call_type == numpy.float64:
-        custom_elemwise_log_c[double, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.float32:
-        custom_elemwise_log_c[float, float](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int64:
-        custom_elemwise_log_c[long, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int32:
-        custom_elemwise_log_c[int, double](array1.get_data(), result.get_data(), size)
-    else:
-        checker_throw_type_error("dpnp_log", call_type)
-
-    return result
-
-
-cpdef dparray dpnp_log10(dparray array1):
-    cdef dparray result
-    cdef size_t size = array1.size
-    call_type = array1.dtype
-
-    if call_type == numpy.float32:
-        result = dparray(array1.shape, dtype=call_type)
-    else:
-        result = dparray(array1.shape)
-
-    if call_type == numpy.float64:
-        custom_elemwise_log10_c[double, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.float32:
-        custom_elemwise_log10_c[float, float](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int64:
-        custom_elemwise_log10_c[long, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int32:
-        custom_elemwise_log10_c[int, double](array1.get_data(), result.get_data(), size)
-    else:
-        checker_throw_type_error("dpnp_log10", call_type)
-
-    return result
-
-
-cpdef dparray dpnp_log1p(dparray array1):
-    cdef dparray result
-    cdef size_t size = array1.size
-    call_type = array1.dtype
-
-    if call_type == numpy.float32:
-        result = dparray(array1.shape, dtype=call_type)
-    else:
-        result = dparray(array1.shape)
-
-    if call_type == numpy.float64:
-        custom_elemwise_log1p_c[double, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.float32:
-        custom_elemwise_log1p_c[float, float](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int64:
-        custom_elemwise_log1p_c[long, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int32:
-        custom_elemwise_log1p_c[int, double](array1.get_data(), result.get_data(), size)
-    else:
-        checker_throw_type_error("dpnp_log1p", call_type)
-
-    return result
-
-
-cpdef dparray dpnp_log2(dparray array1):
-    cdef dparray result
-    cdef size_t size = array1.size
-    call_type = array1.dtype
-
-    if call_type == numpy.float32:
-        result = dparray(array1.shape, dtype=call_type)
-    else:
-        result = dparray(array1.shape)
-
-    if call_type == numpy.float64:
-        custom_elemwise_log2_c[double, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.float32:
-        custom_elemwise_log2_c[float, float](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int64:
-        custom_elemwise_log2_c[long, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int32:
-        custom_elemwise_log2_c[int, double](array1.get_data(), result.get_data(), size)
-    else:
-        checker_throw_type_error("dpnp_log2", call_type)
-
-    return result
-
-
-cpdef dparray dpnp_recip(dparray array1):
-    call_type = array1.dtype
-    cdef size_t size = array1.size
-    cdef dparray result = dparray(array1.shape, dtype=call_type)
-
-    if call_type == numpy.float64:
-        custom_elemwise_recip_c[double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.float32:
-        custom_elemwise_recip_c[float](array1.get_data(), result.get_data(), size)
-    else:
-        checker_throw_type_error("dpnp_recip", call_type)
-
-    return result
-
-
-cpdef dparray dpnp_radians(dparray array1):
-    cdef dparray result
-    cdef size_t size = array1.size
-    call_type = array1.dtype
-
-    if call_type == numpy.float32:
-        result = dparray(array1.shape, dtype=call_type)
-    else:
-        result = dparray(array1.shape)
-
-    if call_type == numpy.float64:
-        custom_elemwise_radians_c[double, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.float32:
-        custom_elemwise_radians_c[float, float](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int64:
-        custom_elemwise_radians_c[long, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int32:
-        custom_elemwise_radians_c[int, double](array1.get_data(), result.get_data(), size)
-    else:
-        checker_throw_type_error("dpnp_radians", call_type)
-
-    return result
-
-
-cpdef dparray dpnp_sin(dparray array1):
-    cdef dparray result
-    cdef size_t size = array1.size
-    call_type = array1.dtype
-
-    if call_type == numpy.float32:
-        result = dparray(array1.shape, dtype=call_type)
-    else:
-        result = dparray(array1.shape)
-
-    if call_type == numpy.float64:
-        custom_elemwise_sin_c[double, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.float32:
-        custom_elemwise_sin_c[float, float](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int64:
-        custom_elemwise_sin_c[long, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int32:
-        custom_elemwise_sin_c[int, double](array1.get_data(), result.get_data(), size)
-    else:
-        checker_throw_type_error("dpnp_sin", call_type)
-
-    return result
-
-
-cpdef dparray dpnp_sinh(dparray array1):
-    cdef dparray result
-    cdef size_t size = array1.size
-    call_type = array1.dtype
-
-    if call_type == numpy.float32:
-        result = dparray(array1.shape, dtype=call_type)
-    else:
-        result = dparray(array1.shape)
-
-    if call_type == numpy.float64:
-        custom_elemwise_sinh_c[double, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.float32:
-        custom_elemwise_sinh_c[float, float](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int64:
-        custom_elemwise_sinh_c[long, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int32:
-        custom_elemwise_sinh_c[int, double](array1.get_data(), result.get_data(), size)
-    else:
-        checker_throw_type_error("dpnp_sinh", call_type)
-
-    return result
-
-
-cpdef dparray dpnp_sqrt(dparray array1):
-    cdef dparray result
-    cdef size_t size = array1.size
-    call_type = array1.dtype
-
-    if call_type == numpy.float32:
-        result = dparray(array1.shape, dtype=call_type)
-    else:
-        result = dparray(array1.shape)
-
-    if call_type == numpy.float64:
-        custom_elemwise_sqrt_c[double, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.float32:
-        custom_elemwise_sqrt_c[float, float](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int64:
-        custom_elemwise_sqrt_c[long, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int32:
-        custom_elemwise_sqrt_c[int, double](array1.get_data(), result.get_data(), size)
-    else:
-        checker_throw_type_error("dpnp_sqrt", call_type)
-
-    return result
-
-
-cpdef dparray dpnp_square(dparray array1):
-    call_type = array1.dtype
-    cdef dparray result = dparray(array1.shape, dtype=call_type)
-    cdef size_t size = result.size
-
-    if call_type == numpy.float64:
-        custom_elemwise_square_c[double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.float32:
-        custom_elemwise_square_c[float](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int64:
-        custom_elemwise_square_c[long](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int32:
-        custom_elemwise_square_c[int](array1.get_data(), result.get_data(), size)
-    else:
-        checker_throw_type_error("dpnp_square", call_type)
-
-    return result
-
-
-cpdef dparray dpnp_tan(dparray array1):
-    cdef dparray result
-    cdef size_t size = array1.size
-    call_type = array1.dtype
-
-    if call_type == numpy.float32:
-        result = dparray(array1.shape, dtype=call_type)
-    else:
-        result = dparray(array1.shape)
-
-    if call_type == numpy.float64:
-        custom_elemwise_tan_c[double, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.float32:
-        custom_elemwise_tan_c[float, float](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int64:
-        custom_elemwise_tan_c[long, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int32:
-        custom_elemwise_tan_c[int, double](array1.get_data(), result.get_data(), size)
-    else:
-        checker_throw_type_error("dpnp_tan", call_type)
-
-    return result
-
-
-cpdef dparray dpnp_tanh(dparray array1):
-    cdef dparray result
-    cdef size_t size = array1.size
-    call_type = array1.dtype
-
-    if call_type == numpy.float32:
-        result = dparray(array1.shape, dtype=call_type)
-    else:
-        result = dparray(array1.shape)
-
-    if call_type == numpy.float64:
-        custom_elemwise_tanh_c[double, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.float32:
-        custom_elemwise_tanh_c[float, float](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int64:
-        custom_elemwise_tanh_c[long, double](array1.get_data(), result.get_data(), size)
-    elif call_type == numpy.int32:
-        custom_elemwise_tanh_c[int, double](array1.get_data(), result.get_data(), size)
-    else:
-        checker_throw_type_error("dpnp_tanh", call_type)
-
-    return result
+cpdef dparray dpnp_arccos(dparray x1):
+    return call_fptr_1in_1out(DPNP_FN_ARCCOS, x1, x1.shape)
+
+
+cpdef dparray dpnp_arccosh(dparray x1):
+    return call_fptr_1in_1out(DPNP_FN_ARCCOSH, x1, x1.shape)
+
+
+cpdef dparray dpnp_arcsin(dparray x1):
+    return call_fptr_1in_1out(DPNP_FN_ARCSIN, x1, x1.shape)
+
+
+cpdef dparray dpnp_arcsinh(dparray x1):
+    return call_fptr_1in_1out(DPNP_FN_ARCSINH, x1, x1.shape)
+
+
+cpdef dparray dpnp_arctan(dparray x1):
+    return call_fptr_1in_1out(DPNP_FN_ARCTAN, x1, x1.shape)
+
+
+cpdef dparray dpnp_arctanh(dparray x1):
+    return call_fptr_1in_1out(DPNP_FN_ARCTANH, x1, x1.shape)
+
+
+cpdef dparray dpnp_cbrt(dparray x1):
+    return call_fptr_1in_1out(DPNP_FN_CBRT, x1, x1.shape)
+
+
+cpdef dparray dpnp_cos(dparray x1):
+    return call_fptr_1in_1out(DPNP_FN_COS, x1, x1.shape)
+
+
+cpdef dparray dpnp_cosh(dparray x1):
+    return call_fptr_1in_1out(DPNP_FN_COSH, x1, x1.shape)
+
+
+cpdef dparray dpnp_degrees(dparray x1):
+    return call_fptr_1in_1out(DPNP_FN_DEGREES, x1, x1.shape)
+
+
+cpdef dparray dpnp_exp(dparray x1):
+    return call_fptr_1in_1out(DPNP_FN_EXP, x1, x1.shape)
+
+
+cpdef dparray dpnp_exp2(dparray x1):
+    return call_fptr_1in_1out(DPNP_FN_EXP2, x1, x1.shape)
+
+
+cpdef dparray dpnp_expm1(dparray x1):
+    return call_fptr_1in_1out(DPNP_FN_EXPM1, x1, x1.shape)
+
+
+cpdef dparray dpnp_log(dparray x1):
+    return call_fptr_1in_1out(DPNP_FN_LOG, x1, x1.shape)
+
+
+cpdef dparray dpnp_log10(dparray x1):
+    return call_fptr_1in_1out(DPNP_FN_LOG10, x1, x1.shape)
+
+
+cpdef dparray dpnp_log1p(dparray x1):
+    return call_fptr_1in_1out(DPNP_FN_LOG1P, x1, x1.shape)
+
+
+cpdef dparray dpnp_log2(dparray x1):
+    return call_fptr_1in_1out(DPNP_FN_LOG2, x1, x1.shape)
+
+
+cpdef dparray dpnp_recip(dparray x1):
+    return call_fptr_1in_1out(DPNP_FN_RECIP, x1, x1.shape)
+
+
+cpdef dparray dpnp_radians(dparray x1):
+    return call_fptr_1in_1out(DPNP_FN_RADIANS, x1, x1.shape)
+
+
+cpdef dparray dpnp_sin(dparray x1):
+    return call_fptr_1in_1out(DPNP_FN_SIN, x1, x1.shape)
+
+
+cpdef dparray dpnp_sinh(dparray x1):
+    return call_fptr_1in_1out(DPNP_FN_SINH, x1, x1.shape)
+
+
+cpdef dparray dpnp_sqrt(dparray x1):
+    return call_fptr_1in_1out(DPNP_FN_SQRT, x1, x1.shape)
+
+
+cpdef dparray dpnp_square(dparray x1):
+    return call_fptr_1in_1out(DPNP_FN_SQUARE, x1, x1.shape)
+
+
+cpdef dparray dpnp_tan(dparray x1):
+    return call_fptr_1in_1out(DPNP_FN_TAN, x1, x1.shape)
+
+
+cpdef dparray dpnp_tanh(dparray x1):
+    return call_fptr_1in_1out(DPNP_FN_TANH, x1, x1.shape)
 
 
 cpdef dparray dpnp_unwrap(dparray array1):


### PR DESCRIPTION
Additionally moved `call_fptr_1in_1out` and `call_fptr_2in_1out` to `backend.pyx`.