### PR TITLE
ENH: impl random.noncentral_chisquare

### DIFF
--- a/dpnp/backend/include/dpnp_iface_fptr.hpp
+++ b/dpnp/backend/include/dpnp_iface_fptr.hpp
@@ -144,6 +144,7 @@ enum class DPNPFuncName : size_t
     DPNP_FN_RNG_MULTINOMIAL,          /**< Used in numpy.random.multinomial() implementation  */
     DPNP_FN_RNG_MULTIVARIATE_NORMAL,  /**< Used in numpy.random.multivariate_normal() implementation  */
     DPNP_FN_RNG_NEGATIVE_BINOMIAL,    /**< Used in numpy.random.negative_binomial() implementation  */
+    DPNP_FN_RNG_NONCENTRAL_CHISQUARE, /**< Used in numpy.random.noncentral_chisquare() implementation  */
     DPNP_FN_RNG_NORMAL,               /**< Used in numpy.random.normal() implementation  */
     DPNP_FN_RNG_PARETO,               /**< Used in numpy.random.pareto() implementation  */
     DPNP_FN_RNG_POISSON,              /**< Used in numpy.random.poisson() implementation  */

--- a/dpnp/backend/include/dpnp_iface_random.hpp
+++ b/dpnp/backend/include/dpnp_iface_random.hpp
@@ -256,6 +256,19 @@ INP_DLLEXPORT void dpnp_rng_negative_binomial_c(void* result, const double a, co
 
 /**
  * @ingroup BACKEND_RANDOM_API
+ * @brief math library implementation of random number generator (noncentral chisquare distribution)
+ *
+ * @param [in]  size   Number of elements in `result` arrays.
+ * @param [in]  df     Degrees of freedom.
+ * @param [in]  nonc   Non-centrality param.
+ * @param [out] result Output array.
+ */
+template <typename _DataType>
+INP_DLLEXPORT void
+    dpnp_rng_noncentral_chisquare_c(void* result, const _DataType df, const _DataType nonc, const size_t size);
+
+/**
+ * @ingroup BACKEND_RANDOM_API
  * @brief math library implementation of random number generator (normal continious distribution)
  *
  * @param [in]  size   Number of elements in `result` arrays.

--- a/dpnp/backend/kernels/dpnp_krnl_random.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_random.cpp
@@ -534,6 +534,292 @@ void dpnp_rng_negative_binomial_c(void* result, const double a, const double p, 
 }
 
 template <typename _DataType>
+void dpnp_rng_noncentral_chisquare_c(void* result, const _DataType df, const _DataType nonc, const size_t size)
+{
+    if (!size)
+    {
+        return;
+    }
+    _DataType* result1 = reinterpret_cast<_DataType*>(result);
+
+    const _DataType d_zero = _DataType(0.0);
+    const _DataType d_one = _DataType(1.0);
+    const _DataType d_two = _DataType(2.0);
+
+    if (dpnp_queue_is_cpu_c())
+    {
+        _DataType shape, loc;
+        size_t i;
+        cl::sycl::event event_out;
+        cl::sycl::vector_class<cl::sycl::event> no_deps;
+
+        if (df > 1)
+        {
+            _DataType* nvec = nullptr;
+
+            shape = 0.5 * (df - 1.0);
+            /* res has chi^2 with (df - 1) */
+            mkl_rng::gamma<_DataType> gamma_distribution(shape, d_zero, d_two);
+            event_out = mkl_rng::generate(gamma_distribution, DPNP_RNG_ENGINE, size, result1);
+            event_out.wait();
+
+            nvec = reinterpret_cast<_DataType*>(dpnp_memory_alloc_c(size * sizeof(_DataType)));
+            if (nvec == nullptr)
+            {
+                throw std::runtime_error("DPNP RNG Error: dpnp_rng_noncentral_chisquare_c() failed.");
+            }
+
+            loc = sqrt(nonc);
+
+            mkl_rng::gaussian<_DataType> gaussian_distribution(loc, d_one);
+            event_out = mkl_rng::generate(gaussian_distribution, DPNP_RNG_ENGINE, size, nvec);
+            event_out.wait();
+
+            /* squaring could result in an overflow */
+            event_out = mkl_vm::sqr(DPNP_QUEUE, size, nvec, nvec, no_deps, mkl_vm::mode::ha);
+            event_out.wait();
+            event_out = mkl_vm::add(DPNP_QUEUE, size, result1, nvec, result1, no_deps, mkl_vm::mode::ha);
+            dpnp_memory_free_c(nvec);
+            event_out.wait();
+        }
+        else if (df < 1)
+        {
+            /* noncentral_chisquare(df, nonc) ~ G( df/2 + Poisson(nonc/2), 2) */
+            double lambda;
+            int* pvec = nullptr;
+            pvec = reinterpret_cast<int*>(dpnp_memory_alloc_c(size * sizeof(int)));
+            if (pvec == nullptr)
+            {
+                throw std::runtime_error("DPNP RNG Error: dpnp_rng_noncentral_chisquare_c() failed.");
+            }
+            // pvec = (int*)mkl_malloc(size * sizeof(int), 64);
+            lambda = 0.5 * nonc;
+
+            mkl_rng::poisson<int> poisson_distribution(lambda);
+            event_out = mkl_rng::generate(poisson_distribution, DPNP_RNG_ENGINE, size, pvec);
+            event_out.wait();
+
+            shape = 0.5 * df;
+
+            if (0.125 * size > sqrt(lambda))
+            {
+                size_t* idx = nullptr;
+                _DataType* tmp = nullptr;
+                idx = reinterpret_cast<size_t*>(dpnp_memory_alloc_c(size * sizeof(size_t)));
+                if (idx == nullptr)
+                {
+                    throw std::runtime_error("DPNP RNG Error: dpnp_rng_noncentral_chisquare_c() failed.");
+                }
+                for (i = 0; i < size; i++)
+                    idx[i] = i;
+
+                std::sort(idx, idx + size, [pvec](size_t i1, size_t i2) { return pvec[i1] < pvec[i2]; });
+                /* idx now contains original indexes of ordered Poisson outputs */
+
+                /* allocate workspace to store samples of gamma, enough to hold entire output */
+                tmp = reinterpret_cast<_DataType*>(dpnp_memory_alloc_c(size * sizeof(_DataType)));
+                if (tmp == nullptr)
+                {
+                    throw std::runtime_error("DPNP RNG Error: dpnp_rng_noncentral_chisquare_c() failed.");
+                }
+                for (i = 0; i < size;)
+                {
+                    size_t k, j;
+                    int cv = pvec[idx[i]];
+
+                    // TODO vectorize
+                    for (j = i + 1; (j < size) && (pvec[idx[j]] == cv); j++)
+                    {
+                    }
+                    // assert(j > i);
+                    if (j <= i)
+                    {
+                        throw std::runtime_error("DPNP RNG Error: dpnp_rng_noncentral_chisquare_c() failed.");
+                    }
+                    mkl_rng::gamma<_DataType> gamma_distribution(shape + cv, d_zero, d_two);
+                    event_out = mkl_rng::generate(gamma_distribution, DPNP_RNG_ENGINE, j - i, tmp);
+                    event_out.wait();
+
+                    // TODO vectorize
+                    for (k = i; k < j; k++)
+                        result1[idx[k]] = tmp[k - i];
+
+                    i = j;
+                }
+
+                dpnp_memory_free_c(tmp);
+                dpnp_memory_free_c(idx);
+            }
+            else
+            {
+                for (i = 0; i < size; i++)
+                {
+                    mkl_rng::gamma<_DataType> gamma_distribution(shape + pvec[i], d_zero, d_two);
+                    event_out = mkl_rng::generate(gamma_distribution, DPNP_RNG_ENGINE, 1, result1 + 1);
+                    event_out.wait();
+                }
+            }
+            dpnp_memory_free_c(pvec);
+        }
+        else
+        {
+            /* noncentral_chisquare(1, nonc) ~ (Z + sqrt(nonc))**2 for df == 1 */
+            loc = sqrt(nonc);
+            mkl_rng::gaussian<_DataType> gaussian_distribution(loc, d_one);
+            event_out = mkl_rng::generate(gaussian_distribution, DPNP_RNG_ENGINE, size, result1);
+            event_out.wait();
+            event_out = mkl_vm::sqr(DPNP_QUEUE, size, result1, result1, no_deps, mkl_vm::mode::ha);
+            event_out.wait();
+        }
+    }
+    else
+    {
+        double shape, loc;
+        int errcode;
+        size_t i;
+
+        if (df > 1)
+        {
+            double* nvec = nullptr;
+
+            shape = 0.5 * (df - 1.0);
+            /* res has chi^2 with (df - 1) */
+            errcode =
+                vdRngGamma(VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, get_rng_stream(), size, result1, shape, d_zero, d_two);
+            // TODO
+            // refactor this check, smth like: void status_assert(errcode, VSL_STATUS_OK, func_name)
+            // or just redesign and return int status:
+            // void dpnp_rng_*_c(..., int& status);
+            // or
+            // int dpnp_rng_*_c(...);
+            if (errcode != VSL_STATUS_OK)
+            {
+                throw std::runtime_error("DPNP RNG Error: dpnp_rng_noncentral_chisquare_c() failed.");
+            }
+
+            nvec = (double*)mkl_malloc(size * sizeof(double), 64);
+            if (nvec == nullptr)
+            {
+                throw std::runtime_error("DPNP RNG Error: dpnp_rng_noncentral_chisquare_c() failed.");
+            }
+            loc = sqrt(nonc);
+            errcode = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, get_rng_stream(), size, nvec, loc, d_one);
+            if (errcode != VSL_STATUS_OK)
+            {
+                throw std::runtime_error("DPNP RNG Error: dpnp_rng_noncentral_chisquare_c() failed.");
+            }
+            /* squaring could result in an overflow */
+            vmdSqr(size, nvec, nvec, VML_HA);
+            vmdAdd(size, result1, nvec, result1, VML_HA);
+
+            mkl_free(nvec);
+        }
+        else if (df < 1)
+        {
+            /* noncentral_chisquare(df, nonc) ~ G( df/2 + Poisson(nonc/2), 2) */
+            double lambda;
+            int* pvec = nullptr;
+            pvec = (int*)mkl_malloc(size * sizeof(int), 64);
+            if (pvec == nullptr)
+            {
+                throw std::runtime_error("DPNP RNG Error: dpnp_rng_noncentral_chisquare_c() failed.");
+            }
+
+            lambda = 0.5 * nonc;
+            errcode = viRngPoisson(VSL_RNG_METHOD_POISSON_PTPE, get_rng_stream(), size, pvec, lambda);
+            if (errcode != VSL_STATUS_OK)
+            {
+                throw std::runtime_error("DPNP RNG Error: dpnp_rng_noncentral_chisquare_c() failed.");
+            }
+
+            shape = 0.5 * df;
+
+            if (0.125 * size > sqrt(lambda))
+            {
+                size_t* idx = nullptr;
+                double* tmp = nullptr;
+
+                idx = (size_t*)mkl_malloc(size * sizeof(size_t), 64);
+                if (idx == nullptr)
+                {
+                    throw std::runtime_error("DPNP RNG Error: dpnp_rng_noncentral_chisquare_c() failed.");
+                }
+
+                for (i = 0; i < size; i++)
+                    idx[i] = i;
+
+                std::sort(idx, idx + size, [pvec](size_t i1, size_t i2) { return pvec[i1] < pvec[i2]; });
+                /* idx now contains original indexes of ordered Poisson outputs */
+
+                /* allocate workspace to store samples of gamma, enough to hold entire output */
+                tmp = (double*)mkl_malloc(size * sizeof(double), 64);
+                if (tmp == nullptr)
+                {
+                    throw std::runtime_error("DPNP RNG Error: dpnp_rng_noncentral_chisquare_c() failed.");
+                }
+                for (i = 0; i < size;)
+                {
+                    size_t k, j;
+                    int cv = pvec[idx[i]];
+
+                    for (j = i + 1; (j < size) && (pvec[idx[j]] == cv); j++)
+                    {
+                    }
+                    // assert(j > i);
+                    if (j <= i)
+                    {
+                        throw std::runtime_error("DPNP RNG Error: dpnp_rng_noncentral_chisquare_c() failed.");
+                    }
+                    errcode = vdRngGamma(
+                        VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE, get_rng_stream(), j - i, tmp, shape + cv, d_zero, d_two);
+                    if (errcode != VSL_STATUS_OK)
+                    {
+                        throw std::runtime_error("DPNP RNG Error: dpnp_rng_noncentral_chisquare_c() failed.");
+                    }
+
+                    for (k = i; k < j; k++)
+                        result1[idx[k]] = tmp[k - i];
+
+                    i = j;
+                }
+                mkl_free(tmp);
+                mkl_free(idx);
+            }
+            else
+            {
+                for (i = 0; i < size; i++)
+                {
+                    errcode = vdRngGamma(VSL_RNG_METHOD_GAMMA_GNORM_ACCURATE,
+                                         get_rng_stream(),
+                                         1,
+                                         result1 + i,
+                                         shape + pvec[i],
+                                         d_zero,
+                                         d_two);
+                    if (errcode != VSL_STATUS_OK)
+                    {
+                        throw std::runtime_error("DPNP RNG Error: dpnp_rng_noncentral_chisquare_c() failed.");
+                    }
+                }
+            }
+            mkl_free(pvec);
+        }
+        else
+        {
+            /* noncentral_chisquare(1, nonc) ~ (Z + sqrt(nonc))**2 for df == 1 */
+            loc = sqrt(nonc);
+            errcode = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, get_rng_stream(), size, result1, loc, d_one);
+            if (errcode != VSL_STATUS_OK)
+            {
+                throw std::runtime_error("DPNP RNG Error: dpnp_rng_noncentral_chisquare_c() failed.");
+            }
+            /* squaring could result in an overflow */
+            vmdSqr(size, result1, result1, VML_HA);
+        }
+    }
+}
+
+template <typename _DataType>
 void dpnp_rng_normal_c(void* result, const _DataType mean, const _DataType stddev, const size_t size)
 {
     if (!size)
@@ -911,6 +1197,9 @@ void func_map_init_random(func_map_t& fmap)
 
     fmap[DPNPFuncName::DPNP_FN_RNG_NEGATIVE_BINOMIAL][eft_INT][eft_INT] = {eft_INT,
                                                                            (void*)dpnp_rng_negative_binomial_c<int>};
+
+    fmap[DPNPFuncName::DPNP_FN_RNG_NONCENTRAL_CHISQUARE][eft_DBL][eft_DBL] = {
+        eft_DBL, (void*)dpnp_rng_noncentral_chisquare_c<double>};
 
     fmap[DPNPFuncName::DPNP_FN_RNG_NORMAL][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_normal_c<double>};
 

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -117,6 +117,7 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_RNG_MULTINOMIAL
         DPNP_FN_RNG_MULTIVARIATE_NORMAL
         DPNP_FN_RNG_NEGATIVE_BINOMIAL
+        DPNP_FN_RNG_NONCENTRAL_CHISQUARE
         DPNP_FN_RNG_NORMAL
         DPNP_FN_RNG_PARETO
         DPNP_FN_RNG_POISSON

--- a/dpnp/random/dpnp_algo_random.pyx
+++ b/dpnp/random/dpnp_algo_random.pyx
@@ -58,6 +58,7 @@ __all__ = [
     "dpnp_rng_multinomial",
     "dpnp_rng_multivariate_normal",
     "dpnp_rng_negative_binomial",
+    "dpnp_rng_noncentral_chisquare",
     "dpnp_rng_normal",
     "dpnp_rng_pareto",
     "dpnp_rng_poisson",
@@ -103,6 +104,7 @@ ctypedef void(*fptr_dpnp_rng_multivariate_normal_c_1out_t)(void * ,
                                                            const size_t,
                                                            const size_t) except +
 ctypedef void(*fptr_dpnp_rng_negative_binomial_c_1out_t)(void * , const double, const double, const size_t) except +
+ctypedef void(*fptr_dpnp_rng_noncentral_chisquare_c_1out_t)(void * , const double, const double, const size_t) except +
 ctypedef void(*fptr_dpnp_rng_normal_c_1out_t)(void * , const double, const double, const size_t) except +
 ctypedef void(*fptr_dpnp_rng_pareto_c_1out_t)(void * , const double, const size_t) except +
 ctypedef void(*fptr_dpnp_rng_poisson_c_1out_t)(void * , const double, const size_t) except +
@@ -627,6 +629,31 @@ cpdef dparray dpnp_rng_negative_binomial(double a, double p, size):
         func = <fptr_dpnp_rng_negative_binomial_c_1out_t > kernel_data.ptr
         # call FPTR function
         func(result.get_data(), a, p, result.size)
+
+    return result
+
+
+cpdef dparray dpnp_rng_noncentral_chisquare(double df, double nonc, size):
+    """
+    Returns an array populated with samples from noncentral chisquare distribution.
+    `dpnp_rng_noncentral_chisquare` generates a matrix filled with random floats sampled from a
+    univariate noncentral chisquare distribution.
+
+    """
+
+    # convert string type names (dparray.dtype) to C enum DPNPFuncType
+    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(numpy.float64)
+
+    # get the FPTR data structure
+    cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_RNG_NONCENTRAL_CHISQUARE, param1_type, param1_type)
+
+    result_type = dpnp_DPNPFuncType_to_dtype(< size_t > kernel_data.return_type)
+    # ceate result array with type given by FPTR data
+    cdef dparray result = dparray(size, dtype=result_type)
+
+    cdef fptr_dpnp_rng_noncentral_chisquare_c_1out_t func = < fptr_dpnp_rng_noncentral_chisquare_c_1out_t > kernel_data.ptr
+    # call FPTR function
+    func(result.get_data(), df, nonc, result.size)
 
     return result
 

--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -815,12 +815,23 @@ def noncentral_chisquare(df, nonc, size=None):
 
     For full documentation refer to :obj:`numpy.random.noncentral_chisquare`.
 
-    Notes
-    -----
-    The function uses `numpy.random.noncentral_chisquare` on the backend and
-    will be executed on fallback backend.
+    TODO
 
     """
+
+    if not use_origin_backend(df):
+        # TODO:
+        # array_like of floats for `mean` and `scale`
+        if not dpnp.isscalar(df):
+            pass
+        elif not dpnp.isscalar(nonc):
+            pass
+        elif df <= 0:
+            pass
+        elif nonc < 0:
+            pass
+        else:
+            return dpnp_rng_noncentral_chisquare(df, nonc, size)
 
     return call_origin(numpy.random.noncentral_chisquare, df, nonc, size)
 

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -606,6 +606,45 @@ class TestDistributionsNormal(TestDistribution):
         self.check_seed('normal', {'loc': loc, 'scale': scale})
 
 
+class TestDistributionsNoncentralChisquare:
+
+    @pytest.mark.parametrize("df", [5.0, 1.0, 0.5], ids=['df_grt_1', 'df_eq_1', 'df_less_1'])
+    def test_moments(self, df):
+        nonc = 20.
+        expected_mean = df + nonc
+        expected_var = 2 * (df + 2 * nonc)
+        size = 10**6
+        seed = 28041995
+        dpnp.random.seed(seed)
+        res = numpy.asarray(dpnp.random.noncentral_chisquare(df, nonc, size=size))
+        var = numpy.var(res)
+        mean = numpy.mean(res)
+        assert math.isclose(var, expected_var, abs_tol=0.6)
+        assert math.isclose(mean, expected_mean, abs_tol=0.6)
+
+    def test_invalid_args(self):
+        size = 10
+        df = 5.0     # OK
+        nonc = -1.0  # non-negative `nonc` is expected
+        with pytest.raises(ValueError):
+            dpnp.random.noncentral_chisquare(df, nonc, size=size)
+        df = -1.0    # positive `df` is expected
+        nonc = 1.0   # OK
+        with pytest.raises(ValueError):
+            dpnp.random.noncentral_chisquare(df, nonc, size=size)
+
+    @pytest.mark.parametrize("df", [5.0, 1.0, 0.5], ids=['df_grt_1', 'df_eq_1', 'df_less_1'])
+    def test_seed(self, df):
+        seed = 28041990
+        size = 10
+        nonc = 1.8
+        dpnp.random.seed(seed)
+        a1 = numpy.asarray(dpnp.random.noncentral_chisquare(df, nonc, size=size))
+        dpnp.random.seed(seed)
+        a2 = numpy.asarray(dpnp.random.noncentral_chisquare(df, nonc, size=size))
+        assert_allclose(a1, a2, rtol=1e-07, atol=0)
+
+
 class TestDistributionsPareto(TestDistribution):
 
     def test_moments(self):

--- a/tests_external/skipped_tests_numpy.tbl
+++ b/tests_external/skipped_tests_numpy.tbl
@@ -1482,6 +1482,7 @@ tests/test_random.py::TestRandomDist::test_lognormal_0
 tests/test_random.py::TestRandomDist::test_multinomial
 tests/test_random.py::TestRandomDist::test_multivariate_normal
 tests/test_random.py::TestRandomDist::test_negative_binomial
+tests/test_random.py::TestRandomDist::test_noncentral_chisquare
 tests/test_random.py::TestRandomDist::test_normal
 tests/test_random.py::TestRandomDist::test_normal_0
 tests/test_random.py::TestRandomDist::test_pareto
@@ -1579,6 +1580,7 @@ tests/test_randomstate.py::TestRandomDist::test_multinomial
 tests/test_randomstate.py::TestRandomDist::test_multivariate_normal
 tests/test_randomstate.py::TestRandomDist::test_negative_binomial
 tests/test_randomstate.py::TestRandomDist::test_negative_binomial_exceptions
+tests/test_randomstate.py::TestRandomDist::test_noncentral_chisquare
 tests/test_randomstate.py::TestRandomDist::test_normal
 tests/test_randomstate.py::TestRandomDist::test_normal_0
 tests/test_randomstate.py::TestRandomDist::test_pareto


### PR DESCRIPTION
## Description
noncentral_chisquare(df, nonc[, size]) Draw samples from a noncentral chi-square distribution.
* disabled (incorrect check for dpnp.random.noncentral_chisquare functionality):
  * random/tests/test_random.py::TestRandomDist::test_noncentral_chisquare - AssertionError: (external)
  * random/tests/test_randomstate.py::TestRandomDist::test_noncentral_chisquare - AssertionError (external)

## TODO
* array_like of floats for `df` and `nonc ` params
* tests for backend `dpnp_rng_noncentral_chisquare_c` (in other PR, after `backend/tests/test_random.cpp` refactoring PR552 )

###  Refactor TODO
* ``if you use this variable for loops only - use standard way to declare it inside loop boby`` https://github.com/IntelPython/dpnp/pull/543#discussion_r571027739
* "DPNP alloc will take care about errors" - don't check errors for DPNP allocator, see https://github.com/IntelPython/dpnp/pull/543#discussion_r571029614


## Reproduce
```python
>>> numpy.mean(numpy.array(numpy.random.noncentral_chisquare(df, nonc, 10**6))); numpy.mean(numpy.array(dpnp.random.noncentral_chisquare(df, nonc, 10**6)))
21.99867794714586
22.006180859608047
>>> numpy.var(numpy.array(numpy.random.noncentral_chisquare(df, nonc, 10**6))); numpy.var(numpy.array(dpnp.random.noncentral_chisquare(df, nonc, 10**6)))
68.10664345997179
67.90847960630143

```

## Checklist

- [x] Docstrings for all functions
- [ ] Gallery example in ./doc/examples (new features only)
- [x] Unit tests:
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)