### PR TITLE
utils function refactoring. move to cdef

### DIFF
--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -238,8 +238,8 @@ cpdef dparray dpnp_flatten(dparray array1)
 """
 Internal functions
 """
-cpdef DPNPFuncType dpnp_dtype_to_DPNPFuncType(dtype)
-cpdef dpnp_DPNPFuncType_to_dtype(size_t type)
+cdef DPNPFuncType dpnp_dtype_to_DPNPFuncType(dtype)
+cdef dpnp_DPNPFuncType_to_dtype(size_t type)
 
 
 """

--- a/dpnp/dpnp_algo/dpnp_algo.pyx
+++ b/dpnp/dpnp_algo/dpnp_algo.pyx
@@ -198,7 +198,7 @@ cpdef dpnp_queue_is_cpu():
 """
 Internal functions
 """
-cpdef DPNPFuncType dpnp_dtype_to_DPNPFuncType(dtype):
+cdef DPNPFuncType dpnp_dtype_to_DPNPFuncType(dtype):
 
     if dtype in [numpy.float64, 'float64']:
         return DPNP_FT_DOUBLE
@@ -215,7 +215,7 @@ cpdef DPNPFuncType dpnp_dtype_to_DPNPFuncType(dtype):
     else:
         utils.checker_throw_type_error("dpnp_dtype_to_DPNPFuncType", dtype)
 
-cpdef dpnp_DPNPFuncType_to_dtype(size_t type):
+cdef dpnp_DPNPFuncType_to_dtype(size_t type):
     """
     Type 'size_t' used instead 'DPNPFuncType' because Cython has lack of Enum support (0.29)
     TODO needs to use DPNPFuncType here

--- a/dpnp/dpnp_utils/dpnp_algo_utils.pyx
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pyx
@@ -53,6 +53,7 @@ __all__ = [
     "checker_throw_runtime_error",
     "checker_throw_type_error",
     "checker_throw_value_error",
+    "create_output_descriptor_py",
     "dp2nd_array",
     "dpnp_descriptor",
     "get_axis_indeces",
@@ -133,6 +134,12 @@ cpdef checker_throw_value_error(function_name, param_name, param, expected):
     err_msg = f"{ERROR_PREFIX} in function {function_name}() paramenter '{param_name}'"
     err_msg += f" expected `{expected}`, but '{param}' provided"
     raise ValueError(err_msg)
+
+
+cpdef dpnp_descriptor create_output_descriptor_py(dparray_shape_type output_shape, object d_type, object requested_out):
+    cdef DPNPFuncType c_type = dpnp_dtype_to_DPNPFuncType(d_type)
+
+    return create_output_descriptor(output_shape, c_type, requested_out)
 
 
 cpdef dp2nd_array(arr):


### PR DESCRIPTION
Cython does not support overloading by different function parameters type. So, new function name implemented.