### PR TITLE
mark unused variable in partable way with no API changes

### DIFF
--- a/dpnp/backend/kernels/dpnp_krnl_mathematical.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_mathematical.cpp
@@ -89,6 +89,7 @@ class dpnp_cross_c_kernel;
 template <typename _DataType_input1, typename _DataType_input2, typename _DataType_output>
 void dpnp_cross_c(void* array1_in, void* array2_in, void* result1, size_t size)
 {
+    (void)size; // avoid warning unused variable
     _DataType_input1* array1 = reinterpret_cast<_DataType_input1*>(array1_in);
     _DataType_input2* array2 = reinterpret_cast<_DataType_input2*>(array2_in);
     _DataType_output* result = reinterpret_cast<_DataType_output*>(result1);


### PR DESCRIPTION
We have several options to do the same
- __attribute__((unused)) it is GCC compiler specific
- [[maybe_unused]] but it requires C++17 and brings changes (at least in style) in API line https://en.cppreference.com/w/cpp/language/attributes/maybe_unused

Need cross platform and cross compiler solution with minimum changes in source code (style and lines length)

So, according to the KISS principle I did this PR
