### PR TITLE
ENH: added `random.multivariate_normal`

### DIFF
--- a/dpnp/backend.pxd
+++ b/dpnp/backend.pxd
@@ -104,6 +104,7 @@ cdef extern from "backend/backend_iface_fptr.hpp" namespace "DPNPFuncName":  # n
         DPNP_FN_RNG_LAPLACE
         DPNP_FN_RNG_LOGNORMAL
         DPNP_FN_RNG_MULTINOMIAL
+        DPNP_FN_RNG_MULTIVARIATE_NORMAL
         DPNP_FN_RNG_NEGATIVE_BINOMIAL
         DPNP_FN_RNG_NORMAL
         DPNP_FN_RNG_POISSON

--- a/dpnp/backend/backend_iface.hpp
+++ b/dpnp/backend/backend_iface.hpp
@@ -821,6 +821,21 @@ INP_DLLEXPORT void custom_rng_multinomial_ccustom_rng_multinomial_c(void* result
 
 /**
  * @ingroup BACKEND_API
+ * @brief math library implementation of random number generator (multinomial distribution)
+ * TODO
+ *
+ */
+template <typename _DataType>
+INP_DLLEXPORT void custom_rng_multivariate_normal_c(void* result,
+                                                    const int dimen,
+                                                    const double* mean_vector,
+                                                    const size_t mean_vector_size,
+                                                    const double* cov_vector,
+                                                    const size_t cov_vector_size,
+                                                    size_t size);
+
+/**
+ * @ingroup BACKEND_API
  * @brief math library implementation of random number generator (negative binomial distribution)
  *
  * @param [in]  size   Number of elements in `result` arrays.

--- a/dpnp/backend/backend_iface_fptr.hpp
+++ b/dpnp/backend/backend_iface_fptr.hpp
@@ -133,6 +133,7 @@ enum class DPNPFuncName : size_t
     DPNP_FN_RNG_LAPLACE,              /**< Used in numpy.random.laplace() implementation  */
     DPNP_FN_RNG_LOGNORMAL,            /**< Used in numpy.random.lognormal() implementation  */
     DPNP_FN_RNG_MULTINOMIAL,          /**< Used in numpy.random.multinomial() implementation  */
+    DPNP_FN_RNG_MULTIVARIATE_NORMAL,  /**< Used in numpy.random.multivariate_normal() implementation  */
     DPNP_FN_RNG_NEGATIVE_BINOMIAL,    /**< Used in numpy.random.negative_binomial() implementation  */
     DPNP_FN_RNG_NORMAL,               /**< Used in numpy.random.normal() implementation  */
     DPNP_FN_RNG_POISSON,              /**< Used in numpy.random.poisson() implementation  */

--- a/dpnp/backend/custom_kernels_random.cpp
+++ b/dpnp/backend/custom_kernels_random.cpp
@@ -236,6 +236,34 @@ void custom_rng_multinomial_c(void* result, int ntrial, const double* p_vector, 
 }
 
 template <typename _DataType>
+void custom_rng_multivariate_normal_c(void* result,
+                                      const int dimen,
+                                      const double* mean_vector,
+                                      const size_t mean_vector_size,
+                                      const double* cov_vector,
+                                      const size_t cov_vector_size,
+                                      size_t size)
+{
+    if (!size)
+    {
+        return;
+    }
+    _DataType* result1 = reinterpret_cast<_DataType*>(result);
+
+    std::vector<double> mean(mean_vector, mean_vector + mean_vector_size);
+    std::vector<double> cov(cov_vector, cov_vector + cov_vector_size);
+
+    // `result` is a array for random numbers
+    // `size` is a `result`'s len.
+    // `size1` is a number of random values to be generated for each dimension.
+    mkl_rng::gaussian_mv<_DataType> distribution(dimen, mean, cov);
+    size_t size1 = size / dimen;
+
+    auto event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size1, result1);
+    event_out.wait();
+}
+
+template <typename _DataType>
 void custom_rng_negative_binomial_c(void* result, double a, double p, size_t size)
 {
     if (!size)
@@ -431,6 +459,8 @@ void func_map_init_random(func_map_t& fmap)
     fmap[DPNPFuncName::DPNP_FN_RNG_LOGNORMAL][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_rng_lognormal_c<double>};
 
     fmap[DPNPFuncName::DPNP_FN_RNG_MULTINOMIAL][eft_INT][eft_INT] = {eft_INT, (void*)custom_rng_multinomial_c<int>};
+
+    fmap[DPNPFuncName::DPNP_FN_RNG_MULTIVARIATE_NORMAL][eft_DBL][eft_DBL] = {eft_DBL, (void*)custom_rng_multivariate_normal_c<double>};
 
     fmap[DPNPFuncName::DPNP_FN_RNG_NEGATIVE_BINOMIAL][eft_INT][eft_INT] = {eft_INT, (void*)custom_rng_negative_binomial_c<int>};
 

--- a/dpnp/random/_random.pyx
+++ b/dpnp/random/_random.pyx
@@ -475,7 +475,7 @@ cpdef dparray dpnp_multinomial(int ntrial, p, size):
     return result
 
 
-cpdef dparray dpnp_multivariate_normal(mean, cov, size):
+cpdef dparray dpnp_multivariate_normal(numpy.ndarray mean, numpy.ndarray cov, size):
     """
     Returns an array populated with samples from multivariate normal distribution.
     `multivariate_normal` generates a matrix filled with random floats sampled from a
@@ -495,14 +495,12 @@ cpdef dparray dpnp_multivariate_normal(mean, cov, size):
     cdef DPNPFuncData kernel_data
     cdef fptr_custom_rng_multivariate_normal_c_1out_t func
 
-    mean_ = numpy.asarray(mean, dtype=numpy.float64)
-    cov_ = numpy.asarray(cov, dtype=numpy.float64)
+    # mean and cov expected numpy.ndarray in C order (row major)
+    mean_vector = <double *> numpy.PyArray_DATA(mean)
+    cov_vector = <double *> numpy.PyArray_DATA(cov)
 
-    mean_vector = <double *> numpy.PyArray_DATA(mean_)
-    cov_vector = <double *> numpy.PyArray_DATA(cov_)
-
-    mean_vector_size = mean_.size
-    cov_vector_size = cov_.size
+    mean_vector_size = mean.size
+    cov_vector_size = cov.size
 
     # convert string type names (dparray.dtype) to C enum DPNPFuncType
     param1_type = dpnp_dtype_to_DPNPFuncType(dtype)

--- a/dpnp/random/_random.pyx
+++ b/dpnp/random/_random.pyx
@@ -37,7 +37,6 @@ import dpnp.config as config
 
 from dpnp.backend cimport *
 from dpnp.dparray cimport dparray
-import dpnp.dparray
 from dpnp.dpnp_utils cimport *
 import numpy
 cimport numpy

--- a/dpnp/random/_random.pyx
+++ b/dpnp/random/_random.pyx
@@ -37,6 +37,7 @@ import dpnp.config as config
 
 from dpnp.backend cimport *
 from dpnp.dparray cimport dparray
+import dpnp.dparray
 from dpnp.dpnp_utils cimport *
 import numpy
 cimport numpy
@@ -54,6 +55,7 @@ __all__ = [
     "dpnp_laplace",
     "dpnp_lognormal",
     "dpnp_multinomial",
+    "dpnp_multivariate_normal",
     "dpnp_negative_binomial",
     "dpnp_normal",
     "dpnp_poisson",
@@ -82,6 +84,13 @@ ctypedef void(*fptr_custom_rng_hypergeometric_c_1out_t)(void *, int, int, int, s
 ctypedef void(*fptr_custom_rng_laplace_c_1out_t)(void *, double, double, size_t) except +
 ctypedef void(*fptr_custom_rng_lognormal_c_1out_t)(void *, double, double, size_t) except +
 ctypedef void(*fptr_custom_rng_multinomial_c_1out_t)(void* result, int, const double*, const size_t, size_t) except +
+ctypedef void(*fptr_custom_rng_multivariate_normal_c_1out_t)(void *,
+                                                             const int,
+                                                             const double *,
+                                                             const size_t,
+                                                             const double *,
+                                                             const size_t,
+                                                             size_t) except +
 ctypedef void(*fptr_custom_rng_negative_binomial_c_1out_t)(void *, double, double, size_t) except +
 ctypedef void(*fptr_custom_rng_normal_c_1out_t)(void *, double, double, size_t) except +
 ctypedef void(*fptr_custom_rng_poisson_c_1out_t)(void *, double, size_t) except +
@@ -462,6 +471,54 @@ cpdef dparray dpnp_multinomial(int ntrial, p, size):
         func = <fptr_custom_rng_multinomial_c_1out_t > kernel_data.ptr
         # call FPTR function
         func(result.get_data(), ntrial, p_vector, p_vector_size, result.size)
+
+    return result
+
+
+cpdef dparray dpnp_multivariate_normal(mean, cov, size):
+    """
+    Returns an array populated with samples from multivariate normal distribution.
+    `multivariate_normal` generates a matrix filled with random floats sampled from a
+    multivariate normal distribution.
+
+    """
+
+    dtype = numpy.float64
+    cdef dparray result
+    cdef int dimen
+    cdef double * mean_vector
+    cdef double * cov_vector
+    cdef size_t mean_vector_size
+    cdef size_t cov_vector_size
+
+    cdef DPNPFuncType param1_type
+    cdef DPNPFuncData kernel_data
+    cdef fptr_custom_rng_multivariate_normal_c_1out_t func
+
+    mean_ = numpy.asarray(mean, dtype=numpy.float64)
+    cov_ = numpy.asarray(cov, dtype=numpy.float64)
+
+    mean_vector = <double *> numpy.PyArray_DATA(mean_)
+    cov_vector = <double *> numpy.PyArray_DATA(cov_)
+
+    mean_vector_size = mean_.size
+    cov_vector_size = cov_.size
+
+    # convert string type names (dparray.dtype) to C enum DPNPFuncType
+    param1_type = dpnp_dtype_to_DPNPFuncType(dtype)
+
+    # get the FPTR data structure
+    kernel_data = get_dpnp_function_ptr(DPNP_FN_RNG_MULTIVARIATE_NORMAL, param1_type, param1_type)
+
+    result_type = dpnp_DPNPFuncType_to_dtype( < size_t > kernel_data.return_type)
+    # ceate result array with type given by FPTR data
+    result = dparray(size, dtype=result_type)
+
+    dimen = len(mean)
+
+    func = <fptr_custom_rng_multivariate_normal_c_1out_t > kernel_data.ptr
+    # call FPTR function
+    func(result.get_data(), dimen, mean_vector, mean_vector_size, cov_vector, cov_vector_size, result.size)
 
     return result
 

--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -881,17 +881,119 @@ def multinomial(n, pvals, size=None):
 
 
 def multivariate_normal(mean, cov, size=None, check_valid='warn', tol=1e-8):
-    """Multivariate distributions.
+    """Multivariate normal distributions.
 
     Draw random samples from a multivariate normal distribution.
+
+    The multivariate normal, multinormal or Gaussian distribution is a
+    generalization of the one-dimensional normal distribution to higher
+    dimensions.  Such a distribution is specified by its mean and
+    covariance matrix.  These parameters are analogous to the mean
+    (average or "center") and variance (standard deviation, or "width,"
+    squared) of the one-dimensional normal distribution.
+
+    Parameters
+    ----------
+    mean : 1-D array_like, of length N
+        Mean of the N-dimensional distribution.
+    cov : 2-D array_like, of shape (N, N)
+        Covariance matrix of the distribution. It must be symmetric and
+        positive-semidefinite for proper sampling.
+    size : int or tuple of ints, optional
+        Given a shape of, for example, ``(m,n,k)``, ``m*n*k`` samples are
+        generated, and packed in an `m`-by-`n`-by-`k` arrangement.  Because
+        each sample is `N`-dimensional, the output shape is ``(m,n,k,N)``.
+        If no shape is specified, a single (`N`-D) sample is returned.
+    check_valid : { 'warn', 'raise', 'ignore' }, optional
+        Behavior when the covariance matrix is not positive semidefinite.
+        Currently ignored and not used.
+    tol : float, optional
+        Tolerance when checking the singular values in covariance matrix.
+        cov is cast to double before the check. Currently ignored and not used.
+
+    Returns
+    -------
+    out : dparray
+        The drawn samples, of shape *size*, if that was provided.  If not,
+        the shape is ``(N,)``.
+        In other words, each entry ``out[i,j,...,:]`` is an N-dimensional
+        value drawn from the distribution.
+
+    Notes
+    -----
+    The mean is a coordinate in N-dimensional space, which represents the
+    location where samples are most likely to be generated.  This is
+    analogous to the peak of the bell curve for the one-dimensional or
+    univariate normal distribution.
+
+    Covariance indicates the level to which two variables vary together.
+    From the multivariate normal distribution, we draw N-dimensional
+    samples, :math:`X = [x_1, x_2, ... x_N]`.  The covariance matrix
+    element :math:`C_{ij}` is the covariance of :math:`x_i` and :math:`x_j`.
+    The element :math:`C_{ii}` is the variance of :math:`x_i` (i.e. its
+    "spread").
+
+    Instead of specifying the full covariance matrix, popular
+    approximations include:
+
+      - Spherical covariance (`cov` is a multiple of the identity matrix)
+      - Diagonal covariance (`cov` has non-negative elements, and only on
+        the diagonal)
+
+    This geometrical property can be seen in two dimensions by plotting
+    generated data-points:
+
+    >>> mean = [0, 0]
+    >>> cov = [[1, 0], [0, 100]]  # diagonal covariance
+
+    Diagonal covariance means that points are oriented along x or y-axis:
+
+    >>> import matplotlib.pyplot as plt
+    >>> x, y = np.random.multivariate_normal(mean, cov, 5000).T
+    >>> plt.plot(x, y, 'x')
+    >>> plt.axis('equal')
+    >>> plt.show()
+
+    Note that the covariance matrix must be positive semidefinite (a.k.a.
+    nonnegative-definite). Otherwise, the behavior of this method is
+    undefined and backwards compatibility is not guaranteed.
+
+    References
+    ----------
+    .. [1] Papoulis, A., "Probability, Random Variables, and Stochastic
+           Processes," 3rd ed., New York: McGraw-Hill, 1991.
+    .. [2] Duda, R. O., Hart, P. E., and Stork, D. G., "Pattern
+           Classification," 2nd ed., New York: Wiley, 2001.
+
+    Examples
+    --------
+    >>> mean = (1, 2)
+    >>> cov = [[1, 0], [0, 1]]
+    >>> x = dpnp.random.multivariate_normal(mean, cov, (3, 3))
+    >>> x.shape
+    (3, 3, 2)
 
     """
 
     if not use_origin_backend(mean) and dpnp_queue_is_cpu():
-        size = size + (len(mean),)
-        # TODO
-        # other shapes of size: None and int
-        return dpnp_multivariate_normal(mean, cov, size)
+        mean = numpy.array(mean, dtype=numpy.float64, order='C')
+        cov = numpy.array(cov, dtype=numpy.float64, order='C')
+        if size is None:
+            shape = []
+        elif isinstance(size, (int, numpy.integer)):
+            shape = [size]
+        else:
+            shape = size
+        if len(mean.shape) != 1:
+            raise ValueError("mean must be 1 dimensional")
+        if (len(cov.shape) != 2) or (cov.shape[0] != cov.shape[1]):
+            raise ValueError("cov must be 2 dimensional and square")
+        if mean.shape[0] != cov.shape[0]:
+            raise ValueError("mean and cov must have same length")
+        final_shape = list(shape[:])
+        final_shape.append(mean.shape[0])
+
+        return dpnp_multivariate_normal(mean, cov, final_shape)
 
     return call_origin(numpy.random.multivariate_normal, mean, cov, size, check_valid, tol)
 

--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -57,6 +57,7 @@ __all__ = [
     'laplace',
     'lognormal',
     'multinomial',
+    'multivariate_normal',
     'negative_binomial',
     'normal',
     'poisson',
@@ -877,6 +878,22 @@ def multinomial(n, pvals, size=None):
             return dpnp_multinomial(int(n), pvals, size)
 
     return call_origin(numpy.random.multinomial, n, pvals, size)
+
+
+def multivariate_normal(mean, cov, size=None, check_valid='warn', tol=1e-8):
+    """Multivariate distributions.
+
+    Draw random samples from a multivariate normal distribution.
+
+    """
+
+    if not use_origin_backend(mean) and dpnp_queue_is_cpu():
+        size = size + (len(mean),)
+        # TODO
+        # other shapes of size: None and int
+        return dpnp_multivariate_normal(mean, cov, size)
+
+    return call_origin(numpy.random.multivariate_normal, mean, cov, size, check_valid, tol)
 
 
 def negative_binomial(n, p, size=None):

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -29,6 +29,10 @@ tests/test_random.py::test_multinomial_check_sum
 tests/test_random.py::test_multinomial_invalid_args
 tests/test_random.py::test_multinomial_check_extreme_value
 tests/test_random.py::test_multinomial_check_moments
+tests/test_random.py::test_multivariate_normal_output_shape_check
+tests/test_random.py::test_multivariate_normal_seed
+tests/test_random.py::test_multivariate_normal_invalid_args
+tests/test_random.py::test_multivariate_normal_check_moments
 tests/test_statistics.py::test_median[2-float32]
 tests/test_statistics.py::test_median[2-float64]
 tests/third_party/cupy/binary_tests/test_elementwise.py::TestElementwise::test_bitwise_and

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -596,6 +596,51 @@ def test_multinomial_check_moments():
     assert math.isclose(mean, expected_mean, abs_tol=0.003)
 
 
+def test_multivariate_normal_output_shape_check():
+    seed = 28041990
+    size = 100
+    mean = [2.56, 3.23]
+    cov = [[1, 0], [0, 1]]
+    expected_shape = (100, 2)
+
+    dpnp.random.seed(seed)
+    res = dpnp.random.multivariate_normal(mean, cov, size=100)
+    assert res.shape == expected_shape
+
+
+def test_multivariate_normal_seed():
+    seed = 28041990
+    size = 100
+    mean = [2.56, 3.23]
+    cov = [[1, 0], [0, 1]]
+
+    dpnp.random.seed(seed)
+    a1 = dpnp.random.multivariate_normal(mean, cov, size)
+    dpnp.random.seed(seed)
+    a2 = dpnp.random.multivariate_normal(mean, cov, size)
+    assert_allclose(a1, a2, rtol=1e-07, atol=0)
+
+
+def test_multivariate_normal_invalid_args():
+    size = 10
+
+    mean = [2.56, 3.23]  # OK
+    cov = [[1, 0]]       # `mean` and `cov` must have same length
+    with pytest.raises(ValueError):
+        dpnp.random.multivariate_normal(mean=mean, cov=cov, size=size)
+
+    mean = [[2.56, 3.23]]   # `mean` must be 1 dimensional
+    cov = [[1, 0], [0, 1]]  # OK
+    with pytest.raises(ValueError):
+        dpnp.random.multivariate_normal(mean=mean, cov=cov, size=size)
+
+
+    mean = [2.56, 3.23]  # OK
+    cov = [1, 0, 0, 1]   # `cov` must be 2 dimensional and square
+    with pytest.raises(ValueError):
+        dpnp.random.multivariate_normal(mean=mean, cov=cov, size=size)
+
+
 def test_negative_binomial_seed():
     seed = 28041990
     size = 100

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -634,11 +634,11 @@ def test_multivariate_normal_invalid_args():
     with pytest.raises(ValueError):
         dpnp.random.multivariate_normal(mean=mean, cov=cov, size=size)
 
-
     mean = [2.56, 3.23]  # OK
     cov = [1, 0, 0, 1]   # `cov` must be 2 dimensional and square
     with pytest.raises(ValueError):
         dpnp.random.multivariate_normal(mean=mean, cov=cov, size=size)
+
 
 def test_multivariate_normal_check_moments():
     seed = 2804183

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -640,6 +640,19 @@ def test_multivariate_normal_invalid_args():
     with pytest.raises(ValueError):
         dpnp.random.multivariate_normal(mean=mean, cov=cov, size=size)
 
+def test_multivariate_normal_check_moments():
+    seed = 2804183
+    dpnp.random.seed(seed)
+
+    mean = [2.56, 3.23]
+    cov = [[1, 0], [0, 1]]
+    size = 10**5
+
+    res = numpy.array(dpnp.random.multivariate_normal(mean=mean, cov=cov, size=size))
+    res_mean = [numpy.mean(res.T[0]), numpy.mean(res.T[1])]
+
+    assert_allclose(res_mean, mean, rtol=1e-03, atol=0)
+
 
 def test_negative_binomial_seed():
     seed = 28041990


### PR DESCRIPTION
## Description
multivariate_normal(mean, cov[, size, ...) Draw random samples from a multivariate normal distribution.

## TODO
* fallback to `numpy` (on other PR)
* update docstrings. Currently modified `numpy`'s one + add block limitations (on other PR)

## Reproduce

```python
>>> mean = (109, 234, 123)
>>> cov = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
>>> np.mean(dpnp.random.multivariate_normal(mean, cov, (3**10, 2))); np.mean(np.random.multivariate_normal(mean, cov, (3**10, 2)))
155.3329662598603
155.33495759713927
>>> np.var(dpnp.random.multivariate_normal(mean, cov, (3**10, 2))); np.var(np.random.multivariate_normal(mean, cov, (3**10, 2)))
3127.633479105447
3127.877595801929

```

## Checklist

- [x] Docstrings for all functions
- [ ] Gallery example in ./doc/examples (new features only)
- [x] Unit tests:
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
