### PR TITLE
ENH: `dpnp.concatenate` fallback; tests

### DIFF
--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -56,6 +56,7 @@ __all__ = [
     "atleast_1d",
     "atleast_2d",
     "atleast_3d",
+    "concatenate",
     "copyto",
     "expand_dims",
     "hstack",
@@ -176,6 +177,43 @@ def atleast_3d(*arys):
             return result
 
     return call_origin(numpy.atleast_3d, *arys)
+
+
+def concatenate(arrs, axis=0, out=None, dtype=None, casting="same_kind"):
+    """
+    Join a sequence of arrays along an existing axis.
+
+    For full documentation refer to :obj:`numpy.concatenate`.
+
+    Examples
+    --------
+    >>> import dpnp
+    >>> a = dpnp.array([[1, 2], [3, 4]])
+    >>> b = dpnp.array([[5, 6]])
+    >>> res = dpnp.concatenate((a, b), axis=0)
+    >>> print(res)
+    [[1 2]
+     [3 4]
+     [5 6]]
+    >>> res = dpnp.concatenate((a, b.T), axis=1)
+    >>> print(res)
+    [[1 2 5]
+     [3 4 6]]
+    >>> res = dpnp.concatenate((a, b), axis=None)
+    >>> print(res)
+    [1 2 3 4 5 6]
+
+    """
+
+    # TODO:
+    # `call_origin` cannot convert sequence of dparray to sequence of
+    # ndarrays
+    arrs_new = []
+    for arr in arrs:
+        arrx = dpnp.asnumpy(arr) if isinstance(arr, dparray) else arr
+        arrs_new.append(arrx)
+
+    return call_origin(numpy.concatenate, arrs_new, axis=axis, out=out, dtype=dtype, casting=casting)
 
 
 def copyto(dst, src, casting='same_kind', where=True):

--- a/tests/test_arraymanipulation.py
+++ b/tests/test_arraymanipulation.py
@@ -17,6 +17,63 @@ def test_asfarray(type, input):
     numpy.testing.assert_array_equal(dpnp_res, np_res)
 
 
+class TestConcatenate:
+    def test_returns_copy(self):
+        a = dpnp.array(numpy.eye(3))
+        b = dpnp.concatenate([a])
+        b[0, 0] = 2
+        assert b[0, 0] != a[0, 0]
+
+    def test_large_concatenate_axis_None(self):
+        x = dpnp.arange(1, 100)
+        r = dpnp.concatenate(x, None)
+        numpy.testing.assert_array_equal(x, r)
+        r = dpnp.concatenate(x, 100)
+        numpy.testing.assert_array_equal(x, r)
+
+    def test_concatenate(self):
+        # Test concatenate function
+        # One sequence returns unmodified (but as array)
+        r4 = list(range(4))
+        numpy.testing.assert_array_equal(dpnp.concatenate((r4,)), r4)
+        # Any sequence
+        numpy.testing.assert_array_equal(dpnp.concatenate((tuple(r4),)), r4)
+        numpy.testing.assert_array_equal(dpnp.concatenate((dpnp.array(r4),)), r4)
+        # 1D default concatenation
+        r3 = list(range(3))
+        numpy.testing.assert_array_equal(dpnp.concatenate((r4, r3)), r4 + r3)
+        # Mixed sequence types
+        numpy.testing.assert_array_equal(dpnp.concatenate((tuple(r4), r3)), r4 + r3)
+        numpy.testing.assert_array_equal(dpnp.concatenate((dpnp.array(r4), r3)), r4 + r3)
+        # Explicit axis specification
+        numpy.testing.assert_array_equal(dpnp.concatenate((r4, r3), 0), r4 + r3)
+        # Including negative
+        numpy.testing.assert_array_equal(dpnp.concatenate((r4, r3), -1), r4 + r3)
+        # 2D
+        a23 = dpnp.array([[10, 11, 12], [13, 14, 15]])
+        a13 = dpnp.array([[0, 1, 2]])
+        res = dpnp.array([[10, 11, 12], [13, 14, 15], [0, 1, 2]])
+        numpy.testing.assert_array_equal(dpnp.concatenate((a23, a13)), res)
+        numpy.testing.assert_array_equal(dpnp.concatenate((a23, a13), 0), res)
+        numpy.testing.assert_array_equal(dpnp.concatenate((a23.T, a13.T), 1), res.T)
+        numpy.testing.assert_array_equal(dpnp.concatenate((a23.T, a13.T), -1), res.T)
+        # Arrays much match shape
+        numpy.testing.assert_raises(ValueError, dpnp.concatenate, (a23.T, a13.T), 0)
+        # 3D
+        res = dpnp.arange(2 * 3 * 7).reshape((2, 3, 7))
+        a0 = res[..., :4]
+        a1 = res[..., 4:6]
+        a2 = res[..., 6:]
+        numpy.testing.assert_array_equal(dpnp.concatenate((a0, a1, a2), 2), res)
+        numpy.testing.assert_array_equal(dpnp.concatenate((a0, a1, a2), -1), res)
+        numpy.testing.assert_array_equal(dpnp.concatenate((a0.T, a1.T, a2.T), 0), res.T)
+
+        out = res.copy()
+        rout = dpnp.concatenate((a0, a1, a2), 2, out=out)
+        numpy.testing.assert_(out is rout)
+        numpy.testing.assert_equal(res, rout)
+
+
 class TestHstack:
     def test_non_iterable(self):
         numpy.testing.assert_raises(TypeError, dpnp.hstack, 1)


### PR DESCRIPTION
## Description
* `dpnp.concatenate` fallback
* examples
* tests (some numpy original tests, while we have issue with them)

## Tests
* pasta some numpy original tests to `tests/test_arraymanipulation.py`, while we have issue with numpy testing
```bash
tests/test_arraymanipulation.py::TestConcatenate::test_returns_copy PASSED
tests/test_arraymanipulation.py::TestConcatenate::test_large_concatenate_axis_None PASSED
tests/test_arraymanipulation.py::TestConcatenate::test_concatenate PASSED
```