### PR TITLE
ENH: dpnp backend fallback to classic MKL; update `random.beta`

### DIFF
--- a/dpnp/backend/kernels/dpnp_krnl_random.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_random.cpp
@@ -23,21 +23,58 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //*****************************************************************************
 
+#include <mkl_vsl.h>
+#include <stdexcept>
+#include <vector>
+
 #include <dpnp_iface.hpp>
+
 #include "dpnp_fptr.hpp"
 #include "dpnp_utils.hpp"
 #include "queue_sycl.hpp"
-#include "mkl_vsl.h"
-
-#include <vector>
 
 namespace mkl_rng = oneapi::mkl::rng;
 namespace mkl_blas = oneapi::mkl::blas;
 
+/**
+ * Use get/set functions to access/modify this variable
+ */
+static VSLStreamStatePtr rng_stream = nullptr;
+
+static void set_rng_stream(size_t seed = 1)
+{
+    if (rng_stream)
+    {
+        vslDeleteStream(&rng_stream);
+        rng_stream = nullptr;
+    }
+
+    vslNewStream(&rng_stream, VSL_BRNG_MT19937, seed);
+}
+
+static VSLStreamStatePtr get_rng_stream()
+{
+    if (!rng_stream)
+    {
+        set_rng_stream();
+    }
+
+    return rng_stream;
+}
+
+void dpnp_srand_c(size_t seed)
+{
+    backend_sycl::backend_sycl_rng_engine_init(seed);
+    set_rng_stream(seed);
+}
+
 template <typename _DataType>
 void dpnp_rng_beta_c(void* result, _DataType a, _DataType b, size_t size)
 {
-    int errcode;  // status TODO: using (could be redesigne)
+    if (!size)
+    {
+        return;
+    }
 
     _DataType displacement = _DataType(0.0);
 
@@ -45,12 +82,7 @@ void dpnp_rng_beta_c(void* result, _DataType a, _DataType b, size_t size)
 
     _DataType* result1 = reinterpret_cast<_DataType*>(result);
 
-    if (!size)
-    {
-        return;
-    }
-
-    if(dpnp_queue_is_cpu_c())
+    if (dpnp_queue_is_cpu_c())
     {
         mkl_rng::beta<_DataType> distribution(a, b, displacement, scalefactor);
         // perform generation
@@ -59,9 +91,15 @@ void dpnp_rng_beta_c(void* result, _DataType a, _DataType b, size_t size)
     }
     else
     {
-        errcode = vdRngBeta(METHOD, DPNP_RNG_STREAM, size, result1, a, b, displacement, scalefactor);
-        assert(errcode == VSL_STATUS_OK);
+        int errcode =
+            vdRngBeta(VSL_RNG_METHOD_BETA_CJA, get_rng_stream(), size, result1, a, b, displacement, scalefactor);
+        if (errcode != VSL_STATUS_OK)
+        {
+            throw std::runtime_error("DPNP RNG Error: dpnp_rng_beta_c() failed.");
+        }
     }
+
+    return;
 }
 
 template <typename _DataType>

--- a/dpnp/backend/src/queue_sycl.cpp
+++ b/dpnp/backend/src/queue_sycl.cpp
@@ -34,6 +34,7 @@
 cl::sycl::queue* backend_sycl::queue = nullptr;
 #endif
 mkl_rng::mt19937* backend_sycl::rng_engine = nullptr;
+VSLStreamStatePtr backend_sycl::stream = NULL;
 
 /**
  * Function push the SYCL kernels to be linked (final stage of the compilation) for the current queue
@@ -142,6 +143,16 @@ void backend_sycl::backend_sycl_rng_engine_init(size_t seed)
     rng_engine = new mkl_rng::mt19937(DPNP_QUEUE, seed);
 }
 
+void backend_sycl::backend_sycl_rng_stream_init(size_t seed)
+{
+    if (stream)
+    {
+        backend_sycl::destroy_rng_stream();
+    }
+    vslNewStream(&stream, BRNG, seed);
+}
+
+
 void dpnp_queue_initialize_c(QueueOptions selector)
 {
     backend_sycl::backend_sycl_queue_init(selector);
@@ -155,4 +166,5 @@ size_t dpnp_queue_is_cpu_c()
 void dpnp_srand_c(size_t seed)
 {
     backend_sycl::backend_sycl_rng_engine_init(seed);
+    backend_sycl::backend_sycl_rng_stream_init(seed);
 }

--- a/dpnp/backend/src/queue_sycl.cpp
+++ b/dpnp/backend/src/queue_sycl.cpp
@@ -34,7 +34,6 @@
 cl::sycl::queue* backend_sycl::queue = nullptr;
 #endif
 mkl_rng::mt19937* backend_sycl::rng_engine = nullptr;
-VSLStreamStatePtr backend_sycl::stream = NULL;
 
 /**
  * Function push the SYCL kernels to be linked (final stage of the compilation) for the current queue
@@ -143,16 +142,6 @@ void backend_sycl::backend_sycl_rng_engine_init(size_t seed)
     rng_engine = new mkl_rng::mt19937(DPNP_QUEUE, seed);
 }
 
-void backend_sycl::backend_sycl_rng_stream_init(size_t seed)
-{
-    if (stream)
-    {
-        backend_sycl::destroy_rng_stream();
-    }
-    vslNewStream(&stream, BRNG, seed);
-}
-
-
 void dpnp_queue_initialize_c(QueueOptions selector)
 {
     backend_sycl::backend_sycl_queue_init(selector);
@@ -161,10 +150,4 @@ void dpnp_queue_initialize_c(QueueOptions selector)
 size_t dpnp_queue_is_cpu_c()
 {
     return backend_sycl::backend_sycl_is_cpu();
-}
-
-void dpnp_srand_c(size_t seed)
-{
-    backend_sycl::backend_sycl_rng_engine_init(seed);
-    backend_sycl::backend_sycl_rng_stream_init(seed);
 }

--- a/dpnp/backend/src/queue_sycl.hpp
+++ b/dpnp/backend/src/queue_sycl.hpp
@@ -39,7 +39,6 @@
 #pragma clang diagnostic pop
 
 #include <ctime>
-#include <mkl_vsl.h>
 
 #if !defined(DPNP_LOCAL_QUEUE)
 #include <dpctl_sycl_queue_manager.h>
@@ -51,10 +50,6 @@ namespace mkl_rng = oneapi::mkl::rng;
 
 #define DPNP_QUEUE      backend_sycl::get_queue()
 #define DPNP_RNG_ENGINE backend_sycl::get_rng_engine()
-#define DPNP_RNG_STREAM backend_sycl::get_rng_stream()
-
-#define METHOD  VSL_RNG_METHOD_BETA_CJA
-#define BRNG    VSL_BRNG_MT19937
 
 /**
  * This is container for the SYCL queue, random number generation engine and related functions like queue and engine
@@ -68,12 +63,10 @@ class backend_sycl
     static cl::sycl::queue* queue; /**< contains SYCL queue pointer initialized in @ref backend_sycl_queue_init */
 #endif
     static mkl_rng::mt19937* rng_engine; /**< RNG engine ptr. initialized in @ref backend_sycl_rng_engine_init */
-    static VSLStreamStatePtr stream; /**< Ptr. to the stream state structure @ref backend_sycl_rng_stream_init */
 
     static void destroy()
     {
         backend_sycl::destroy_rng_engine();
-        backend_sycl::destroy_rng_stream();
 #if defined(DPNP_LOCAL_QUEUE)
         delete queue;
         queue = nullptr;
@@ -86,20 +79,12 @@ class backend_sycl
         rng_engine = nullptr;
     }
 
-    static void destroy_rng_stream()
-    {
-        if(stream) {
-            vslDeleteStream(&stream);
-        }
-    }
-
 public:
     backend_sycl()
     {
 #if defined(DPNP_LOCAL_QUEUE)
         queue = nullptr;
         rng_engine = nullptr;
-        stream = NULL;
 #endif
     }
 
@@ -130,11 +115,6 @@ public:
     static void backend_sycl_rng_engine_init(size_t seed = 1);
 
     /**
-     * Initialize @ref stream
-     */
-    static void backend_sycl_rng_stream_init(size_t seed = 1);
-
-    /**
      * Return the @ref queue to the user
      */
     static cl::sycl::queue& get_queue()
@@ -163,18 +143,6 @@ public:
             backend_sycl_rng_engine_init();
         }
         return *rng_engine;
-    }
-
-    /**
-     * Return the @ref stream to the user
-     */
-    static VSLStreamStatePtr get_rng_stream()
-    {
-        if (!stream)
-        {
-            backend_sycl_rng_stream_init();
-        }
-        return stream;
     }
 };
 

--- a/dpnp/backend/src/queue_sycl.hpp
+++ b/dpnp/backend/src/queue_sycl.hpp
@@ -39,6 +39,7 @@
 #pragma clang diagnostic pop
 
 #include <ctime>
+#include <mkl_vsl.h>
 
 #if !defined(DPNP_LOCAL_QUEUE)
 #include <dpctl_sycl_queue_manager.h>
@@ -50,6 +51,10 @@ namespace mkl_rng = oneapi::mkl::rng;
 
 #define DPNP_QUEUE      backend_sycl::get_queue()
 #define DPNP_RNG_ENGINE backend_sycl::get_rng_engine()
+#define DPNP_RNG_STREAM backend_sycl::get_rng_stream()
+
+#define METHOD  VSL_RNG_METHOD_BETA_CJA
+#define BRNG    VSL_BRNG_MCG31  // TODO: will be changed
 
 /**
  * This is container for the SYCL queue, random number generation engine and related functions like queue and engine
@@ -63,14 +68,17 @@ class backend_sycl
     static cl::sycl::queue* queue; /**< contains SYCL queue pointer initialized in @ref backend_sycl_queue_init */
 #endif
     static mkl_rng::mt19937* rng_engine; /**< RNG engine ptr. initialized in @ref backend_sycl_rng_engine_init */
+    static VSLStreamStatePtr stream; /**< TODO ?>**/
 
     static void destroy()
     {
         backend_sycl::destroy_rng_engine();
+        backend_sycl::destroy_rng_stream();
 #if defined(DPNP_LOCAL_QUEUE)
         delete queue;
         queue = nullptr;
 #endif
+
     }
 
     static void destroy_rng_engine()
@@ -79,12 +87,20 @@ class backend_sycl
         rng_engine = nullptr;
     }
 
+    static void destroy_rng_stream()
+    {
+        if(stream) {
+            vslDeleteStream(&stream);
+        }
+    }
+
 public:
     backend_sycl()
     {
 #if defined(DPNP_LOCAL_QUEUE)
         queue = nullptr;
         rng_engine = nullptr;
+        stream = NULL;
 #endif
     }
 
@@ -115,6 +131,11 @@ public:
     static void backend_sycl_rng_engine_init(size_t seed = 1);
 
     /**
+     * Initialize @ref rng_engine
+     */
+    static void backend_sycl_rng_stream_init(size_t seed = 1);
+
+    /**
      * Return the @ref queue to the user
      */
     static cl::sycl::queue& get_queue()
@@ -143,6 +164,18 @@ public:
             backend_sycl_rng_engine_init();
         }
         return *rng_engine;
+    }
+
+    /**
+     * Return the @ref stream to the user
+     */
+    static VSLStreamStatePtr get_rng_stream()
+    {
+        if (!stream)
+        {
+            backend_sycl_rng_stream_init();
+        }
+        return stream;
     }
 };
 

--- a/dpnp/backend/src/queue_sycl.hpp
+++ b/dpnp/backend/src/queue_sycl.hpp
@@ -54,7 +54,7 @@ namespace mkl_rng = oneapi::mkl::rng;
 #define DPNP_RNG_STREAM backend_sycl::get_rng_stream()
 
 #define METHOD  VSL_RNG_METHOD_BETA_CJA
-#define BRNG    VSL_BRNG_MCG31  // TODO: will be changed
+#define BRNG    VSL_BRNG_MT19937
 
 /**
  * This is container for the SYCL queue, random number generation engine and related functions like queue and engine
@@ -68,7 +68,7 @@ class backend_sycl
     static cl::sycl::queue* queue; /**< contains SYCL queue pointer initialized in @ref backend_sycl_queue_init */
 #endif
     static mkl_rng::mt19937* rng_engine; /**< RNG engine ptr. initialized in @ref backend_sycl_rng_engine_init */
-    static VSLStreamStatePtr stream; /**< TODO ?>**/
+    static VSLStreamStatePtr stream; /**< Ptr. to the stream state structure @ref backend_sycl_rng_stream_init */
 
     static void destroy()
     {
@@ -78,7 +78,6 @@ class backend_sycl
         delete queue;
         queue = nullptr;
 #endif
-
     }
 
     static void destroy_rng_engine()
@@ -131,7 +130,7 @@ public:
     static void backend_sycl_rng_engine_init(size_t seed = 1);
 
     /**
-     * Initialize @ref rng_engine
+     * Initialize @ref stream
      */
     static void backend_sycl_rng_stream_init(size_t seed = 1);
 


### PR DESCRIPTION
# Description
* added stream for classic MKL call
* update `radnom.beta` backend func, when GPU selector

# TODO
* backend tests -> TODO pytest_cpp will be added -> other PR
* update example5.cpp -> other PR
* * rename `backend_sycl` -> other PR