### PR TITLE
FIX: `random.gumbel` moments, issue #257

### DIFF
--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -125,7 +125,6 @@ tests/test_linalg.py::test_norm3[(1, 2)-2-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
 tests/test_linalg.py::test_norm3[(1, 2)-2-[[[1, 0], [3, 0]], [[5, 0], [7, 0]]]]
 tests/test_linalg.py::test_norm3[(1, 2)-3-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
 tests/test_linalg.py::test_norm3[(1, 2)-3-[[[1, 0], [3, 0]], [[5, 0], [7, 0]]]]
-tests/test_random.py::test_rayleigh_check_moments
 tests/test_random.py::TestDistributionsGumbel::test_moments
 tests/test_random.py::TestDistributionsRayleigh::test_moments
 tests/third_party/cupy/binary_tests/test_elementwise.py::TestElementwise::test_bitwise_and

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -125,7 +125,6 @@ tests/test_linalg.py::test_norm3[(1, 2)-2-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
 tests/test_linalg.py::test_norm3[(1, 2)-2-[[[1, 0], [3, 0]], [[5, 0], [7, 0]]]]
 tests/test_linalg.py::test_norm3[(1, 2)-3-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
 tests/test_linalg.py::test_norm3[(1, 2)-3-[[[1, 0], [3, 0]], [[5, 0], [7, 0]]]]
-tests/test_random.py::TestDistributionsGumbel::test_moments
 tests/test_random.py::TestDistributionsRayleigh::test_moments
 tests/third_party/cupy/binary_tests/test_elementwise.py::TestElementwise::test_bitwise_and
 tests/third_party/cupy/binary_tests/test_elementwise.py::TestElementwise::test_bitwise_or

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -126,7 +126,6 @@ tests/test_linalg.py::test_norm3[(1, 2)-2-[[[1, 0], [3, 0]], [[5, 0], [7, 0]]]]
 tests/test_linalg.py::test_norm3[(1, 2)-3-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
 tests/test_linalg.py::test_norm3[(1, 2)-3-[[[1, 0], [3, 0]], [[5, 0], [7, 0]]]]
 tests/test_random.py::test_rayleigh_check_moments
-tests/test_random.py::test_gumbel_check_moments
 tests/third_party/cupy/binary_tests/test_elementwise.py::TestElementwise::test_bitwise_and
 tests/third_party/cupy/binary_tests/test_elementwise.py::TestElementwise::test_bitwise_or
 tests/third_party/cupy/binary_tests/test_elementwise.py::TestElementwise::test_bitwise_xor

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -160,7 +160,6 @@ tests/test_random.py::TestDistributionsBeta::test_seed
 tests/test_random.py::TestDistributionsBinomial::test_seed
 tests/test_random.py::TestDistributionsChisquare::test_seed
 tests/test_random.py::TestDistributionsGamma::test_seed
-tests/test_random.py::TestDistributionsGumbel::test_moments
 tests/test_random.py::TestDistributionsHypergeometric::test_seed
 tests/test_random.py::TestDistributionsMultinomial::test_invalid_args
 tests/test_random.py::TestDistributionsMultinomial::test_seed

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -149,9 +149,6 @@ tests/test_random.py::test_multinomial_check_moments
 tests/test_random.py::test_multinomial_check_sum
 tests/test_random.py::test_multinomial_invalid_args
 tests/test_random.py::test_multinomial_seed
-tests/test_random.py::test_multivariate_normal_check_moments
-tests/test_random.py::test_multivariate_normal_invalid_args
-tests/test_random.py::test_multivariate_normal_output_shape_check
 tests/test_random.py::test_multivariate_normal_seed
 tests/test_random.py::test_negative_binomial_seed
 tests/test_random.py::test_rayleigh_check_moments 

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -137,7 +137,6 @@ tests/test_random.py::test_binomial_seed
 tests/test_random.py::test_chisquare_seed
 tests/test_random.py::test_gamma_check_moments
 tests/test_random.py::test_gamma_seed 
-tests/test_random.py::test_gumbel_check_moments
 tests/test_random.py::test_hypergeometric_check_extreme_value
 tests/test_random.py::test_hypergeometric_check_moments
 tests/test_random.py::test_hypergeometric_invalid_args


### PR DESCRIPTION
## Description
Closes #257 
* Fix `random.gumbel` moments issue.
* enabled tests for the check.

## Reproduce
```python
>>> np.mean(dpnp.random.gumbel(12, 0.8, 10**6));np.mean(np.random.gumbel(12, 0.8, 10**6))
12.463093507232983
12.464127453889729
>>> np.var(dpnp.random.gumbel(12, 0.8, 10**6));np.var(np.random.gumbel(12, 0.8, 10**6))
1.0524031728788483
1.0538524917740162

```