### PR TITLE
MULTIPLY enable broadcasting

### DIFF
--- a/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
@@ -365,14 +365,14 @@ static void func_map_init_elemwise_1arg_1type(func_map_t& fmap)
         _DataType_input2* input2_data = reinterpret_cast<_DataType_input2*>(const_cast<void*>(input2_in));             \
         _DataType_output* result = reinterpret_cast<_DataType_output*>(result_out);                                    \
                                                                                                                        \
-        std::vector<size_t> result_shape = get_common_shape(input1_shape, input1_shape_ndim,                           \
+        std::vector<size_t> result_shape = get_result_shape(input1_shape, input1_shape_ndim,                           \
                                                             input2_shape, input2_shape_ndim);                          \
                                                                                                                        \
         DPNPC_id<_DataType_input1> input1(input1_data, input1_shape, input1_shape_ndim);                               \
-        input1.broadcast(result_shape);                                                                                \
+        input1.broadcast_to_shape(result_shape);                                                                       \
                                                                                                                        \
         DPNPC_id<_DataType_input2> input2(input2_data, input2_shape, input2_shape_ndim);                               \
-        input2.broadcast(result_shape);                                                                                \
+        input2.broadcast_to_shape(result_shape);                                                                       \
                                                                                                                        \
         const size_t result_size = input1.get_output_size();                                                           \
                                                                                                                        \

--- a/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
@@ -28,6 +28,7 @@
 
 #include <dpnp_iface.hpp>
 #include "dpnp_fptr.hpp"
+#include "dpnp_iterator.hpp"
 #include "dpnp_utils.hpp"
 #include "queue_sycl.hpp"
 
@@ -353,10 +354,6 @@ static void func_map_init_elemwise_1arg_1type(func_map_t& fmap)
                   const size_t* where)                                                                                 \
     {                                                                                                                  \
         /* avoid warning unused variable*/                                                                             \
-        (void)input1_shape;                                                                                            \
-        (void)input1_shape_ndim;                                                                                       \
-        (void)input2_shape;                                                                                            \
-        (void)input2_shape_ndim;                                                                                       \
         (void)where;                                                                                                   \
                                                                                                                        \
         if (!input1_size || !input2_size)                                                                              \
@@ -364,17 +361,34 @@ static void func_map_init_elemwise_1arg_1type(func_map_t& fmap)
             return;                                                                                                    \
         }                                                                                                              \
                                                                                                                        \
-        const size_t result_size = (input2_size > input1_size) ? input2_size : input1_size;                            \
-                                                                                                                       \
-        const _DataType_input1* input1_data = reinterpret_cast<const _DataType_input1*>(input1_in);                    \
-        const _DataType_input2* input2_data = reinterpret_cast<const _DataType_input2*>(input2_in);                    \
+        _DataType_input1* input1_data = reinterpret_cast<_DataType_input1*>(const_cast<void*>(input1_in));             \
+        _DataType_input2* input2_data = reinterpret_cast<_DataType_input2*>(const_cast<void*>(input2_in));             \
         _DataType_output* result = reinterpret_cast<_DataType_output*>(result_out);                                    \
+                                                                                                                       \
+        std::vector<size_t> result_shape = get_result_shape(input1_shape, input1_shape_ndim,                           \
+                                                            input2_shape, input2_shape_ndim);                          \
+                                                                                                                       \
+        DPNPC_id<_DataType_input1>* input1_it;                                                                         \
+        const size_t input1_it_size_in_bytes = sizeof(DPNPC_id<_DataType_input1>);                                     \
+        input1_it = reinterpret_cast<DPNPC_id<_DataType_input1>*>(dpnp_memory_alloc_c(input1_it_size_in_bytes));       \
+        new (input1_it) DPNPC_id<_DataType_input1>(input1_data, input1_shape, input1_shape_ndim);                      \
+                                                                                                                       \
+        input1_it->broadcast_to_shape(result_shape);                                                                   \
+                                                                                                                       \
+        DPNPC_id<_DataType_input2>* input2_it;                                                                         \
+        const size_t input2_it_size_in_bytes = sizeof(DPNPC_id<_DataType_input2>);                                     \
+        input2_it = reinterpret_cast<DPNPC_id<_DataType_input2>*>(dpnp_memory_alloc_c(input2_it_size_in_bytes));       \
+        new (input2_it) DPNPC_id<_DataType_input2>(input2_data, input2_shape, input2_shape_ndim);                      \
+                                                                                                                       \
+        input2_it->broadcast_to_shape(result_shape);                                                                   \
+                                                                                                                       \
+        const size_t result_size = input1_it->get_output_size();                                                       \
                                                                                                                        \
         cl::sycl::range<1> gws(result_size);                                                                           \
         auto kernel_parallel_for_func = [=](cl::sycl::id<1> global_id) {                                               \
-            size_t i = global_id[0]; /*for (size_t i = 0; i < result_size; ++i)*/                                      \
-            const _DataType_output input1_elem = (input1_size == 1) ? input1_data[0] : input1_data[i];                 \
-            const _DataType_output input2_elem = (input2_size == 1) ? input2_data[0] : input2_data[i];                 \
+            const size_t i = global_id[0]; /*for (size_t i = 0; i < result_size; ++i)*/                                \
+            const _DataType_output input1_elem = (*input1_it)[i];                                                      \
+            const _DataType_output input2_elem = (*input2_it)[i];                                                      \
             result[i] = __operation1__;                                                                                \
         };                                                                                                             \
         auto kernel_func = [&](cl::sycl::handler& cgh) {                                                               \
@@ -390,9 +404,7 @@ static void func_map_init_elemwise_1arg_1type(func_map_t& fmap)
                            std::is_same<_DataType_input1, float>::value) &&                                            \
                           std::is_same<_DataType_input2, _DataType_input1>::value)                                     \
             {                                                                                                          \
-                _DataType_input1* input1 = const_cast<_DataType_input1*>(input1_data);                                 \
-                _DataType_input2* input2 = const_cast<_DataType_input2*>(input2_data);                                 \
-                event = __operation2__(DPNP_QUEUE, result_size, input1, input2, result);                               \
+                event = __operation2__(DPNP_QUEUE, result_size, input1_data, input2_data, result);                     \
             }                                                                                                          \
             else                                                                                                       \
             {                                                                                                          \
@@ -405,6 +417,9 @@ static void func_map_init_elemwise_1arg_1type(func_map_t& fmap)
         }                                                                                                              \
                                                                                                                        \
         event.wait();                                                                                                  \
+                                                                                                                       \
+        input1_it->~DPNPC_id();                                                                                        \
+        input2_it->~DPNPC_id();                                                                                        \
     }
 
 #include <dpnp_gen_2arg_3type_tbl.hpp>

--- a/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
@@ -28,7 +28,6 @@
 
 #include <dpnp_iface.hpp>
 #include "dpnp_fptr.hpp"
-#include "dpnp_iterator.hpp"
 #include "dpnp_utils.hpp"
 #include "queue_sycl.hpp"
 
@@ -354,6 +353,10 @@ static void func_map_init_elemwise_1arg_1type(func_map_t& fmap)
                   const size_t* where)                                                                                 \
     {                                                                                                                  \
         /* avoid warning unused variable*/                                                                             \
+        (void)input1_shape;                                                                                            \
+        (void)input1_shape_ndim;                                                                                       \
+        (void)input2_shape;                                                                                            \
+        (void)input2_shape_ndim;                                                                                       \
         (void)where;                                                                                                   \
                                                                                                                        \
         if (!input1_size || !input2_size)                                                                              \
@@ -361,31 +364,18 @@ static void func_map_init_elemwise_1arg_1type(func_map_t& fmap)
             return;                                                                                                    \
         }                                                                                                              \
                                                                                                                        \
-        _DataType_input1* input1_data = reinterpret_cast<_DataType_input1*>(const_cast<void*>(input1_in));             \
-        _DataType_input2* input2_data = reinterpret_cast<_DataType_input2*>(const_cast<void*>(input2_in));             \
+        const size_t result_size = (input2_size > input1_size) ? input2_size : input1_size;                            \
+                                                                                                                       \
+        const _DataType_input1* input1_data = reinterpret_cast<const _DataType_input1*>(input1_in);                    \
+        const _DataType_input2* input2_data = reinterpret_cast<const _DataType_input2*>(input2_in);                    \
         _DataType_output* result = reinterpret_cast<_DataType_output*>(result_out);                                    \
                                                                                                                        \
-        std::vector<size_t> result_shape = get_result_shape(input1_shape, input1_shape_ndim,                           \
-                                                            input2_shape, input2_shape_ndim);                          \
-                                                                                                                       \
-        DPNPC_id<_DataType_input1> input1(input1_data, input1_shape, input1_shape_ndim);                               \
-        input1.broadcast_to_shape(result_shape);                                                                       \
-                                                                                                                       \
-        DPNPC_id<_DataType_input2> input2(input2_data, input2_shape, input2_shape_ndim);                               \
-        input2.broadcast_to_shape(result_shape);                                                                       \
-                                                                                                                       \
-        const size_t result_size = input1.get_output_size();                                                           \
-                                                                                                                       \
         cl::sycl::range<1> gws(result_size);                                                                           \
-        const DPNPC_id<_DataType_input1>* input1_it = &input1;                                                         \
-        const DPNPC_id<_DataType_input2>* input2_it = &input2;                                                         \
         auto kernel_parallel_for_func = [=](cl::sycl::id<1> global_id) {                                               \
-            const size_t i = global_id[0]; /*for (size_t i = 0; i < result_size; ++i)*/                                \
-            {                                                                                                          \
-                const _DataType_output input1_elem = (*input1_it)[i];                                                  \
-                const _DataType_output input2_elem = (*input2_it)[i];                                                  \
-                result[i] = __operation1__;                                                                            \
-            }                                                                                                          \
+            size_t i = global_id[0]; /*for (size_t i = 0; i < result_size; ++i)*/                                      \
+            const _DataType_output input1_elem = (input1_size == 1) ? input1_data[0] : input1_data[i];                 \
+            const _DataType_output input2_elem = (input2_size == 1) ? input2_data[0] : input2_data[i];                 \
+            result[i] = __operation1__;                                                                                \
         };                                                                                                             \
         auto kernel_func = [&](cl::sycl::handler& cgh) {                                                               \
             cgh.parallel_for<class __name__##_kernel<_DataType_output, _DataType_input1,                               \
@@ -400,7 +390,9 @@ static void func_map_init_elemwise_1arg_1type(func_map_t& fmap)
                            std::is_same<_DataType_input1, float>::value) &&                                            \
                           std::is_same<_DataType_input2, _DataType_input1>::value)                                     \
             {                                                                                                          \
-                event = __operation2__(DPNP_QUEUE, result_size, input1_data, input2_data, result);                     \
+                _DataType_input1* input1 = const_cast<_DataType_input1*>(input1_data);                                 \
+                _DataType_input2* input2 = const_cast<_DataType_input2*>(input2_data);                                 \
+                event = __operation2__(DPNP_QUEUE, result_size, input1, input2, result);                               \
             }                                                                                                          \
             else                                                                                                       \
             {                                                                                                          \

--- a/dpnp/backend/src/dpnp_iterator.hpp
+++ b/dpnp/backend/src/dpnp_iterator.hpp
@@ -258,14 +258,7 @@ public:
         if (broadcastable(input_shape, input_shape_size, __shape))
         {
             broadcast_axes.clear();
-            output_size = size_type{};
-            output_shape_size = size_type{};
-            dpnp_memory_free_c(output_shape);
-            dpnp_memory_free_c(output_shape_strides);
-            dpnp_memory_free_c(sycl_output_xyz);
-            output_shape = nullptr;
-            output_shape_strides = nullptr;
-            sycl_output_xyz = nullptr;
+            free_output_memory();
 
             broadcast_use = true;
 

--- a/dpnp/backend/src/dpnp_iterator.hpp
+++ b/dpnp/backend/src/dpnp_iterator.hpp
@@ -240,9 +240,9 @@ public:
 
     /**
      * @ingroup BACKEND_UTILS
-     * @brief Set output shape for the data object to use in computation.
+     * @brief Broadcast input data to specified shape.
      *
-     * Set shape of output array to use in computation of input array index by index of output array.
+     * Set output shape to use in computation of input index by output index.
      *
      * @note this function is designed for non-SYCL environment execution
      *
@@ -329,7 +329,7 @@ public:
 
     /**
      * @ingroup BACKEND_UTILS
-     * @brief Broadcast input data to specified shape.
+     * @brief Set axes for the data object to use in computation.
      *
      * Set axes of the shape of input array to use in iteration.
      * Axes might be negative to indicate axes as reverse iterator

--- a/dpnp/backend/src/dpnp_iterator.hpp
+++ b/dpnp/backend/src/dpnp_iterator.hpp
@@ -257,10 +257,15 @@ public:
 
         if (broadcastable(input_shape, input_shape_size, __shape))
         {
+            broadcast_axes.clear();
+            output_size = size_type{};
+            output_shape_size = size_type{};
             dpnp_memory_free_c(output_shape);
             dpnp_memory_free_c(output_shape_strides);
             dpnp_memory_free_c(sycl_output_xyz);
-            broadcast_axes.clear();
+            output_shape = nullptr;
+            output_shape_strides = nullptr;
+            sycl_output_xyz = nullptr;
 
             broadcast_use = true;
 

--- a/dpnp/backend/src/dpnp_utils.hpp
+++ b/dpnp/backend/src/dpnp_utils.hpp
@@ -182,19 +182,17 @@ static inline bool
  * @return                         Common shape.
  */
 static inline std::vector<size_t>
-    get_common_shape(const size_t* input1_shape, const size_t input1_shape_size,
+    get_result_shape(const size_t* input1_shape, const size_t input1_shape_size,
                      const size_t* input2_shape, const size_t input2_shape_size)
 {
     const size_t result_shape_size = (input2_shape_size > input1_shape_size) ? input2_shape_size : input1_shape_size;
     std::vector<size_t> result_shape;
     result_shape.reserve(result_shape_size);
 
-    int in1_idx = input1_shape_size - 1;
-    int in2_idx = input2_shape_size - 1;
-    for (; in1_idx >= 0 || in2_idx >= 0; --in1_idx, --in2_idx)
+    for (int irit1 = input1_shape_size - 1, irit2 = input2_shape_size - 1; irit1 >= 0 || irit2 >= 0; --irit1, --irit2)
     {
-        size_t input1_val = (in1_idx >= 0) ? input1_shape[in1_idx] : 1;
-        size_t input2_val = (in2_idx >= 0) ? input2_shape[in2_idx] : 1;
+        size_t input1_val = (irit1 >= 0) ? input1_shape[irit1] : 1;
+        size_t input2_val = (irit2 >= 0) ? input2_shape[irit2] : 1;
 
         if (input1_val == input2_val || input1_val == 1)
         {

--- a/dpnp/backend/tests/CMakeLists.txt
+++ b/dpnp/backend/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ link_directories(${GTEST_LIB_DIR})
 
 # TODO split
 add_executable(dpnpc_tests
+               test_broadcast_iterator.cpp
                test_main.cpp
                test_random.cpp
                test_utils.cpp

--- a/dpnp/backend/tests/dpnp_test_utils.hpp
+++ b/dpnp/backend/tests/dpnp_test_utils.hpp
@@ -1,0 +1,30 @@
+#include <iostream>
+#include <vector>
+
+#include "dpnp_iterator.hpp"
+
+using namespace std;
+using dpnpc_it_t = DPNPC_id<size_t>::iterator;
+using dpnpc_value_t = dpnpc_it_t::value_type;
+using dpnpc_index_t = dpnpc_it_t::size_type;
+
+template <typename _DataType>
+vector<_DataType> get_input_data(const vector<dpnpc_index_t>& shape)
+{
+    const dpnpc_index_t size = accumulate(shape.begin(), shape.end(), dpnpc_index_t(1), multiplies<dpnpc_index_t>());
+
+    vector<_DataType> input_data(size);
+    iota(input_data.begin(), input_data.end(), 1); // let's start from 1 to avoid cleaned memory comparison
+
+    return input_data;
+}
+
+template <typename _DataType>
+_DataType* get_shared_data(const vector<_DataType>& input_data)
+{
+    const size_t data_size_in_bytes = input_data.size() * sizeof(_DataType);
+    _DataType* shared_data = reinterpret_cast<_DataType*>(dpnp_memory_alloc_c(data_size_in_bytes));
+    copy(input_data.begin(), input_data.end(), shared_data);
+
+    return shared_data;
+}

--- a/dpnp/backend/tests/test_broadcast_iterator.cpp
+++ b/dpnp/backend/tests/test_broadcast_iterator.cpp
@@ -1,0 +1,202 @@
+//*****************************************************************************
+// Copyright (c) 2016-2020, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//*****************************************************************************
+
+#include <gtest/gtest.h>
+#include <numeric>
+#include <vector>
+
+#include "dpnp_iterator.hpp"
+
+#define DPNP_LOCAL_QUEUE 1 // TODO need to fix build procedure and remove this workaround. Issue #551
+#include "queue_sycl.hpp"
+
+using namespace std;
+using dpnpc_it_t = DPNPC_id<size_t>::iterator;
+using dpnpc_value_t = dpnpc_it_t::value_type;
+using dpnpc_index_t = dpnpc_it_t::size_type;
+
+template <typename _DataType>
+vector<_DataType> get_input_data(const vector<dpnpc_index_t>& shape)
+{
+    const dpnpc_index_t size = accumulate(shape.begin(), shape.end(), dpnpc_index_t(1), multiplies<dpnpc_index_t>());
+
+    vector<_DataType> input_data(size);
+    iota(input_data.begin(), input_data.end(), 1); // let's start from 1 to avoid cleaned memory comparison
+
+    return input_data;
+}
+
+TEST(TestBroadcastIterator, take_value_broadcast_loop_2D)
+{
+    vector<dpnpc_value_t> expected_data{1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3};
+    // expected input data 1, 2, 3
+    vector<dpnpc_value_t> input_data = get_input_data<dpnpc_value_t>({3, 1});
+    DPNPC_id<dpnpc_value_t> result_obj(input_data.data(), {3, 1});
+    result_obj.broadcast_to_shape({3, 4});
+
+    for (dpnpc_index_t output_id = 0; output_id < result_obj.get_output_size(); ++output_id)
+    {
+        EXPECT_EQ(result_obj[output_id], expected_data[output_id]);
+    }
+}
+
+TEST(TestBroadcastIterator, take_value_broadcast_loop_3D)
+{
+    vector<dpnpc_value_t> expected_data{1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6};
+    // expected input data 1, 2, 3, 4, 5, 6
+    vector<dpnpc_value_t> input_data = get_input_data<dpnpc_value_t>({2, 3});
+    DPNPC_id<dpnpc_value_t> result_obj(input_data.data(), {2, 3});
+    result_obj.broadcast_to_shape({2, 2, 3});
+
+    for (dpnpc_index_t output_id = 0; output_id < result_obj.get_output_size(); ++output_id)
+    {
+        EXPECT_EQ(result_obj[output_id], expected_data[output_id]);
+    }
+}
+
+TEST(TestBroadcastIterator, output_size_broadcast)
+{
+    vector<dpnpc_value_t> input_data = get_input_data<dpnpc_value_t>({3, 4});
+    DPNPC_id<dpnpc_value_t> result_obj(input_data.data(), {3, 4});
+    result_obj.broadcast_to_shape({2, 3, 4});
+
+    const dpnpc_index_t output_size = result_obj.get_output_size();
+    EXPECT_EQ(output_size, 24);
+}
+
+struct IteratorParameters
+{
+    vector<dpnpc_it_t::size_type> input_shape;
+    vector<dpnpc_it_t::size_type> output_shape;
+    vector<dpnpc_value_t> result;
+
+    /// Operator needs to print this container in human readable form in error reporting
+    friend std::ostream& operator<<(std::ostream& out, const IteratorParameters& data)
+    {
+        out << "IteratorParameters(input_shape=" << data.input_shape << ", output_shape=" << data.output_shape
+            << ", result=" << data.result << ")";
+
+        return out;
+    }
+};
+
+class IteratorBroadcasting : public ::testing::TestWithParam<IteratorParameters>
+{
+};
+
+TEST_P(IteratorBroadcasting, loop_broadcast)
+{
+    const IteratorParameters& param = GetParam();
+    const dpnpc_index_t result_size = param.result.size();
+
+    vector<dpnpc_value_t> input_data = get_input_data<dpnpc_value_t>(param.input_shape);
+    DPNPC_id<dpnpc_value_t> input(input_data.data(), param.input_shape);
+    input.broadcast_to_shape(param.output_shape);
+
+    ASSERT_EQ(input.get_output_size(), result_size);
+
+    vector<dpnpc_value_t> test_result(result_size, 42);
+    for (dpnpc_index_t output_id = 0; output_id < result_size; ++output_id)
+    {
+        test_result[output_id] = input[output_id];
+        std::cout << "test_result[" << output_id << "] = " << test_result[output_id] << std::endl;
+        std::cout << "param.result.at(" << output_id << ") = " << param.result.at(output_id) << std::endl;
+        EXPECT_EQ(test_result[output_id], param.result.at(output_id));
+    }
+}
+
+TEST_P(IteratorBroadcasting, sycl_broadcast)
+{
+    using data_type = double;
+
+    const IteratorParameters& param = GetParam();
+    const dpnpc_index_t result_size = param.result.size();
+    vector<data_type> result(result_size, 42);
+    data_type* result_ptr = result.data();
+
+    vector<data_type> input_data = get_input_data<data_type>(param.input_shape);
+    DPNPC_id<data_type> input(input_data.data(), param.input_shape);
+    input.broadcast_to_shape(param.output_shape);
+
+    ASSERT_EQ(input.get_output_size(), result_size);
+
+    cl::sycl::range<1> gws(result_size);
+    const DPNPC_id<data_type>* input_it = &input;
+    auto kernel_parallel_for_func = [=](cl::sycl::id<1> global_id) {
+        const size_t idx = global_id[0];
+        result_ptr[idx] = (*input_it)[idx];
+    };
+
+    auto kernel_func = [&](cl::sycl::handler& cgh) {
+        cgh.parallel_for<class test_sycl_reduce_axis_kernel>(gws, kernel_parallel_for_func);
+    };
+
+    cl::sycl::event event = DPNP_QUEUE.submit(kernel_func);
+    event.wait();
+
+    for (dpnpc_index_t i = 0; i < result_size; ++i)
+    {
+        EXPECT_EQ(result.at(i), param.result.at(i));
+    }
+}
+
+/**
+ * Expected values produced by following script:
+ *
+ * import numpy as np
+ *
+ * input_size = 12
+ * input_shape = [3, 4]
+ * input = np.arange(1, input_size + 1, dtype=np.int64).reshape(input_shape)
+ * print(f"input shape={input.shape}")
+ * print(f"input:\n{input}\n")
+ * 
+ * output_shape = [2, 3, 4]
+ * output = np.ones(output_shape, dtype=np.int64)
+ * print(f"output shape={output.shape}")
+ *
+ * result = input * output
+ * print(f"result={np.array2string(result.reshape(result.size), separator=', ')}\n", sep=", ")
+ */
+INSTANTIATE_TEST_SUITE_P(
+    TestBroadcastIterator,
+    IteratorBroadcasting,
+    testing::Values(
+        IteratorParameters{{1}, {1}, {1}},
+        IteratorParameters{{1}, {4}, {1, 1, 1, 1}},
+        IteratorParameters{{1}, {3, 4}, {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}},
+        IteratorParameters{{1}, {2, 3, 4}, {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}},
+        IteratorParameters{{4}, {4}, {1, 2, 3, 4}},
+        IteratorParameters{{4}, {3, 4}, {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}},
+        IteratorParameters{{4}, {2, 3, 4}, {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}},
+        IteratorParameters{{3, 4}, {3, 4}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}},
+        IteratorParameters{{3, 4}, {2, 3, 4}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+                                               1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}},
+        IteratorParameters{{2, 3, 4}, {2, 3, 4}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+                                                  13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}},
+        IteratorParameters{{2, 3, 1}, {2, 3, 4}, {1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3,
+                                                  4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6}},
+        IteratorParameters{{2, 1, 4}, {2, 3, 4}, {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4,
+                                                  5, 6, 7, 8, 5, 6, 7, 8, 5, 6, 7, 8}}));

--- a/dpnp/backend/tests/test_utils_iterator.cpp
+++ b/dpnp/backend/tests/test_utils_iterator.cpp
@@ -28,25 +28,12 @@
 #include <vector>
 
 #include "dpnp_iterator.hpp"
+#include "dpnp_test_utils.hpp"
 
 #define DPNP_LOCAL_QUEUE 1 // TODO need to fix build procedure and remove this workaround. Issue #551
 #include "queue_sycl.hpp"
 
 using namespace std;
-using dpnpc_it_t = DPNPC_id<size_t>::iterator;
-using dpnpc_value_t = dpnpc_it_t::value_type;
-using dpnpc_index_t = dpnpc_it_t::size_type;
-
-template <typename _DataType>
-vector<_DataType> get_input_data(const vector<dpnpc_index_t>& shape)
-{
-    const dpnpc_index_t size = accumulate(shape.begin(), shape.end(), dpnpc_index_t(1), multiplies<dpnpc_index_t>());
-
-    vector<_DataType> input_data(size);
-    iota(input_data.begin(), input_data.end(), 1); // let's start from 1 to avoid cleaned memory comparison
-
-    return input_data;
-}
 
 TEST(TestUtilsIterator, begin_prefix_postfix)
 {

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -1071,6 +1071,10 @@ def multiply(x1, x2, dtype=None, out=None, where=True, **kwargs):
             pass
         elif x2_is_dparray and x2.ndim == 0:
             pass
+        elif x1_is_dparray and x2_is_dparray and x1.size != x2.size:
+            pass
+        elif x1_is_dparray and x2_is_dparray and x1.shape != x2.shape:
+            pass
         elif dtype is not None:
             pass
         elif out is not None:

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -1071,10 +1071,6 @@ def multiply(x1, x2, dtype=None, out=None, where=True, **kwargs):
             pass
         elif x2_is_dparray and x2.ndim == 0:
             pass
-        elif x1_is_dparray and x2_is_dparray and x1.size != x2.size:
-            pass
-        elif x1_is_dparray and x2_is_dparray and x1.shape != x2.shape:
-            pass
         elif dtype is not None:
             pass
         elif out is not None:


### PR DESCRIPTION
This PR shows current status of broadcasting implementation through USM iterator.

Currently issue below is under investigation:
```
DPNP_QUEUE_GPU=1 python -c "import dpnp; a = dpnp.array([7]); b = dpnp.array([7]); c = dpnp.multiply(a, b); print(c)"
Available SYCL devices:
 - id=4466, type=8, gws=67108864, cu=12, name=Intel(R) FPGA Emulation Device
 - id=32902, type=2, gws=8192, cu=12, name=Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz
 - id=32902, type=4, gws=256, cu=24, name=Intel(R) Graphics [0x9bca]
 - id=32902, type=4, gws=256, cu=24, name=Intel(R) Graphics [0x9bca]
 - id=32902, type=18, gws=1, cu=1, name=SYCL host device
Running on: Intel(R) Graphics [0x9bca]
queue initialization time: 0.000503686 (sec.)
SYCL kernels link time: 0.112728 (sec.)

terminate called after throwing an instance of 'cl::sycl::runtime_error'
  what():  Native API failed. Native API returns: -30 (CL_INVALID_VALUE) -30 (CL_INVALID_VALUE)
Aborted (core dumped)
```