### PR TITLE
Fix test test_asfarray and add test test_asfarray2

### DIFF
--- a/tests/test_arraymanipulation.py
+++ b/tests/test_arraymanipulation.py
@@ -4,17 +4,30 @@ import dpnp
 import numpy
 
 
-@pytest.mark.parametrize("type",
+@pytest.mark.parametrize("dtype",
                          [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
-                         ids=['float64', 'float32', 'int64', 'int32'])
-@pytest.mark.parametrize("input",
-                         [[1, 2, 3], [1., 2., 3.], dpnp.array([1, 2, 3]), dpnp.array([1., 2., 3.])],
-                         ids=['intlist', 'floatlist', 'intarray', 'floatarray'])
-def test_asfarray(type, input):
-    np_res = numpy.asfarray(input, type)
-    dpnp_res = dpnp.asfarray(input, type)
+                         ids=["float64", "float32", "int64", "int32"])
+@pytest.mark.parametrize("data",
+                         [[1, 2, 3], [1., 2., 3.]],
+                         ids=["[1, 2, 3]", "[1., 2., 3.]"])
+def test_asfarray(dtype, data):
+    expected = numpy.asfarray(data, dtype)
+    result = dpnp.asfarray(data, dtype)
 
-    numpy.testing.assert_array_equal(dpnp_res, np_res)
+    numpy.testing.assert_array_equal(result, expected)
+
+
+@pytest.mark.parametrize("dtype",
+                         [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
+                         ids=["float64", "float32", "int64", "int32"])
+@pytest.mark.parametrize("data",
+                         [[1, 2, 3], [1., 2., 3.]],
+                         ids=["[1, 2, 3]", "[1., 2., 3.]"])
+def test_asfarray2(dtype, data):
+    expected = numpy.asfarray(numpy.array(data), dtype)
+    result = dpnp.asfarray(dpnp.array(data), dtype)
+
+    numpy.testing.assert_array_equal(result, expected)
 
 
 class TestConcatenate:


### PR DESCRIPTION
We can't pass `usm_ndarray` as parameter to `numpy.asfarray()`.