### PR TITLE
add custom kernel to fft.fft()

### DIFF
--- a/dpnp/backend.pxd
+++ b/dpnp/backend.pxd
@@ -131,6 +131,7 @@ cdef extern from "backend/backend_iface_fptr.hpp" namespace "DPNPFuncType":  # n
         DPNP_FT_LONG
         DPNP_FT_FLOAT
         DPNP_FT_DOUBLE
+        DPNP_FT_CMPLX128
 
 cdef extern from "backend/backend_iface_fptr.hpp":
     struct DPNPFuncData:

--- a/dpnp/backend.pyx
+++ b/dpnp/backend.pyx
@@ -246,6 +246,8 @@ cpdef DPNPFuncType dpnp_dtype_to_DPNPFuncType(dtype):
         return DPNP_FT_LONG
     elif dtype == numpy.int32:
         return DPNP_FT_INT
+    elif dtype == numpy.complex128:
+        return DPNP_FT_CMPLX128
     else:
         checker_throw_type_error("dpnp_dtype_to_DPNPFuncType", dtype)
 
@@ -262,6 +264,8 @@ cpdef dpnp_DPNPFuncType_to_dtype(size_t type):
         return numpy.int64
     elif type == <size_t > DPNP_FT_INT:
         return numpy.int32
+    elif type == <size_t > DPNP_FT_CMPLX128:
+        return numpy.complex128
     else:
         checker_throw_type_error("dpnp_DPNPFuncType_to_dtype", type)
 

--- a/dpnp/backend/backend_fptr.hpp
+++ b/dpnp/backend/backend_fptr.hpp
@@ -60,6 +60,7 @@ const DPNPFuncType eft_INT = DPNPFuncType::DPNP_FT_INT;
 const DPNPFuncType eft_LNG = DPNPFuncType::DPNP_FT_LONG;
 const DPNPFuncType eft_FLT = DPNPFuncType::DPNP_FT_FLOAT;
 const DPNPFuncType eft_DBL = DPNPFuncType::DPNP_FT_DOUBLE;
+const DPNPFuncType eft_C128 = DPNPFuncType::DPNP_FT_CMPLX128;
 
 /**
  * FPTR interface initialization functions

--- a/dpnp/backend/backend_iface_fptr.hpp
+++ b/dpnp/backend/backend_iface_fptr.hpp
@@ -164,11 +164,12 @@ enum class DPNPFuncName : size_t
  */
 enum class DPNPFuncType : size_t
 {
-    DPNP_FT_NONE,  /**< Very first element of the enumeration */
-    DPNP_FT_INT,   /**< analog of numpy.int32 or int */
-    DPNP_FT_LONG,  /**< analog of numpy.int64 or long */
-    DPNP_FT_FLOAT, /**< analog of numpy.float32 or float */
-    DPNP_FT_DOUBLE /**< analog of numpy.float32 or double */
+    DPNP_FT_NONE,    /**< Very first element of the enumeration */
+    DPNP_FT_INT,     /**< analog of numpy.int32 or int */
+    DPNP_FT_LONG,    /**< analog of numpy.int64 or long */
+    DPNP_FT_FLOAT,   /**< analog of numpy.float32 or float */
+    DPNP_FT_DOUBLE,  /**< analog of numpy.float32 or double */
+    DPNP_FT_CMPLX128 /**< analog of numpy.complex128 or std::complex<double> */
 };
 
 /**

--- a/dpnp/fft/dpnp_algo_fft.pyx
+++ b/dpnp/fft/dpnp_algo_fft.pyx
@@ -56,7 +56,7 @@ cpdef dparray dpnp_fft(dparray input):
     # get the FPTR data structure
     cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_FFT_FFT, param1_type, param1_type)
 
-    result_type = dpnp.complex128  # dpnp_DPNPFuncType_to_dtype(< size_t > kernel_data.return_type)
+    result_type = dpnp_DPNPFuncType_to_dtype(< size_t > kernel_data.return_type)
     # ceate result array with type given by FPTR data
     cdef dparray result = dparray(input_shape, dtype=result_type)
 

--- a/dpnp/fft/dpnp_iface_fft.py
+++ b/dpnp/fft/dpnp_iface_fft.py
@@ -65,12 +65,15 @@ def fft(x1, n=None, axis=-1, norm=None):
 
     is_x1_dparray = isinstance(x1, dparray)
 
-    if (not use_origin_backend(x1) and is_x1_dparray and 0):
+    if (not use_origin_backend(x1) and is_x1_dparray):
         if n is not None:
             pass
-        if axis != -1:
+        elif axis != -1:
             pass
-        if norm is not None:
+        elif norm is not None:
+            pass
+        elif x1.size < 1:
+            # need to properly raise an exception. let's pass it to fallback
             pass
         else:
             return dpnp_fft(x1)

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -319,7 +319,6 @@ tests/third_party/cupy/fft_tests/test_fft.py::TestFft_param_28_{n=5, norm='ortho
 tests/third_party/cupy/fft_tests/test_fft.py::TestFft_param_28_{n=5, norm='ortho', shape=(0,)}::test_ifft
 tests/third_party/cupy/fft_tests/test_fft.py::TestFft_param_29_{n=5, norm='ortho', shape=(10, 0)}::test_fft
 tests/third_party/cupy/fft_tests/test_fft.py::TestFft_param_29_{n=5, norm='ortho', shape=(10, 0)}::test_ifft
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft_param_2_{n=None, norm=None, shape=(10,)}::test_fft
 tests/third_party/cupy/fft_tests/test_fft.py::TestFft_param_2_{n=None, norm=None, shape=(10,)}::test_ifft
 tests/third_party/cupy/fft_tests/test_fft.py::TestFft_param_30_{n=5, norm='ortho', shape=(10,)}::test_fft
 tests/third_party/cupy/fft_tests/test_fft.py::TestFft_param_30_{n=5, norm='ortho', shape=(10,)}::test_ifft


### PR DESCRIPTION
need to add limited support for `DPNP_FT_CMPLX128` because `fft.fft()` is required it (output type is always complex128)