### PR TITLE
adding dpcpp compilation control

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -26,6 +26,8 @@ build:
       - DPCPPROOT
       - MKLROOT
       - TBBROOT
+      - DPSTL_USE_PARALLEL_POLICIES
+      - D_GLIBCXX_USE_TBB_PAR_BACKEND
 
 test:
     requires:


### PR DESCRIPTION
These two env variables can be required if trying to build using DPCPP along with Gold TBB if gcc 9 or 10 is used.

PR allows the variables to pass into build env from CI env.
