### PR TITLE
TEST: enabled some third_party/cupy tests for `random` module

### DIFF
--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -1912,8 +1912,6 @@ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsWeib
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsWeibull_param_3_{a_shape=(3, 2), shape=(3, 2)}::test_weibull_for_negative_a
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsZipf_param_0_{a_shape=(), shape=(4, 3, 2)}::test_zipf
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsZipf_param_1_{a_shape=(), shape=(3, 2)}::test_zipf
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsZipf_param_2_{a_shape=(3, 2), shape=(4, 3, 2)}::test_zipf
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsZipf_param_3_{a_shape=(3, 2), shape=(3, 2)}::test_zipf
 tests/third_party/cupy/random_tests/test_sample.py::TestChoice::test_no_none
 tests/third_party/cupy/random_tests/test_sample.py::TestChoice::test_p_is_none
 tests/third_party/cupy/random_tests/test_sample.py::TestChoice::test_replace_and_p_are_none

--- a/tests/third_party/cupy/random_tests/test_distributions.py
+++ b/tests/third_party/cupy/random_tests/test_distributions.py
@@ -16,13 +16,12 @@ _int_dtypes = _signed_dtypes + _unsigned_dtypes
 
 
 class RandomDistributionsTestCase(unittest.TestCase):
-    def check_distribution(self, dist_name, params, dtype):
+    def check_distribution(self, dist_name, params):
         cp_params = {k: cupy.asarray(params[k]) for k in params}
         np_out = numpy.asarray(
-            getattr(numpy.random, dist_name)(size=self.shape, **params),
-            dtype)
+            getattr(numpy.random, dist_name)(size=self.shape, **params))
         cp_out = getattr(_distributions, dist_name)(
-            size=self.shape, dtype=dtype, **cp_params)
+            size=self.shape, **cp_params)
         self.assertEqual(cp_out.shape, np_out.shape)
         self.assertEqual(cp_out.dtype, np_out.dtype)
 
@@ -795,4 +794,4 @@ class TestDistributionsZipf(RandomDistributionsTestCase):
     @helper.for_float_dtypes('a_dtype')
     def test_zipf(self, a_dtype, dtype):
         a = numpy.full(self.a_shape, 2, dtype=a_dtype)
-        self.check_distribution('zipf', {'a': a}, dtype)
+        self.check_distribution('zipf', {'a': a})

--- a/tests/third_party/cupy/random_tests/test_distributions.py
+++ b/tests/third_party/cupy/random_tests/test_distributions.py
@@ -18,10 +18,9 @@ _int_dtypes = _signed_dtypes + _unsigned_dtypes
 class RandomDistributionsTestCase(unittest.TestCase):
     def check_distribution(self, dist_name, params):
         cp_params = {k: cupy.asarray(params[k]) for k in params}
-        np_out = numpy.asarray(
-            getattr(numpy.random, dist_name)(size=self.shape, **params))
-        cp_out = getattr(_distributions, dist_name)(
-            size=self.shape, **cp_params)
+        np_out = numpy.asarray(getattr(numpy.random, dist_name)(size=self.shape, **params))
+        cp_out = getattr(_distributions, dist_name)(size=self.shape, **cp_params)
+
         self.assertEqual(cp_out.shape, np_out.shape)
         self.assertEqual(cp_out.dtype, np_out.dtype)
 


### PR DESCRIPTION
## Description:
waiting merge #332 (CI will be green after)
* fixed tests for random.zipf
* enabled:
  - tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsZipf_param_2_{a_shape=(3, 2), shape=(4, 3, 2)}::test_zipf
  - tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsZipf_param_3_{a_shape=(3, 2), shape=(3, 2)}::test_zipf

## TODO:
- tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsZipf_param_0_{a_shape=(), shape=(4, 3, 2)}::test_zipf
- tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsZipf_param_1_{a_shape=(), shape=(3, 2)}::test_zipf
