### PR TITLE
ENH: added `random.standard_normal`

### DIFF
--- a/dpnp/backend.pxd
+++ b/dpnp/backend.pxd
@@ -108,6 +108,7 @@ cdef extern from "backend/backend_iface_fptr.hpp" namespace "DPNPFuncName":  # n
         DPNP_FN_SQRT
         DPNP_FN_SQUARE
         DPNP_FN_STANDARD_CAUCHY
+        DPNP_FN_STANDARD_NORMAL
         DPNP_FN_STD
         DPNP_FN_SUBTRACT
         DPNP_FN_SUM

--- a/dpnp/backend/backend_iface_fptr.hpp
+++ b/dpnp/backend/backend_iface_fptr.hpp
@@ -136,6 +136,7 @@ enum class DPNPFuncName : size_t
     DPNP_FN_SQRT,               /**< Used in numpy.sqrt() implementation  */
     DPNP_FN_SQUARE,             /**< Used in numpy.square() implementation  */
     DPNP_FN_STANDARD_CAUCHY,    /**< Used in numpy.random.standard_cauchy() implementation  */
+    DPNP_FN_STANDARD_NORMAL,    /**< Used in numpy.random.standard_normal() implementation  */
     DPNP_FN_STD,                /**< Used in numpy.std() implementation  */
     DPNP_FN_SUBTRACT,           /**< Used in numpy.subtract() implementation  */
     DPNP_FN_SUM,                /**< Used in numpy.sum() implementation  */

--- a/dpnp/backend/custom_kernels_random.cpp
+++ b/dpnp/backend/custom_kernels_random.cpp
@@ -183,6 +183,21 @@ void custom_rng_standard_cauchy_c(void* result, size_t size)
 }
 
 template <typename _DataType>
+void custom_rng_standard_normal_c(void* result, size_t size)
+{
+    if (!size)
+    {
+        return;
+    }
+    _DataType* result1 = reinterpret_cast<_DataType*>(result);
+
+    const _DataType mean =  _DataType(0.0);
+    const _DataType stddev =  _DataType(1.0);
+
+    custom_rng_gaussian_c(result, mean, stddev, size);
+}
+
+template <typename _DataType>
 void custom_rng_uniform_c(void* result, long low, long high, size_t size)
 {
     if (!size)
@@ -226,6 +241,8 @@ void func_map_init_random(func_map_t& fmap)
     fmap[DPNPFuncName::DPNP_FN_NEGATIVE_BINOMIAL][eft_INT][eft_INT] = {eft_INT, (void*)custom_rng_negative_binomial_c<int>};
 
     fmap[DPNPFuncName::DPNP_FN_STANDARD_CAUCHY][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_rng_standard_cauchy_c<double>};
+
+    fmap[DPNPFuncName::DPNP_FN_STANDARD_NORMAL][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_rng_standard_normal_c<double>};
 
     fmap[DPNPFuncName::DPNP_FN_UNIFORM][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_rng_uniform_c<double>};
     fmap[DPNPFuncName::DPNP_FN_UNIFORM][eft_FLT][eft_FLT] = {eft_FLT, (void*)custom_rng_uniform_c<float>};

--- a/dpnp/random/_random.pyx
+++ b/dpnp/random/_random.pyx
@@ -54,6 +54,7 @@ __all__ = [
     "dpnp_random",
     "dpnp_srand",
     "dpnp_standard_cauchy",
+    "dpnp_standard_normal",
     "dpnp_uniform"
 ]
 
@@ -67,6 +68,7 @@ ctypedef void(*fptr_custom_rng_gaussian_c_1out_t)(void *, double, double, size_t
 ctypedef void(*fptr_custom_rng_laplace_c_1out_t)(void *, double, double, size_t)
 ctypedef void(*fptr_custom_rng_negative_binomial_c_1out_t)(void *, double, double, size_t)
 ctypedef void(*fptr_custom_rng_standard_cauchy_c_1out_t)(void *, size_t) except +
+ctypedef void(*fptr_custom_rng_standard_normal_c_1out_t)(void *, size_t) except +
 ctypedef void(*fptr_custom_rng_uniform_c_1out_t)(void *, long, long, size_t)
 
 
@@ -368,6 +370,31 @@ cpdef dparray dpnp_standard_cauchy(size):
     cdef dparray result = dparray(size, dtype=result_type)
 
     cdef fptr_custom_rng_standard_cauchy_c_1out_t func = < fptr_custom_rng_standard_cauchy_c_1out_t > kernel_data.ptr
+    # call FPTR function
+    func(result.get_data(), result.size)
+
+    return result
+
+
+cpdef dparray dpnp_standard_normal(size):
+    """
+    Returns an array populated with samples from beta distribution.
+    `dpnp_standard_normal` generates a matrix filled with random floats sampled from a
+    univariate standard normal(Gaussian) distribution.
+
+    """
+
+    # convert string type names (dparray.dtype) to C enum DPNPFuncType
+    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(numpy.float64)
+
+    # get the FPTR data structure
+    cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_STANDARD_NORMAL, param1_type, param1_type)
+
+    result_type = dpnp_DPNPFuncType_to_dtype( < size_t > kernel_data.return_type)
+    # ceate result array with type given by FPTR data
+    cdef dparray result = dparray(size, dtype=result_type)
+
+    cdef fptr_custom_rng_standard_normal_c_1out_t func = < fptr_custom_rng_standard_normal_c_1out_t > kernel_data.ptr
     # call FPTR function
     func(result.get_data(), result.size)
 

--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -932,6 +932,21 @@ def standard_cauchy(size=None):
 def standard_normal(size=None):
     """Standard normal distribution.
 
+    Draw samples from a standard Normal distribution (mean=0, stdev=1).
+
+    Parameters
+    ----------
+    size : int, optional
+        Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+        ``m * n * k`` samples are drawn.  Default is None, in which case a
+        single value is returned.
+ 
+    Returns
+    -------
+    out : float or ndarray
+        A floating-point array of shape ``size`` of drawn samples, or a
+        single sample if ``size`` was not specified.
+
     """
 
     if not use_origin_backend(size):

--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -61,6 +61,7 @@ __all__ = [
     'sample',
     'seed',
     'standard_cauchy',
+    'standard_normal',
     'uniform'
 ]
 
@@ -926,6 +927,26 @@ def standard_cauchy(size=None):
         return dpnp_standard_cauchy(size)
 
     return call_origin(numpy.random.standard_cauchy, size)
+
+
+def standard_normal(size=None):
+    """Standard normal distribution.
+
+    """
+
+    if not use_origin_backend(size):
+        if size is None:
+            size = 1
+        elif isinstance(size, tuple):
+            for dim in size:
+                if not isinstance(dim, int):
+                    checker_throw_value_error("standard_normal", "type(dim)", type(dim), int)
+        elif not isinstance(size, int):
+            checker_throw_value_error("standard_normal", "type(size)", type(size), int)
+
+        return dpnp_standard_normal(size)
+
+    return call_origin(numpy.random.standard_normal, size)
 
 
 def uniform(low=0.0, high=1.0, size=None):

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -369,3 +369,26 @@ def test_standard_cauchy_seed():
     dpnp.random.seed(seed)
     a2 = dpnp.random.standard_cauchy(size)
     assert_allclose(a1, a2, rtol=1e-07, atol=0)
+
+
+def test_standard_normal_seed():
+    seed = 28041990
+    size = 100
+
+    dpnp.random.seed(seed)
+    a1 = dpnp.random.standard_normal(size)
+    dpnp.random.seed(seed)
+    a2 = dpnp.random.standard_normal(size)
+    assert_allclose(a1, a2, rtol=1e-07, atol=0)
+
+
+def test_standard_normal_check_moments():
+    seed = 28041995
+    dpnp.random.seed(seed)
+    size = 10**6
+    expected_mean = 0.0
+    expected_var = 1.0
+    var = numpy.var(dpnp.random.standard_normal(size=size))
+    mean = numpy.mean(dpnp.random.standard_normal(size=size))
+    assert math.isclose(var, expected_var, abs_tol=0.003)
+    assert math.isclose(mean, expected_mean, abs_tol=0.003)


### PR DESCRIPTION
## Description
standard_normal([size]) Draw samples from a standard Normal distribution (mean=0, stdev=1).

## TODO
* after merge of this PR, `randn` will be redesigned and `normal` will be added
* is it needed `standard_normal` on backend? We just can call `normal` with params (mean=0, stdev=1) from `standard_normal` on python level.
## Reproduce

```python
>>> np.mean(dpnp.random.standard_normal(10**6));np.var(dpnp.random.standard_normal(10**6))
0.00030427453642504083
1.0013896813115708
>>> np.mean(np.random.standard_normal(10**6));np.var(np.random.standard_normal(10**6))
0.00011309454634553527
1.0003356224869078
```

## Checklist

- [x] Docstrings for all functions
- [ ] Gallery example in ./doc/examples (new features only)
- [x] Unit tests:
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)