### PR TITLE
ENH: added `random.poisson`

### DIFF
--- a/dpnp/backend.pxd
+++ b/dpnp/backend.pxd
@@ -101,6 +101,7 @@ cdef extern from "backend/backend_iface_fptr.hpp" namespace "DPNPFuncName":  # n
         DPNP_FN_REMAINDER
         DPNP_FN_RECIP
         DPNP_FN_RIGHT_SHIFT
+        DPNP_FN_RNG_POISSON
         DPNP_FN_SIGN
         DPNP_FN_SIN
         DPNP_FN_SINH

--- a/dpnp/backend/backend_iface_fptr.hpp
+++ b/dpnp/backend/backend_iface_fptr.hpp
@@ -129,6 +129,7 @@ enum class DPNPFuncName : size_t
     DPNP_FN_REMAINDER,          /**< Used in numpy.remainder() implementation  */
     DPNP_FN_RECIP,              /**< Used in numpy.recip() implementation  */
     DPNP_FN_RIGHT_SHIFT,        /**< Used in numpy.right_shift() implementation  */
+    DPNP_FN_RNG_POISSON,        /**< Used in numpy.random.poisson() implementation  */
     DPNP_FN_SIGN,               /**< Used in numpy.sign() implementation  */
     DPNP_FN_SIN,                /**< Used in numpy.sin() implementation  */
     DPNP_FN_SINH,               /**< Used in numpy.sinh() implementation  */

--- a/dpnp/backend/custom_kernels_random.cpp
+++ b/dpnp/backend/custom_kernels_random.cpp
@@ -164,6 +164,21 @@ void custom_rng_negative_binomial_c(void* result, double a, double p, size_t siz
 }
 
 template <typename _DataType>
+void custom_rng_poisson_c(void* result, double lambda, size_t size)
+{
+    if (!size)
+    {
+        return;
+    }
+    _DataType* result1 = reinterpret_cast<_DataType*>(result);
+
+    mkl_rng::poisson<_DataType> distribution(lambda);
+    // perform generation
+    auto event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
+    event_out.wait();
+}
+
+template <typename _DataType>
 void custom_rng_standard_cauchy_c(void* result, size_t size)
 {
     if (!size)
@@ -260,6 +275,8 @@ void func_map_init_random(func_map_t& fmap)
     fmap[DPNPFuncName::DPNP_FN_LAPLACE][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_rng_laplace_c<double>};
 
     fmap[DPNPFuncName::DPNP_FN_NEGATIVE_BINOMIAL][eft_INT][eft_INT] = {eft_INT, (void*)custom_rng_negative_binomial_c<int>};
+
+    fmap[DPNPFuncName::DPNP_FN_RNG_POISSON][eft_INT][eft_INT] = {eft_INT, (void*)custom_rng_poisson_c<int>};
 
     fmap[DPNPFuncName::DPNP_FN_STANDARD_CAUCHY][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_rng_standard_cauchy_c<double>};
 

--- a/dpnp/random/_random.pyx
+++ b/dpnp/random/_random.pyx
@@ -313,7 +313,7 @@ cpdef dparray dpnp_poisson(double lam, size):
 
     if lam == 0:
         result = dparray(size, dtype=dtype)
-        result.fill(0.0)
+        result.fill(0)
     else:
         # convert string type names (dparray.dtype) to C enum DPNPFuncType
         param1_type = dpnp_dtype_to_DPNPFuncType(dtype)

--- a/dpnp/random/_random.pyx
+++ b/dpnp/random/_random.pyx
@@ -50,6 +50,7 @@ __all__ = [
     "dpnp_gamma",
     "dpnp_laplace",
     "dpnp_negative_binomial",
+    "dpnp_poisson",
     "dpnp_randn",
     "dpnp_random",
     "dpnp_srand",
@@ -68,6 +69,7 @@ ctypedef void(*fptr_custom_rng_gamma_c_1out_t)(void *, double, double, size_t)
 ctypedef void(*fptr_custom_rng_gaussian_c_1out_t)(void *, double, double, size_t)
 ctypedef void(*fptr_custom_rng_laplace_c_1out_t)(void *, double, double, size_t)
 ctypedef void(*fptr_custom_rng_negative_binomial_c_1out_t)(void *, double, double, size_t)
+ctypedef void(*fptr_custom_rng_poisson_c_1out_t)(void *, double, size_t) except +
 ctypedef void(*fptr_custom_rng_standard_cauchy_c_1out_t)(void *, size_t) except +
 ctypedef void(*fptr_custom_rng_standard_normal_c_1out_t)(void *, size_t) except +
 ctypedef void(*fptr_custom_rng_uniform_c_1out_t)(void *, long, long, size_t)
@@ -291,6 +293,41 @@ cpdef dparray dpnp_laplace(double loc, double scale, size):
         func = <fptr_custom_rng_laplace_c_1out_t > kernel_data.ptr
         # call FPTR function
         func(result.get_data(), loc, scale, result.size)
+
+    return result
+
+
+cpdef dparray dpnp_poisson(double lam, size):
+    """
+    Returns an array populated with samples from Poisson distribution.
+    `dpnp_poisson` generates a matrix filled with random floats sampled from a
+    univariate Poisson distribution for a given number of independent trials and
+    success probability p of a single trial.
+    """
+
+    dtype = numpy.int32
+    cdef dparray result
+    cdef DPNPFuncType param1_type
+    cdef DPNPFuncData kernel_data
+    cdef fptr_custom_rng_poisson_c_1out_t func
+
+    if lam == 0:
+        result = dparray(size, dtype=dtype)
+        result.fill(0.0)
+    else:
+        # convert string type names (dparray.dtype) to C enum DPNPFuncType
+        param1_type = dpnp_dtype_to_DPNPFuncType(dtype)
+
+        # get the FPTR data structure
+        kernel_data = get_dpnp_function_ptr(DPNP_FN_RNG_POISSON, param1_type, param1_type)
+
+        result_type = dpnp_DPNPFuncType_to_dtype( < size_t > kernel_data.return_type)
+        # ceate result array with type given by FPTR data
+        result = dparray(size, dtype=result_type)
+
+        func = <fptr_custom_rng_poisson_c_1out_t > kernel_data.ptr
+        # call FPTR function
+        func(result.get_data(), lam, result.size)
 
     return result
 

--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -52,6 +52,7 @@ __all__ = [
     'gamma',
     'laplace',
     'negative_binomial',
+    'poisson',
     'rand',
     'ranf',
     'randint',
@@ -576,6 +577,76 @@ def negative_binomial(n, p, size=None):
         return dpnp_negative_binomial(n, p, size)
 
     return call_origin(numpy.random.negative_binomial, n, p, size)
+
+
+def poisson(lam=1.0, size=None):
+    """Poisson distribution.
+
+    Draw samples from a Poisson distribution.
+
+    The Poisson distribution is the limit of the binomial distribution
+    for large N.
+
+    Parameters
+    ----------
+    lam : float or array_like of floats
+        Expectation of interval, must be >= 0. A sequence of expectation
+        intervals must be broadcastable over the requested size.
+    size : int or tuple of ints, optional
+        Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+        ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+        a single value is returned if ``lam`` is a scalar.
+
+    Returns
+    -------
+    out : dparray, int32
+        Drawn samples from the parameterized Poisson distribution.
+
+    Notes
+    -----
+    The Poisson distribution
+
+    .. math:: f(k; \\lambda)=\\frac{\\lambda^k e^{-\\lambda}}{k!}
+
+    For events with an expected separation :math:`\\lambda` the Poisson
+    distribution :math:`f(k; \\lambda)` describes the probability of
+    :math:`k` events occurring within the observed
+    interval :math:`\\lambda`.
+
+    References
+    ----------
+    .. [1] Weisstein, Eric W. "Poisson Distribution."
+           From MathWorld--A Wolfram Web Resource.
+           http://mathworld.wolfram.com/PoissonDistribution.html
+    .. [2] Wikipedia, "Poisson distribution",
+           https://en.wikipedia.org/wiki/Poisson_distribution
+
+    Examples
+    --------
+    Draw samples from the distribution:
+    >>> import numpy as np
+    >>> s = dpnp.random.poisson(5, 10000)
+
+    """
+
+    if not use_origin_backend(lam):
+        if size is None:
+            size = 1
+        elif isinstance(size, tuple):
+            for dim in size:
+                if not isinstance(dim, int):
+                    checker_throw_value_error("poisson", "type(dim)", type(dim), int)
+        elif not isinstance(size, int):
+            checker_throw_value_error("poisson", "type(size)", type(size), int)
+
+        # TODO:
+        # array_like of floats for `lam` param
+        if lam < 0:
+            checker_throw_value_error("poisson", "lam", lam, "non-negative")
+
+        return dpnp_poisson(lam, size)
+
+    return call_origin(numpy.random.poisson, lam, size)
 
 
 def rand(d0, *dn):

--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -589,10 +589,10 @@ def poisson(lam=1.0, size=None):
 
     Parameters
     ----------
-    lam : float or array_like of floats
+    lam : float
         Expectation of interval, must be >= 0. A sequence of expectation
         intervals must be broadcastable over the requested size.
-    size : int or tuple of ints, optional
+    size : int, optional
         Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``lam`` is a scalar.

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -339,6 +339,48 @@ def test_negative_binomial_check_extreme_value():
     assert numpy.unique(res)[0] == check_val
 
 
+def test_poisson_seed():
+    seed = 28041990
+    size = 100
+    lam = 0.8
+
+    dpnp.random.seed(seed)
+    a1 = dpnp.random.poisson(lam, size)
+    dpnp.random.seed(seed)
+    a2 = dpnp.random.poisson(lam, size)
+    assert_allclose(a1, a2, rtol=1e-07, atol=0)
+
+
+def test_poisson_invalid_args():
+    size = 10
+    lam = -1.0    # non-negative `lam` is expected
+    with pytest.raises(ValueError):
+        dpnp.random.poisson(lam=lam, size=size)
+
+
+def test_poisson_check_moments():
+    seed = 28041995
+    dpnp.random.seed(seed)
+    lam = 0.8
+    size = 10**6
+    expected_mean = lam
+    expected_var = lam
+    var = numpy.var(dpnp.random.poisson(lam=lam, size=size))
+    mean = numpy.mean(dpnp.random.poisson(lam=lam, size=size))
+    assert math.isclose(var, expected_var, abs_tol=0.003)
+    assert math.isclose(mean, expected_mean, abs_tol=0.003)
+
+
+def test_poisson_check_extreme_value():
+    seed = 28041990
+    dpnp.random.seed(seed)
+
+    lam = 0.0
+    res = numpy.asarray(dpnp.random.poisson(lam=lam, size=100))
+    assert len(numpy.unique(res)) == 1
+    assert numpy.unique(res)[0] == 0.0
+
+
 def test_randn_normal_distribution():
     """ Check if the sample obtained from the dpnp.random.randn differs from
     the normal distribution.


### PR DESCRIPTION
## Description
poisson([lam, size]) Draw samples from a Poisson distribution.

## TODO
* array_like of floats for `lam` params

## Reproduce

```python
>>> np.mean(dpnp.random.poisson(12, 10**6))
12.00312
>>> np.var(dpnp.random.poisson(12, 10**6))
12.02310547279755
>>> # theoretical mean and var are equal to lam

```

## Checklist

- [x] Docstrings for all functions
- [ ] Gallery example in ./doc/examples (new features only)
- [x] Unit tests:
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)