### PR TITLE
adding -DPSTL_USE_PARALLEL_POLICIES=0 for TBB

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,8 +115,8 @@ Set compiler for the project
 # default variables (for Linux)
 _project_compiler = "clang++"
 _project_linker = "clang++"
-_project_cmplr_flag_sycl_devel = ["-fsycl-device-code-split=per_kernel"]
-_project_cmplr_flag_sycl = ["-fsycl"]
+_project_cmplr_flag_sycl_devel = ["-fsycl-device-code-split=per_kernel", "-DPSTL_USE_PARALLEL_POLICIES=0"]
+_project_cmplr_flag_sycl = ["-fsycl", "-DPSTL_USE_PARALLEL_POLICIES=0"]
 _project_cmplr_flag_compatibility = ["-Wl,--enable-new-dtags"]
 _project_cmplr_flag_lib = ["-shared"]
 _project_cmplr_flag_release_build = ["-O3", "-DNDEBUG", "-fPIC"]


### PR DESCRIPTION
Needed for compatibility with oneAPI TBB. Known issue when building with gcc 9