### PR TITLE
replace conv2scalar function

### DIFF
--- a/dpnp/dpnp_iface.py
+++ b/dpnp/dpnp_iface.py
@@ -135,15 +135,16 @@ def asnumpy(input, order='C'):
     return numpy.asarray(input, order=order)
 
 
-def convert_single_elem_array_to_scalar(obj):
+def convert_single_elem_array_to_scalar(obj, keepdims=False):
     """
     Convert array with single element to scalar
     """
 
-    if obj.shape == (1,): # TODO handle shapes like (1,1,1,1)
+    if (obj.ndim > 0) and (obj.size == 1) and (keepdims is False):
         return obj.dtype.type(obj[0])
 
     return obj
+
 
 def get_dpnp_descriptor(ext_obj):
     """

--- a/dpnp/dpnp_iface_logic.py
+++ b/dpnp/dpnp_iface_logic.py
@@ -761,7 +761,7 @@ def not_equal(x1, x2):
     x2_desc = dpnp.get_dpnp_descriptor(x2)
     is_x1_scalar = dpnp.isscalar(x1)
     is_x2_scalar = dpnp.isscalar(x2)
-    if 0 and (x1_desc and x2_desc and (x1_desc or is_x1_scalar)) and (not use_origin_backend(x2) and (x2_desc or is_x2_scalar)) and not(is_x1_scalar and is_x2_scalar):
+    if 0 and (x1_desc and x2_desc and (x1_desc or is_x1_scalar)) and (x2_desc or is_x2_scalar) and not(is_x1_scalar and is_x2_scalar):
         if is_x1_scalar:
             result = dpnp_not_equal(x2_desc, x1_desc)
         else:

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -40,12 +40,12 @@ it contains:
 """
 
 
-import numpy
-
 from dpnp.dpnp_algo import *
 from dpnp.dparray import dparray
 from dpnp.dpnp_utils import *
+
 import dpnp
+import numpy
 
 
 __all__ = [
@@ -91,15 +91,6 @@ __all__ = [
     "true_divide",
     "trunc"
 ]
-
-
-def convert_result_scalar(result, keepdims):
-    # one element array result should be converted into scalar
-    # TODO empty shape must be converted into scalar (it is not in test system)
-    if (len(result.shape) > 0) and (result.size == 1) and (keepdims is False):
-        return result.dtype.type(result[0])
-    else:
-        return result
 
 
 def abs(*args, **kwargs):
@@ -1377,8 +1368,10 @@ def prod(x1, axis=None, dtype=None, out=None, keepdims=False, initial=None, wher
         elif where is not True:
             pass
         else:
-            result = dpnp_prod(x1, axis, dtype, out, keepdims, initial, where)
-            return convert_result_scalar(result, keepdims)
+            result_obj = dpnp_prod(x1, axis, dtype, out, keepdims, initial, where)
+            result = dpnp.convert_single_elem_array_to_scalar(result_obj, keepdims) 
+
+            return result
 
     return call_origin(numpy.prod, x1, axis=axis, dtype=dtype, out=out, keepdims=keepdims, initial=initial, where=where)
 
@@ -1555,8 +1548,10 @@ def sum(x1, axis=None, dtype=None, out=None, keepdims=False, initial=None, where
         elif where is not True:
             pass
         else:
-            result = dpnp_sum(x1, axis, dtype, out, keepdims, initial, where)
-            return convert_result_scalar(result, keepdims)
+            result_obj = dpnp_sum(x1, axis, dtype, out, keepdims, initial, where)
+            result = dpnp.convert_single_elem_array_to_scalar(result_obj, keepdims)
+
+            return result
 
     return call_origin(numpy.sum, x1, axis=axis, dtype=dtype, out=out, keepdims=keepdims, initial=initial, where=where)
 


### PR DESCRIPTION
No algorithm changes.
Simple replace "convert_result_scalar" with "convert_single_elem_array_to_scalar".
+support shape[1,1,1,1,1] in "convert_single_elem_array_to_scalar"
+few style improvements.
