### PR TITLE
MKL version mismatch in conda and intelOneAPI

### DIFF
--- a/scripts/install_python_deps.sh
+++ b/scripts/install_python_deps.sh
@@ -9,8 +9,8 @@ echo ========================= Conda: install prerequisites ====================
 # because numpy is installed with openblas for Python 3.9 by default
 conda install -y conda-build numpy=1.20.1 blas=*=mkl cython pytest hypothesis
 
-# echo ========================= Conda: remove mkl ====================================
-# conda remove mkl --force -y || true
+echo ========================= Conda: remove mkl ====================================
+conda remove mkl --force -y || true
 
 echo ========================= PIP3: install prerequisites ==========================
 pip3 install pytest-valgrind


### PR DESCRIPTION
Current version of MKL in conda "mkl-2021.2.0-h06a4308_296"
MKL version in Intel One API is "2021.3.0"
So, libraries could not be used simultaneously because DPNP uses python MKL but DPNPC uses intel one API MKL.

Direct linking with particular version of MKL looks impossible because lack of version support in MKL.
The library has the same file name in diffrent real versions
```
/home/work/anaconda3/lib/libmkl_core.so -> libmkl_core.so.1
and
/opt/intel/oneapi/mkl/2021.3.0/lib/intel64/libmkl_core.so -> libmkl_core.so.1
```