### PR TITLE
STY: style fix (whitespace, PEP8)

### DIFF
--- a/doc/docstring_template.py
+++ b/doc/docstring_template.py
@@ -63,7 +63,7 @@ Recommendations:
    >>> [i for i in a]
    [0, 1, 2]
 
-`dpnp.array` contains a good example of docstring. 
+`dpnp.array` contains a good example of docstring.
 
 """
 

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -962,7 +962,7 @@ def zeros(shape, dtype=None, order='C'):
     [0.0, 0.0, 0.0, 0.0, 0.0]
     >>> x = np.zeros((2, 1))
     >>> x.ndim, x.size, x.shape
-    (2, 2, (2, 1))  
+    (2, 2, (2, 1))
     >>> [i for i in x]
     [0.0, 0.0]
 

--- a/dpnp/dpnp_iface_linearalgebra.py
+++ b/dpnp/dpnp_iface_linearalgebra.py
@@ -134,7 +134,7 @@ def einsum(*args, **kwargs):
 
 def einsum_path(*args, **kwargs):
     """
-    Evaluates the lowest cost contraction order for an einsum expression 
+    Evaluates the lowest cost contraction order for an einsum expression
     by considering the creation of intermediate arrays.
 
     For full documentation refer to :obj:`numpy.einsum_path`.

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -254,7 +254,7 @@ def moveaxis(x1, source, destination):
     for destination_id, source_id in sorted(zip(destination_norm, source_norm)):
         # if destination_id in input_permute:
         # pytest tests/third_party/cupy/manipulation_tests/test_transpose.py::TestTranspose::test_moveaxis_invalid5_3
-        #checker_throw_value_error("swapaxes", "source_id exists", source_id, input_permute)
+        # checker_throw_value_error("swapaxes", "source_id exists", source_id, input_permute)
         input_permute.insert(destination_id, source_id)
 
     return transpose(x1, axes=input_permute)
@@ -318,11 +318,7 @@ def repeat(x1, repeats, axis=None):
 
     is_x1_dparray = isinstance(x1, dparray)
 
-    if (not use_origin_backend(x1)
-        and is_x1_dparray
-        and (axis is None or axis == 0)
-        and (x1.ndim < 2)
-        ):
+    if (not use_origin_backend(x1) and is_x1_dparray and (axis is None or axis == 0) and (x1.ndim < 2)):
 
         repeat_val = repeats
         if isinstance(repeats, (tuple, list)):

--- a/tests/tests_perf/math_tests/test_trigonometric.py
+++ b/tests/tests_perf/math_tests/test_trigonometric.py
@@ -21,7 +21,10 @@ def cos_2_args(input_A, input_B, lib):
 
 class TestDPNPTrigonometric(DPNPTestPerfBase):
 
-    @pytest.mark.parametrize("func_name", ["arccos", "arccosh", "arcsin", "arcsinh", "arctan", "arctanh", "cbrt", "cos", "cosh", "deg2rad", "degrees", "exp", "exp2", "expm1", "log", "log10", "log1p", "log2", "rad2deg", "radians", "reciprocal", "sin", "sinh", "sqrt", "square", "tan", "tanh"])
+    @pytest.mark.parametrize("func_name", ["arccos", "arccosh", "arcsin", "arcsinh", "arctan", "arctanh",
+                                           "cbrt", "cos", "cosh", "deg2rad", "degrees", "exp", "exp2",
+                                           "expm1", "log", "log10", "log1p", "log2", "rad2deg", "radians",
+                                           "reciprocal", "sin", "sinh", "sqrt", "square", "tan", "tanh"])
     @pytest.mark.parametrize("dtype", [numpy.float64, numpy.float32, numpy.int64, numpy.int32])
     @pytest.mark.parametrize("size", [512, 1024, 2048, 4096, 8192, 16384, 32768])
     def test_trig1(self, func_name, lib, dtype, size):
@@ -33,10 +36,11 @@ class TestDPNPTrigonometric(DPNPTestPerfBase):
     @pytest.mark.parametrize("size", [16777216])
     def test_app1(self, lib, dtype, size):
         """
-        /opt/intel/oneapi/vtune/2021.1-beta10/bin64/vtune -collect gpu-offload 
+        /opt/intel/oneapi/vtune/2021.1-beta10/bin64/vtune -collect gpu-offload
             -knob enable-stack-collection=true -app-working-dir /home/work/dpnp --
-            /home/work/anaconda3/bin/python -m pytest 
-                tests/tests_perf/math_tests/test_trigonometric.py::TestDPNPTrigonometric::test_app1[32768-float64-dpnp] -sv
+            /home/work/anaconda3/bin/python -m pytest
+                tests/tests_perf/math_tests/test_trigonometric.py::TestDPNPTrigonometric::test_app1[32768-float64-dpnp]
+                -sv
         """
         input1 = gen_array_1d(lib, size, dtype=dtype, seed=self.seed)
         input2 = gen_array_1d(lib, size, dtype=dtype, seed=self.seed)

--- a/tests/third_party/cupy/random_tests/test_distributions.py
+++ b/tests/third_party/cupy/random_tests/test_distributions.py
@@ -302,7 +302,6 @@ class TestDistributionsLognormal(RandomDistributionsTestCase):
 @testing.gpu
 class TestDistributionsLogseries(RandomDistributionsTestCase):
 
-
     @helper.for_float_dtypes('p_dtype', no_float16=True)
     def test_logseries(self, p_dtype):
         p = numpy.full(self.p_shape, 0.5, dtype=p_dtype)

--- a/utils/dpnp_build_utils.py
+++ b/utils/dpnp_build_utils.py
@@ -216,7 +216,7 @@ def _find_mathlib_in_mathlib_root(verbose=False):
     """
     rel_header_paths = ["mkl.h"]
     rel_lib_paths = ["libmkl_sycl.so"]
-    rel_include_path = os.path.join("latest", "include") 
+    rel_include_path = os.path.join("latest", "include")
     rel_libdir_path = os.path.join("latest", "lib", "intel64")
 
     return find_library("MKLROOT", rel_header_paths, rel_lib_paths, rel_include_path=rel_include_path,


### PR DESCRIPTION
## Description:
Style fix (whitespace, PEP8):
/utils/dpnp_build_utils.py:219:57: W291 trailing whitespace
/doc/docstring_template.py:66:51: W291 trailing whitespace
/dpnp/dpnp_iface_arraycreation.py:965:19: W291 trailing whitespace
/dpnp/dpnp_iface_linearalgebra.py:137:73: W291 trailing whitespace
/dpnp/dpnp_iface_manipulation.py:257:9: E265 block comment should start with '# '
/dpnp/dpnp_iface_manipulation.py:322:9: W503 line break before binary operator
/dpnp/dpnp_iface_manipulation.py:323:9: W503 line break before binary operator
/dpnp/dpnp_iface_manipulation.py:324:9: W503 line break before binary operator
/dpnp/dpnp_iface_manipulation.py:325:9: E125 continuation line with same indent as next logical line
/tests/third_party/cupy/random_tests/test_distributions.py:306:5: E303 too many blank lines (2)
/tests/tests_perf/math_tests/test_trigonometric.py:24:121: E501 line too long (292 > 120 characters)
/tests/tests_perf/math_tests/test_trigonometric.py:36:79: W291 trailing whitespace
/tests/tests_perf/math_tests/test_trigonometric.py:38:54: W291 trailing whitespace
/tests/tests_perf/math_tests/test_trigonometric.py:39:121: E501 line too long (123 > 120 characters)