### PR TITLE
ENH: `random.standard_t` impl

### DIFF
--- a/dpnp/backend/include/dpnp_iface.hpp
+++ b/dpnp/backend/include/dpnp_iface.hpp
@@ -935,6 +935,20 @@ INP_DLLEXPORT void dpnp_rng_standard_gamma_c(void* result, _DataType shape, size
 
 /**
  * @ingroup BACKEND_API
+ * @brief math library implementation of random number generator (standard Student's t distribution)
+ *
+ * @param [in]  size   Number of elements in `result` arrays.
+ *
+ * @param [in]  df     Degrees of freedom.
+ *
+ * @param [out] result Output array.
+ *
+ */
+template <typename _DataType>
+INP_DLLEXPORT void dpnp_rng_standard_t_c(void* result, _DataType df, size_t size);
+
+/**
+ * @ingroup BACKEND_API
  * @brief math library implementation of random number generator (uniform distribution)
  *
  * @param [in]  low    Left bound of array values.

--- a/dpnp/backend/include/dpnp_iface_fptr.hpp
+++ b/dpnp/backend/include/dpnp_iface_fptr.hpp
@@ -143,6 +143,7 @@ enum class DPNPFuncName : size_t
     DPNP_FN_RNG_STANDARD_EXPONENTIAL, /**< Used in numpy.random.standard_exponential() implementation  */
     DPNP_FN_RNG_STANDARD_GAMMA,       /**< Used in numpy.random.standard_gamma() implementation  */
     DPNP_FN_RNG_STANDARD_NORMAL,      /**< Used in numpy.random.standard_normal() implementation  */
+    DPNP_FN_RNG_STANDARD_T,           /**< Used in numpy.random.standard_t() implementation  */
     DPNP_FN_RNG_UNIFORM,              /**< Used in numpy.random.uniform() implementation  */
     DPNP_FN_RNG_WEIBULL,              /**< Used in numpy.random.weibull() implementation  */
     DPNP_FN_SIGN,                     /**< Used in numpy.sign() implementation  */

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -116,6 +116,7 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_RNG_STANDARD_EXPONENTIAL
         DPNP_FN_RNG_STANDARD_GAMMA
         DPNP_FN_RNG_STANDARD_NORMAL
+        DPNP_FN_RNG_STANDARD_T
         DPNP_FN_RNG_UNIFORM
         DPNP_FN_RNG_WEIBULL
         DPNP_FN_SIGN

--- a/dpnp/random/dpnp_algo_random.pyx
+++ b/dpnp/random/dpnp_algo_random.pyx
@@ -66,6 +66,7 @@ __all__ = [
     "dpnp_standard_exponential",
     "dpnp_standard_gamma",
     "dpnp_standard_normal",
+    "dpnp_standard_t",
     "dpnp_uniform",
     "dpnp_weibull"
 ]
@@ -98,6 +99,7 @@ ctypedef void(*fptr_dpnp_rng_standard_cauchy_c_1out_t)(void *, size_t) except +
 ctypedef void(*fptr_dpnp_rng_standard_exponential_c_1out_t)(void *, size_t) except +
 ctypedef void(*fptr_dpnp_rng_standard_gamma_c_1out_t)(void *, double, size_t) except +
 ctypedef void(*fptr_dpnp_rng_standard_normal_c_1out_t)(void *, size_t) except +
+ctypedef void(*fptr_dpnp_rng_standard_t_c_1out_t)(void *, double, size_t) except +
 ctypedef void(*fptr_dpnp_rng_uniform_c_1out_t)(void *, long, long, size_t) except +
 ctypedef void(*fptr_dpnp_rng_weibull_c_1out_t)(void *, double, size_t) except +
 
@@ -836,6 +838,30 @@ cpdef dparray dpnp_standard_normal(size):
     cdef fptr_dpnp_rng_standard_normal_c_1out_t func = < fptr_dpnp_rng_standard_normal_c_1out_t > kernel_data.ptr
     # call FPTR function
     func(result.get_data(), result.size)
+
+    return result
+
+cpdef dparray dpnp_standard_t(double df, size):
+    """
+    Returns an array populated with samples from standard t distribution.
+    `dpnp_standard_t` generates a matrix filled with random floats sampled from a
+    univariate standard t distribution for a given number of degrees of freedom.
+
+    """
+
+    # convert string type names (dparray.dtype) to C enum DPNPFuncType
+    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(numpy.float64)
+
+    # get the FPTR data structure
+    cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_RNG_STANDARD_T, param1_type, param1_type)
+
+    result_type = dpnp_DPNPFuncType_to_dtype( < size_t > kernel_data.return_type)
+    # ceate result array with type given by FPTR data
+    cdef dparray result = dparray(size, dtype=result_type)
+
+    cdef fptr_dpnp_rng_standard_t_c_1out_t func = <fptr_dpnp_rng_standard_t_c_1out_t > kernel_data.ptr
+    # call FPTR function
+    func(result.get_data(), df, result.size)
 
     return result
 

--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -1341,20 +1341,38 @@ def standard_normal(size=None):
 
 
 def standard_t(df, size=None):
-    """Power distribution.
+    """Standard Student’s t distribution.
 
-    Draw samples from a standard Student’s t distribution with df degrees
-    of freedom.
+    Draw samples from a standard Student’s t distribution with
+    df degrees of freedom.
 
     For full documentation refer to :obj:`numpy.random.standard_t`.
 
-    Notes
-    -----
-    The function uses `numpy.random.standard_t` on the backend and
-    will be executed on fallback backend.
+    Limitations
+    -----------
+    Parameter ``df`` is supported as a scalar.
+    Otherwise, :obj:`numpy.random.standard_t(df, size)` samples
+    are drawn.
+    Output array data type is :obj:`dpnp.float64`.
+
+    Examples
+    --------
+    Draw samples from the distribution:
+    >>> df = 2.
+    >>> s = dpnp.random.standard_t(df, 1000000)
 
     """
 
+    if not use_origin_backend(df) and dpnp_queue_is_cpu():
+        # TODO:
+        # array_like of floats for `df`
+        if not dpnp.isscalar(df):
+            pass
+        elif df <= 0:
+            pass
+        else:
+            return dpnp_standard_t(df, size)
+    print("here")
     return call_origin(numpy.random.standard_t, df, size)
 
 

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -652,6 +652,23 @@ class TestDistributionsStandardNormal(TestDistribution):
         self.check_seed('standard_normal', {})
 
 
+class TestDistributionsStandardT(TestDistribution):
+
+    def test_moments(self):
+        df = 300.0
+        expected_mean = 0.0
+        expected_var = df / (df - 2)
+        self.check_moments('standard_t', expected_mean,
+                           expected_var, {'df': df})
+
+    def test_invalid_args(self):
+        df = 0.0   # positive `df` is expected
+        self.check_invalid_args('standard_t', {'df': df})
+
+    def test_seed(self):
+        self.check_seed('standard_t', {'df': 10.0})
+
+
 class TestDistributionsUniform(TestDistribution):
 
     def test_extreme_value(self):

--- a/tests_external/skipped_tests_numpy.tbl
+++ b/tests_external/skipped_tests_numpy.tbl
@@ -1501,6 +1501,7 @@ tests/test_random.py::TestRandomDist::test_standard_exponential
 tests/test_random.py::TestRandomDist::test_standard_gamma
 tests/test_random.py::TestRandomDist::test_standard_gamma_0
 tests/test_random.py::TestRandomDist::test_standard_normal
+tests/test_random.py::TestRandomDist::test_standard_t
 tests/test_random.py::TestRandomDist::test_uniform
 tests/test_random.py::TestRandomDist::test_uniform_range_bounds
 tests/test_random.py::TestRandomDist::test_weibull
@@ -1595,6 +1596,7 @@ tests/test_randomstate.py::TestRandomDist::test_standard_exponential
 tests/test_randomstate.py::TestRandomDist::test_standard_gamma
 tests/test_randomstate.py::TestRandomDist::test_standard_gamma_0
 tests/test_randomstate.py::TestRandomDist::test_standard_normal
+tests/test_randomstate.py::TestRandomDist::test_standard_t
 tests/test_randomstate.py::TestRandomDist::test_tomaxint
 tests/test_randomstate.py::TestRandomDist::test_uniform
 tests/test_randomstate.py::TestRandomDist::test_uniform_range_bounds


### PR DESCRIPTION
## Description
standard_t(df[, size]) Draw samples from a standard Student’s t distribution with df degrees of freedom.

## TODO
* array_like of floats for `df` param
* tests for backend `dpnp_rng_standard_t_c`

## Reproduce
```python
>>> df = 300.
>>> np.mean(dpnp.random.standard_t(df, size=10**6)); np.mean(np.random.standard_t(df, size=10**6))
-0.0006127286643388802
-0.0005636420187996591
>>> np.var(dpnp.random.standard_t(df, size=10**6)); np.var(np.random.standard_t(df, size=10**6))
1.0054421001664342
1.0065497207136775

```

## Checklist

- [x] Docstrings for all functions
- [ ] Gallery example in ./doc/examples (new features only)
- [x] Unit tests:
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)