### PR TITLE
ENH: random distributions funcs, numpy call, [2/3]

### DIFF
--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -2115,7 +2115,6 @@ def wald(mean, scale, size=None):
     return call_origin(numpy.random.wald, mean, scale, size)
 
 
-
 def weibull(a, size=None):
     """
 

--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -2174,8 +2174,7 @@ def weibull(a, size=None):
 def zipf(a, size=None, dtype=int):
     """Zipf distribution.
 
-    Returns an array of samples drawn from the Zipf distribution. Its
-    probability mass function is defined as
+    Returns an array of samples drawn from the Zipf distribution.
 
     For full documentation refer to :obj:`numpy.random.zipf`.
 

--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -66,8 +66,11 @@ __all__ = [
     'negative_binomial',
     'normal',
     'noncentral_chisquare',
+    'noncentral_f',
+    'pareto',
     'permutation',
     'poisson',
+    'power',
     'rand',
     'randint',
     'randn',
@@ -82,6 +85,7 @@ __all__ = [
     'standard_exponential',
     'standard_gamma',
     'standard_normal',
+    'standard_t',
     'shuffle',
     'uniform',
     'weibull'
@@ -1181,23 +1185,6 @@ def negative_binomial(n, p, size=None):
     return call_origin(numpy.random.negative_binomial, n, p, size)
 
 
-def noncentral_chisquare(df, nonc, size=None):
-    """Noncentral chi-square distribution.
-
-    Draw samples from a noncentral chi-square distribution.
-
-    For full documentation refer to :obj:`numpy.random.noncentral_chisquare`.
-
-    Notes
-    -----
-    The function uses `numpy.random.noncentral_chisquare` on the backend and
-    will be executed on fallback backend.
-
-    """
-
-    return call_origin(numpy.random.noncentral_chisquare, df, nonc, size)
-
-
 def normal(loc=0.0, scale=1.0, size=None):
     """Normal distribution.
 
@@ -1281,6 +1268,57 @@ def normal(loc=0.0, scale=1.0, size=None):
         return dpnp_normal(loc, scale, size)
 
     return call_origin(numpy.random.normal, loc, scale, size)
+
+
+def noncentral_chisquare(df, nonc, size=None):
+    """Noncentral chi-square distribution.
+
+    Draw samples from a noncentral chi-square distribution.
+
+    For full documentation refer to :obj:`numpy.random.noncentral_chisquare`.
+
+    Notes
+    -----
+    The function uses `numpy.random.noncentral_chisquare` on the backend and
+    will be executed on fallback backend.
+
+    """
+
+    return call_origin(numpy.random.noncentral_chisquare, df, nonc, size)
+
+
+def noncentral_f(dfnum, dfden, nonc, size=None):
+    """Noncentral F distribution.
+
+    Draw samples from the noncentral F distribution.
+
+    For full documentation refer to :obj:`numpy.random.noncentral_f`.
+
+    Notes
+    -----
+    The function uses `numpy.random.noncentral_f` on the backend and
+    will be executed on fallback backend.
+
+    """
+
+    return call_origin(numpy.random.noncentral_f, dfnum, dfden, nonc, size)
+
+
+def pareto(a, size=None):
+    """Pareto II or Lomax distribution.
+
+    Draw samples from a Pareto II or Lomax distribution with specified shape.
+
+    For full documentation refer to :obj:`numpy.random.pareto`.
+
+    Notes
+    -----
+    The function uses `numpy.random.pareto` on the backend and
+    will be executed on fallback backend.
+
+    """
+
+    return call_origin(numpy.random.pareto, a, size)
 
 
 def permutation(x):
@@ -1367,6 +1405,24 @@ def poisson(lam=1.0, size=None):
         return dpnp_poisson(lam, size)
 
     return call_origin(numpy.random.poisson, lam, size)
+
+
+def power(a, size=None):
+    """Power distribution.
+
+    Draws samples in [0, 1] from a power distribution with positive exponent
+    a - 1.
+
+    For full documentation refer to :obj:`numpy.random.power`.
+
+    Notes
+    -----
+    The function uses `numpy.random.power` on the backend and
+    will be executed on fallback backend.
+
+    """
+
+    return call_origin(numpy.random.power, a, size)
 
 
 def rand(d0, *dn):
@@ -1916,6 +1972,24 @@ def standard_normal(size=None):
         return dpnp_standard_normal(size)
 
     return call_origin(numpy.random.standard_normal, size)
+
+
+def standard_t(df, size=None):
+    """Power distribution.
+
+    Draw samples from a standard Student’s t distribution with df degrees
+    of freedom.
+
+    For full documentation refer to :obj:`numpy.random.standard_t`.
+
+    Notes
+    -----
+    The function uses `numpy.random.standard_t` on the backend and
+    will be executed on fallback backend.
+
+    """
+
+    return call_origin(numpy.random.standard_t, df, size)
 
 
 def shuffle(x):

--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -80,15 +80,19 @@ __all__ = [
     'ranf',
     'rayleigh',
     'sample',
+    'shuffle',
     'seed',
     'standard_cauchy',
     'standard_exponential',
     'standard_gamma',
     'standard_normal',
     'standard_t',
-    'shuffle',
+    'triangular',
     'uniform',
-    'weibull'
+    'vonmises',
+    'wald',
+    'weibull',
+    'zipf'
 ]
 
 
@@ -1759,6 +1763,22 @@ def sample(size):
     return call_origin(numpy.random.sample, size)
 
 
+def shuffle(x):
+    """
+    Modify a sequence in-place by shuffling its contents.
+
+    For full documentation refer to :obj:`numpy.random.shuffle`.
+
+    Notes
+    -----
+    The function uses `numpy.random.shuffle` on the backend and will be
+    executed on fallback backend.
+
+    """
+
+    return call_origin(numpy.random.shuffle, x)
+
+
 def seed(seed=None):
     """
     Reseed a legacy philox4x32x10 random number generator engine.
@@ -1992,20 +2012,22 @@ def standard_t(df, size=None):
     return call_origin(numpy.random.standard_t, df, size)
 
 
-def shuffle(x):
-    """
-    Modify a sequence in-place by shuffling its contents.
+def triangular(left, mode, right, size=None):
+    """Triangular distribution.
 
-    For full documentation refer to :obj:`numpy.random.shuffle`.
+    Draw samples from the triangular distribution over the interval
+    [left, right].
+
+    For full documentation refer to :obj:`numpy.random.triangular`.
 
     Notes
     -----
-    The function uses `numpy.random.shuffle` on the backend and will be
-    executed on fallback backend.
+    The function uses `numpy.random.triangular` on the backend and
+    will be executed on fallback backend.
 
     """
 
-    return call_origin(numpy.random.shuffle, x)
+    return call_origin(numpy.random.triangular, left, mode, right, size)
 
 
 def uniform(low=0.0, high=1.0, size=None):
@@ -2057,6 +2079,41 @@ def uniform(low=0.0, high=1.0, size=None):
         return dpnp_uniform(low, high, size, dtype=numpy.float64)
 
     return call_origin(numpy.random.uniform, low, high, size)
+
+
+def vonmises(mu, kappa, size=None):
+    """von Mises distribution.
+
+    Draw samples from a von Mises distribution.
+
+    For full documentation refer to :obj:`numpy.random.vonmises`.
+
+    Notes
+    -----
+    The function uses `numpy.random.vonmises` on the backend and
+    will be executed on fallback backend.
+
+    """
+
+    return call_origin(numpy.random.vonmises, mu, kappa, size)
+
+
+def wald(mean, scale, size=None):
+    """Wald distribution.
+
+    Draw samples from a Wald, or inverse Gaussian, distribution.
+
+    For full documentation refer to :obj:`numpy.random.wald`.
+
+    Notes
+    -----
+    The function uses `numpy.random.wald` on the backend and
+    will be executed on fallback backend.
+
+    """
+
+    return call_origin(numpy.random.wald, mean, scale, size)
+
 
 
 def weibull(a, size=None):
@@ -2112,3 +2169,21 @@ def weibull(a, size=None):
         return dpnp_weibull(a, size)
 
     return call_origin(numpy.random.weibull, a, size)
+
+
+def zipf(a, size=None, dtype=int):
+    """Zipf distribution.
+
+    Returns an array of samples drawn from the Zipf distribution. Its
+    probability mass function is defined as
+
+    For full documentation refer to :obj:`numpy.random.zipf`.
+
+    Notes
+    -----
+    The function uses `numpy.random.zipf` on the backend and
+    will be executed on fallback backend.
+
+    """
+
+    return call_origin(numpy.random.zipf, a, size, dtype)


### PR DESCRIPTION
## Description
* noncentral_f(dfnum, dfden, nonc[, size]) Draw samples from the noncentral F distribution.
* pareto(a[, size]) Draw samples from a Pareto II or Lomax distribution with specified shape.
* power(a[, size]) Draws samples in [0, 1] from a power distribution with positive exponent a - 1.
* standard_t(df[, size]) Draw samples from a standard Student’s t distribution with df degrees of freedom.
* triangular(left, mode, right[, size]) Draw samples from the triangular distribution over the interval [left, right].
* vonmises(mu, kappa[, size]) Draw samples from a von Mises distribution.
* wald(mean, scale[, size]) Draw samples from a Wald, or inverse Gaussian, distribution.
* zipf(a[, size]) Draw samples from a Zipf distribution.

## Note:
* functions uses `numpy` on the backend