### PR TITLE
FIX: `random.binomial` fallback

### DIFF
--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -169,8 +169,7 @@ def binomial(n, p, size=None):
     -----------
     Output array data type is :obj:`dpnp.int32`.
     Parameters ``n`` and ``p`` are supported as scalar.
-    Otherwise the function will use :obj:`numpy.random.binomial` on the
-    backend and will be executed on fallback backend.
+    Otherwise, :obj:`numpy.random.binomial(n, p, size)` samples are drawn.
 
     Examples
     --------

--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -169,7 +169,6 @@ def binomial(n, p, size=None):
     -----------
     Output array data type is :obj:`dpnp.int32`.
     Parameters ``n`` and ``p`` are supported as scalar.
-    Parameter ``size`` is supported as a ``tuple`` of ``ints`` or ``int``.
     Otherwise the function will use :obj:`numpy.random.binomial` on the
     backend and will be executed on fallback backend.
 
@@ -190,18 +189,12 @@ def binomial(n, p, size=None):
     """
 
     if not use_origin_backend(n) and dpnp_queue_is_cpu():
-        if isinstance(size, tuple):
-            for dim in size:
-                if not isinstance(dim, int):
-                    pass
-        elif not isinstance(size, int):
-            pass
-        elif not dpnp.isscalar(n):
+        # TODO:
+        # array_like of floats for `p` param
+        if not dpnp.isscalar(n):
             pass
         elif not dpnp.isscalar(p):
             pass
-        # TODO:
-        # array_like of floats for `p` param
         elif p > 1 or p < 0:
             pass
         elif n < 0:

--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -163,60 +163,15 @@ def binomial(n, p, size=None):
 
     Draw samples from a binomial distribution.
 
-    Samples are drawn from a binomial distribution with specified
-    parameters, n trials and p probability of success where
-    n an integer >= 0 and p is in the interval [0,1]. (n may be
-    input as a float, but it is truncated to an integer in use)
+    For full documentation refer to :obj:`numpy.random.binomial`.
 
-    Parameters
-    ----------
-    n : int
-        Parameter of the distribution, >= 0. Floats are also accepted,
-        but they will be truncated to integers.
-    p : float
-        Parameter of the distribution, >= 0 and <=1.
-    size : int or tuple of ints, optional
-        Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-        ``m * n * k`` samples are drawn.  If size is ``None`` (default),
-        a single value is returned if ``n`` and ``p`` are both scalars.
-        Otherwise, ``np.broadcast(n, p).size`` samples are drawn.
-
-    Returns
-    -------
-    out : dparray, int32
-        Drawn samples from the parameterized binomial distribution, where
-        each sample is equal to the number of successes over the n trials.
-
-    Notes
-    -----
-    The probability density for the binomial distribution is
-
-    .. math:: P(N) = \\binom{n}{N}p^N(1-p)^{n-N},
-
-    where :math:`n` is the number of trials, :math:`p` is the probability
-    of success, and :math:`N` is the number of successes.
-
-    When estimating the standard error of a proportion in a population by
-    using a random sample, the normal distribution works well unless the
-    product p*n <=5, where p = population proportion estimate, and n =
-    number of samples, in which case the binomial distribution is used
-    instead. For example, a sample of 15 people shows 4 who are left
-    handed, and 11 who are right handed. Then p = 4/15 = 27%. 0.27*15 = 4,
-    so the binomial distribution should be used in this case.
-
-    References
-    ----------
-    .. [1] Dalgaard, Peter, "Introductory Statistics with R",
-           Springer-Verlag, 2002.
-    .. [2] Glantz, Stanton A. "Primer of Biostatistics.", McGraw-Hill,
-           Fifth Edition, 2002.
-    .. [3] Lentner, Marvin, "Elementary Applied Statistics", Bogden
-           and Quigley, 1972.
-    .. [4] Weisstein, Eric W. "Binomial Distribution." From MathWorld--A
-           Wolfram Web Resource.
-           http://mathworld.wolfram.com/BinomialDistribution.html
-    .. [5] Wikipedia, "Binomial distribution",
-           https://en.wikipedia.org/wiki/Binomial_distribution
+    Limitations
+    -----------
+    Output array data type is :obj:`dpnp.int32`.
+    Parameters ``n`` and ``p`` are supported as scalar.
+    Parameter ``size`` is supported as a ``tuple`` of ``ints`` or ``int``.
+    Otherwise the functions will use :obj:`numpy.random.binomial` on the
+    backend and will be executed on fallback backend.
 
     Examples
     --------
@@ -235,23 +190,26 @@ def binomial(n, p, size=None):
     """
 
     if not use_origin_backend(n) and dpnp_queue_is_cpu():
-        if size is None:
-            size = 1
-        elif isinstance(size, tuple):
+        if isinstance(size, tuple):
             for dim in size:
                 if not isinstance(dim, int):
-                    checker_throw_value_error("binomial", "type(dim)", type(dim), int)
+                    pass
         elif not isinstance(size, int):
-            checker_throw_value_error("binomial", "type(size)", type(size), int)
-
+            pass
+        elif not dpnp.isscalar(n):
+            pass
+        elif not dpnp.isscalar(p):
+            pass
         # TODO:
         # array_like of floats for `p` param
-        if p > 1 or p < 0:
-            checker_throw_value_error("binomial", "p", p, "in [0, 1]")
-        if n < 0:
-            checker_throw_value_error("binomial", "n", n, "non-negative")
-
-        return dpnp_binomial(int(n), p, size)
+        elif p > 1 or p < 0:
+            pass
+        elif n < 0:
+            pass
+        else:
+            if size is None:
+                size = 1
+            return dpnp_binomial(int(n), p, size)
 
     return call_origin(numpy.random.binomial, n, p, size)
 

--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -170,7 +170,7 @@ def binomial(n, p, size=None):
     Output array data type is :obj:`dpnp.int32`.
     Parameters ``n`` and ``p`` are supported as scalar.
     Parameter ``size`` is supported as a ``tuple`` of ``ints`` or ``int``.
-    Otherwise the functions will use :obj:`numpy.random.binomial` on the
+    Otherwise the function will use :obj:`numpy.random.binomial` on the
     backend and will be executed on fallback backend.
 
     Examples

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -176,6 +176,19 @@ def test_binomial_check_extreme_value():
     assert numpy.unique(res)[0] == 5
 
 
+def test_binomial_invalid_args():
+    size = 10
+    n = -5     # non-negative `n` is expected
+    p = 0.4    # OK
+    with pytest.raises(ValueError):
+        dpnp.random.binomial(n=n, p=p, size=size)
+
+    n = 5      # OK
+    p = -0.5   # `p` is expected from [0, 1]
+    with pytest.raises(ValueError):
+        dpnp.random.binomial(n=n, p=p, size=size)
+
+
 def test_chisquare_seed():
     seed = 28041990
     size = 100


### PR DESCRIPTION
## Description
* fix `random.binomial` fallback
* update `random.binomial` docstring: align docstrings with template
* add `test_binomial_invalid_args`

## Checklist

- [x] Docstrings for all functions
- [x] Unit tests:
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)