### PR TITLE
add native version function fill_diagonal

### DIFF
--- a/dpnp/backend/include/dpnp_iface.hpp
+++ b/dpnp/backend/include/dpnp_iface.hpp
@@ -547,6 +547,18 @@ INP_DLLEXPORT void dpnp_invert_c(void* array1_in, void* result, size_t size);
 
 /**
  * @ingroup BACKEND_API
+ * @brief fill_diagonal function.
+ *
+ * @param [in]  array1_in    Input array.
+ * @param [in]  val          Value to write on the diagonal.
+ * @param [in]  shape        Input shape.
+ * @param [in]  ndim         Number of elements in shape.
+ */
+template <typename _DataType>
+INP_DLLEXPORT void dpnp_fill_diagonal_c(void* array1_in, void* val, size_t* shape, const size_t ndim);
+
+/**
+ * @ingroup BACKEND_API
  * @brief floor_divide function.
  *
  * @param [in]  array1_in    Input array 1.

--- a/dpnp/backend/include/dpnp_iface_fptr.hpp
+++ b/dpnp/backend/include/dpnp_iface_fptr.hpp
@@ -102,6 +102,7 @@ enum class DPNPFuncName : size_t
     DPNP_FN_EXPM1,                    /**< Used in numpy.expm1() implementation  */
     DPNP_FN_FABS,                     /**< Used in numpy.fabs() implementation  */
     DPNP_FN_FFT_FFT,                  /**< Used in numpy.fft.fft() implementation  */
+    DPNP_FN_FILL_DIAGONAL,            /**< Used in numpy.fill_diagonal() implementation  */
     DPNP_FN_FLOOR,                    /**< Used in numpy.floor() implementation  */
     DPNP_FN_FLOOR_DIVIDE,             /**< Used in numpy.floor_divide() implementation  */
     DPNP_FN_FMOD,                     /**< Used in numpy.fmod() implementation  */

--- a/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
@@ -143,6 +143,38 @@ void dpnp_diagonal_c(
     return;
 }
 
+template <typename _DataType>
+void dpnp_fill_diagonal_c(void* array1_in, void* val_in, size_t* shape, const size_t ndim)
+{
+    _DataType* array_1 = reinterpret_cast<_DataType*>(array1_in);
+    _DataType* val_arr = reinterpret_cast<_DataType*>(val_in);
+
+    size_t min_shape = shape[0];
+    for (size_t i = 0; i < ndim; ++i)
+    {
+        if (shape[i] < min_shape)
+        {
+            min_shape = shape[i];
+        }
+    }
+
+    _DataType val = val_arr[0];
+
+    for (size_t i = 0; i < min_shape; ++i)
+    {
+        size_t ind = 0;
+        size_t n = 1;
+        for (size_t k = 0; k < ndim; k++)
+        {
+            size_t ind_ = ndim - 1 - k;
+            ind += n * i;
+            n *= shape[ind_];
+        }
+        array_1[ind] = val;
+    }
+    return;
+}
+
 template <typename _DataType, typename _IndecesType, typename _ValueType>
 void dpnp_put_c(void* array1_in, void* ind_in, void* v_in, const size_t size, const size_t size_ind, const size_t size_v)
 {
@@ -197,6 +229,11 @@ void func_map_init_indexing_func(func_map_t& fmap)
     fmap[DPNPFuncName::DPNP_FN_DIAGONAL][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_diagonal_c<long>};
     fmap[DPNPFuncName::DPNP_FN_DIAGONAL][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_diagonal_c<float>};
     fmap[DPNPFuncName::DPNP_FN_DIAGONAL][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_diagonal_c<double>};
+
+    fmap[DPNPFuncName::DPNP_FN_FILL_DIAGONAL][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_fill_diagonal_c<int>};
+    fmap[DPNPFuncName::DPNP_FN_FILL_DIAGONAL][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_fill_diagonal_c<long>};
+    fmap[DPNPFuncName::DPNP_FN_FILL_DIAGONAL][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_fill_diagonal_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_FILL_DIAGONAL][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_fill_diagonal_c<double>};
 
     fmap[DPNPFuncName::DPNP_FN_PUT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_put_c<int, long, int>};
     fmap[DPNPFuncName::DPNP_FN_PUT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_put_c<long, long, long>};

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -75,6 +75,7 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_EXPM1
         DPNP_FN_FABS
         DPNP_FN_FFT_FFT
+        DPNP_FN_FILL_DIAGONAL
         DPNP_FN_FLOOR
         DPNP_FN_FLOOR_DIVIDE
         DPNP_FN_FMOD


### PR DESCRIPTION
Implemented native version for function dpnp.fill_diagonal().

tests:

tests/test_indexing.py::test_fill_diagonal[[[0, 0], [0, 0]]--1]
tests/test_indexing.py::test_fill_diagonal[[[0, 0], [0, 0]]-0]
tests/test_indexing.py::test_fill_diagonal[[[0, 0], [0, 0]]-1]
tests/test_indexing.py::test_fill_diagonal[[[1, 2], [1, 2]]--1]
tests/test_indexing.py::test_fill_diagonal[[[1, 2], [1, 2]]-0]
tests/test_indexing.py::test_fill_diagonal[[[1, 2], [1, 2]]-1]
tests/test_indexing.py::test_fill_diagonal[[[1, 2], [3, 4]]--1]
tests/test_indexing.py::test_fill_diagonal[[[1, 2], [3, 4]]-0]
tests/test_indexing.py::test_fill_diagonal[[[1, 2], [3, 4]]-1]
tests/test_indexing.py::test_fill_diagonal[[[0, 1, 2], [3, 4, 5], [6, 7, 8]]--1]
tests/test_indexing.py::test_fill_diagonal[[[0, 1, 2], [3, 4, 5], [6, 7, 8]]-0]
tests/test_indexing.py::test_fill_diagonal[[[0, 1, 2], [3, 4, 5], [6, 7, 8]]-1]
tests/test_indexing.py::test_fill_diagonal[[[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]--1]
tests/test_indexing.py::test_fill_diagonal[[[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]-0] 
tests/test_indexing.py::test_fill_diagonal[[[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]-1] 
tests/test_indexing.py::test_fill_diagonal[[[[[1, 2], [3, 4]], [[1, 2], [2, 1]]], [[[1, 3], [3, 1]], [[0, 1], [1, 3]]]]--1]
tests/test_indexing.py::test_fill_diagonal[[[[[1, 2], [3, 4]], [[1, 2], [2, 1]]], [[[1, 3], [3, 1]], [[0, 1], [1, 3]]]]-0]
tests/test_indexing.py::test_fill_diagonal[[[[[1, 2], [3, 4]], [[1, 2], [2, 1]]], [[[1, 3], [3, 1]], [[0, 1], [1, 3]]]]-1]
tests/third_party/cupy/indexing_tests/test_insert.py::TestFillDiagonal_param_1_{shape=(3, 3), val=1, wrap=False}::test_fill_diagonal
tests/third_party/cupy/indexing_tests/test_insert.py::TestFillDiagonal_param_3_{shape=(3, 3), val=0, wrap=False}::test_fill_diagonal
tests/third_party/cupy/indexing_tests/test_insert.py::TestFillDiagonal_param_9_{shape=(2, 2, 2), val=1, wrap=False}::test_fill_diagonal
tests/third_party/cupy/indexing_tests/test_insert.py::TestFillDiagonal_param_11_{shape=(2, 2, 2), val=0, wrap=False}::test_fill_diagonal
tests/third_party/cupy/indexing_tests/test_insert.py::TestFillDiagonal_param_17_{shape=(3, 5), val=1, wrap=False}::test_fill_diagonal
tests/third_party/cupy/indexing_tests/test_insert.py::TestFillDiagonal_param_19_{shape=(3, 5), val=0, wrap=False}::test_fill_diagonal
tests/third_party/cupy/indexing_tests/test_insert.py::TestFillDiagonal_param_25_{shape=(5, 3), val=1, wrap=False}::test_fill_diagonal
tests/third_party/cupy/indexing_tests/test_insert.py::TestFillDiagonal_param_27_{shape=(5, 3), val=0, wrap=False}::test_fill_diagonal
