### PR TITLE
ENH: `where`, `searchsorted`; fallbacks

### DIFF
--- a/dpnp/dpnp_iface_searching.py
+++ b/dpnp/dpnp_iface_searching.py
@@ -50,7 +50,9 @@ import numpy
 
 __all__ = [
     'argmax',
-    'argmin'
+    'argmin',
+    'searchsorted',
+    'where'
 ]
 
 
@@ -162,3 +164,25 @@ def argmin(x1, axis=None, out=None):
             return result
 
     return call_origin(numpy.argmin, x1, axis, out)
+
+
+def searchsorted(a, v, side='left', sorter=None):
+    """
+    Find indices where elements should be inserted to maintain order.
+
+    For full documentation refer to :obj:`numpy.searchsorted`.
+
+    """
+
+    return call_origin(numpy.where, a, v, side, sorter)
+
+
+def where(condition, x=None, y=None):
+    """
+    Find indices where elements should be inserted to maintain order.
+
+    For full documentation refer to :obj:`numpy.searchsorted`.
+
+    """
+
+    return call_origin(numpy.where, condition, x, y)


### PR DESCRIPTION
## Description
* `dpnp.searchsorted`, `dpnp.where`. fallbacks to numpy

## Tests
* cupy tests for `searchsorted`, `where`
* TODO: numpy tests will be moved to DPNP own