### PR TITLE
Add scalar support in bitwise functions (partial)

### DIFF
--- a/dpnp/backend/include/dpnp_gen_2arg_1type_tbl.hpp
+++ b/dpnp/backend/include/dpnp_gen_2arg_1type_tbl.hpp
@@ -46,12 +46,13 @@
     /**                                                                                                              */ \
     /** Function "__name__" executes operator "__operation__" over corresponding elements of input arrays            */ \
     /**                                                                                                              */ \
-    /** @param[in]  array1   Input array 1.                                                                          */ \
-    /** @param[in]  array2   Input array 2.                                                                          */ \
     /** @param[out] result1  Output array.                                                                           */ \
-    /** @param[in]  size     Number of elements in the output array.                                                 */ \
+    /** @param[in]  array1   Input array 1.                                                                          */ \
+    /** @param[in]  size1    Number of elements in @ref array1                                                       */ \
+    /** @param[in]  array2   Input array 2.                                                                          */ \
+    /** @param[in]  size2    Number of elements in @ref array2                                                       */ \
     template <typename _DataType>                                                                                       \
-    void __name__(void* array1, void* array2, void* result1, size_t size);
+    void __name__(void* result1, const void* array1, const size_t size1, const void* array2, const size_t size2);
 
 #endif
 

--- a/dpnp/backend/include/dpnp_iface.hpp
+++ b/dpnp/backend/include/dpnp_iface.hpp
@@ -666,7 +666,8 @@ INP_DLLEXPORT void dpnp_invert_c(void* array1_in, void* result, size_t size);
 
 #define MACRO_2ARG_1TYPE_OP(__name__, __operation__)                                                                   \
     template <typename _DataType>                                                                                      \
-    INP_DLLEXPORT void __name__(void* array1_in1, void* array2_in, void* result1, size_t size);
+    INP_DLLEXPORT void __name__(                                                                                       \
+        void* result1, const void* array1, const size_t size1, const void* array2, const size_t size2);
 
 #include <dpnp_gen_2arg_1type_tbl.hpp>
 

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -211,12 +211,13 @@ cdef extern from "dpnp_iface.hpp":
 ctypedef void(*fptr_1out_t)(void *, size_t)
 ctypedef void(*fptr_1in_1out_t)(void * , void * , size_t)
 ctypedef void(*fptr_2in_1out_t)(void * , void*, void*, size_t)
+ctypedef void(*fptr_2in_1out_new_t)(void * , void*, size_t, void*, size_t) # to be fused with fptr_2in_1out_t
 ctypedef void(*fptr_blas_gemm_2in_1out_t)(void * , void * , void * , size_t, size_t, size_t)
 ctypedef void(*dpnp_reduction_c_t)(void * , const void * , const size_t*, const size_t, const long*, const size_t, const void * , const long*)
 
 cdef dparray call_fptr_1out(DPNPFuncName fptr_name, result_shape, result_dtype)
 cdef dparray call_fptr_1in_1out(DPNPFuncName fptr_name, dparray x1, dparray_shape_type result_shape)
-cdef dparray call_fptr_2in_1out(DPNPFuncName fptr_name, dparray x1, dparray x2, dparray_shape_type result_shape)
+cdef dparray call_fptr_2in_1out(DPNPFuncName fptr_name, dparray x1, dparray x2, dparray_shape_type result_shape, new_version=*)
 
 
 cpdef dparray dpnp_astype(dparray array1, dtype_target)

--- a/dpnp/dpnp_algo/dpnp_algo.pyx
+++ b/dpnp/dpnp_algo/dpnp_algo.pyx
@@ -330,7 +330,7 @@ cdef dparray call_fptr_1in_1out(DPNPFuncName fptr_name, dparray x1, dparray_shap
     return result
 
 
-cdef dparray call_fptr_2in_1out(DPNPFuncName fptr_name, dparray x1, dparray x2, dparray_shape_type result_shape):
+cdef dparray call_fptr_2in_1out(DPNPFuncName fptr_name, dparray x1, dparray x2, dparray_shape_type result_shape, new_version=False):
 
     """ Convert string type names (dparray.dtype) to C enum DPNPFuncType """
     cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(x1.dtype)
@@ -343,8 +343,13 @@ cdef dparray call_fptr_2in_1out(DPNPFuncName fptr_name, dparray x1, dparray x2, 
     """ Create result array with type given by FPTR data """
     cdef dparray result = dparray(result_shape, dtype=result_type)
 
-    cdef fptr_2in_1out_t func = <fptr_2in_1out_t > kernel_data.ptr
     """ Call FPTR function """
-    func(x1.get_data(), x2.get_data(), result.get_data(), x1.size)
+    # parameter 'new_version' must be removed in shortly
+    cdef fptr_2in_1out_t func_old = <fptr_2in_1out_t > kernel_data.ptr  # can't define it inside 'if' due Cython limitation
+    cdef fptr_2in_1out_new_t func_new = <fptr_2in_1out_new_t > kernel_data.ptr
+    if (new_version):
+        func_new(result.get_data(), x1.get_data(), x1.size, x2.get_data(), x2.size)
+    else:
+        func_old(x1.get_data(), x2.get_data(), result.get_data(), x1.size)
 
     return result

--- a/dpnp/dpnp_algo/dpnp_algo_bitwise.pyx
+++ b/dpnp/dpnp_algo/dpnp_algo_bitwise.pyx
@@ -47,15 +47,15 @@ __all__ += [
 
 
 cpdef dparray dpnp_bitwise_and(dparray array1, dparray array2):
-    return call_fptr_2in_1out(DPNP_FN_BITWISE_AND, array1, array2, array1.shape)
+    return call_fptr_2in_1out(DPNP_FN_BITWISE_AND, array1, array2, array1.shape, True)
 
 
 cpdef dparray dpnp_bitwise_or(dparray array1, dparray array2):
-    return call_fptr_2in_1out(DPNP_FN_BITWISE_OR, array1, array2, array1.shape)
+    return call_fptr_2in_1out(DPNP_FN_BITWISE_OR, array1, array2, array1.shape, True)
 
 
 cpdef dparray dpnp_bitwise_xor(dparray array1, dparray array2):
-    return call_fptr_2in_1out(DPNP_FN_BITWISE_XOR, array1, array2, array1.shape)
+    return call_fptr_2in_1out(DPNP_FN_BITWISE_XOR, array1, array2, array1.shape, True)
 
 
 cpdef dparray dpnp_invert(dparray arr):
@@ -63,7 +63,7 @@ cpdef dparray dpnp_invert(dparray arr):
 
 
 cpdef dparray dpnp_left_shift(dparray array1, dparray array2):
-    return call_fptr_2in_1out(DPNP_FN_LEFT_SHIFT, array1, array2, array1.shape)
+    return call_fptr_2in_1out(DPNP_FN_LEFT_SHIFT, array1, array2, array1.shape, True)
 
 cpdef dparray dpnp_right_shift(dparray array1, dparray array2):
-    return call_fptr_2in_1out(DPNP_FN_RIGHT_SHIFT, array1, array2, array1.shape)
+    return call_fptr_2in_1out(DPNP_FN_RIGHT_SHIFT, array1, array2, array1.shape, True)


### PR DESCRIPTION
- parameters order changed
- 'const' added
- supported scalar as parameter to kernels

no tests for this case found