### PR TITLE
API: changed `random.multinomial` backend function api

### DIFF
--- a/dpnp/backend/backend_iface.hpp
+++ b/dpnp/backend/backend_iface.hpp
@@ -817,17 +817,23 @@ INP_DLLEXPORT void custom_rng_lognormal_c(void* result, _DataType mean, _DataTyp
  * @ingroup BACKEND_API
  * @brief math library implementation of random number generator (multinomial distribution)
  *
- * @param [in]  size     Number of elements in `result` arrays.
+ * @param [in]  size          Number of elements in `result` arrays.
  *
- * @param [in]  ntrial   Number of independent trials.
+ * @param [in]  ntrial        Number of independent trials.
  *
- * @param [in]  p_vector Probability vector of possible outcomes (k length).
+ * @param [in]  p_vector      Probability vector of possible outcomes (k length).
  *
- * @param [out] result   Output array.
+ * @param [in]  p_vector_size Length of `p_vector`.
+ *
+ * @param [out] result        Output array.
  *
  */
 template <typename _DataType>
-INP_DLLEXPORT void custom_rng_multinomial_c(void* result, int ntrial, std::vector<double>& p_vector, size_t size);
+INP_DLLEXPORT void custom_rng_multinomial_ccustom_rng_multinomial_c(void* result,
+                                                                    int ntrial,
+                                                                    const double* p_vector,
+                                                                    const size_t p_vector_size,
+                                                                    size_t size);
 
 /**
  * @ingroup BACKEND_API

--- a/dpnp/backend/custom_kernels_random.cpp
+++ b/dpnp/backend/custom_kernels_random.cpp
@@ -215,21 +215,21 @@ void custom_rng_lognormal_c(void* result, _DataType mean, _DataType stddev, size
 }
 
 template <typename _DataType>
-void custom_rng_multinomial_c(void* result, int ntrial, std::vector<double>& p_vector, size_t size)
+void custom_rng_multinomial_c(void* result, int ntrial, const double* p_vector, const size_t p_vector_size, size_t size)
 {
     if (!size)
     {
         return;
     }
     std::int32_t* result1 = reinterpret_cast<std::int32_t*>(result);
+    std::vector<double> p(p_vector, p_vector + p_vector_size);
 
-    mkl_rng::multinomial<std::int32_t> distribution(ntrial, p_vector);
-
+    mkl_rng::multinomial<std::int32_t> distribution(ntrial, p);
     // size = size
     // `result` is a array for random numbers
-    // `size` is a `result`'s len. `size = n * p_vector.size()`
+    // `size` is a `result`'s len. `size = n * p.size()`
     // `n` is a number of random values to be generated.
-    size_t n = size / p_vector.size();
+    size_t n = size / p.size();
     // perform generation
     auto event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, n, result1);
     event_out.wait();

--- a/dpnp/random/_random.pyx
+++ b/dpnp/random/_random.pyx
@@ -38,7 +38,6 @@ import dpnp.config as config
 from dpnp.backend cimport *
 from dpnp.dparray cimport dparray
 from dpnp.dpnp_utils cimport *
-from libcpp.vector cimport vector
 import numpy
 cimport numpy
 
@@ -82,7 +81,7 @@ ctypedef void(*fptr_custom_rng_gumbel_c_1out_t)(void *, double, double, size_t) 
 ctypedef void(*fptr_custom_rng_hypergeometric_c_1out_t)(void *, int, int, int, size_t) except +
 ctypedef void(*fptr_custom_rng_laplace_c_1out_t)(void *, double, double, size_t) except +
 ctypedef void(*fptr_custom_rng_lognormal_c_1out_t)(void *, double, double, size_t) except +
-ctypedef void(*fptr_custom_rng_multinomial_c_1out_t)(void *, int, vector[double]&, size_t) except +
+ctypedef void(*fptr_custom_rng_multinomial_c_1out_t)(void* result, int, const double*, const size_t, size_t) except +
 ctypedef void(*fptr_custom_rng_negative_binomial_c_1out_t)(void *, double, double, size_t) except +
 ctypedef void(*fptr_custom_rng_normal_c_1out_t)(void *, double, double, size_t) except +
 ctypedef void(*fptr_custom_rng_poisson_c_1out_t)(void *, double, size_t) except +
@@ -470,8 +469,10 @@ cpdef dparray dpnp_multinomial(int ntrial, p, size):
     cdef DPNPFuncType param1_type
     cdef DPNPFuncData kernel_data
     cdef fptr_custom_rng_multinomial_c_1out_t func
+    p = numpy.asarray(p, dtype=numpy.float64)
 
-    cdef vector[double] p_vector = p
+    cdef double * p_vector = <double*> numpy.PyArray_DATA(p)
+    cdef size_t p_vector_size = len(p)
     size = size + (len(p),)
 
     if ntrial == 0:
@@ -490,7 +491,7 @@ cpdef dparray dpnp_multinomial(int ntrial, p, size):
 
         func = <fptr_custom_rng_multinomial_c_1out_t > kernel_data.ptr
         # call FPTR function
-        func(result.get_data(), ntrial, p_vector, result.size)
+        func(result.get_data(), ntrial, p_vector, p_vector_size, result.size)
 
     return result
 


### PR DESCRIPTION
## Description
* using 'simple' interface instead of STL. ( `const double* p_vector, const size_t p_vector_size` instead of `std::vector<double>& p_vector`) -> `random.multinomial` backend function (`custom_rng_multinomial_c` signature was changed)
>Perhaps it might be fixed later.
This is a not quite good to use STL in the functions interface. These containers are good for regular usage but in our case we need to provide "simple" interface. Usually we use Cython or Numba IR as a customer for this intrface. Importing C++ STL is a quite big pain for such usage model.
Please use const double* p_vector, size_t p_vector_size instead. @shssf . See #276 
