### PR TITLE
Implement script to show coverage dpnp vs cupy

### DIFF
--- a/utils/dpnp_coverage.py
+++ b/utils/dpnp_coverage.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# *****************************************************************************
+# Copyright (c) 2016-2020, Intel Corporation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# - Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+# *****************************************************************************
+
+from types import FunctionType, MethodType
+
+try:
+    import cupy
+except (ModuleNotFoundError, OSError):
+    pass
+
+import numpy
+import dpnp
+
+
+def get_object_funcs(obj):
+    """Get all functions of specified object"""
+    return [item for item in dir(obj) if isinstance(getattr(obj, item), FunctionType)]
+
+
+def get_object_methods(obj):
+    """Get all methods of specified object"""
+    return [item for item in dir(obj) if isinstance(getattr(obj, item), MethodType)]
+
+
+def get_object_properties(obj):
+    """Get all properties of specified object"""
+    return [item for item in dir(obj) if isinstance(getattr(obj, item), property)]
+
+
+def get_module_classes(py_module):
+    """Get all classes of specified module"""
+    return [item for item in dir(py_module) if isinstance(getattr(py_module, item), type)]
+
+
+def get_module_methods(py_module):
+    """
+    Get all methods of specified module in the following structure:
+        {'class_name': ['first_method_name', 'second_method_name', 'third_method_name']}
+    """
+    all_methods = {}
+    for class_name in get_module_classes(py_module):
+        attr = getattr(py_module, class_name)
+        methods = get_object_funcs(attr) + get_object_methods(attr)
+        if methods:
+            all_methods[class_name] = methods
+    return all_methods
+
+
+def get_module_properties(py_module):
+    """
+    Get all properties of specified module in the following structure:
+        {'class_name': ['first_property_name', 'second_property_name', 'third_property_name']}
+    """
+    all_props = {}
+    for class_name in get_module_classes(py_module):
+        props = get_object_properties(getattr(py_module, class_name))
+        if props:
+            all_props[class_name] = props
+    return all_props
+
+def get_module_items(py_module):
+    """
+    Get all items of specified module in the following structure:
+        {'class_name': ['first_item_name', 'second_item_name', 'third_item_name']}
+    """
+    all_items = {}
+    for class_name in get_module_classes(py_module):
+        attr = getattr(py_module, class_name)
+        items = get_object_funcs(attr) + get_object_methods(attr) + get_object_properties(attr)
+        if items:
+            all_items[class_name] = items
+    return all_items
+
+
+def get_public(items):
+    return [i for i in items if not i.startswith('_')]
+
+
+class LibAPI:
+    def __init__(self, lib):
+        self.lib = lib
+
+        self.all_funcs = get_object_funcs(self.lib)
+        self.all_classes = get_module_classes(self.lib)
+        self.all_methods = get_module_methods(self.lib)
+        self.all_props = get_module_properties(self.lib)
+        self.all_items = get_module_items(self.lib)
+
+        self.public_funcs = [name for name in self.all_funcs if not name.startswith('_')]
+        self.public_methods = {cl: get_public(methods) for cl, methods in self.all_methods.items()}
+        self.public_props = {cl: get_public(props) for cl, props in self.all_props.items()}
+        self.public_items = {cl: get_public(items) for cl, items in self.all_items.items()}
+
+    @property
+    def total_funcs(self):
+        return len(self.public_funcs)
+
+    @property
+    def total_methods(self):
+        return sum(len(methods) for methods in self.public_methods.values())
+
+    @property
+    def total_props(self):
+        return sum(len(props) for props in self.public_props.values())
+
+    @property
+    def total_items(self):
+        return sum(len(items) for items in self.public_items.values())
+
+    @property
+    def total(self):
+        return self.total_funcs + self.total_items
+
+    @property
+    def public_funcs_as_str(self, separator=', '):
+        return separator.join(self.public_funcs)
+
+    @property
+    def public_methods_as_str(self, separator=', '):
+        return separator.join(f'{cl}.{m}' for cl, methods in self.public_methods.items() for m in methods)
+
+    @property
+    def public_props_as_str(self, separator=', '):
+        return separator.join(f'{cl}.{p}' for cl, props in self.public_props.items() for p in props)
+
+    def show(self):
+        tmpl = """{lib_name} public API:
+    functions: {public_funcs}
+    methods: {public_methods}
+    properties: {public_props}
+
+        """
+        data = {
+            'lib_name': self.lib.__name__,
+            'public_funcs': self.public_funcs_as_str,
+            'public_methods': self.public_methods_as_str,
+            'public_props': self.public_props_as_str,
+        }
+        print(tmpl.format(**data))
+
+
+if __name__ == '__main__':
+    LibAPI(numpy).show()
+
+    try:
+        LibAPI(cupy).show()
+    except NameError:
+        pass
+
+    LibAPI(dpnp).show()


### PR DESCRIPTION
Example output:
```
numpy public API:                                                                                                                                                                                                 
    functions: add_newdoc, alen, all, allclose, alltrue, amax, amin, angle, any, append, apply_along_axis, apply_over_axes, argmax, argmin, argpartition, argsort, argwhere, around, array2string, array_equal, array_equiv, array_repr, array_split, array_str, asanyarray, asarray, asarray_chkfinite, ascontiguousarray, asfarray, asfortranarray, asmatrix, asscalar, atleast_1d, atleast_2d, atleast_3d, average, bartlett, base_repr, binary_repr, bincount, blackman, block, bmat, broadcast_arrays, broadcast_to, busday_count, busday_offset, byte_bounds, can_cast, choose, clip, column_stack, common_type, compress, concatenate, convolve, copy, copyto, corrcoef, correlate, count_nonzero, cov, cross, cumprod, cumproduct, cumsum, datetime_as_string, delete, deprecate, deprecate_with_doc, diag, diag_indices, diag_indices_from, diagflat, diagonal, diff, digitize, disp, dot, dsplit, dstack, ediff1d, einsum, einsum_path, empty_like, expand_dims, extract, eye, fill_diagonal, find_common_type, fix, flatnonzero, flip, fliplr, flipud, format_float_positional, format_float_scientific, fromfunction, fromregex, full, full_like, fv, genfromtxt, geomspace, get_array_wrap, get_include, get_printoptions, getbufsize, geterr, geterrcall, gradient, ha
mming, hanning, histogram, histogram2d, histogram_bin_edges, histogramdd, hsplit, hstack, i0, identity, imag, in1d, indices, info, inner, insert, interp, intersect1d, ipmt, irr, is_busday, isclose, iscomple
x, iscomplexobj, isfortran, isin, isneginf, isposinf, isreal, isrealobj, isscalar, issctype, issubclass_, issubdtype, issubsctype, iterable, ix_, kaiser, kron, lexsort, linspace, load, loads, loadtxt, logspace, lookfor, mafromtxt, mask_indices, mat, max, maximum_sctype, may_share_memory, mean, median, meshgrid, min, min_scalar_type, mintypecode, mirr, moveaxis, msort, nan_to_num, nanargmax, nanargmin, nancumprod, nancumsum, nanmax, nanmean, nanmedian, nanmin, nanpercentile, nanprod, nanquantile, nanstd, nansum, nanvar, ndfromtxt, ndim, nonzero, nper, npv, obj2sctype, ones, ones_like, outer, packbits, pad, partition, percentile, piecewise, place, pmt, poly, polyadd, polyder, polydiv, polyfit, polyint, polymul, polysub, polyval, ppmt, printoptions, prod, product, ptp, put, put_along_axis, putmask, pv, quantile, rate, ravel, ravel_multi_index, real, real_if_close, recfromcsv, recfromtxt, repeat, require, reshape, resize, result_type, roll, rollaxis, roots, rot90, round, round_, row_stack, safe_eval, save, savetxt, savez, savez_compressed, sctype2char, searchsorted, select, set_printoptions, set_string_function, setbufsize, setdiff1d, seterr, seterrcall, setxor1d, shape, shares_memory, show_config, sinc, size, sometrue, sort, sort_complex, source, split, squeeze, stack, std, sum, swapaxes, take, take_along_axis, tensordot, tile, trace, transpose, trapz, tri, tril, tril_indices, tril_indices_from, trim_zeros, triu, triu_indices, triu_indices_from, typename, union1d, unique, unpackbits, unravel_index, unwrap, vander, var, vdot, vsplit, vstack, where, who, zeros_like
    methods: DataSource.abspath, DataSource.exists, DataSource.open, Tester.bench, Tester.prepare_test_args, Tester.test, chararray.argsort, chararray.capitalize, chararray.center, chararray.count, chararra
y.decode, chararray.encode, chararray.endswith, chararray.expandtabs, chararray.find, chararray.index, chararray.isalnum, chararray.isalpha, chararray.isdecimal, chararray.isdigit, chararray.islower, charar
ray.isnumeric, chararray.isspace, chararray.istitle, chararray.isupper, chararray.join, chararray.ljust, chararray.lower, chararray.lstrip, chararray.partition, chararray.replace, chararray.rfind, chararray
.rindex, chararray.rjust, chararray.rpartition, chararray.rsplit, chararray.rstrip, chararray.split, chararray.splitlines, chararray.startswith, chararray.strip, chararray.swapcase, chararray.title, chararr
ay.translate, chararray.upper, chararray.zfill, matrix.all, matrix.any, matrix.argmax, matrix.argmin, matrix.flatten, matrix.getA, matrix.getA1, matrix.getH, matrix.getI, matrix.getT, matrix.max, matrix.mea
n, matrix.min, matrix.prod, matrix.ptp, matrix.ravel, matrix.squeeze, matrix.std, matrix.sum, matrix.tolist, matrix.var, memmap.flush, ndenumerate.next, ndindex.ndincr, ndindex.next, poly1d.deriv, poly1d.in
teg, recarray.field, record.pprint
    properties: iinfo.max, iinfo.min, matrix.A, matrix.A1, matrix.H, matrix.I, matrix.T, poly1d.c, poly1d.coef, poly1d.coefficients, poly1d.coeffs, poly1d.o, poly1d.order, poly1d.r, poly1d.roots, poly1d.var
iable


dpnp public API:
    functions: abs, absolute, add, all, amax, amin, any, arange, arccos, arccosh, arcsin, arcsinh, arctan, arctan2, arctanh, argmax, argmin, argsort, array, array_equal, asarray, asnumpy, average, bitwise_a
nd, bitwise_not, bitwise_or, bitwise_xor, cbrt, ceil, copysign, copyto, cos, cosh, count_nonzero, cov, deg2rad, degrees, divide, dot, einsum, einsum_path, empty, empty_like, equal, erf, exp, exp2, expm1, fa
bs, floor, floor_divide, fmax, fmin, fmod, full, full_like, get_include, greater, greater_equal, hypot, inner, invert, isclose, isfinite, isinf, isnan, isscalar, kron, left_shift, less, less_equal, log, log
10, log1p, log2, logical_and, logical_not, logical_or, logical_xor, matmul, max, maximum, mean, median, min, minimum, mod, modf, moveaxis, multiply, negative, not_equal, ones, ones_like, outer, power, prod,
 rad2deg, radians, ravel, reciprocal, remainder, repeat, right_shift, rollaxis, sign, sin, sinh, sort, sqrt, square, std, subtract, sum, swapaxes, tan, tanh, tensordot, transpose, true_divide, trunc, unwrap
, var, vdot, zeros, zeros_like
    methods:
    properties:
```
We don't see `dparray` methods beacuse `type(dpnp.dparray)` is `<class 'module'>` instead of `<class 'type'>` as it's in `numpy`. Maybe it makes sense to expand the script logic or somehow make `type(dpnp.dparray)` to be `<class 'type'>`.