### PR TITLE
TEST: env val to enbale DPNP backend tests

### DIFF
--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -255,4 +255,5 @@ jobs:
       ./scripts/install_system_deps.sh  # no intel python
       ./scripts/install_python_deps.sh  # numpy, conda-build and etc.
       echo ========================= build DPNP package ===============================
+      export DPNP_BACKEND_TESTS_ENABLE=1
       ./0.build.sh

--- a/utils/command_build_cmake_clib.py
+++ b/utils/command_build_cmake_clib.py
@@ -73,6 +73,11 @@ except ImportError:
     """
     pass
 
+"""
+Detect enabling DPNP backend tests
+"""
+_dpnp_backend_tests_enable = os.environ.get('DPNP_BACKEND_TESTS_ENABLE', None)
+
 
 """
 CmakeList.txt based build_clib
@@ -99,7 +104,7 @@ class custom_build_cmake_clib(build_clib.build_clib):
 
         if IS_WIN:
             cmake_generator = "-GNinja"
-        if IS_LIN:
+        if _dpnp_backend_tests_enable is not None:
             enable_tests = "ON"
 
         cmake_args = [


### PR DESCRIPTION
## Description
* added env val to enbale DPNP backend tests

## TODO
* update README.md (add `Gtest`, as deps if is needed enabling dpnp backend tests)
* add `export DPNP_BACKEND_TESTS_ENABLE=1` to some azure-pipelines job (`dpnp/scripts/azure-pipelines.yml`)