### PR TITLE
TEST: enabled third_party cupy tests for distributions check 2

### DIFF
--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -1505,10 +1505,6 @@ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_3_{a_shape=(), b_shape=(3, 2), shape=(3, 2)}::test_beta
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_4_{a_shape=(3, 2), b_shape=(), shape=(4, 3, 2)}::test_beta
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_5_{a_shape=(3, 2), b_shape=(), shape=(3, 2)}::test_beta
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_0_{df_shape=(), shape=(4, 3, 2)}::test_chisquare
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_1_{df_shape=(), shape=(3, 2)}::test_chisquare
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_2_{df_shape=(3, 2), shape=(4, 3, 2)}::test_chisquare
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_3_{df_shape=(3, 2), shape=(3, 2)}::test_chisquare
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsDirichlet_param_0_{alpha_shape=(3,), shape=(4, 3, 2, 3)}::test_dirichlet
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsDirichlet_param_1_{alpha_shape=(3,), shape=(3, 2, 3)}::test_dirichlet
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponentialError::test_negative_scale

--- a/tests/third_party/cupy/random_tests/test_distributions.py
+++ b/tests/third_party/cupy/random_tests/test_distributions.py
@@ -71,16 +71,16 @@ class TestDistributionsBinomial(RandomDistributionsTestCase):
 @testing.gpu
 class TestDistributionsChisquare(unittest.TestCase):
 
-    def check_distribution(self, dist_func, df_dtype, dtype):
+    def check_distribution(self, dist_func, df_dtype):
         df = cupy.full(self.df_shape, 5, dtype=df_dtype)
-        out = dist_func(df, self.shape, dtype)
+        out = dist_func(df, self.shape)
         self.assertEqual(self.shape, out.shape)
-        self.assertEqual(out.dtype, dtype)
+        # numpy and dpdp output dtype is float64
+        self.assertEqual(out.dtype, numpy.float64)
 
     @helper.for_float_dtypes('df_dtype')
-    @helper.for_float_dtypes('dtype')
-    def test_chisquare(self, df_dtype, dtype):
-        self.check_distribution(_distributions.chisquare, df_dtype, dtype)
+    def test_chisquare(self, df_dtype):
+        self.check_distribution(_distributions.chisquare, df_dtype)
 
 
 @testing.parameterize(*testing.product({

--- a/utils/dpnp_build_utils.py
+++ b/utils/dpnp_build_utils.py
@@ -219,9 +219,8 @@ def _find_mathlib_in_mathlib_root(verbose=False):
     rel_include_path = os.path.join("latest", "include") 
     rel_libdir_path = os.path.join("latest", "lib", "intel64")
 
-#    return find_library("MKLROOT", rel_header_paths, rel_lib_paths, rel_include_path=rel_include_path,
-#                        rel_libdir_path=rel_libdir_path, verbose=verbose)
-    return (["/opt/intel/oneapi/mkl/latest/include"], ["/opt/intel/oneapi/mkl/latest/lib/intel64"])
+    return find_library("MKLROOT", rel_header_paths, rel_lib_paths, rel_include_path=rel_include_path,
+                        rel_libdir_path=rel_libdir_path, verbose=verbose)
 
 
 def find_mathlib(verbose=False):

--- a/utils/dpnp_build_utils.py
+++ b/utils/dpnp_build_utils.py
@@ -219,8 +219,9 @@ def _find_mathlib_in_mathlib_root(verbose=False):
     rel_include_path = os.path.join("latest", "include") 
     rel_libdir_path = os.path.join("latest", "lib", "intel64")
 
-    return find_library("MKLROOT", rel_header_paths, rel_lib_paths, rel_include_path=rel_include_path,
-                        rel_libdir_path=rel_libdir_path, verbose=verbose)
+#    return find_library("MKLROOT", rel_header_paths, rel_lib_paths, rel_include_path=rel_include_path,
+#                        rel_libdir_path=rel_libdir_path, verbose=verbose)
+    return (["/opt/intel/oneapi/mkl/latest/include"], ["/opt/intel/oneapi/mkl/latest/lib/intel64"])
 
 
 def find_mathlib(verbose=False):


### PR DESCRIPTION
## Description:

* fixed tests for `chisquare` distributions

* removed 4 test cases from skipp list

##  TODO

1) fails when calls dpnp on backend (CPU):
+ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_0_{df_shape=(), shape=(4, 3, 2)}::test_chisquare
+ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_1_{df_shape=(), shape=(3, 2)}::test_chisquare
+ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_2_{df_shape=(3, 2), shape=(4, 3, 2)}::test_chisquare
+ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_3_{df_shape=(3, 2), shape=(3, 2)}::test_chisquare

