### PR TITLE
Use ctypedef ... except + to intercept oneMKL exceptions

### DIFF
--- a/dpnp/random/_random.pyx
+++ b/dpnp/random/_random.pyx
@@ -57,15 +57,15 @@ __all__ = [
 ]
 
 
-ctypedef void(*fptr_custom_rng_beta_c_1out_t)(void *, double, double, size_t)
-ctypedef void(*fptr_custom_rng_binomial_c_1out_t)(void *, int, double, size_t)
-ctypedef void(*fptr_custom_rng_chi_square_c_1out_t)(void *, int, size_t)
-ctypedef void(*fptr_custom_rng_exponential_c_1out_t)(void *, double, size_t)
-ctypedef void(*fptr_custom_rng_gamma_c_1out_t)(void *, double, double, size_t)
-ctypedef void(*fptr_custom_rng_gaussian_c_1out_t)(void *, double, double, size_t)
-ctypedef void(*fptr_custom_rng_laplace_c_1out_t)(void *, double, double, size_t)
-ctypedef void(*fptr_custom_rng_negative_binomial_c_1out_t)(void *, double, double, size_t)
-ctypedef void(*fptr_custom_rng_uniform_c_1out_t)(void *, long, long, size_t)
+ctypedef void(*fptr_custom_rng_beta_c_1out_t)(void *, double, double, size_t) except +
+ctypedef void(*fptr_custom_rng_binomial_c_1out_t)(void *, int, double, size_t) except +
+ctypedef void(*fptr_custom_rng_chi_square_c_1out_t)(void *, int, size_t) except +
+ctypedef void(*fptr_custom_rng_exponential_c_1out_t)(void *, double, size_t) except +
+ctypedef void(*fptr_custom_rng_gamma_c_1out_t)(void *, double, double, size_t) except +
+ctypedef void(*fptr_custom_rng_gaussian_c_1out_t)(void *, double, double, size_t) except +
+ctypedef void(*fptr_custom_rng_laplace_c_1out_t)(void *, double, double, size_t) except +
+ctypedef void(*fptr_custom_rng_negative_binomial_c_1out_t)(void *, double, double, size_t) except +
+ctypedef void(*fptr_custom_rng_uniform_c_1out_t)(void *, long, long, size_t) except +
 
 
 cpdef dparray dpnp_beta(double a, double b, size):


### PR DESCRIPTION
E.g.

```
In [1]: import dpnp
mkl-service + Intel(R) MKL: THREADING LAYER: (null)
mkl-service + Intel(R) MKL: setting Intel(R) MKL to use INTEL OpenMP runtime
mkl-service + Intel(R) MKL: preloading libiomp5.so runtime
MKL_VERBOSE Intel(R) MKL 2021.0 Update 1 beta10 build 20201008 for Intel(R) 64 architecture Intel(R) Advanced Vector Extensions 2 (Intel(R) AVX2) enabled processors, Lnx 1.
10GHz lp64 intel_thread
MKL_VERBOSE SDOT(2,0x561c72606c10,1,0x561c72606c10,1) 1.41ms CNR:OFF Dyn:1 FastMM:1 TID:0  NThr:6
Running on: Intel(R) Graphics Gen9 [0x9bca]
DPCtrl SYCL queue used
SYCL kernels link time: 0.190619 (sec.)

In [2]: dpnp.random.gamma(3.4, 0.67)
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)

<< stack elided >>

RuntimeError: oneMKL: rng/generate: Intel(R) Graphics Gen9 [0x9bca] is not supported

In [3]: quit
```