### PR TITLE
ENH: enabled random.permutation on CPU and GPU

### DIFF
--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -893,7 +893,22 @@ def permutation(x):
 
     For full documentation refer to :obj:`numpy.random.permutation`.
 
-    # TODO
+    Examples
+    --------
+    >>> arr = dpnp.random.permutation(10)
+    >>> print(arr)
+    [3 8 7 9 0 6 1 2 4 5] # random
+
+    >>> arr = dpnp.random.permutation([1, 4, 9, 12, 15])
+    >>> print(arr)
+    [12  1  4  9 15] # random
+
+    >>> arr = dpnp.arange(9).reshape((3, 3))
+    >>> dpnp.random.permutation(arr)
+    >>> print(arr)
+    [[0 1 2]
+     [3 4 5]
+     [6 7 8]]  # random
 
     """
     if not use_origin_backend(x):

--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -893,12 +893,16 @@ def permutation(x):
 
     For full documentation refer to :obj:`numpy.random.permutation`.
 
-    Notes
-    -----
-    The function uses `numpy.random.permutation` on the backend and will be
-    executed on fallback backend.
+    # TODO
 
     """
+    if not use_origin_backend(x):
+        if isinstance(x, (int, dpnp.integer)):
+            arr = dpnp.arange(x)
+        else:
+            arr = dpnp.array(x)
+        shuffle(arr)
+        return arr
 
     return call_origin(numpy.random.permutation, x)
 

--- a/tests_external/skipped_tests_numpy.tbl
+++ b/tests_external/skipped_tests_numpy.tbl
@@ -1594,6 +1594,7 @@ tests/test_randomstate.py::TestRandomDist::test_noncentral_chisquare
 tests/test_randomstate.py::TestRandomDist::test_normal
 tests/test_randomstate.py::TestRandomDist::test_normal_0
 tests/test_randomstate.py::TestRandomDist::test_pareto
+tests/test_randomstate.py::TestRandomDist::test_permutation
 tests/test_randomstate.py::TestRandomDist::test_poisson
 tests/test_randomstate.py::TestRandomDist::test_poisson_exceptions
 tests/test_randomstate.py::TestRandomDist::test_power


### PR DESCRIPTION
## Description
`permutation(x)` Randomly permute a sequence, or return a permuted range.

disabled (incorrect check for dpnp.random.permutation functionality):
* random/tests/test_randomstate.py::TestRandomDist::test_permutation - AssertionError: (external)

## Reproduce
``` python
>>> dpnp.random.permutation(10)
<DPNP DParray:name=dparray: mem=0x560e5f71bd00: size=10: shape=(10,): type=int64>
>>> print(dpnp.random.permutation(10))
[3 8 7 9 0 6 1 2 4 5]
```
