### PR TITLE
show message if numpy loaded first and fix module loading order

### DIFF
--- a/dpnp/__init__.py
+++ b/dpnp/__init__.py
@@ -24,6 +24,11 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 # *****************************************************************************
 
+import sys
+import warnings
+
+if "numpy" in sys.modules:
+    warnings.warn("\nDPNP: Module NumPy found. Please load DPNP module before NumPy.\n")
 
 from dpnp.dparray import dparray as ndarray
 from dpnp.dpnp_iface import *

--- a/examples/example1.py
+++ b/examples/example1.py
@@ -36,9 +36,6 @@ and DPNP for several matrix multiplication
 """
 
 
-import numpy
-import time
-
 try:
     import dpnp
 except ImportError:
@@ -49,6 +46,9 @@ except ImportError:
     sys.path.append(root_dir)
 
     import dpnp
+
+import numpy
+import time
 
 
 def run_dgemm(executor, name, size, test_type, repetition):

--- a/examples/example2.py
+++ b/examples/example2.py
@@ -36,9 +36,6 @@ over diffrent types of input data
 """
 
 
-import numpy
-import time
-
 try:
     import dpnp
 except ImportError:
@@ -50,6 +47,8 @@ except ImportError:
 
     import dpnp
 
+import numpy
+import time
 
 common_function_one_input = numpy.sin
 """

--- a/examples/example6.py
+++ b/examples/example6.py
@@ -33,9 +33,6 @@ dpnp.random.randn
 """
 
 
-import numpy
-import time
-
 try:
     import dpnp
 except ImportError:
@@ -46,6 +43,10 @@ except ImportError:
     sys.path.append(root_dir)
 
     import dpnp
+
+import numpy
+import time
+
 
 if __name__ == '__main__':
     # TODO

--- a/examples/example7.py
+++ b/examples/example7.py
@@ -36,9 +36,6 @@ and DPNP for several matrix multiplication
 """
 
 
-import numpy
-import time
-
 try:
     import dpnp
 except ImportError:
@@ -49,6 +46,9 @@ except ImportError:
     sys.path.append(root_dir)
 
     import dpnp
+
+import numpy
+import time
 
 
 def run_function(executor, name, size, test_type, repetition):


### PR DESCRIPTION
This PR is close issue #132 

if we load `numpy` from `inteloneapi` it loads MKL library. Usually, loaded MKL has some old version and some symbols can not be resolved correctly.
The solution is to load `DPNP` before `numpy`.

This PR add a warning about unexpected loading order of a modules.