### PR TITLE
TEST: enabled third-party tests for random funcs

### DIFF
--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -1186,149 +1186,15 @@ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChis
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsChisquare_param_3_{df_shape=(3, 2), shape=(3, 2)}::test_chisquare
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsDirichlet_param_0_{alpha_shape=(3,), shape=(4, 3, 2, 3)}::test_dirichlet
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsDirichlet_param_1_{alpha_shape=(3,), shape=(3, 2, 3)}::test_dirichlet
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponentialError::test_negative_scale
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponential_param_0_{scale_shape=(), shape=(4, 3, 2)}::test_exponential
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponential_param_1_{scale_shape=(), shape=(3, 2)}::test_exponential
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponential_param_2_{scale_shape=(), shape=None}::test_exponential
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponential_param_3_{scale_shape=(3, 2), shape=(4, 3, 2)}::test_exponential
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponential_param_4_{scale_shape=(3, 2), shape=(3, 2)}::test_exponential
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponential_param_5_{scale_shape=(3, 2), shape=None}::test_exponential
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_0_{dtype=float64, scale_shape=(), shape=(4, 3, 2), shape_shape=()}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_10_{dtype=float32, scale_shape=(), shape=(3, 2), shape_shape=()}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_11_{dtype=float32, scale_shape=(), shape=(3, 2), shape_shape=(3, 2)}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_12_{dtype=float32, scale_shape=(3, 2), shape=(4, 3, 2), shape_shape=()}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_13_{dtype=float32, scale_shape=(3, 2), shape=(4, 3, 2), shape_shape=(3, 2)}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_14_{dtype=float32, scale_shape=(3, 2), shape=(3, 2), shape_shape=()}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_15_{dtype=float32, scale_shape=(3, 2), shape=(3, 2), shape_shape=(3, 2)}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_16_{dtype=float16, scale_shape=(), shape=(4, 3, 2), shape_shape=()}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_17_{dtype=float16, scale_shape=(), shape=(4, 3, 2), shape_shape=(3, 2)}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_18_{dtype=float16, scale_shape=(), shape=(3, 2), shape_shape=()}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_19_{dtype=float16, scale_shape=(), shape=(3, 2), shape_shape=(3, 2)}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_1_{dtype=float64, scale_shape=(), shape=(4, 3, 2), shape_shape=(3, 2)}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_20_{dtype=float16, scale_shape=(3, 2), shape=(4, 3, 2), shape_shape=()}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_21_{dtype=float16, scale_shape=(3, 2), shape=(4, 3, 2), shape_shape=(3, 2)}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_22_{dtype=float16, scale_shape=(3, 2), shape=(3, 2), shape_shape=()}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_23_{dtype=float16, scale_shape=(3, 2), shape=(3, 2), shape_shape=(3, 2)}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_2_{dtype=float64, scale_shape=(), shape=(3, 2), shape_shape=()}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_3_{dtype=float64, scale_shape=(), shape=(3, 2), shape_shape=(3, 2)}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_4_{dtype=float64, scale_shape=(3, 2), shape=(4, 3, 2), shape_shape=()}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_5_{dtype=float64, scale_shape=(3, 2), shape=(4, 3, 2), shape_shape=(3, 2)}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_6_{dtype=float64, scale_shape=(3, 2), shape=(3, 2), shape_shape=()}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_7_{dtype=float64, scale_shape=(3, 2), shape=(3, 2), shape_shape=(3, 2)}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_8_{dtype=float32, scale_shape=(), shape=(4, 3, 2), shape_shape=()}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_9_{dtype=float32, scale_shape=(), shape=(4, 3, 2), shape_shape=(3, 2)}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_0_{dtype=int8, p_shape=(), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_10_{dtype=int32, p_shape=(3, 2), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_11_{dtype=int32, p_shape=(3, 2), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_12_{dtype=int64, p_shape=(), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_13_{dtype=int64, p_shape=(), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_14_{dtype=int64, p_shape=(3, 2), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_15_{dtype=int64, p_shape=(3, 2), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_16_{dtype=longlong, p_shape=(), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_17_{dtype=longlong, p_shape=(), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_18_{dtype=longlong, p_shape=(3, 2), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_19_{dtype=longlong, p_shape=(3, 2), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_1_{dtype=int8, p_shape=(), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_20_{dtype=uint8, p_shape=(), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_21_{dtype=uint8, p_shape=(), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_22_{dtype=uint8, p_shape=(3, 2), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_23_{dtype=uint8, p_shape=(3, 2), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_24_{dtype=uint16, p_shape=(), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_25_{dtype=uint16, p_shape=(), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_26_{dtype=uint16, p_shape=(3, 2), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_27_{dtype=uint16, p_shape=(3, 2), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_28_{dtype=uint32, p_shape=(), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_29_{dtype=uint32, p_shape=(), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_2_{dtype=int8, p_shape=(3, 2), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_30_{dtype=uint32, p_shape=(3, 2), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_31_{dtype=uint32, p_shape=(3, 2), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_32_{dtype=uint64, p_shape=(), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_33_{dtype=uint64, p_shape=(), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_34_{dtype=uint64, p_shape=(3, 2), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_35_{dtype=uint64, p_shape=(3, 2), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_36_{dtype=ulonglong, p_shape=(), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_37_{dtype=ulonglong, p_shape=(), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_38_{dtype=ulonglong, p_shape=(3, 2), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_39_{dtype=ulonglong, p_shape=(3, 2), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_3_{dtype=int8, p_shape=(3, 2), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_4_{dtype=int16, p_shape=(), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_5_{dtype=int16, p_shape=(), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_6_{dtype=int16, p_shape=(3, 2), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_7_{dtype=int16, p_shape=(3, 2), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_8_{dtype=int32, p_shape=(), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_9_{dtype=int32, p_shape=(), shape=(3, 2)}::test_geometric
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGumbel_param_0_{loc_shape=(), scale_shape=(), shape=(4, 3, 2)}::test_gumbel
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGumbel_param_1_{loc_shape=(), scale_shape=(), shape=(3, 2)}::test_gumbel
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGumbel_param_2_{loc_shape=(), scale_shape=(3, 2), shape=(4, 3, 2)}::test_gumbel
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGumbel_param_3_{loc_shape=(), scale_shape=(3, 2), shape=(3, 2)}::test_gumbel
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGumbel_param_4_{loc_shape=(3, 2), scale_shape=(), shape=(4, 3, 2)}::test_gumbel
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGumbel_param_5_{loc_shape=(3, 2), scale_shape=(), shape=(3, 2)}::test_gumbel
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGumbel_param_6_{loc_shape=(3, 2), scale_shape=(3, 2), shape=(4, 3, 2)}::test_gumbel
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGumbel_param_7_{loc_shape=(3, 2), scale_shape=(3, 2), shape=(3, 2)}::test_gumbel
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_0_{dtype=int32, nbad_shape=(), ngood_shape=(), nsample_dtype=int32, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_10_{dtype=int32, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_11_{dtype=int32, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_12_{dtype=int32, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_13_{dtype=int32, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_14_{dtype=int32, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_15_{dtype=int32, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_16_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int32, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_17_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int32, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_18_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int32, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_19_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int32, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_1_{dtype=int32, nbad_shape=(), ngood_shape=(), nsample_dtype=int32, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_20_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int64, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_21_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int64, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_22_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int64, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_23_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int64, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_24_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_25_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_26_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_27_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_28_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_29_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_2_{dtype=int32, nbad_shape=(), ngood_shape=(), nsample_dtype=int32, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_30_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_31_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_32_{dtype=int64, nbad_shape=(), ngood_shape=(), nsample_dtype=int32, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_33_{dtype=int64, nbad_shape=(), ngood_shape=(), nsample_dtype=int32, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_34_{dtype=int64, nbad_shape=(), ngood_shape=(), nsample_dtype=int32, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_35_{dtype=int64, nbad_shape=(), ngood_shape=(), nsample_dtype=int32, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_36_{dtype=int64, nbad_shape=(), ngood_shape=(), nsample_dtype=int64, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_37_{dtype=int64, nbad_shape=(), ngood_shape=(), nsample_dtype=int64, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_38_{dtype=int64, nbad_shape=(), ngood_shape=(), nsample_dtype=int64, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_39_{dtype=int64, nbad_shape=(), ngood_shape=(), nsample_dtype=int64, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_3_{dtype=int32, nbad_shape=(), ngood_shape=(), nsample_dtype=int32, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_40_{dtype=int64, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_41_{dtype=int64, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_42_{dtype=int64, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_43_{dtype=int64, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_44_{dtype=int64, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_45_{dtype=int64, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_46_{dtype=int64, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_47_{dtype=int64, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_48_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int32, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_49_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int32, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_4_{dtype=int32, nbad_shape=(), ngood_shape=(), nsample_dtype=int64, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_50_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int32, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_51_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int32, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_52_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int64, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_53_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int64, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_54_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int64, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_55_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int64, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_56_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_57_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_58_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_59_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_5_{dtype=int32, nbad_shape=(), ngood_shape=(), nsample_dtype=int64, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_60_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_61_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_62_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_63_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_6_{dtype=int32, nbad_shape=(), ngood_shape=(), nsample_dtype=int64, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_7_{dtype=int32, nbad_shape=(), ngood_shape=(), nsample_dtype=int64, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_8_{dtype=int32, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_9_{dtype=int32, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsLogistic_param_0_{loc_shape=(), scale_shape=(), shape=(4, 3, 2)}::test_logistic
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsLogistic_param_1_{loc_shape=(), scale_shape=(), shape=(3, 2)}::test_logistic
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsLogistic_param_2_{loc_shape=(), scale_shape=(3, 2), shape=(4, 3, 2)}::test_logistic
@@ -1341,170 +1207,18 @@ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsLogs
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsLogseries_param_0_{p_shape=(), shape=(4, 3, 2)}::test_logseries_for_invalid_p
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsLogseries_param_1_{p_shape=(), shape=(3, 2)}::test_logseries
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsLogseries_param_1_{p_shape=(), shape=(3, 2)}::test_logseries_for_invalid_p
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsMultivariateNormal_param_0_{d=2, shape=(4, 3, 2)}::test_normal
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsMultivariateNormal_param_1_{d=2, shape=(3, 2)}::test_normal
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsMultivariateNormal_param_2_{d=4, shape=(4, 3, 2)}::test_normal
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsMultivariateNormal_param_3_{d=4, shape=(3, 2)}::test_normal
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_0_{dtype=int8, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_0_{dtype=int8, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_10_{dtype=int16, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_10_{dtype=int16, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_11_{dtype=int16, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_11_{dtype=int16, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_12_{dtype=int16, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_12_{dtype=int16, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_13_{dtype=int16, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_13_{dtype=int16, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_14_{dtype=int16, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_14_{dtype=int16, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_15_{dtype=int16, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_15_{dtype=int16, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_16_{dtype=int32, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_16_{dtype=int32, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_17_{dtype=int32, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_17_{dtype=int32, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_18_{dtype=int32, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_18_{dtype=int32, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_19_{dtype=int32, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_19_{dtype=int32, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_1_{dtype=int8, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_1_{dtype=int8, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_20_{dtype=int32, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_20_{dtype=int32, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_21_{dtype=int32, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_21_{dtype=int32, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_22_{dtype=int32, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_22_{dtype=int32, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_23_{dtype=int32, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_23_{dtype=int32, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_24_{dtype=int64, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_24_{dtype=int64, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_25_{dtype=int64, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_25_{dtype=int64, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_26_{dtype=int64, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_26_{dtype=int64, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_27_{dtype=int64, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_27_{dtype=int64, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_28_{dtype=int64, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_28_{dtype=int64, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_29_{dtype=int64, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_29_{dtype=int64, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_2_{dtype=int8, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_2_{dtype=int8, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_30_{dtype=int64, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_30_{dtype=int64, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_31_{dtype=int64, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_31_{dtype=int64, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_32_{dtype=longlong, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_32_{dtype=longlong, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_33_{dtype=longlong, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_33_{dtype=longlong, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_34_{dtype=longlong, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_34_{dtype=longlong, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_35_{dtype=longlong, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_35_{dtype=longlong, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_36_{dtype=longlong, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_36_{dtype=longlong, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_37_{dtype=longlong, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_37_{dtype=longlong, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_38_{dtype=longlong, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_38_{dtype=longlong, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_39_{dtype=longlong, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_39_{dtype=longlong, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_3_{dtype=int8, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_3_{dtype=int8, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_40_{dtype=uint8, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_40_{dtype=uint8, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_41_{dtype=uint8, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_41_{dtype=uint8, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_42_{dtype=uint8, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_42_{dtype=uint8, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_43_{dtype=uint8, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_43_{dtype=uint8, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_44_{dtype=uint8, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_44_{dtype=uint8, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_45_{dtype=uint8, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_45_{dtype=uint8, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_46_{dtype=uint8, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_46_{dtype=uint8, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_47_{dtype=uint8, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_47_{dtype=uint8, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_48_{dtype=uint16, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_48_{dtype=uint16, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_49_{dtype=uint16, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_49_{dtype=uint16, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_4_{dtype=int8, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_4_{dtype=int8, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_50_{dtype=uint16, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_50_{dtype=uint16, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_51_{dtype=uint16, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_51_{dtype=uint16, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_52_{dtype=uint16, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_52_{dtype=uint16, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_53_{dtype=uint16, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_53_{dtype=uint16, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_54_{dtype=uint16, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_54_{dtype=uint16, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_55_{dtype=uint16, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_55_{dtype=uint16, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_56_{dtype=uint32, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_56_{dtype=uint32, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_57_{dtype=uint32, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_57_{dtype=uint32, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_58_{dtype=uint32, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_58_{dtype=uint32, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_59_{dtype=uint32, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_59_{dtype=uint32, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_5_{dtype=int8, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_5_{dtype=int8, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_60_{dtype=uint32, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_60_{dtype=uint32, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_61_{dtype=uint32, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_61_{dtype=uint32, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_62_{dtype=uint32, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_62_{dtype=uint32, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_63_{dtype=uint32, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_63_{dtype=uint32, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_64_{dtype=uint64, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_64_{dtype=uint64, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_65_{dtype=uint64, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_65_{dtype=uint64, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_66_{dtype=uint64, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_66_{dtype=uint64, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_67_{dtype=uint64, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_67_{dtype=uint64, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_68_{dtype=uint64, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_68_{dtype=uint64, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_69_{dtype=uint64, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_69_{dtype=uint64, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_6_{dtype=int8, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_6_{dtype=int8, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_70_{dtype=uint64, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_70_{dtype=uint64, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_71_{dtype=uint64, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_71_{dtype=uint64, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_72_{dtype=ulonglong, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_72_{dtype=ulonglong, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_73_{dtype=ulonglong, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_73_{dtype=ulonglong, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_74_{dtype=ulonglong, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_74_{dtype=ulonglong, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_75_{dtype=ulonglong, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_75_{dtype=ulonglong, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_76_{dtype=ulonglong, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_76_{dtype=ulonglong, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_77_{dtype=ulonglong, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_77_{dtype=ulonglong, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_78_{dtype=ulonglong, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_78_{dtype=ulonglong, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_79_{dtype=ulonglong, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_79_{dtype=ulonglong, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_7_{dtype=int8, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_7_{dtype=int8, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_8_{dtype=int16, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_8_{dtype=int16, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_9_{dtype=int16, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_9_{dtype=int16, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_0_{n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_0_{n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_1_{n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_1_{n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_2_{n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_2_{n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_3_{n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_3_{n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_4_{n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_4_{n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_5_{n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_5_{n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNoncentralChisquare_param_0_{df_shape=(), nonc_shape=(), shape=(4, 3, 2)}::test_noncentral_chisquare
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNoncentralChisquare_param_1_{df_shape=(), nonc_shape=(), shape=(3, 2)}::test_noncentral_chisquare
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNoncentralChisquare_param_2_{df_shape=(), nonc_shape=(3, 2), shape=(4, 3, 2)}::test_noncentral_chisquare
@@ -1531,12 +1245,6 @@ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNorm
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNormal_param_3_{loc_shape=(), scale_shape=(3, 2), shape=(3, 2)}::test_normal
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNormal_param_4_{loc_shape=(3, 2), scale_shape=(), shape=(4, 3, 2)}::test_normal
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNormal_param_5_{loc_shape=(3, 2), scale_shape=(), shape=(3, 2)}::test_normal
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNormal_param_6_{loc_shape=(3, 2), scale_shape=(3, 2), shape=(4, 3, 2)}::test_normal
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNormal_param_7_{loc_shape=(3, 2), scale_shape=(3, 2), shape=(3, 2)}::test_normal
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsPoisson_param_0_{lam_shape=(), shape=(4, 3, 2)}::test_poisson
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsPoisson_param_1_{lam_shape=(), shape=(3, 2)}::test_poisson
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsPoisson_param_2_{lam_shape=(3, 2), shape=(4, 3, 2)}::test_poisson
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsPoisson_param_3_{lam_shape=(3, 2), shape=(3, 2)}::test_poisson
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsPower_param_0_{a_shape=(), shape=(4, 3, 2)}::test_power
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsPower_param_0_{a_shape=(), shape=(4, 3, 2)}::test_power_for_negative_a
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsPower_param_1_{a_shape=(), shape=(3, 2)}::test_power
@@ -1547,14 +1255,8 @@ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsRayl
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsRayleigh_param_1_{scale_shape=(), shape=(3, 2)}::test_rayleigh
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsRayleigh_param_1_{scale_shape=(), shape=(3, 2)}::test_rayleigh_for_negative_scale
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsRayleigh_param_1_{scale_shape=(), shape=(3, 2)}::test_rayleigh_for_zero_scale
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsStandardCauchy_param_0_{shape=(4, 3, 2)}::test_standard_cauchy
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsStandardCauchy_param_1_{shape=(3, 2)}::test_standard_cauchy
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsStandardExponential_param_0_{shape=(4, 3, 2)}::test_standard_exponential
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsStandardExponential_param_1_{shape=(3, 2)}::test_standard_exponential
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsStandardGamma_param_0_{shape=(4, 3, 2), shape_shape=()}::test_standard_gamma
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsStandardGamma_param_2_{shape=(3, 2), shape_shape=()}::test_standard_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsStandardNormal_param_0_{shape=(4, 3, 2)}::test_standard_normal
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsStandardNormal_param_1_{shape=(3, 2)}::test_standard_normal
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsTriangular_param_0_{left_shape=(), mode_shape=(), right_shape=(), shape=(4, 3, 2)}::test_triangular
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsTriangular_param_1_{left_shape=(), mode_shape=(), right_shape=(), shape=(3, 2)}::test_triangular
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsTriangular_param_2_{left_shape=(), mode_shape=(), right_shape=(3, 2), shape=(4, 3, 2)}::test_triangular
@@ -1575,8 +1277,6 @@ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsuLap
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsuLaplace_param_3_{loc_shape=(), scale_shape=(3, 2), shape=(3, 2)}::test_laplace
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsuLaplace_param_4_{loc_shape=(3, 2), scale_shape=(), shape=(4, 3, 2)}::test_laplace
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsuLaplace_param_5_{loc_shape=(3, 2), scale_shape=(), shape=(3, 2)}::test_laplace
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsuLaplace_param_6_{loc_shape=(3, 2), scale_shape=(3, 2), shape=(4, 3, 2)}::test_laplace
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsuLaplace_param_7_{loc_shape=(3, 2), scale_shape=(3, 2), shape=(3, 2)}::test_laplace
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsUniform_param_0_{high_shape=(), low_shape=(), shape=(4, 3, 2)}::test_uniform
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsUniform_param_1_{high_shape=(), low_shape=(), shape=(3, 2)}::test_uniform
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsUniform_param_2_{high_shape=(), low_shape=(3, 2), shape=(4, 3, 2)}::test_uniform

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -1544,149 +1544,15 @@ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_5_{a_shape=(3, 2), b_shape=(), shape=(3, 2)}::test_beta
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsDirichlet_param_0_{alpha_shape=(3,), shape=(4, 3, 2, 3)}::test_dirichlet
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsDirichlet_param_1_{alpha_shape=(3,), shape=(3, 2, 3)}::test_dirichlet
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponentialError::test_negative_scale
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponential_param_0_{scale_shape=(), shape=(4, 3, 2)}::test_exponential
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponential_param_1_{scale_shape=(), shape=(3, 2)}::test_exponential
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponential_param_2_{scale_shape=(), shape=None}::test_exponential
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponential_param_3_{scale_shape=(3, 2), shape=(4, 3, 2)}::test_exponential
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponential_param_4_{scale_shape=(3, 2), shape=(3, 2)}::test_exponential
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsExponential_param_5_{scale_shape=(3, 2), shape=None}::test_exponential
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_0_{dtype=float64, scale_shape=(), shape=(4, 3, 2), shape_shape=()}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_10_{dtype=float32, scale_shape=(), shape=(3, 2), shape_shape=()}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_11_{dtype=float32, scale_shape=(), shape=(3, 2), shape_shape=(3, 2)}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_12_{dtype=float32, scale_shape=(3, 2), shape=(4, 3, 2), shape_shape=()}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_13_{dtype=float32, scale_shape=(3, 2), shape=(4, 3, 2), shape_shape=(3, 2)}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_14_{dtype=float32, scale_shape=(3, 2), shape=(3, 2), shape_shape=()}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_15_{dtype=float32, scale_shape=(3, 2), shape=(3, 2), shape_shape=(3, 2)}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_16_{dtype=float16, scale_shape=(), shape=(4, 3, 2), shape_shape=()}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_17_{dtype=float16, scale_shape=(), shape=(4, 3, 2), shape_shape=(3, 2)}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_18_{dtype=float16, scale_shape=(), shape=(3, 2), shape_shape=()}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_19_{dtype=float16, scale_shape=(), shape=(3, 2), shape_shape=(3, 2)}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_1_{dtype=float64, scale_shape=(), shape=(4, 3, 2), shape_shape=(3, 2)}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_20_{dtype=float16, scale_shape=(3, 2), shape=(4, 3, 2), shape_shape=()}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_21_{dtype=float16, scale_shape=(3, 2), shape=(4, 3, 2), shape_shape=(3, 2)}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_22_{dtype=float16, scale_shape=(3, 2), shape=(3, 2), shape_shape=()}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_23_{dtype=float16, scale_shape=(3, 2), shape=(3, 2), shape_shape=(3, 2)}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_2_{dtype=float64, scale_shape=(), shape=(3, 2), shape_shape=()}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_3_{dtype=float64, scale_shape=(), shape=(3, 2), shape_shape=(3, 2)}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_4_{dtype=float64, scale_shape=(3, 2), shape=(4, 3, 2), shape_shape=()}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_5_{dtype=float64, scale_shape=(3, 2), shape=(4, 3, 2), shape_shape=(3, 2)}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_6_{dtype=float64, scale_shape=(3, 2), shape=(3, 2), shape_shape=()}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_7_{dtype=float64, scale_shape=(3, 2), shape=(3, 2), shape_shape=(3, 2)}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_8_{dtype=float32, scale_shape=(), shape=(4, 3, 2), shape_shape=()}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGamma_param_9_{dtype=float32, scale_shape=(), shape=(4, 3, 2), shape_shape=(3, 2)}::test_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_0_{dtype=int8, p_shape=(), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_10_{dtype=int32, p_shape=(3, 2), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_11_{dtype=int32, p_shape=(3, 2), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_12_{dtype=int64, p_shape=(), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_13_{dtype=int64, p_shape=(), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_14_{dtype=int64, p_shape=(3, 2), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_15_{dtype=int64, p_shape=(3, 2), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_16_{dtype=longlong, p_shape=(), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_17_{dtype=longlong, p_shape=(), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_18_{dtype=longlong, p_shape=(3, 2), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_19_{dtype=longlong, p_shape=(3, 2), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_1_{dtype=int8, p_shape=(), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_20_{dtype=uint8, p_shape=(), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_21_{dtype=uint8, p_shape=(), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_22_{dtype=uint8, p_shape=(3, 2), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_23_{dtype=uint8, p_shape=(3, 2), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_24_{dtype=uint16, p_shape=(), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_25_{dtype=uint16, p_shape=(), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_26_{dtype=uint16, p_shape=(3, 2), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_27_{dtype=uint16, p_shape=(3, 2), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_28_{dtype=uint32, p_shape=(), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_29_{dtype=uint32, p_shape=(), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_2_{dtype=int8, p_shape=(3, 2), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_30_{dtype=uint32, p_shape=(3, 2), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_31_{dtype=uint32, p_shape=(3, 2), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_32_{dtype=uint64, p_shape=(), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_33_{dtype=uint64, p_shape=(), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_34_{dtype=uint64, p_shape=(3, 2), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_35_{dtype=uint64, p_shape=(3, 2), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_36_{dtype=ulonglong, p_shape=(), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_37_{dtype=ulonglong, p_shape=(), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_38_{dtype=ulonglong, p_shape=(3, 2), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_39_{dtype=ulonglong, p_shape=(3, 2), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_3_{dtype=int8, p_shape=(3, 2), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_4_{dtype=int16, p_shape=(), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_5_{dtype=int16, p_shape=(), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_6_{dtype=int16, p_shape=(3, 2), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_7_{dtype=int16, p_shape=(3, 2), shape=(3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_8_{dtype=int32, p_shape=(), shape=(4, 3, 2)}::test_geometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGeometric_param_9_{dtype=int32, p_shape=(), shape=(3, 2)}::test_geometric
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGumbel_param_0_{loc_shape=(), scale_shape=(), shape=(4, 3, 2)}::test_gumbel
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGumbel_param_1_{loc_shape=(), scale_shape=(), shape=(3, 2)}::test_gumbel
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGumbel_param_2_{loc_shape=(), scale_shape=(3, 2), shape=(4, 3, 2)}::test_gumbel
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGumbel_param_3_{loc_shape=(), scale_shape=(3, 2), shape=(3, 2)}::test_gumbel
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGumbel_param_4_{loc_shape=(3, 2), scale_shape=(), shape=(4, 3, 2)}::test_gumbel
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGumbel_param_5_{loc_shape=(3, 2), scale_shape=(), shape=(3, 2)}::test_gumbel
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGumbel_param_6_{loc_shape=(3, 2), scale_shape=(3, 2), shape=(4, 3, 2)}::test_gumbel
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsGumbel_param_7_{loc_shape=(3, 2), scale_shape=(3, 2), shape=(3, 2)}::test_gumbel
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_0_{dtype=int32, nbad_shape=(), ngood_shape=(), nsample_dtype=int32, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_10_{dtype=int32, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_11_{dtype=int32, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_12_{dtype=int32, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_13_{dtype=int32, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_14_{dtype=int32, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_15_{dtype=int32, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_16_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int32, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_17_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int32, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_18_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int32, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_19_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int32, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_1_{dtype=int32, nbad_shape=(), ngood_shape=(), nsample_dtype=int32, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_20_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int64, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_21_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int64, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_22_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int64, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_23_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int64, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_24_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_25_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_26_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_27_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_28_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_29_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_2_{dtype=int32, nbad_shape=(), ngood_shape=(), nsample_dtype=int32, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_30_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_31_{dtype=int32, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_32_{dtype=int64, nbad_shape=(), ngood_shape=(), nsample_dtype=int32, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_33_{dtype=int64, nbad_shape=(), ngood_shape=(), nsample_dtype=int32, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_34_{dtype=int64, nbad_shape=(), ngood_shape=(), nsample_dtype=int32, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_35_{dtype=int64, nbad_shape=(), ngood_shape=(), nsample_dtype=int32, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_36_{dtype=int64, nbad_shape=(), ngood_shape=(), nsample_dtype=int64, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_37_{dtype=int64, nbad_shape=(), ngood_shape=(), nsample_dtype=int64, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_38_{dtype=int64, nbad_shape=(), ngood_shape=(), nsample_dtype=int64, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_39_{dtype=int64, nbad_shape=(), ngood_shape=(), nsample_dtype=int64, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_3_{dtype=int32, nbad_shape=(), ngood_shape=(), nsample_dtype=int32, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_40_{dtype=int64, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_41_{dtype=int64, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_42_{dtype=int64, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_43_{dtype=int64, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_44_{dtype=int64, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_45_{dtype=int64, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_46_{dtype=int64, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_47_{dtype=int64, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_48_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int32, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_49_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int32, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_4_{dtype=int32, nbad_shape=(), ngood_shape=(), nsample_dtype=int64, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_50_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int32, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_51_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int32, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_52_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int64, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_53_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int64, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_54_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int64, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_55_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(), nsample_dtype=int64, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_56_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_57_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_58_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_59_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_5_{dtype=int32, nbad_shape=(), ngood_shape=(), nsample_dtype=int64, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_60_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_61_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_62_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_63_{dtype=int64, nbad_shape=(3, 2), ngood_shape=(3, 2), nsample_dtype=int64, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_6_{dtype=int32, nbad_shape=(), ngood_shape=(), nsample_dtype=int64, nsample_shape=(3, 2), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_7_{dtype=int32, nbad_shape=(), ngood_shape=(), nsample_dtype=int64, nsample_shape=(3, 2), shape=(3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_8_{dtype=int32, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(), shape=(4, 3, 2)}::test_hypergeometric
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsHyperGeometric_param_9_{dtype=int32, nbad_shape=(), ngood_shape=(3, 2), nsample_dtype=int32, nsample_shape=(), shape=(3, 2)}::test_hypergeometric
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsLogistic_param_0_{loc_shape=(), scale_shape=(), shape=(4, 3, 2)}::test_logistic
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsLogistic_param_1_{loc_shape=(), scale_shape=(), shape=(3, 2)}::test_logistic
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsLogistic_param_2_{loc_shape=(), scale_shape=(3, 2), shape=(4, 3, 2)}::test_logistic
@@ -1699,170 +1565,18 @@ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsLogs
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsLogseries_param_0_{p_shape=(), shape=(4, 3, 2)}::test_logseries_for_invalid_p
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsLogseries_param_1_{p_shape=(), shape=(3, 2)}::test_logseries
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsLogseries_param_1_{p_shape=(), shape=(3, 2)}::test_logseries_for_invalid_p
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsMultivariateNormal_param_0_{d=2, shape=(4, 3, 2)}::test_normal
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsMultivariateNormal_param_1_{d=2, shape=(3, 2)}::test_normal
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsMultivariateNormal_param_2_{d=4, shape=(4, 3, 2)}::test_normal
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsMultivariateNormal_param_3_{d=4, shape=(3, 2)}::test_normal
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_0_{dtype=int8, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_0_{dtype=int8, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_10_{dtype=int16, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_10_{dtype=int16, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_11_{dtype=int16, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_11_{dtype=int16, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_12_{dtype=int16, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_12_{dtype=int16, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_13_{dtype=int16, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_13_{dtype=int16, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_14_{dtype=int16, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_14_{dtype=int16, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_15_{dtype=int16, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_15_{dtype=int16, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_16_{dtype=int32, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_16_{dtype=int32, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_17_{dtype=int32, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_17_{dtype=int32, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_18_{dtype=int32, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_18_{dtype=int32, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_19_{dtype=int32, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_19_{dtype=int32, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_1_{dtype=int8, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_1_{dtype=int8, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_20_{dtype=int32, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_20_{dtype=int32, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_21_{dtype=int32, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_21_{dtype=int32, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_22_{dtype=int32, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_22_{dtype=int32, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_23_{dtype=int32, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_23_{dtype=int32, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_24_{dtype=int64, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_24_{dtype=int64, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_25_{dtype=int64, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_25_{dtype=int64, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_26_{dtype=int64, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_26_{dtype=int64, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_27_{dtype=int64, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_27_{dtype=int64, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_28_{dtype=int64, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_28_{dtype=int64, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_29_{dtype=int64, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_29_{dtype=int64, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_2_{dtype=int8, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_2_{dtype=int8, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_30_{dtype=int64, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_30_{dtype=int64, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_31_{dtype=int64, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_31_{dtype=int64, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_32_{dtype=longlong, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_32_{dtype=longlong, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_33_{dtype=longlong, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_33_{dtype=longlong, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_34_{dtype=longlong, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_34_{dtype=longlong, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_35_{dtype=longlong, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_35_{dtype=longlong, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_36_{dtype=longlong, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_36_{dtype=longlong, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_37_{dtype=longlong, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_37_{dtype=longlong, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_38_{dtype=longlong, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_38_{dtype=longlong, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_39_{dtype=longlong, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_39_{dtype=longlong, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_3_{dtype=int8, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_3_{dtype=int8, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_40_{dtype=uint8, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_40_{dtype=uint8, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_41_{dtype=uint8, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_41_{dtype=uint8, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_42_{dtype=uint8, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_42_{dtype=uint8, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_43_{dtype=uint8, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_43_{dtype=uint8, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_44_{dtype=uint8, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_44_{dtype=uint8, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_45_{dtype=uint8, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_45_{dtype=uint8, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_46_{dtype=uint8, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_46_{dtype=uint8, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_47_{dtype=uint8, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_47_{dtype=uint8, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_48_{dtype=uint16, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_48_{dtype=uint16, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_49_{dtype=uint16, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_49_{dtype=uint16, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_4_{dtype=int8, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_4_{dtype=int8, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_50_{dtype=uint16, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_50_{dtype=uint16, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_51_{dtype=uint16, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_51_{dtype=uint16, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_52_{dtype=uint16, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_52_{dtype=uint16, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_53_{dtype=uint16, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_53_{dtype=uint16, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_54_{dtype=uint16, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_54_{dtype=uint16, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_55_{dtype=uint16, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_55_{dtype=uint16, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_56_{dtype=uint32, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_56_{dtype=uint32, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_57_{dtype=uint32, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_57_{dtype=uint32, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_58_{dtype=uint32, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_58_{dtype=uint32, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_59_{dtype=uint32, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_59_{dtype=uint32, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_5_{dtype=int8, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_5_{dtype=int8, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_60_{dtype=uint32, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_60_{dtype=uint32, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_61_{dtype=uint32, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_61_{dtype=uint32, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_62_{dtype=uint32, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_62_{dtype=uint32, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_63_{dtype=uint32, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_63_{dtype=uint32, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_64_{dtype=uint64, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_64_{dtype=uint64, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_65_{dtype=uint64, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_65_{dtype=uint64, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_66_{dtype=uint64, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_66_{dtype=uint64, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_67_{dtype=uint64, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_67_{dtype=uint64, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_68_{dtype=uint64, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_68_{dtype=uint64, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_69_{dtype=uint64, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_69_{dtype=uint64, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_6_{dtype=int8, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_6_{dtype=int8, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_70_{dtype=uint64, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_70_{dtype=uint64, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_71_{dtype=uint64, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_71_{dtype=uint64, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_72_{dtype=ulonglong, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_72_{dtype=ulonglong, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_73_{dtype=ulonglong, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_73_{dtype=ulonglong, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_74_{dtype=ulonglong, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_74_{dtype=ulonglong, n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_75_{dtype=ulonglong, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_75_{dtype=ulonglong, n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_76_{dtype=ulonglong, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_76_{dtype=ulonglong, n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_77_{dtype=ulonglong, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_77_{dtype=ulonglong, n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_78_{dtype=ulonglong, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_78_{dtype=ulonglong, n_shape=(3, 2), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_79_{dtype=ulonglong, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_79_{dtype=ulonglong, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_7_{dtype=int8, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_7_{dtype=int8, n_shape=(3, 2), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_8_{dtype=int16, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_8_{dtype=int16, n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_9_{dtype=int16, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_9_{dtype=int16, n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_0_{n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_0_{n_shape=(), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_1_{n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_1_{n_shape=(), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_2_{n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_2_{n_shape=(), p_shape=(3, 2), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_3_{n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_3_{n_shape=(), p_shape=(3, 2), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_4_{n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_4_{n_shape=(3, 2), p_shape=(), shape=(4, 3, 2)}::test_negative_binomial_for_noninteger_n
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_5_{n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial
+tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNegativeBinomial_param_5_{n_shape=(3, 2), p_shape=(), shape=(3, 2)}::test_negative_binomial_for_noninteger_n
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNoncentralChisquare_param_0_{df_shape=(), nonc_shape=(), shape=(4, 3, 2)}::test_noncentral_chisquare
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNoncentralChisquare_param_1_{df_shape=(), nonc_shape=(), shape=(3, 2)}::test_noncentral_chisquare
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNoncentralChisquare_param_2_{df_shape=(), nonc_shape=(3, 2), shape=(4, 3, 2)}::test_noncentral_chisquare
@@ -1889,12 +1603,6 @@ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNorm
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNormal_param_3_{loc_shape=(), scale_shape=(3, 2), shape=(3, 2)}::test_normal
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNormal_param_4_{loc_shape=(3, 2), scale_shape=(), shape=(4, 3, 2)}::test_normal
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNormal_param_5_{loc_shape=(3, 2), scale_shape=(), shape=(3, 2)}::test_normal
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNormal_param_6_{loc_shape=(3, 2), scale_shape=(3, 2), shape=(4, 3, 2)}::test_normal
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsNormal_param_7_{loc_shape=(3, 2), scale_shape=(3, 2), shape=(3, 2)}::test_normal
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsPoisson_param_0_{lam_shape=(), shape=(4, 3, 2)}::test_poisson
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsPoisson_param_1_{lam_shape=(), shape=(3, 2)}::test_poisson
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsPoisson_param_2_{lam_shape=(3, 2), shape=(4, 3, 2)}::test_poisson
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsPoisson_param_3_{lam_shape=(3, 2), shape=(3, 2)}::test_poisson
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsPower_param_0_{a_shape=(), shape=(4, 3, 2)}::test_power
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsPower_param_0_{a_shape=(), shape=(4, 3, 2)}::test_power_for_negative_a
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsPower_param_1_{a_shape=(), shape=(3, 2)}::test_power
@@ -1905,14 +1613,8 @@ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsRayl
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsRayleigh_param_1_{scale_shape=(), shape=(3, 2)}::test_rayleigh
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsRayleigh_param_1_{scale_shape=(), shape=(3, 2)}::test_rayleigh_for_negative_scale
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsRayleigh_param_1_{scale_shape=(), shape=(3, 2)}::test_rayleigh_for_zero_scale
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsStandardCauchy_param_0_{shape=(4, 3, 2)}::test_standard_cauchy
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsStandardCauchy_param_1_{shape=(3, 2)}::test_standard_cauchy
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsStandardExponential_param_0_{shape=(4, 3, 2)}::test_standard_exponential
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsStandardExponential_param_1_{shape=(3, 2)}::test_standard_exponential
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsStandardGamma_param_0_{shape=(4, 3, 2), shape_shape=()}::test_standard_gamma
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsStandardGamma_param_2_{shape=(3, 2), shape_shape=()}::test_standard_gamma
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsStandardNormal_param_0_{shape=(4, 3, 2)}::test_standard_normal
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsStandardNormal_param_1_{shape=(3, 2)}::test_standard_normal
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsTriangular_param_0_{left_shape=(), mode_shape=(), right_shape=(), shape=(4, 3, 2)}::test_triangular
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsTriangular_param_1_{left_shape=(), mode_shape=(), right_shape=(), shape=(3, 2)}::test_triangular
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsTriangular_param_2_{left_shape=(), mode_shape=(), right_shape=(3, 2), shape=(4, 3, 2)}::test_triangular
@@ -1933,8 +1635,6 @@ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsuLap
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsuLaplace_param_3_{loc_shape=(), scale_shape=(3, 2), shape=(3, 2)}::test_laplace
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsuLaplace_param_4_{loc_shape=(3, 2), scale_shape=(), shape=(4, 3, 2)}::test_laplace
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsuLaplace_param_5_{loc_shape=(3, 2), scale_shape=(), shape=(3, 2)}::test_laplace
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsuLaplace_param_6_{loc_shape=(3, 2), scale_shape=(3, 2), shape=(4, 3, 2)}::test_laplace
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsuLaplace_param_7_{loc_shape=(3, 2), scale_shape=(3, 2), shape=(3, 2)}::test_laplace
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsUniform_param_0_{high_shape=(), low_shape=(), shape=(4, 3, 2)}::test_uniform
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsUniform_param_1_{high_shape=(), low_shape=(), shape=(3, 2)}::test_uniform
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsUniform_param_2_{high_shape=(), low_shape=(3, 2), shape=(4, 3, 2)}::test_uniform

--- a/tests/third_party/cupy/random_tests/test_distributions.py
+++ b/tests/third_party/cupy/random_tests/test_distributions.py
@@ -106,12 +106,10 @@ class TestDistributionsDirichlet(RandomDistributionsTestCase):
 @testing.gpu
 class TestDistributionsExponential(RandomDistributionsTestCase):
 
-    @helper.for_float_dtypes('dtype', no_float16=True)
     @helper.for_float_dtypes('scale_dtype')
-    def test_exponential(self, scale_dtype, dtype):
+    def test_exponential(self, scale_dtype):
         scale = numpy.ones(self.scale_shape, dtype=scale_dtype)
-        self.check_distribution('exponential',
-                                {'scale': scale}, dtype)
+        self.check_distribution('exponential', {'scale': scale})
 
 
 @testing.gpu
@@ -151,45 +149,43 @@ class TestDistributionsF(unittest.TestCase):
     'shape': [(4, 3, 2), (3, 2)],
     'shape_shape': [(), (3, 2)],
     'scale_shape': [(), (3, 2)],
-    'dtype': _float_dtypes,  # to escape timeout
 })
 )
 @testing.gpu
 class TestDistributionsGamma(unittest.TestCase):
 
-    def check_distribution(self, dist_func, shape_dtype, scale_dtype, dtype):
+    def check_distribution(self, dist_func, shape_dtype, scale_dtype):
         shape = cupy.ones(self.shape_shape, dtype=shape_dtype)
         scale = cupy.ones(self.scale_shape, dtype=scale_dtype)
-        out = dist_func(shape, scale, self.shape, dtype)
+        out = dist_func(shape, scale, self.shape)
         self.assertEqual(self.shape, out.shape)
-        self.assertEqual(out.dtype, dtype)
+        # numpy and dpdp output dtype is float64
+        self.assertEqual(out.dtype, numpy.float64)
 
     @helper.for_dtypes_combination(
-        _float_dtypes, names=['shape_dtype', 'scale_dtype'])
+        _regular_float_dtypes, names=['shape_dtype', 'scale_dtype'])
     def test_gamma(self, shape_dtype, scale_dtype):
-        self.check_distribution(_distributions.gamma,
-                                shape_dtype, scale_dtype, self.dtype)
+        self.check_distribution(_distributions.gamma, shape_dtype, scale_dtype)
 
 
 @testing.parameterize(*testing.product({
     'shape': [(4, 3, 2), (3, 2)],
     'p_shape': [(), (3, 2)],
-    'dtype': _int_dtypes,  # to escape timeout
 })
 )
 @testing.gpu
 class TestDistributionsGeometric(unittest.TestCase):
 
-    def check_distribution(self, dist_func, p_dtype, dtype):
+    def check_distribution(self, dist_func, p_dtype):
         p = 0.5 * cupy.ones(self.p_shape, dtype=p_dtype)
-        out = dist_func(p, self.shape, dtype)
+        out = dist_func(p, self.shape)
         self.assertEqual(self.shape, out.shape)
-        self.assertEqual(out.dtype, dtype)
+        # numpy output dtype is int64, dpnp output is int32
+        self.assertEqual(out.dtype, numpy.int64)
 
     @helper.for_float_dtypes('p_dtype')
     def test_geometric(self, p_dtype):
-        self.check_distribution(_distributions.geometric,
-                                p_dtype, self.dtype)
+        self.check_distribution(_distributions.geometric, p_dtype)
 
 
 @testing.parameterize(*testing.product({
@@ -201,14 +197,12 @@ class TestDistributionsGeometric(unittest.TestCase):
 @testing.gpu
 class TestDistributionsGumbel(RandomDistributionsTestCase):
 
-    @helper.for_float_dtypes('dtype', no_float16=True)
     @helper.for_dtypes_combination(
-        _float_dtypes, names=['loc_dtype', 'scale_dtype'])
-    def test_gumbel(self, loc_dtype, scale_dtype, dtype):
+        _regular_float_dtypes, names=['loc_dtype', 'scale_dtype'])
+    def test_gumbel(self, loc_dtype, scale_dtype):
         loc = numpy.ones(self.loc_shape, dtype=loc_dtype)
         scale = numpy.ones(self.scale_shape, dtype=scale_dtype)
-        self.check_distribution('gumbel',
-                                {'loc': loc, 'scale': scale}, dtype)
+        self.check_distribution('gumbel', {'loc': loc, 'scale': scale})
 
 
 @testing.parameterize(*testing.product({
@@ -217,26 +211,26 @@ class TestDistributionsGumbel(RandomDistributionsTestCase):
     'nbad_shape': [(), (3, 2)],
     'nsample_shape': [(), (3, 2)],
     'nsample_dtype': [numpy.int32, numpy.int64],  # to escape timeout
-    'dtype': [numpy.int32, numpy.int64],  # to escape timeout
 })
 )
 @testing.gpu
 class TestDistributionsHyperGeometric(unittest.TestCase):
 
     def check_distribution(self, dist_func, ngood_dtype, nbad_dtype,
-                           nsample_dtype, dtype):
+                           nsample_dtype):
         ngood = cupy.ones(self.ngood_shape, dtype=ngood_dtype)
         nbad = cupy.ones(self.nbad_shape, dtype=nbad_dtype)
         nsample = cupy.ones(self.nsample_shape, dtype=nsample_dtype)
-        out = dist_func(ngood, nbad, nsample, self.shape, dtype)
+        out = dist_func(ngood, nbad, nsample, self.shape)
         self.assertEqual(self.shape, out.shape)
-        self.assertEqual(out.dtype, dtype)
+        # numpy output dtype is int64, dpnp output is int32
+        self.assertEqual(out.dtype, numpy.int64)
 
     @helper.for_dtypes_combination(
         [numpy.int32, numpy.int64], names=['ngood_dtype', 'nbad_dtype'])
     def test_hypergeometric(self, ngood_dtype, nbad_dtype):
         self.check_distribution(_distributions.hypergeometric, ngood_dtype,
-                                nbad_dtype, self.nsample_dtype, self.dtype)
+                                nbad_dtype, self.nsample_dtype)
 
 
 @testing.parameterize(*testing.product({
@@ -248,14 +242,12 @@ class TestDistributionsHyperGeometric(unittest.TestCase):
 @testing.gpu
 class TestDistributionsuLaplace(RandomDistributionsTestCase):
 
-    @helper.for_float_dtypes('dtype', no_float16=True)
     @helper.for_dtypes_combination(
-        _float_dtypes, names=['loc_dtype', 'scale_dtype'])
-    def test_laplace(self, loc_dtype, scale_dtype, dtype):
+        _regular_float_dtypes, names=['loc_dtype', 'scale_dtype'])
+    def test_laplace(self, loc_dtype, scale_dtype):
         loc = numpy.ones(self.loc_shape, dtype=loc_dtype)
         scale = numpy.ones(self.scale_shape, dtype=scale_dtype)
-        self.check_distribution('laplace',
-                                {'loc': loc, 'scale': scale}, dtype)
+        self.check_distribution('laplace', {'loc': loc, 'scale': scale})
 
 
 @testing.parameterize(*testing.product({
@@ -284,14 +276,12 @@ class TestDistributionsLogistic(RandomDistributionsTestCase):
 @testing.gpu
 class TestDistributionsLognormal(RandomDistributionsTestCase):
 
-    @helper.for_float_dtypes('dtype', no_float16=True)
     @helper.for_dtypes_combination(
-        _float_dtypes, names=['mean_dtype', 'sigma_dtype'])
-    def test_lognormal(self, mean_dtype, sigma_dtype, dtype):
+        _regular_float_dtypes, names=['mean_dtype', 'sigma_dtype'])
+    def test_lognormal(self, mean_dtype, sigma_dtype):
         mean = numpy.ones(self.mean_shape, dtype=mean_dtype)
         sigma = numpy.ones(self.sigma_shape, dtype=sigma_dtype)
-        self.check_distribution('lognormal',
-                                {'mean': mean, 'sigma': sigma}, dtype)
+        self.check_distribution('lognormal', {'mean': mean, 'sigma': sigma})
 
 
 @testing.parameterize(*testing.product({
@@ -325,27 +315,31 @@ class TestDistributionsLogseries(RandomDistributionsTestCase):
 @testing.gpu
 class TestDistributionsMultivariateNormal(unittest.TestCase):
 
-    def check_distribution(self, dist_func, mean_dtype, cov_dtype, dtype):
+    def check_distribution(self, dist_func, mean_dtype, cov_dtype):
         mean = cupy.zeros(self.d, dtype=mean_dtype)
-        cov = cupy.random.normal(size=(self.d, self.d), dtype=cov_dtype)
+        cov = cupy.random.normal(size=(self.d, self.d))
+        # dpnp.dparray doesn't have .dot
+        # TODO
+        # no conversation to ndarray
+        cov = numpy.array(cov)
         cov = cov.T.dot(cov)
-        out = dist_func(mean, cov, self.shape, dtype=dtype)
+        cov = cupy.array(cov)
+        out = dist_func(mean, cov, self.shape)
         self.assertEqual(self.shape + (self.d,), out.shape)
-        self.assertEqual(out.dtype, dtype)
+        # numpy and dpdp output dtype is float64
+        self.assertEqual(out.dtype, numpy.float64)
 
-    @helper.for_float_dtypes('dtype', no_float16=True)
     @helper.for_float_dtypes('mean_dtype', no_float16=True)
     @helper.for_float_dtypes('cov_dtype', no_float16=True)
-    def test_normal(self, mean_dtype, cov_dtype, dtype):
+    def test_normal(self, mean_dtype, cov_dtype):
         self.check_distribution(_distributions.multivariate_normal,
-                                mean_dtype, cov_dtype, dtype)
+                                mean_dtype, cov_dtype)
 
 
 @testing.parameterize(*testing.product({
     'shape': [(4, 3, 2), (3, 2)],
     'n_shape': [(), (3, 2)],
     'p_shape': [(), (3, 2)],
-    'dtype': _int_dtypes,  # to escape timeout
 })
 )
 @testing.gpu
@@ -357,7 +351,7 @@ class TestDistributionsNegativeBinomial(RandomDistributionsTestCase):
         n = numpy.full(self.n_shape, 5, dtype=n_dtype)
         p = numpy.full(self.p_shape, 0.5, dtype=p_dtype)
         self.check_distribution('negative_binomial',
-                                {'n': n, 'p': p}, self.dtype)
+                                {'n': n, 'p': p})
 
     @helper.for_float_dtypes('n_dtype')
     @helper.for_float_dtypes('p_dtype')
@@ -365,7 +359,7 @@ class TestDistributionsNegativeBinomial(RandomDistributionsTestCase):
         n = numpy.full(self.n_shape, 5.5, dtype=n_dtype)
         p = numpy.full(self.p_shape, 0.5, dtype=p_dtype)
         self.check_distribution('negative_binomial',
-                                {'n': n, 'p': p}, self.dtype)
+                                {'n': n, 'p': p})
 
 
 @testing.parameterize(*testing.product({
@@ -453,14 +447,12 @@ class TestDistributionsNoncentralF(RandomDistributionsTestCase):
 @testing.gpu
 class TestDistributionsNormal(RandomDistributionsTestCase):
 
-    @helper.for_float_dtypes('dtype', no_float16=True)
     @helper.for_dtypes_combination(
-        _float_dtypes, names=['loc_dtype', 'scale_dtype'])
-    def test_normal(self, loc_dtype, scale_dtype, dtype):
+        _regular_float_dtypes, names=['loc_dtype', 'scale_dtype'])
+    def test_normal(self, loc_dtype, scale_dtype):
         loc = numpy.ones(self.loc_shape, dtype=loc_dtype)
         scale = numpy.ones(self.scale_shape, dtype=scale_dtype)
-        self.check_distribution('normal',
-                                {'loc': loc, 'scale': scale}, dtype)
+        self.check_distribution('normal', {'loc': loc, 'scale': scale})
 
 
 @testing.parameterize(*testing.product({
@@ -492,16 +484,16 @@ class TestDistributionsPareto(unittest.TestCase):
 @testing.gpu
 class TestDistributionsPoisson(unittest.TestCase):
 
-    def check_distribution(self, dist_func, lam_dtype, dtype):
+    def check_distribution(self, dist_func, lam_dtype):
         lam = cupy.full(self.lam_shape, 5, dtype=lam_dtype)
-        out = dist_func(lam, self.shape, dtype)
+        out = dist_func(lam, self.shape)
         self.assertEqual(self.shape, out.shape)
-        self.assertEqual(out.dtype, dtype)
+        # numpy output dtype is int64, dpnp output is int32
+        self.assertEqual(out.dtype, numpy.int64)
 
-    @helper.for_int_dtypes('dtype')
     @helper.for_float_dtypes('lam_dtype')
-    def test_poisson(self, lam_dtype, dtype):
-        self.check_distribution(_distributions.poisson, lam_dtype, dtype)
+    def test_poisson(self, lam_dtype):
+        self.check_distribution(_distributions.poisson, lam_dtype)
 
 
 @testing.parameterize(*testing.product({
@@ -512,20 +504,18 @@ class TestDistributionsPoisson(unittest.TestCase):
 @testing.gpu
 class TestDistributionsPower(RandomDistributionsTestCase):
 
-    @helper.for_float_dtypes('dtype', no_float16=True)
     @helper.for_float_dtypes('a_dtype')
-    def test_power(self, a_dtype, dtype):
+    def test_power(self, a_dtype):
         a = numpy.full(self.a_shape, 0.5, dtype=a_dtype)
-        self.check_distribution('power', {'a': a}, dtype)
+        self.check_distribution('power', {'a': a})
 
-    @helper.for_float_dtypes('dtype', no_float16=True)
     @helper.for_float_dtypes('a_dtype')
-    def test_power_for_negative_a(self, a_dtype, dtype):
+    def test_power_for_negative_a(self, a_dtype):
         a = numpy.full(self.a_shape, -0.5, dtype=a_dtype)
         with self.assertRaises(ValueError):
             cp_params = {'a': cupy.asarray(a)}
             getattr(_distributions, 'power')(
-                size=self.shape, dtype=dtype, **cp_params)
+                size=self.shape, **cp_params)
 
 
 @testing.parameterize(*testing.product({
@@ -561,9 +551,8 @@ class TestDistributionsRayleigh(RandomDistributionsTestCase):
 @testing.gpu
 class TestDistributionsStandardCauchy(RandomDistributionsTestCase):
 
-    @helper.for_float_dtypes('dtype', no_float16=True)
-    def test_standard_cauchy(self, dtype):
-        self.check_distribution('standard_cauchy', {}, dtype)
+    def test_standard_cauchy(self):
+        self.check_distribution('standard_cauchy', {})
 
 
 @testing.parameterize(*testing.product({
@@ -573,9 +562,8 @@ class TestDistributionsStandardCauchy(RandomDistributionsTestCase):
 @testing.gpu
 class TestDistributionsStandardExponential(RandomDistributionsTestCase):
 
-    @helper.for_float_dtypes('dtype', no_float16=True)
-    def test_standard_exponential(self, dtype):
-        self.check_distribution('standard_exponential', {}, dtype)
+    def test_standard_exponential(self):
+        self.check_distribution('standard_exponential', {})
 
 
 @testing.parameterize(*testing.product({
@@ -600,9 +588,8 @@ class TestDistributionsStandardGamma(RandomDistributionsTestCase):
 @testing.gpu
 class TestDistributionsStandardNormal(RandomDistributionsTestCase):
 
-    @helper.for_float_dtypes('dtype', no_float16=True)
-    def test_standard_normal(self, dtype):
-        self.check_distribution('standard_normal', {}, dtype)
+    def test_standard_normal(self):
+        self.check_distribution('standard_normal', {})
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
## Description
* enabled third-party tests for random funcs

## Note:
__324 test cases removed form skip lists__

```DPNP_QUEUE_GPU=1 pytest tests/third_party/cupy/random_tests/test_distributions.py```
Before: 176 passed, 421 skipped
After: 248 passed, 121 skipped 
__Update: ++72 passed, --300 skipped__

```DPNP_QUEUE_GPU=0 pytest tests/third_party/cupy/random_tests/test_distributions.py```
Before: 172 passed, 425 skipped
After: 244 passed, 125 skipped 
__Update: ++72 passed, --300 skipped__