### PR TITLE
ENH: added `random.standard_cauchy`

### DIFF
--- a/dpnp/backend.pxd
+++ b/dpnp/backend.pxd
@@ -106,6 +106,7 @@ cdef extern from "backend/backend_iface_fptr.hpp" namespace "DPNPFuncName":  # n
         DPNP_FN_SORT
         DPNP_FN_SQRT
         DPNP_FN_SQUARE
+        DPNP_FN_STANDARD_CAUCHY
         DPNP_FN_STD
         DPNP_FN_SUBTRACT
         DPNP_FN_SUM

--- a/dpnp/backend/backend_iface_fptr.hpp
+++ b/dpnp/backend/backend_iface_fptr.hpp
@@ -134,6 +134,7 @@ enum class DPNPFuncName : size_t
     DPNP_FN_SORT,               /**< Used in numpy.sort() implementation  */
     DPNP_FN_SQRT,               /**< Used in numpy.sqrt() implementation  */
     DPNP_FN_SQUARE,             /**< Used in numpy.square() implementation  */
+    DPNP_FN_STANDARD_CAUCHY,    /**< Used in numpy.random.standard_cauchy() implementation  */
     DPNP_FN_STD,                /**< Used in numpy.std() implementation  */
     DPNP_FN_SUBTRACT,           /**< Used in numpy.subtract() implementation  */
     DPNP_FN_SUM,                /**< Used in numpy.sum() implementation  */

--- a/dpnp/backend/custom_kernels_random.cpp
+++ b/dpnp/backend/custom_kernels_random.cpp
@@ -149,6 +149,25 @@ void custom_rng_negative_binomial_c(void* result, double a, double p, size_t siz
 }
 
 template <typename _DataType>
+void custom_rng_standard_cauchy_c(void* result, size_t size)
+{
+    if (!size)
+    {
+        return;
+    }
+    _DataType* result1 = reinterpret_cast<_DataType*>(result);
+
+    _DataType displacement = _DataType(0.0);
+
+    _DataType scalefactor = _DataType(1.0);
+
+    mkl_rng::cauchy<_DataType> distribution(displacement, scalefactor);
+    // perform generation
+    auto event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
+    event_out.wait();
+}
+
+template <typename _DataType>
 void custom_rng_uniform_c(void* result, long low, long high, size_t size)
 {
     if (!size)
@@ -188,6 +207,8 @@ void func_map_init_random(func_map_t& fmap)
     fmap[DPNPFuncName::DPNP_FN_GAUSSIAN][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_rng_gaussian_c<float>};
 
     fmap[DPNPFuncName::DPNP_FN_NEGATIVE_BINOMIAL][eft_INT][eft_INT] = {eft_INT, (void*)custom_rng_negative_binomial_c<int>};
+
+    fmap[DPNPFuncName::DPNP_FN_STANDARD_CAUCHY][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_rng_standard_cauchy_c<double>};
 
     fmap[DPNPFuncName::DPNP_FN_UNIFORM][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_rng_uniform_c<double>};
     fmap[DPNPFuncName::DPNP_FN_UNIFORM][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_rng_uniform_c<float>};

--- a/dpnp/random/_random.pyx
+++ b/dpnp/random/_random.pyx
@@ -52,6 +52,7 @@ __all__ = [
     "dpnp_randn",
     "dpnp_random",
     "dpnp_srand",
+    "dpnp_standard_cauchy",
     "dpnp_uniform"
 ]
 
@@ -63,6 +64,7 @@ ctypedef void(*fptr_custom_rng_exponential_c_1out_t)(void *, double, size_t)
 ctypedef void(*fptr_custom_rng_gamma_c_1out_t)(void *, double, double, size_t)
 ctypedef void(*fptr_custom_rng_gaussian_c_1out_t)(void *, double, double, size_t)
 ctypedef void(*fptr_custom_rng_negative_binomial_c_1out_t)(void *, double, double, size_t)
+ctypedef void(*fptr_custom_rng_standard_cauchy_c_1out_t)(void *, size_t)
 ctypedef void(*fptr_custom_rng_uniform_c_1out_t)(void *, long, long, size_t)
 
 
@@ -308,6 +310,31 @@ cpdef dpnp_srand(seed):
     Initialize basic random number generator.
     """
     dpnp_srand_c(seed)
+
+
+cpdef dparray dpnp_standard_cauchy(size):
+    """
+    Returns an array populated with samples from beta distribution.
+    `dpnp_standard_cauchy` generates a matrix filled with random floats sampled from a
+    univariate standard cauchy distribution.
+
+    """
+
+    # convert string type names (dparray.dtype) to C enum DPNPFuncType
+    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(numpy.float64)
+
+    # get the FPTR data structure
+    cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_STANDARD_CAUCHY, param1_type, param1_type)
+
+    result_type = dpnp_DPNPFuncType_to_dtype( < size_t > kernel_data.return_type)
+    # ceate result array with type given by FPTR data
+    cdef dparray result = dparray(size, dtype=result_type)
+
+    cdef fptr_custom_rng_standard_cauchy_c_1out_t func = < fptr_custom_rng_standard_cauchy_c_1out_t > kernel_data.ptr
+    # call FPTR function
+    func(result.get_data(), result.size)
+
+    return result
 
 
 cpdef dparray dpnp_uniform(long low, long high, size, dtype=numpy.int32):

--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -57,8 +57,9 @@ __all__ = [
     'random',
     'random_integers',
     'random_sample',
-    'seed',
     'sample',
+    'seed',
+    'standard_cauchy',
     'uniform'
 ]
 
@@ -825,6 +826,50 @@ def sample(size):
         return dpnp_random(size)
 
     return call_origin(numpy.random.sample, size)
+
+
+def standard_cauchy(size=None):
+    """Standard cauchy distribution.
+
+    Draw samples from a standard Cauchy distribution with mode = 0.
+
+    Also known as the Lorentz distribution.
+
+    Parameters
+    ----------
+    size : int, optional
+        Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+        ``m * n * k`` samples are drawn.
+
+    Returns
+    -------
+    samples : dparray
+        The drawn samples.
+
+    Examples
+    --------
+    Draw samples and plot the distribution:
+    >>> import matplotlib.pyplot as plt
+    >>> s = dpnp.random.standard_cauchy(1000000)
+    >>> s = s[(s>-25) & (s<25)]  # truncate distribution so it plots well
+    >>> plt.hist(s, bins=100)
+    >>> plt.show()
+
+    """
+
+    if not use_origin_backend(size):
+        if size is None:
+            size = 1
+        elif isinstance(size, tuple):
+            for dim in size:
+                if not isinstance(dim, int):
+                    checker_throw_value_error("standard_cauchy", "type(dim)", type(dim), int)
+        elif not isinstance(size, int):
+            checker_throw_value_error("standard_cauchy", "type(size)", type(size), int)
+
+        return dpnp_standard_cauchy(size)
+
+    return call_origin(numpy.random.standard_cauchy, size)
 
 
 def uniform(low=0.0, high=1.0, size=None):

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -311,3 +311,14 @@ def test_randn_normal_distribution():
     # dataset does not significantly deviate from normal.
     # If p > alpha, the null hypothesis cannot be rejected.
     assert p > alpha
+
+
+def test_standard_cauchy_seed():
+    seed = 28041990
+    size = 100
+
+    dpnp.random.seed(seed)
+    a1 = dpnp.random.standard_cauchy(size)
+    dpnp.random.seed(seed)
+    a2 = dpnp.random.standard_cauchy(size)
+    assert_allclose(a1, a2, rtol=1e-07, atol=0)


### PR DESCRIPTION
## Description
standard_cauchy([size]) Draw samples from a standard Cauchy distribution with mode = 0.

## TODO
* more tests

## Reproduce

```python

```

## Checklist

- [x] Docstrings for all functions
- [ ] Gallery example in ./doc/examples (new features only)
- [x] Unit tests:
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)