### PR TITLE
add native version nonzero

### DIFF
--- a/dpnp/backend/include/dpnp_iface.hpp
+++ b/dpnp/backend/include/dpnp_iface.hpp
@@ -191,6 +191,20 @@ INP_DLLEXPORT void
 
 /**
  * @ingroup BACKEND_API
+ * @brief Return the indices of the elements that are non-zero.
+ *
+ * @param [in]  array1    Input array.
+ * @param [out] result1   Output array.
+ * @param [in]  shape     Shape of input array.
+ * @param [in]  ndim      Number of elements in shape.
+ * @param [in]  j         Number input array.
+ */
+template <typename _DataType>
+INP_DLLEXPORT void
+    dpnp_nonzero_c(const void* array1, void* result1, const size_t* shape, const size_t ndim, const size_t j);
+
+/**
+ * @ingroup BACKEND_API
  * @brief absolute function.
  *
  * @param [in]  array1_in    Input array.

--- a/dpnp/backend/include/dpnp_iface_fptr.hpp
+++ b/dpnp/backend/include/dpnp_iface_fptr.hpp
@@ -132,6 +132,7 @@ enum class DPNPFuncName : size_t
     DPNP_FN_MINIMUM,                  /**< Used in numpy.minimum() implementation  */
     DPNP_FN_MODF,                     /**< Used in numpy.modf() implementation  */
     DPNP_FN_MULTIPLY,                 /**< Used in numpy.multiply() implementation  */
+    DPNP_FN_NONZERO,                  /**< Used in numpy.nonzero() implementation  */
     DPNP_FN_ONES,                     /**< Used in numpy.ones() implementation */
     DPNP_FN_ONES_LIKE,                /**< Used in numpy.ones_like() implementation */
     DPNP_FN_PLACE,                    /**< Used in numpy.place() implementation  */

--- a/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
@@ -176,6 +176,50 @@ void dpnp_fill_diagonal_c(void* array1_in, void* val_in, size_t* shape, const si
 }
 
 template <typename _DataType>
+void dpnp_nonzero_c(const void* in_array1, void* result1, const size_t* shape, const size_t ndim, const size_t j)
+{
+    if ((in_array1 == nullptr) || (result1 == nullptr))
+    {
+        return;
+    }
+
+    if (ndim == 0)
+    {
+        return;
+    }
+
+    const _DataType* arr = reinterpret_cast<const _DataType*>(in_array1);
+    long* result = reinterpret_cast<long*>(result1);
+
+    size_t size = 1;
+    for (size_t i = 0; i < ndim; ++i)
+    {
+        size *= shape[i];
+    }
+
+    size_t idx = 0;
+    for (size_t i = 0; i < size; ++i)
+    {
+        if (arr[i] != 0)
+        {
+            size_t ids[ndim];
+            size_t ind1 = size;
+            size_t ind2 = i;
+            for (size_t k = 0; k < ndim; ++k)
+            {
+                ind1 = ind1 / shape[k];
+                ids[k] = ind2 / ind1;
+                ind2 = ind2 % ind1;
+            }
+
+            result[idx] = ids[j];
+            idx += 1;
+        }
+    }
+    return;
+}
+
+template <typename _DataType>
 void dpnp_place_c(void* arr_in, long* mask_in, void* vals_in, const size_t arr_size, const size_t vals_size)
 {
     if (!arr_size)
@@ -440,6 +484,11 @@ void func_map_init_indexing_func(func_map_t& fmap)
     fmap[DPNPFuncName::DPNP_FN_FILL_DIAGONAL][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_fill_diagonal_c<long>};
     fmap[DPNPFuncName::DPNP_FN_FILL_DIAGONAL][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_fill_diagonal_c<float>};
     fmap[DPNPFuncName::DPNP_FN_FILL_DIAGONAL][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_fill_diagonal_c<double>};
+
+    fmap[DPNPFuncName::DPNP_FN_NONZERO][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_nonzero_c<int>};
+    fmap[DPNPFuncName::DPNP_FN_NONZERO][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_nonzero_c<long>};
+    fmap[DPNPFuncName::DPNP_FN_NONZERO][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_nonzero_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_NONZERO][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_nonzero_c<double>};
 
     fmap[DPNPFuncName::DPNP_FN_PLACE][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_place_c<int>};
     fmap[DPNPFuncName::DPNP_FN_PLACE][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_place_c<long>};

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -105,6 +105,7 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_MINIMUM
         DPNP_FN_MODF
         DPNP_FN_MULTIPLY
+        DPNP_FN_NONZERO
         DPNP_FN_ONES
         DPNP_FN_ONES_LIKE
         DPNP_FN_PLACE

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -83,6 +83,32 @@ def test_indices(dimension):
     numpy.testing.assert_array_equal(expected, result)
 
 
+@pytest.mark.parametrize("array",
+                         [[],
+                          [[0, 0], [0, 0]],
+                          [[1, 0], [1, 0]],
+                          [[1, 2], [3, 4]],
+                          [[0, 1, 2], [3, 0, 5], [6, 7, 0]],
+                          [[0, 1, 0, 3, 0], [5, 0, 7, 0, 9]],
+                          [[[1, 2], [0, 4]], [[0, 2], [0, 1]], [[0, 0], [3, 1]]],
+                          [[[[1, 2, 3], [3, 4, 5]], [[1, 2, 3], [2, 1, 0]]], [
+                              [[1, 3, 5], [3, 1, 0]], [[0, 1, 2], [1, 3, 4]]]]],
+                         ids=['[]',
+                              '[[0, 0], [0, 0]]',
+                              '[[1, 0], [1, 0]]',
+                              '[[1, 2], [3, 4]]',
+                              '[[0, 1, 2], [3, 0, 5], [6, 7, 0]]',
+                              '[[0, 1, 0, 3, 0], [5, 0, 7, 0, 9]]',
+                              '[[[1, 2], [0, 4]], [[0, 2], [0, 1]], [[0, 0], [3, 1]]]',
+                              '[[[[1, 2, 3], [3, 4, 5]], [[1, 2, 3], [2, 1, 0]]], [[[1, 3, 5], [3, 1, 0]], [[0, 1, 2], [1, 3, 4]]]]'])
+def test_nonzero(array):
+    a = numpy.array(array)
+    ia = dpnp.array(array)
+    expected = numpy.nonzero(a)
+    result = dpnp.nonzero(ia)
+    numpy.testing.assert_array_equal(expected, result)
+
+
 @pytest.mark.parametrize("vals",
                          [[100, 200],
                           (100, 200)],


### PR DESCRIPTION
tests/test_indexing.py::test_nonzero[[[1, 0], [1, 0]]] 
tests/test_indexing.py::test_nonzero[[[1, 2], [3, 4]]] 
tests/test_indexing.py::test_nonzero[[[0, 1, 2], [3, 0, 5], [6, 7, 0]]]
tests/test_indexing.py::test_nonzero[[[0, 1, 0, 3, 0], [5, 0, 7, 0, 9]]] 
tests/test_indexing.py::test_nonzero[[[[1, 2], [0, 4]], [[0, 2], [0, 1]], [[0, 0], [3, 1]]]] 
tests/test_indexing.py::test_nonzero[[[[[1, 2, 3], [3, 4, 5]], [[1, 2, 3], [2, 1, 0]]], [[[1, 3, 5], [3, 1, 0]], [[0, 1, 2], [1, 3, 4]]]]]
