### PR TITLE
return full tests in recipe

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -36,6 +36,7 @@ test:
         - tests
     commands:
       - python -c "import dpnp"
+      - pytest
       - conda list
       - ls -laR /opt/intel/oneapi/intelpython/latest/conda-bld/
       - pytest tests/third_party/cupy/math_tests/test_arithmetic.py -sv


### PR DESCRIPTION
It is a bad idea to exclude full testing from recipe in https://github.com/IntelPython/dpnp/pull/415 (merged).