### PR TITLE
Replace numpy-devel with numpy

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -8,7 +8,7 @@ requirements:
     host:
       - python
       - setuptools
-      - numpy-devel >=1.18
+      - numpy >=1.15
       - cython
       - cmake >=3.16.5
       - dpctl >=0.5.0a0
@@ -22,6 +22,7 @@ requirements:
       - dpcpp_cpp_rt >=2021.1.1
       - mkl >=2021.1.1
       - mkl-dpcpp >=2021.1.1
+      - numpy >=1.15
 
 build:
     number: {{ GIT_DESCRIBE_NUMBER }}


### PR DESCRIPTION
numpy-devel binds package with specific version of numpy.
It allows use dpnp package with different versions of numpy that needed by numpy-dppy CI.