### PR TITLE
dpnpc_sum move result parameter to the front

### DIFF
--- a/dpnp/backend/examples/example9.cpp
+++ b/dpnp/backend/examples/example9.cpp
@@ -54,7 +54,7 @@ int main(int, char**)
         result_verification += i;
     }
 
-    dpnp_sum_c<long, long>(array, &result, &size, 1, NULL, 0, NULL, NULL);
+    dpnp_sum_c<long, long>(&result, array, &size, 1, NULL, 0, NULL, NULL);
 
     std::cout << "SUM() value: " << result << " verification value: " << result_verification << std::endl;
 

--- a/dpnp/backend/include/dpnp_iface.hpp
+++ b/dpnp/backend/include/dpnp_iface.hpp
@@ -224,8 +224,8 @@ INP_DLLEXPORT void dpnp_cumsum_c(void* array1_in, void* result1, size_t size);
  * @param [in]  where             mask array
  */
 template <typename _DataType_input, typename _DataType_output>
-INP_DLLEXPORT void dpnp_sum_c(const void* input_in,
-                              void* result_out,
+INP_DLLEXPORT void dpnp_sum_c(void* result_out,
+                              const void* input_in,
                               const size_t* input_shape,
                               const size_t input_shape_ndim,
                               const long* axes,

--- a/dpnp/backend/kernels/dpnp_krnl_mathematical.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_mathematical.cpp
@@ -324,7 +324,7 @@ void dpnp_trapz_c(
 
         event.wait();
 
-        dpnp_sum_c<_DataType_output, _DataType_output>(cur_res, result, &cur_res_size, 1, NULL, 0, NULL, NULL);
+        dpnp_sum_c<_DataType_output, _DataType_output>(result, cur_res, &cur_res_size, 1, NULL, 0, NULL, NULL);
 
         dpnp_memory_free_c(cur_res);
 
@@ -335,7 +335,7 @@ void dpnp_trapz_c(
     }
     else
     {
-        dpnp_sum_c<_DataType_input1, _DataType_output>(array1, result, &array1_size, 1, NULL, 0, NULL, NULL);
+        dpnp_sum_c<_DataType_input1, _DataType_output>(result, array1, &array1_size, 1, NULL, 0, NULL, NULL);
 
         result[0] -= (array1[0] + array1[array1_size - 1]) * 0.5;
         result[0] *= dx;

--- a/dpnp/backend/kernels/dpnp_krnl_reduction.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_reduction.cpp
@@ -56,8 +56,8 @@ template <typename _KernelNameSpecialization1, typename _KernelNameSpecializatio
 class dpnp_sum_c_kernel;
 
 template <typename _DataType_input, typename _DataType_output>
-void dpnp_sum_c(const void* input_in,
-                void* result_out,
+void dpnp_sum_c(void* result_out,
+                const void* input_in,
                 const size_t* input_shape,
                 const size_t input_shape_ndim,
                 const long* axes,

--- a/dpnp/backend/kernels/dpnp_krnl_statistics.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_statistics.cpp
@@ -196,7 +196,7 @@ void dpnp_mean_c(void* array1_in, void* result1, const size_t* shape, size_t ndi
         _ResultType* sum = reinterpret_cast<_ResultType*>(dpnp_memory_alloc_c(1 * sizeof(_ResultType)));
 
         dpnp_sum_c<_DataType, _ResultType>(
-            array1_in, sum, shape, ndim, reinterpret_cast<const long*>(axis), naxis, nullptr, nullptr);
+            sum, array1_in, shape, ndim, reinterpret_cast<const long*>(axis), naxis, nullptr, nullptr);
 
         result[0] = sum[0] / static_cast<_ResultType>(size);
 

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -206,7 +206,7 @@ ctypedef void(*fptr_1out_t)(void *, size_t)
 ctypedef void(*fptr_1in_1out_t)(void * , void * , size_t)
 ctypedef void(*fptr_2in_1out_t)(void * , void*, void*, size_t)
 ctypedef void(*fptr_blas_gemm_2in_1out_t)(void * , void * , void * , size_t, size_t, size_t)
-ctypedef void(*dpnp_reduction_c_t)(const void * , void * , const size_t*, const size_t, const long*, const size_t, const void * , const long*)
+ctypedef void(*dpnp_reduction_c_t)(void * , const void * , const size_t*, const size_t, const long*, const size_t, const void * , const long*)
 
 cdef dparray call_fptr_1out(DPNPFuncName fptr_name, result_shape, result_dtype)
 cdef dparray call_fptr_1in_1out(DPNPFuncName fptr_name, dparray x1, dparray_shape_type result_shape)

--- a/dpnp/dpnp_algo/dpnp_algo_mathematical.pyx
+++ b/dpnp/dpnp_algo/dpnp_algo_mathematical.pyx
@@ -423,7 +423,7 @@ cpdef dparray dpnp_sum(dparray input, object axis=None, object dtype=None, dparr
     cdef dpnp_reduction_c_t func = <dpnp_reduction_c_t > kernel_data.ptr
 
     """ Call FPTR interface function """
-    func(input.get_data(), result.get_data(), < size_t * >input_shape.data(), input_shape.size(), axis_shape.data(), axis_shape.size(), NULL, NULL)
+    func(result.get_data(), input.get_data(), < size_t * >input_shape.data(), input_shape.size(), axis_shape.data(), axis_shape.size(), NULL, NULL)
 
     return result
 


### PR DESCRIPTION
Make output array pointer as a first parameter of the function call.
In this case, all other parameters starting from second are input (const) parameters