### PR TITLE
TEST: enabled third_party cupy tests for distributions check

### DIFF
--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -954,8 +954,6 @@ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChis
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_1_{df_shape=(), shape=(3, 2)}::test_chisquare
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_2_{df_shape=(3, 2), shape=(4, 3, 2)}::test_chisquare
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_3_{df_shape=(3, 2), shape=(3, 2)}::test_chisquare
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsDirichlet_param_0_{alpha_shape=(3,), shape=(4, 3, 2, 3)}::test_dirichlet
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsDirichlet_param_1_{alpha_shape=(3,), shape=(3, 2, 3)}::test_dirichlet
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponentialError::test_negative_scale
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponential_param_0_{scale_shape=(), shape=(4, 3, 2)}::test_exponential
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponential_param_1_{scale_shape=(), shape=(3, 2)}::test_exponential

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -926,34 +926,18 @@ tests/third_party/cupy/manipulation_tests/test_dims.py::TestInvalidBroadcast_par
 tests/third_party/cupy/manipulation_tests/test_dims.py::TestInvalidBroadcast_param_2_{shapes=[(3, 2), (3, 4)]}::test_invalid_broadcast_arrays
 tests/third_party/cupy/manipulation_tests/test_dims.py::TestInvalidBroadcast_param_3_{shapes=[(0,), (2,)]}::test_invalid_broadcast
 tests/third_party/cupy/manipulation_tests/test_dims.py::TestInvalidBroadcast_param_3_{shapes=[(0,), (2,)]}::test_invalid_broadcast_arrays
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_0_{a_shape=(), b_shape=(), dtype=float64, shape=(4, 3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_10_{a_shape=(), b_shape=(3, 2), dtype=float16, shape=(4, 3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_11_{a_shape=(), b_shape=(3, 2), dtype=float16, shape=(3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_12_{a_shape=(3, 2), b_shape=(), dtype=float64, shape=(4, 3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_13_{a_shape=(3, 2), b_shape=(), dtype=float64, shape=(3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_14_{a_shape=(3, 2), b_shape=(), dtype=float32, shape=(4, 3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_15_{a_shape=(3, 2), b_shape=(), dtype=float32, shape=(3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_16_{a_shape=(3, 2), b_shape=(), dtype=float16, shape=(4, 3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_17_{a_shape=(3, 2), b_shape=(), dtype=float16, shape=(3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_18_{a_shape=(3, 2), b_shape=(3, 2), dtype=float64, shape=(4, 3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_19_{a_shape=(3, 2), b_shape=(3, 2), dtype=float64, shape=(3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_1_{a_shape=(), b_shape=(), dtype=float64, shape=(3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_20_{a_shape=(3, 2), b_shape=(3, 2), dtype=float32, shape=(4, 3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_21_{a_shape=(3, 2), b_shape=(3, 2), dtype=float32, shape=(3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_22_{a_shape=(3, 2), b_shape=(3, 2), dtype=float16, shape=(4, 3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_23_{a_shape=(3, 2), b_shape=(3, 2), dtype=float16, shape=(3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_2_{a_shape=(), b_shape=(), dtype=float32, shape=(4, 3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_3_{a_shape=(), b_shape=(), dtype=float32, shape=(3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_4_{a_shape=(), b_shape=(), dtype=float16, shape=(4, 3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_5_{a_shape=(), b_shape=(), dtype=float16, shape=(3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_6_{a_shape=(), b_shape=(3, 2), dtype=float64, shape=(4, 3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_7_{a_shape=(), b_shape=(3, 2), dtype=float64, shape=(3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_8_{a_shape=(), b_shape=(3, 2), dtype=float32, shape=(4, 3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_9_{a_shape=(), b_shape=(3, 2), dtype=float32, shape=(3, 2)}::test_beta
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_0_{a_shape=(), b_shape=(), shape=(4, 3, 2)}::test_beta
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_1_{a_shape=(), b_shape=(), shape=(3, 2)}::test_beta
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_2_{a_shape=(), b_shape=(3, 2), shape=(4, 3, 2)}::test_beta
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_3_{a_shape=(), b_shape=(3, 2), shape=(3, 2)}::test_beta
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_4_{a_shape=(3, 2), b_shape=(), shape=(4, 3, 2)}::test_beta
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_5_{a_shape=(3, 2), b_shape=(), shape=(3, 2)}::test_beta
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_0_{df_shape=(), shape=(4, 3, 2)}::test_chisquare
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_1_{df_shape=(), shape=(3, 2)}::test_chisquare
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_2_{df_shape=(3, 2), shape=(4, 3, 2)}::test_chisquare
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_3_{df_shape=(3, 2), shape=(3, 2)}::test_chisquare
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsDirichlet_param_0_{alpha_shape=(3,), shape=(4, 3, 2, 3)}::test_dirichlet
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsDirichlet_param_1_{alpha_shape=(3,), shape=(3, 2, 3)}::test_dirichlet
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponentialError::test_negative_scale
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponential_param_0_{scale_shape=(), shape=(4, 3, 2)}::test_exponential
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponential_param_1_{scale_shape=(), shape=(3, 2)}::test_exponential

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -1171,34 +1171,18 @@ tests/third_party/cupy/math_tests/test_trigonometric.py::TestUnwrap::test_unwrap
 tests/third_party/cupy/math_tests/test_trigonometric.py::TestUnwrap::test_unwrap_2dim_with_axis
 tests/third_party/cupy/math_tests/test_trigonometric.py::TestUnwrap::test_unwrap_2dim_with_discont
 tests/third_party/cupy/math_tests/test_trigonometric.py::TestUnwrap::test_unwrap_2dim_without_axis
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_0_{a_shape=(), b_shape=(), dtype=float64, shape=(4, 3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_10_{a_shape=(), b_shape=(3, 2), dtype=float16, shape=(4, 3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_11_{a_shape=(), b_shape=(3, 2), dtype=float16, shape=(3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_12_{a_shape=(3, 2), b_shape=(), dtype=float64, shape=(4, 3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_13_{a_shape=(3, 2), b_shape=(), dtype=float64, shape=(3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_14_{a_shape=(3, 2), b_shape=(), dtype=float32, shape=(4, 3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_15_{a_shape=(3, 2), b_shape=(), dtype=float32, shape=(3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_16_{a_shape=(3, 2), b_shape=(), dtype=float16, shape=(4, 3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_17_{a_shape=(3, 2), b_shape=(), dtype=float16, shape=(3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_18_{a_shape=(3, 2), b_shape=(3, 2), dtype=float64, shape=(4, 3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_19_{a_shape=(3, 2), b_shape=(3, 2), dtype=float64, shape=(3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_1_{a_shape=(), b_shape=(), dtype=float64, shape=(3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_20_{a_shape=(3, 2), b_shape=(3, 2), dtype=float32, shape=(4, 3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_21_{a_shape=(3, 2), b_shape=(3, 2), dtype=float32, shape=(3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_22_{a_shape=(3, 2), b_shape=(3, 2), dtype=float16, shape=(4, 3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_23_{a_shape=(3, 2), b_shape=(3, 2), dtype=float16, shape=(3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_2_{a_shape=(), b_shape=(), dtype=float32, shape=(4, 3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_3_{a_shape=(), b_shape=(), dtype=float32, shape=(3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_4_{a_shape=(), b_shape=(), dtype=float16, shape=(4, 3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_5_{a_shape=(), b_shape=(), dtype=float16, shape=(3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_6_{a_shape=(), b_shape=(3, 2), dtype=float64, shape=(4, 3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_7_{a_shape=(), b_shape=(3, 2), dtype=float64, shape=(3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_8_{a_shape=(), b_shape=(3, 2), dtype=float32, shape=(4, 3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_9_{a_shape=(), b_shape=(3, 2), dtype=float32, shape=(3, 2)}::test_beta
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_0_{a_shape=(), b_shape=(), shape=(4, 3, 2)}::test_beta
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_1_{a_shape=(), b_shape=(), shape=(3, 2)}::test_beta
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_2_{a_shape=(), b_shape=(3, 2), shape=(4, 3, 2)}::test_beta
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_3_{a_shape=(), b_shape=(3, 2), shape=(3, 2)}::test_beta
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_4_{a_shape=(3, 2), b_shape=(), shape=(4, 3, 2)}::test_beta
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_5_{a_shape=(3, 2), b_shape=(), shape=(3, 2)}::test_beta
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_0_{df_shape=(), shape=(4, 3, 2)}::test_chisquare
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_1_{df_shape=(), shape=(3, 2)}::test_chisquare
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_2_{df_shape=(3, 2), shape=(4, 3, 2)}::test_chisquare
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_3_{df_shape=(3, 2), shape=(3, 2)}::test_chisquare
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsDirichlet_param_0_{alpha_shape=(3,), shape=(4, 3, 2, 3)}::test_dirichlet
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsDirichlet_param_1_{alpha_shape=(3,), shape=(3, 2, 3)}::test_dirichlet
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponentialError::test_negative_scale
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponential_param_0_{scale_shape=(), shape=(4, 3, 2)}::test_exponential
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponential_param_1_{scale_shape=(), shape=(3, 2)}::test_exponential

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -1199,8 +1199,6 @@ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChis
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_1_{df_shape=(), shape=(3, 2)}::test_chisquare
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_2_{df_shape=(3, 2), shape=(4, 3, 2)}::test_chisquare
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_3_{df_shape=(3, 2), shape=(3, 2)}::test_chisquare
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsDirichlet_param_0_{alpha_shape=(3,), shape=(4, 3, 2, 3)}::test_dirichlet
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsDirichlet_param_1_{alpha_shape=(3,), shape=(3, 2, 3)}::test_dirichlet
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponentialError::test_negative_scale
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponential_param_0_{scale_shape=(), shape=(4, 3, 2)}::test_exponential
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponential_param_1_{scale_shape=(), shape=(3, 2)}::test_exponential

--- a/tests/third_party/cupy/random_tests/test_distributions.py
+++ b/tests/third_party/cupy/random_tests/test_distributions.py
@@ -94,11 +94,10 @@ class TestDistributionsChisquare(unittest.TestCase):
 class TestDistributionsDirichlet(RandomDistributionsTestCase):
 
     @helper.for_dtypes_combination(
-        _float_dtypes, names=['alpha_dtype', 'dtype'])
-    def test_dirichlet(self, alpha_dtype, dtype):
+        _regular_float_dtypes, names=['alpha_dtype'])
+    def test_dirichlet(self, alpha_dtype):
         alpha = numpy.ones(self.alpha_shape, dtype=alpha_dtype)
-        self.check_distribution('dirichlet',
-                                {'alpha': alpha}, dtype)
+        self.check_distribution('dirichlet', {'alpha': alpha})
 
 
 @testing.parameterize(*testing.product({

--- a/tests/third_party/cupy/random_tests/test_distributions.py
+++ b/tests/third_party/cupy/random_tests/test_distributions.py
@@ -29,19 +29,17 @@ class RandomDistributionsTestCase(unittest.TestCase):
     'shape': [(4, 3, 2), (3, 2)],
     'a_shape': [(), (3, 2)],
     'b_shape': [(), (3, 2)],
-    'dtype': _float_dtypes,  # to escape timeout
 })
 )
 @testing.gpu
 class TestDistributionsBeta(RandomDistributionsTestCase):
 
     @helper.for_dtypes_combination(
-        _float_dtypes, names=['a_dtype', 'b_dtype'])
+        _regular_float_dtypes, names=['a_dtype', 'b_dtype'])
     def test_beta(self, a_dtype, b_dtype):
         a = numpy.full(self.a_shape, 3, dtype=a_dtype)
         b = numpy.full(self.b_shape, 3, dtype=b_dtype)
-        self.check_distribution('beta',
-                                {'a': a, 'b': b}, self.dtype)
+        self.check_distribution('beta', {'a': a, 'b': b})
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
## Description:

* fixed tests for `dirichlet`, `beta` distributions

* removed 20 test cases form list

##  TODO
1) 
+ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_0_{a_shape=(), b_shape=(), shape=(4, 3, 2)}::test_beta
+ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_1_{a_shape=(), b_shape=(), shape=(3, 2)}::test_beta
+ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_2_{a_shape=(), b_shape=(3, 2), shape=(4, 3, 2)}::test_beta
+ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_3_{a_shape=(), b_shape=(3, 2), shape=(3, 2)}::test_beta
+ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_4_{a_shape=(3, 2), b_shape=(), shape=(4, 3, 2)}::test_beta
+ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_5_{a_shape=(3, 2), b_shape=(), shape=(3, 2)}::test_beta

the same comment as is on #342 

2) fails when calls dpnp on backend (CPU):
+ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_0_{df_shape=(), shape=(4, 3, 2)}::test_chisquare
+ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_1_{df_shape=(), shape=(3, 2)}::test_chisquare
+ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_2_{df_shape=(3, 2), shape=(4, 3, 2)}::test_chisquare
+ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_3_{df_shape=(3, 2), shape=(3, 2)}::test_chisquare

