### PR TITLE
REFACTOR: renamed random module functions and sources names

### DIFF
--- a/dpnp/backend/backend_iface.hpp
+++ b/dpnp/backend/backend_iface.hpp
@@ -520,7 +520,7 @@ INP_DLLEXPORT void custom_elemwise_transpose_c(void* array1_in,
  *
  */
 template <typename _DataType>
-INP_DLLEXPORT void mkl_rng_gaussian(void* result, _DataType mean, _DataType stddev, size_t size);
+INP_DLLEXPORT void custom_rng_gaussian_c(void* result, _DataType mean, _DataType stddev, size_t size);
 
 /**
  * @ingroup BACKEND_API
@@ -536,7 +536,7 @@ INP_DLLEXPORT void mkl_rng_gaussian(void* result, _DataType mean, _DataType stdd
  *
  */
 template <typename _DataType>
-INP_DLLEXPORT void mkl_rng_uniform(void* result, long low, long high, size_t size);
+INP_DLLEXPORT void custom_rng_uniform_c(void* result, long low, long high, size_t size);
 
 /**
  * @ingroup BACKEND_API

--- a/dpnp/backend/custom_kernels_random.cpp
+++ b/dpnp/backend/custom_kernels_random.cpp
@@ -31,7 +31,7 @@
 namespace mkl_rng = oneapi::mkl::rng;
 
 template <typename _DataType>
-void mkl_rng_gaussian(void* result, _DataType mean, _DataType stddev, size_t size)
+void custom_rng_gaussian_c(void* result, _DataType mean, _DataType stddev, size_t size)
 {
     if (!size)
     {
@@ -46,7 +46,7 @@ void mkl_rng_gaussian(void* result, _DataType mean, _DataType stddev, size_t siz
 }
 
 template <typename _DataType>
-void mkl_rng_uniform(void* result, long low, long high, size_t size)
+void custom_rng_uniform_c(void* result, long low, long high, size_t size)
 {
     if (!size)
     {
@@ -68,12 +68,12 @@ void mkl_rng_uniform(void* result, long low, long high, size_t size)
 
 void func_map_init_random(func_map_t& fmap)
 {
-    fmap[DPNPFuncName::DPNP_FN_GAUSSIAN][eft_DBL][eft_DBL] = {eft_DBL, (void*)mkl_rng_gaussian<double>};
-    fmap[DPNPFuncName::DPNP_FN_GAUSSIAN][eft_FLT][eft_FLT] = {eft_DBL, (void*)mkl_rng_gaussian<float>};
+    fmap[DPNPFuncName::DPNP_FN_GAUSSIAN][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_rng_gaussian_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_GAUSSIAN][eft_FLT][eft_FLT] = {eft_DBL, (void*)custom_rng_gaussian_c<float>};
 
-    fmap[DPNPFuncName::DPNP_FN_UNIFORM][eft_INT][eft_INT] = {eft_INT, (void*)mkl_rng_uniform<int>};
-    fmap[DPNPFuncName::DPNP_FN_UNIFORM][eft_FLT][eft_FLT] = {eft_FLT, (void*)mkl_rng_uniform<float>};
-    fmap[DPNPFuncName::DPNP_FN_UNIFORM][eft_DBL][eft_DBL] = {eft_DBL, (void*)mkl_rng_uniform<double>};
+    fmap[DPNPFuncName::DPNP_FN_UNIFORM][eft_INT][eft_INT] = {eft_INT, (void*)custom_rng_uniform_c<int>};
+    fmap[DPNPFuncName::DPNP_FN_UNIFORM][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_rng_uniform_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_UNIFORM][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_rng_uniform_c<double>};
 
     return;
 }

--- a/dpnp/random/_random.pyx
+++ b/dpnp/random/_random.pyx
@@ -49,8 +49,8 @@ __all__ = [
     "dpnp_uniform"
 ]
 
-ctypedef void(*fptr_mkl_rng_gaussian_1out_t)(void *, double, double, size_t)
-ctypedef void(*fptr_mkl_rng_uniform_1out_t)(void *, long, long, size_t)
+ctypedef void(*fptr_custom_rng_gaussian_c_1out_t)(void *, double, double, size_t)
+ctypedef void(*fptr_custom_rng_uniform_c_1out_t)(void *, long, long, size_t)
 
 
 cpdef dparray dpnp_randn(dims):
@@ -74,7 +74,7 @@ cpdef dparray dpnp_randn(dims):
     # ceate result array with type given by FPTR data
     cdef dparray result = dparray(dims, dtype=result_type)
 
-    cdef fptr_mkl_rng_gaussian_1out_t func = <fptr_mkl_rng_gaussian_1out_t > kernel_data.ptr
+    cdef fptr_custom_rng_gaussian_c_1out_t func = <fptr_custom_rng_gaussian_c_1out_t > kernel_data.ptr
     # call FPTR function
     func(result.get_data(), mean, stddev, result.size)
 
@@ -100,7 +100,7 @@ cpdef dparray dpnp_random(dims):
     # ceate result array with type given by FPTR data
     cdef dparray result = dparray(dims, dtype=result_type)
 
-    cdef fptr_mkl_rng_uniform_1out_t func = <fptr_mkl_rng_uniform_1out_t > kernel_data.ptr
+    cdef fptr_custom_rng_uniform_c_1out_t func = <fptr_custom_rng_uniform_c_1out_t > kernel_data.ptr
     # call FPTR function
     func(result.get_data(), low, high, result.size)
 
@@ -134,7 +134,7 @@ cpdef dparray dpnp_uniform(long low, long high, size, dtype=numpy.int32):
     # ceate result array with type given by FPTR data
     cdef dparray result = dparray(size, dtype=result_type)
 
-    cdef fptr_mkl_rng_uniform_1out_t func = <fptr_mkl_rng_uniform_1out_t > kernel_data.ptr
+    cdef fptr_custom_rng_uniform_c_1out_t func = <fptr_custom_rng_uniform_c_1out_t > kernel_data.ptr
     # call FPTR function
     func(result.get_data(), low, high, result.size)
 

--- a/examples/example5.cpp
+++ b/examples/example5.cpp
@@ -30,7 +30,7 @@ int main(int, char**)
     for (size_t i = 0; i < 4; ++i)
     {
         dpnp_srand_c(seed);
-        mkl_rng_uniform<double>(result, low, high, size);
+        custom_rng_uniform_c<double>(result, low, high, size);
         print_dpnp_array(result, 10);
     }
 
@@ -38,7 +38,7 @@ int main(int, char**)
     dpnp_srand_c();
     for (size_t i = 0; i < 4; ++i)
     {
-        mkl_rng_uniform<double>(result, low, high, size);
+        custom_rng_uniform_c<double>(result, low, high, size);
         print_dpnp_array(result, 10);
     }
 

--- a/setup.py
+++ b/setup.py
@@ -266,12 +266,12 @@ dpnp_backend_c = [
                 "dpnp/backend/custom_kernels_linalg.cpp",
                 "dpnp/backend/custom_kernels_manipulation.cpp",
                 "dpnp/backend/custom_kernels_mathematical.cpp",
+                "dpnp/backend/custom_kernels_random.cpp",
                 "dpnp/backend/custom_kernels_reduction.cpp",
                 "dpnp/backend/custom_kernels_searching.cpp",
                 "dpnp/backend/custom_kernels_sorting.cpp",
                 "dpnp/backend/custom_kernels_statistics.cpp",
                 "dpnp/backend/memory_sycl.cpp",
-                "dpnp/backend/mkl_wrap_rng.cpp",
                 "dpnp/backend/queue_sycl.cpp"
             ],
             "include_dirs": _mathlib_include + _project_backend_dir + _dpctrl_include,


### PR DESCRIPTION
* renamed `mkl_wrap_rng.cpp` to `dpnp/backend/custom_kernels_random.cpp`
* renamed backend kernels names for `random` module