### PR TITLE
STY: style fix (whitespace, PEP8), refactoring docs for random module

### DIFF
--- a/dpnp/random/_random.pyx
+++ b/dpnp/random/_random.pyx
@@ -82,7 +82,7 @@ ctypedef void(*fptr_custom_rng_gumbel_c_1out_t)(void *, double, double, size_t) 
 ctypedef void(*fptr_custom_rng_hypergeometric_c_1out_t)(void *, int, int, int, size_t) except +
 ctypedef void(*fptr_custom_rng_laplace_c_1out_t)(void *, double, double, size_t) except +
 ctypedef void(*fptr_custom_rng_lognormal_c_1out_t)(void *, double, double, size_t) except +
-ctypedef void(*fptr_custom_rng_multinomial_c_1out_t)(void *, int, vector[double]&, size_t) except +
+ctypedef void(*fptr_custom_rng_multinomial_c_1out_t)(void *, int, vector[double] &, size_t) except +
 ctypedef void(*fptr_custom_rng_negative_binomial_c_1out_t)(void *, double, double, size_t) except +
 ctypedef void(*fptr_custom_rng_normal_c_1out_t)(void *, double, double, size_t) except +
 ctypedef void(*fptr_custom_rng_poisson_c_1out_t)(void *, double, size_t) except +
@@ -100,6 +100,7 @@ cpdef dparray dpnp_beta(double a, double b, size):
     Returns an array populated with samples from beta distribution.
     `dpnp_beta` generates a matrix filled with random floats sampled from a
     univariate beta distribution.
+
     """
 
     # convert string type names (dparray.dtype) to C enum DPNPFuncType
@@ -125,6 +126,7 @@ cpdef dparray dpnp_binomial(int ntrial, double p, size):
     `dpnp_binomial` generates a matrix filled with random floats sampled from a
     univariate binomial distribution for a given number of independent trials and
     success probability p of a single trial.
+
     """
 
     dtype = numpy.int32
@@ -162,6 +164,7 @@ cpdef dparray dpnp_chisquare(int df, size):
     Returns an array populated with samples from chi-square distribution.
     `dpnp_chisquare` generates a matrix filled with random floats sampled from a
     univariate chi-square distribution for a given number of degrees of freedom.
+
     """
 
     # convert string type names (dparray.dtype) to C enum DPNPFuncType
@@ -186,6 +189,7 @@ cpdef dparray dpnp_exponential(double beta, size):
     Returns an array populated with samples from exponential distribution.
     `dpnp_exponential` generates a matrix filled with random floats sampled from a
     univariate exponential distribution of `beta`.
+
     """
 
     dtype = numpy.float64
@@ -211,6 +215,7 @@ cpdef dparray dpnp_gamma(double shape, double scale, size):
     Returns an array populated with samples from gamma distribution.
     `dpnp_gamma` generates a matrix filled with random floats sampled from a
     univariate gamma distribution of `shape` and `scale`.
+
     """
 
     dtype = numpy.float64
@@ -278,7 +283,7 @@ cpdef dparray dpnp_geometric(float p, size):
 
 cpdef dparray dpnp_gumbel(double loc, double scale, size):
     """
-    Returns an array populated with samples from beta distribution.
+    Returns an array populated with samples from gumbel distribution.
     `dpnp_gumbel` generates a matrix filled with random floats sampled from a
     univariate Gumbel distribution.
 
@@ -311,7 +316,7 @@ cpdef dparray dpnp_gumbel(double loc, double scale, size):
     return result
 
 
-cpdef dparray dpnp_hypergeometric(int l, int s, int m,  size):
+cpdef dparray dpnp_hypergeometric(int l, int s, int m, size):
     """
     Returns an array populated with samples from hypergeometric distribution.
     `dpnp_hypergeometric` generates a matrix filled with random floats sampled from a
@@ -386,7 +391,7 @@ cpdef dparray dpnp_normal(double loc, double scale, size):
 
 cpdef dparray dpnp_laplace(double loc, double scale, size):
     """
-    Returns an array populated with samples from beta distribution.
+    Returns an array populated with samples from laplace distribution.
     `dpnp_laplace` generates a matrix filled with random floats sampled from a
     univariate laplace distribution.
 
@@ -421,7 +426,7 @@ cpdef dparray dpnp_laplace(double loc, double scale, size):
 
 cpdef dparray dpnp_lognormal(double mean, double stddev, size):
     """
-    Returns an array populated with samples from beta distribution.
+    Returns an array populated with samples from lognormal distribution.
     `dpnp_lognormal` generates a matrix filled with random floats sampled from a
     univariate lognormal distribution.
 
@@ -542,6 +547,7 @@ cpdef dparray dpnp_poisson(double lam, size):
     `dpnp_poisson` generates a matrix filled with random floats sampled from a
     univariate Poisson distribution for a given number of independent trials and
     success probability p of a single trial.
+
     """
 
     dtype = numpy.int32
@@ -576,6 +582,7 @@ cpdef dparray dpnp_randn(dims):
     Returns an array populated with samples from standard normal distribution.
     `dpnp_randn` generates a matrix filled with random floats sampled from a
     univariate normal (Gaussian) distribution of mean 0 and variance 1.
+
     """
     cdef double mean = 0.0
     cdef double stddev = 1.0
@@ -601,6 +608,7 @@ cpdef dparray dpnp_random(dims):
     """
     Create an array of the given shape and populate it
     with random samples from a uniform distribution over [0, 1).
+
     """
     cdef long low = 0
     cdef long high = 1
@@ -660,13 +668,15 @@ cpdef dparray dpnp_rayleigh(double scale, size):
 cpdef dpnp_srand(seed):
     """
     Initialize basic random number generator.
+
     """
+
     dpnp_srand_c(seed)
 
 
 cpdef dparray dpnp_standard_cauchy(size):
     """
-    Returns an array populated with samples from beta distribution.
+    Returns an array populated with samples from standard cauchy distribution.
     `dpnp_standard_cauchy` generates a matrix filled with random floats sampled from a
     univariate standard cauchy distribution.
 
@@ -697,6 +707,8 @@ cpdef dparray dpnp_standard_exponential(size):
 
     """
 
+    cdef fptr_custom_rng_standard_exponential_c_1out_t func
+
     # convert string type names (dparray.dtype) to C enum DPNPFuncType
     cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(numpy.float64)
 
@@ -707,7 +719,7 @@ cpdef dparray dpnp_standard_exponential(size):
     # ceate result array with type given by FPTR data
     cdef dparray result = dparray(size, dtype=result_type)
 
-    cdef fptr_custom_rng_standard_exponential_c_1out_t func = < fptr_custom_rng_standard_exponential_c_1out_t > kernel_data.ptr
+    func = < fptr_custom_rng_standard_exponential_c_1out_t > kernel_data.ptr
     # call FPTR function
     func(result.get_data(), result.size)
 
@@ -751,7 +763,7 @@ cpdef dparray dpnp_standard_gamma(double shape, size):
 
 cpdef dparray dpnp_standard_normal(size):
     """
-    Returns an array populated with samples from beta distribution.
+    Returns an array populated with samples from standard normal(Gaussian) distribution.
     `dpnp_standard_normal` generates a matrix filled with random floats sampled from a
     univariate standard normal(Gaussian) distribution.
 
@@ -780,6 +792,7 @@ cpdef dparray dpnp_uniform(long low, long high, size, dtype=numpy.int32):
     Generates a matrix filled with random numbers sampled from a
     uniform distribution of the certain left (low) and right (high)
     bounds.
+
     """
     # convert string type names (dparray.dtype) to C enum DPNPFuncType
     cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(dtype)
@@ -800,9 +813,10 @@ cpdef dparray dpnp_uniform(long low, long high, size, dtype=numpy.int32):
 
 cpdef dparray dpnp_weibull(double a, size):
     """
-    Returns an array populated with samples from beta distribution.
+    Returns an array populated with samples from weibull distribution.
     `dpnp_weibull` generates a matrix filled with random floats sampled from a
     univariate weibull distribution.
+
     """
 
     dtype = numpy.float64

--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -98,10 +98,6 @@ def beta(a, b, size=None):
 
     It is often seen in Bayesian inference and order statistics.
 
-    .. note::
-        New code should use the ``beta`` method of a ``default_rng()``
-        instance instead; please see the :ref:`random-quick-start`.
-
     Parameters
     ----------
     a : float
@@ -344,10 +340,6 @@ def exponential(scale=1.0, size=None):
     the size of raindrops measured over many rainstorms [1]_, or the time
     between page requests to Wikipedia [2]_.
 
-    .. note::
-        New code should use the ``exponential`` method of a ``default_rng()``
-        instance instead; please see the :ref:`random-quick-start`.
-
     Parameters
     ----------
     scale : float
@@ -401,10 +393,6 @@ def gamma(shape, scale=1.0, size=None):
     Samples are drawn from a Gamma distribution with specified parameters,
     `shape` (sometimes designated "k") and `scale` (sometimes designated
     "theta"), where both parameters are > 0.
-
-    .. note::
-        New code should use the ``gamma`` method of a ``default_rng()``
-        instance instead; please see the :ref:`random-quick-start`.
 
     Parameters
     ----------
@@ -675,7 +663,6 @@ def hypergeometric(ngood, nbad, nsample, size=None):
             checker_throw_value_error("hypergeometric", "nsample", nsample, "ngood + nbad >= nsample")
         if nsample < 1:
             checker_throw_value_error("hypergeometric", "nsample", nsample, ">= 1")
-
 
         m = int(ngood)
         l = int(ngood) + int(nbad)
@@ -1193,11 +1180,13 @@ def randint(low, high=None, size=None, dtype=int):
     dtype : dtype, optional
         Desired dtype of the result. Byteorder must be native.
         The default value is int.
+
     Returns
     -------
     out : array of random ints
         `size`-shaped array of random integers from the appropriate
         distribution, or a single such random int if `size` not provided.
+
     See Also
     --------
     :obj:`dpnp.random.random_integers` : similar to `randint`, only for the closed
@@ -1321,11 +1310,13 @@ def random_integers(low, high=None, size=None):
         Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
         ``m * n * k`` samples are drawn.  Default is None, in which case a
         single value is returned.
+
     Returns
     -------
     out : array of random ints
         `size`-shaped array of random integers from the appropriate
         distribution, or a single such random int if `size` not provided.
+
     See Also
     --------
     :obj:`dpnp.random.randint`
@@ -1470,7 +1461,7 @@ def sample(size):
 
 def seed(seed=None):
     """
-    Reseed a legacy philox4x32x10 random number generator engine
+    Reseed a legacy philox4x32x10 random number generator engine.
 
     Parameters
     ----------
@@ -1642,7 +1633,7 @@ def standard_gamma(shape, size=None):
 
         if shape < 0:
             checker_throw_value_error("standard_gamma", "shape", shape, "non-negative")
-    
+
         return dpnp_standard_gamma(shape, size)
 
     return call_origin(numpy.random.standard_gamma, shape, size)
@@ -1659,7 +1650,7 @@ def standard_normal(size=None):
         Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
         ``m * n * k`` samples are drawn.  Default is None, in which case a
         single value is returned.
- 
+
     Returns
     -------
     out : float or ndarray

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -402,7 +402,7 @@ def test_hypergeometric_check_moments():
 
     size = 10**5
     expected_mean = nsample * (ngood / (ngood + nbad))
-    expected_var = nsample * (ngood / (ngood + nbad)) * (nbad / (ngood + nbad)) * (((ngood + nbad) - nsample) / ((ngood + nbad) - 1))
+    expected_var = expected_mean * (nbad / (ngood + nbad)) * (((ngood + nbad) - nsample) / ((ngood + nbad) - 1))
 
     var = numpy.var(dpnp.random.hypergeometric(ngood=ngood, nbad=nbad, nsample=nsample, size=size))
     mean = numpy.mean(dpnp.random.hypergeometric(ngood=ngood, nbad=nbad, nsample=nsample, size=size))


### PR DESCRIPTION
## Description
style fix (whitespace, PEP8), refactoring docs for random module

Fixed:
* dpnp/random/_random.pyx:314:55: E241 multiple spaces after ','
* dpnp/random/_random.pyx:710:121: E501 line too long (127 > 120 characters)
* dpnp/random/dpnp_iface_random.py:680:9: E303 too many blank lines (2)
* dpnp/random/dpnp_iface_random.py:1645:1: W293 blank line contains whitespace
* dpnp/random/dpnp_iface_random.py:1662:1: W293 blank line contains whitespace
* tests/test_random.py:405:121: E501 line too long (133 > 120 characters)

Corrected:
* function names in docstrings
* docstrings in numpy style 
  * added needed blanklines
  * misc updates