### PR TITLE
FIX: update `random.uniform`

### DIFF
--- a/dpnp/random/_random.pyx
+++ b/dpnp/random/_random.pyx
@@ -841,7 +841,7 @@ cpdef dparray dpnp_standard_normal(size):
     return result
 
 
-cpdef dparray dpnp_uniform(low, high, size, dtype=numpy.int32):
+cpdef dparray dpnp_uniform(long low, long high, size, dtype):
     """
     Returns an array populated with samples from standard uniform distribution.
     Generates a matrix filled with random numbers sampled from a
@@ -857,7 +857,7 @@ cpdef dparray dpnp_uniform(low, high, size, dtype=numpy.int32):
 
     if low == high:
         result = dparray(size, dtype=dtype)
-        result.fill(0.0)
+        result.fill(low)
     else:
         # convert string type names (dparray.dtype) to C enum DPNPFuncType
         param1_type = dpnp_dtype_to_DPNPFuncType(dtype)

--- a/dpnp/random/_random.pyx
+++ b/dpnp/random/_random.pyx
@@ -841,7 +841,7 @@ cpdef dparray dpnp_standard_normal(size):
     return result
 
 
-cpdef dparray dpnp_uniform(long low, long high, size, dtype=numpy.int32):
+cpdef dparray dpnp_uniform(low, high, size, dtype=numpy.int32):
     """
     Returns an array populated with samples from standard uniform distribution.
     Generates a matrix filled with random numbers sampled from a
@@ -849,19 +849,29 @@ cpdef dparray dpnp_uniform(long low, long high, size, dtype=numpy.int32):
     bounds.
 
     """
-    # convert string type names (dparray.dtype) to C enum DPNPFuncType
-    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(dtype)
 
-    # get the FPTR data structure
-    cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_RNG_UNIFORM, param1_type, param1_type)
+    cdef dparray result
+    cdef DPNPFuncType param1_type
+    cdef DPNPFuncData kernel_data
+    cdef fptr_custom_rng_uniform_c_1out_t func
 
-    result_type = dpnp_DPNPFuncType_to_dtype( < size_t > kernel_data.return_type)
-    # ceate result array with type given by FPTR data
-    cdef dparray result = dparray(size, dtype=result_type)
+    if low == high:
+        result = dparray(size, dtype=dtype)
+        result.fill(0.0)
+    else:
+        # convert string type names (dparray.dtype) to C enum DPNPFuncType
+        param1_type = dpnp_dtype_to_DPNPFuncType(dtype)
 
-    cdef fptr_custom_rng_uniform_c_1out_t func = <fptr_custom_rng_uniform_c_1out_t > kernel_data.ptr
-    # call FPTR function
-    func(result.get_data(), low, high, result.size)
+        # get the FPTR data structure
+        kernel_data = get_dpnp_function_ptr(DPNP_FN_RNG_UNIFORM, param1_type, param1_type)
+
+        result_type = dpnp_DPNPFuncType_to_dtype( < size_t > kernel_data.return_type)
+        # ceate result array with type given by FPTR data
+        result = dparray(size, dtype=result_type)
+
+        func = <fptr_custom_rng_uniform_c_1out_t > kernel_data.ptr
+        # call FPTR function
+        func(result.get_data(), low, high, result.size)
 
     return result
 

--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -1505,7 +1505,7 @@ def uniform(low=0.0, high=1.0, size=None):
         else:
             if low > high:
                 low, high = high, low
-        return dpnp_uniform(low, high, size, dtype=dpnp.float64)
+            return dpnp_uniform(low, high, size, dtype=numpy.float64)
 
     return call_origin(numpy.random.uniform, low, high, size)
 

--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -1476,28 +1476,20 @@ def uniform(low=0.0, high=1.0, size=None):
     uniform(low=0.0, high=1.0, size=None)
 
     Draw samples from a uniform distribution.
-    Samples are uniformly distributed over the half-open interval
-    ``[low, high)`` (includes low, but excludes high).  In other words,
-    any value within the given interval is equally likely to be drawn
-    by `uniform`.
 
-    Parameters
-    ----------
-    low : float, optional
-        Lower boundary of the output interval.  All values generated will be
-        greater than or equal to low.  The default value is 0.
-    high : float
-        Upper boundary of the output interval.  All values generated will be
-        less than high.  The default value is 1.0.
-    size : int or tuple of ints, optional
-        Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-        ``m * n * k`` samples are drawn.  If size is ``None`` (default),
-        a single value is returned if ``low`` and ``high`` are both scalars.
+    For full documentation refer to :obj:`numpy.random.uniform`.
 
-    Returns
-    -------
-    out : array or scalar
-        Drawn samples from the parameterized uniform distribution.
+    Limitations
+    -----------
+    Parameters ``low`` and ``high`` are supported as scalar.
+    Otherwise, :obj:`numpy.random.uniform(low, high, size)` samples are drawn.
+    Output array data type is :obj:`dpnp.float64`.
+
+    Examples
+    --------
+    Draw samples from the distribution:
+    >>> low, high = 0, 0.1 # low and high
+    >>> s = dpnp.random.uniform(low, high, 10000)
 
     See Also
     --------
@@ -1506,16 +1498,14 @@ def uniform(low=0.0, high=1.0, size=None):
     """
 
     if not use_origin_backend(low):
-        if low == high:
-            # TODO:
-            # currently dparray.full is not implemented
-            # return dpnp.dparray.dparray.full(size, low, dtype=numpy.float64)
-            message = "`low` equal to `high`, should return an array, filled with `low` value."
-            message += "  Currently not supported. See: numpy.full TODO"
-            checker_throw_runtime_error("uniform", message)
-        elif low > high:
-            low, high = high, low
-        return dpnp_uniform(low, high, size, dtype=numpy.float64)
+        if not dpnp.isscalar(low):
+            pass
+        elif not dpnp.isscalar(high):
+            pass
+        else:
+            if low > high:
+                low, high = high, low
+        return dpnp_uniform(low, high, size, dtype=dpnp.float64)
 
     return call_origin(numpy.random.uniform, low, high, size)
 

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -1282,8 +1282,6 @@ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsUnif
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsUniform_param_3_{high_shape=(), low_shape=(3, 2), shape=(3, 2)}::test_uniform
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsUniform_param_4_{high_shape=(3, 2), low_shape=(), shape=(4, 3, 2)}::test_uniform
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsUniform_param_5_{high_shape=(3, 2), low_shape=(), shape=(3, 2)}::test_uniform
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsUniform_param_6_{high_shape=(3, 2), low_shape=(3, 2), shape=(4, 3, 2)}::test_uniform
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsUniform_param_7_{high_shape=(3, 2), low_shape=(3, 2), shape=(3, 2)}::test_uniform
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsWald_param_0_{mean_shape=(), scale_shape=(), shape=(4, 3, 2)}::test_wald
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsWald_param_1_{mean_shape=(), scale_shape=(), shape=(3, 2)}::test_wald
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsWald_param_2_{mean_shape=(), scale_shape=(3, 2), shape=(4, 3, 2)}::test_wald

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -1640,8 +1640,6 @@ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsUnif
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsUniform_param_3_{high_shape=(), low_shape=(3, 2), shape=(3, 2)}::test_uniform
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsUniform_param_4_{high_shape=(3, 2), low_shape=(), shape=(4, 3, 2)}::test_uniform
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsUniform_param_5_{high_shape=(3, 2), low_shape=(), shape=(3, 2)}::test_uniform
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsUniform_param_6_{high_shape=(3, 2), low_shape=(3, 2), shape=(4, 3, 2)}::test_uniform
-tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsUniform_param_7_{high_shape=(3, 2), low_shape=(3, 2), shape=(3, 2)}::test_uniform
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsWald_param_0_{mean_shape=(), scale_shape=(), shape=(4, 3, 2)}::test_wald
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsWald_param_1_{mean_shape=(), scale_shape=(), shape=(3, 2)}::test_wald
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsWald_param_2_{mean_shape=(), scale_shape=(3, 2), shape=(4, 3, 2)}::test_wald

--- a/tests/third_party/cupy/random_tests/test_distributions.py
+++ b/tests/third_party/cupy/random_tests/test_distributions.py
@@ -658,21 +658,19 @@ class TestDistributionsTriangular(RandomDistributionsTestCase):
 
 @testing.parameterize(*testing.product({
     'shape': [(4, 3, 2), (3, 2)],
-    'low_shape': [(), (3, 2)],
-    'high_shape': [(), (3, 2)],
+    'low_shape': [(1), (3, 2)],
+    'high_shape': [(1), (3, 2)],
 })
 )
 @testing.gpu
 class TestDistributionsUniform(RandomDistributionsTestCase):
 
-    @helper.for_float_dtypes('dtype', no_float16=True)
     @helper.for_dtypes_combination(
-        _float_dtypes, names=['low_dtype', 'high_dtype'])
-    def test_uniform(self, low_dtype, high_dtype, dtype):
+        _regular_float_dtypes, names=['low_dtype', 'high_dtype'])
+    def test_uniform(self, low_dtype, high_dtype):
         low = numpy.ones(self.low_shape, dtype=low_dtype)
         high = numpy.ones(self.high_shape, dtype=high_dtype) * 2.
-        self.check_distribution('uniform',
-                                {'low': low, 'high': high}, dtype)
+        self.check_distribution('uniform', {'low': low, 'high': high})
 
 
 @testing.parameterize(*testing.product({

--- a/tests/third_party/cupy/random_tests/test_distributions.py
+++ b/tests/third_party/cupy/random_tests/test_distributions.py
@@ -658,8 +658,8 @@ class TestDistributionsTriangular(RandomDistributionsTestCase):
 
 @testing.parameterize(*testing.product({
     'shape': [(4, 3, 2), (3, 2)],
-    'low_shape': [(1), (3, 2)],
-    'high_shape': [(1), (3, 2)],
+    'low_shape': [(), (3, 2)],
+    'high_shape': [(), (3, 2)],
 })
 )
 @testing.gpu


### PR DESCRIPTION
## Description
* update `random.uniform`
* update `dpnp_uniform`
* align with template docstring for `random.uniform`
* enables cupy tests for check
* removed tests from skip lists ++2 passed test cases

## TODO
test. root cause as on #346 , #347 :

- tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsUniform_param_0_{high_shape=(), low_shape=(), shape=(4, 3, 2)}::test_uniform
- tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsUniform_param_1_{high_shape=(), low_shape=(), shape=(3, 2)}::test_uniform
- tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsUniform_param_2_{high_shape=(), low_shape=(3, 2), shape=(4, 3, 2)}::test_uniform
- tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsUniform_param_3_{high_shape=(), low_shape=(3, 2), shape=(3, 2)}::test_uniform
- tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsUniform_param_4_{high_shape=(3, 2), low_shape=(), shape=(4, 3, 2)}::test_uniform
- tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsUniform_param_5_{high_shape=(3, 2), low_shape=(), shape=(3, 2)}::test_uniform