### PR TITLE
scalar support in normalize_axis()

### DIFF
--- a/dpnp/dpnp_utils/dpnp_algo_utils.pxd
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pxd
@@ -77,7 +77,7 @@ Return:
 cpdef tuple _object_to_tuple(object obj)
 cdef int _normalize_order(order, cpp_bool allow_k=*) except? 0
 
-cpdef dparray_shape_type normalize_axis(dparray_shape_type axis, size_t shape_size)
+cpdef dparray_shape_type normalize_axis(object axis, size_t shape_size)
 """
 Conversion of the transformation shape axis [-1, 0, 1] into [2, 0, 1] where numbers are `id`s of array shape axis
 """

--- a/dpnp/dpnp_utils/dpnp_algo_utils.pyx
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pyx
@@ -355,11 +355,12 @@ cpdef nd2dp_array(arr):
     return result
 
 
-cpdef dparray_shape_type normalize_axis(dparray_shape_type axis, size_t shape_size_inp):
+cpdef dparray_shape_type normalize_axis(object axis_obj, size_t shape_size_inp):
     """
     Conversion of the transformation shape axis [-1, 0, 1] into [2, 0, 1] where numbers are `id`s of array shape axis
     """
 
+    cdef dparray_shape_type axis = _object_to_tuple(axis_obj)  # axis_obj might be a scalar
     cdef ssize_t shape_size = shape_size_inp  # convert type for comparison with axis id
 
     cdef size_t axis_size = axis.size()


### PR DESCRIPTION
`axis` parameter might be a scalar. the function failed and throw Python exception "scalar is not iterable".
Integer to `dparray_shape_type` (std::vector) conversion attempted.