### PR TITLE
FIX: `random.chisquare` fallback to `numpy`

### DIFF
--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -98,26 +98,12 @@ def chisquare(df, size=None):
 
     """
 
-    if not use_origin_backend(df):
-        if size is None:
-            size = 1
-        elif isinstance(size, tuple):
-            for dim in size:
-                if not isinstance(dim, int):
-                    checker_throw_value_error("chisquare", "type(dim)", type(dim), int)
-        elif not isinstance(size, int):
-            checker_throw_value_error("chisquare", "type(size)", type(size), int)
+#    if not use_origin_backend(df):
+#        # TODO:
+#        # raise warning and call_origin? 
+#        pass
 
-        # TODO:
-        # array_like of floats for `df`
-        # add check for df array like, after adding array-like interface for df param
-        if df <= 0:
-            checker_throw_value_error("chisquare", "df", df, "positive")
-        # TODO:
-        # float to int, safe
-        return dpnp_chisquare(int(df), size)
-
-    return call_origin(df, size)
+    return call_origin(numpy.random.chisquare, df, size)
 
 
 def exponential(scale=1.0, size=None):

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -124,22 +124,3 @@ def test_exponential_invalid_scale():
     scale = -1 # non-negative `scale` is expected
     with pytest.raises(ValueError):
         dpnp.random.exponential(scale, size)
-
-
-def test_radnom_chisquare_seed():
-    seed = 28041990
-    size = 100
-    df = 3  # number of degrees of freedom
-
-    dpnp.random.seed(seed)
-    a1 = dpnp.random.chisquare(df, size)
-    dpnp.random.seed(seed)
-    a2 = dpnp.random.chisquare(df, size)
-    assert_allclose(a1, a2, rtol=1e-07, atol=0)
-
-
-def test_chisquare_invalid_df():
-    size = 10
-    df = -1 # positive `df` is expected
-    with pytest.raises(ValueError):
-        dpnp.random.chisquare(df, size)


### PR DESCRIPTION
* `random.chisquare` fallback to `numpy`
* removed tests ???

## TODO:
NOTE: problems with seed, when using `original_call`. Need to be fixed or documented `dpnp.random.seed` and `np.random.seed`