### PR TITLE
Support MLK 2021.2.0

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
       - dpctl >=0.5.0a0
       - dpcpp_cpp_rt >=2021.1.1
       - mkl >=2021.1.1
+      - mkl-dpcpp >=2021.1.1
 
 build:
     number: {{ GIT_DESCRIBE_NUMBER }}


### PR DESCRIPTION
`libmkl_sycl.so` was moved to separate package `mkl-dpcpp` for MLK of version `2021.2.0`. So now we need the package to be installed in internal CI environment.