### PR TITLE
ENH: update `random.standart_t`

### DIFF
--- a/dpnp/backend/kernels/dpnp_krnl_random.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_random.cpp
@@ -1108,7 +1108,8 @@ void dpnp_rng_standard_t_c(void* result, const _DataType df, const size_t size)
         mkl_rng::gaussian<_DataType> gaussian_distribution(d_zero, d_one);
         auto gaussian_distr_event = mkl_rng::generate(gaussian_distribution, DPNP_RNG_ENGINE, size, sn);
 
-        auto event_out = mkl_vm::mul(DPNP_QUEUE, size, result1, sn, result1, {invsqrt_event, gaussian_distr_event}, mkl_vm::mode::ha);
+        auto event_out = mkl_vm::mul(
+            DPNP_QUEUE, size, result1, sn, result1, {invsqrt_event, gaussian_distr_event}, mkl_vm::mode::ha);
         free(sn, DPNP_QUEUE);
         event_out.wait();
     }

--- a/dpnp/backend/kernels/dpnp_krnl_random.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_random.cpp
@@ -1086,11 +1086,10 @@ void dpnp_rng_standard_normal_c(void* result, size_t size)
 template <typename _DataType>
 void dpnp_rng_standard_t_c(void* result, const _DataType df, const size_t size)
 {
-    if (!size)
+    if (!size || !result)
     {
         return;
     }
-    cl::sycl::vector_class<cl::sycl::event> no_deps;
 
     _DataType* result1 = reinterpret_cast<_DataType*>(result);
     const _DataType d_zero = 0.0, d_one = 1.0;
@@ -1100,19 +1099,17 @@ void dpnp_rng_standard_t_c(void* result, const _DataType df, const size_t size)
     if (dpnp_queue_is_cpu_c())
     {
         mkl_rng::gamma<_DataType> gamma_distribution(shape, d_zero, 1.0 / shape);
-        auto event_out = mkl_rng::generate(gamma_distribution, DPNP_RNG_ENGINE, size, result1);
-        event_out.wait();
-        event_out = mkl_vm::invsqrt(DPNP_QUEUE, size, result1, result1, no_deps, mkl_vm::mode::ha);
-        event_out.wait();
+        auto gamma_distr_event = mkl_rng::generate(gamma_distribution, DPNP_RNG_ENGINE, size, result1);
 
-        sn = reinterpret_cast<_DataType*>(dpnp_memory_alloc_c(size * sizeof(_DataType)));
+        auto invsqrt_event = mkl_vm::invsqrt(DPNP_QUEUE, size, result1, result1, {gamma_distr_event}, mkl_vm::mode::ha);
+
+        sn = reinterpret_cast<_DataType*>(malloc_shared(size * sizeof(_DataType), DPNP_QUEUE));
 
         mkl_rng::gaussian<_DataType> gaussian_distribution(d_zero, d_one);
-        event_out = mkl_rng::generate(gaussian_distribution, DPNP_RNG_ENGINE, size, sn);
-        event_out.wait();
+        auto gaussian_distr_event = mkl_rng::generate(gaussian_distribution, DPNP_RNG_ENGINE, size, sn);
 
-        event_out = mkl_vm::mul(DPNP_QUEUE, size, result1, sn, result1, no_deps, mkl_vm::mode::ha);
-        dpnp_memory_free_c(sn);
+        auto event_out = mkl_vm::mul(DPNP_QUEUE, size, result1, sn, result1, {invsqrt_event, gaussian_distr_event}, mkl_vm::mode::ha);
+        free(sn, DPNP_QUEUE);
         event_out.wait();
     }
     else

--- a/dpnp/backend/kernels/dpnp_krnl_random.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_random.cpp
@@ -1085,14 +1085,14 @@ void dpnp_rng_standard_t_c(void* result, const _DataType df, const size_t size)
 
         auto invsqrt_event = mkl_vm::invsqrt(DPNP_QUEUE, size, result1, result1, {gamma_distr_event}, mkl_vm::mode::ha);
 
-        sn = reinterpret_cast<_DataType*>(malloc_shared(size * sizeof(_DataType), DPNP_QUEUE));
+        sn = reinterpret_cast<_DataType*>(dpnp_memory_alloc_c(size * sizeof(_DataType)));
 
         mkl_rng::gaussian<_DataType> gaussian_distribution(d_zero, d_one);
         auto gaussian_distr_event = mkl_rng::generate(gaussian_distribution, DPNP_RNG_ENGINE, size, sn);
 
         auto event_out = mkl_vm::mul(
             DPNP_QUEUE, size, result1, sn, result1, {invsqrt_event, gaussian_distr_event}, mkl_vm::mode::ha);
-        free(sn, DPNP_QUEUE);
+        dpnp_memory_free_c(sn);
         event_out.wait();
     }
     else


### PR DESCRIPTION
## Description
delegate sync on device

## Tests
* dpnp own
```shell
tests/test_random.py::TestDistributionsStandardT::test_invalid_args PASSED
tests/test_random.py::TestDistributionsStandardT::test_moments PASSED
tests/test_random.py::TestDistributionsStandardT::test_seed PASSED 
```
* \+ numpy external