### PR TITLE
BUG: fix asanyarray fallback + disabled tests

### DIFF
--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -249,9 +249,9 @@ def asanyarray(a, dtype=None, order='C'):
             return a
 
         if order != 'C':
-            checker_throw_value_error("asanyarray", "order", order, 'C')
-
-        return array(a, dtype=dtype, order=order)
+            pass
+        else:
+            return array(a, dtype=dtype, order=order)
 
     return call_origin(numpy.asanyarray, a, dtype, order)
 

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -205,9 +205,12 @@ tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_arra
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_array_from_numpy_scalar
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_array_no_copy
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_array_no_copy_ndmin
+tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asanyarray_with_order
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_cuda_array_zero_dim
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_cuda_array_zero_dim_dtype
+tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_from_numpy
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_is_not_copied
+tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_with_order
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_with_order_copy_behavior
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_ascontiguousarray_on_noncontiguous_array
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asfortranarray_cuda_array_zero_dim

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -517,12 +517,9 @@ tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_arra
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_array_from_numpy_scalar
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_array_no_copy
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_array_no_copy_ndmin
-tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asanyarray_with_order
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_cuda_array_zero_dim
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_cuda_array_zero_dim_dtype
-tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_from_numpy
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_is_not_copied
-tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_with_order
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_with_order_copy_behavior
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_ascontiguousarray_on_noncontiguous_array
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asfortranarray_cuda_array_zero_dim

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -35,8 +35,6 @@ tests/third_party/cupy/core_tests/test_ndarray_math.py::TestRoundHalfway_param_0
 tests/third_party/cupy/core_tests/test_ndarray_math.py::TestRoundHalfway_param_1_{decimals=-2}::test_round_halfway_float
 tests/third_party/cupy/core_tests/test_ndarray_math.py::TestRoundHalfway_param_2_{decimals=-1}::test_round_halfway_float
 tests/third_party/cupy/core_tests/test_ndarray_math.py::TestRoundHalfway_param_3_{decimals=0}::test_round_halfway_float
-tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asanyarray_with_order
-tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_from_numpy
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_preserves_numpy_array_order
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_with_order
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_ascontiguousarray_on_contiguous_array
@@ -728,7 +726,6 @@ tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asar
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_cuda_array_zero_dim_dtype
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_from_numpy
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_is_not_copied
-tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_with_order
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_with_order_copy_behavior
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_ascontiguousarray_on_noncontiguous_array
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asfortranarray_cuda_array_zero_dim

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -721,10 +721,8 @@ tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_arra
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_array_from_numpy_scalar
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_array_no_copy
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_array_no_copy_ndmin
-tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asanyarray_with_order
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_cuda_array_zero_dim
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_cuda_array_zero_dim_dtype
-tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_from_numpy
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_is_not_copied
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_with_order_copy_behavior
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_ascontiguousarray_on_noncontiguous_array

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -230,9 +230,12 @@ tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_arra
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_array_from_numpy_scalar
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_array_no_copy
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_array_no_copy_ndmin
+tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asanyarray_with_order
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_cuda_array_zero_dim
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_cuda_array_zero_dim_dtype
+tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_from_numpy
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_is_not_copied
+tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_with_order
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_with_order_copy_behavior
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_ascontiguousarray_on_noncontiguous_array
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asfortranarray_cuda_array_zero_dim


### PR DESCRIPTION
## Description
* removed dpnp error raise, fallback when order is not c contiguous
 DPNP error: in function asanyarray() paramenter 'order' expected `C`, but 'None' provided -> 'int' object has no attribute 'c_contiguous'
* disabled tests for ['int' object has no attribute 'c_contiguous']. See `Reproduce dpctl usm_array flags` below
```bash
tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asanyarray_with_order
tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_from_numpy
tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asarray_with_order
```

## Test
FAILED tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asanyarray_with_order
```bash
tests/third_party/cupy/creation_tests/test_from_data.py:365: in test_asanyarray_with_order
    b = xp.asanyarray(a, order=order)
dpnp/dpnp_iface_arraycreation.py:252: in asanyarray
    checker_throw_value_error("asanyarray", "order", order, 'C')
dpnp/dpnp_utils/dpnp_algo_utils.pyx:189: in dpnp.dpnp_utils.dpnp_algo_utils.checker_throw_value_error
    cpdef checker_throw_value_error(function_name, param_name, param, expected):
dpnp/dpnp_utils/dpnp_algo_utils.pyx:194: in dpnp.dpnp_utils.dpnp_algo_utils.checker_throw_value_error
    raise ValueError(err_msg)
E   AssertionError: Only cupy raises error
E   
E     File "/localdisk/work/snasibli/dpnp_work/tmp2/dpnp/tests/third_party/cupy/testing/helper.py", line 30, in _call_func
E       result = impl(self, *args, **kw)
E     File "/localdisk/work/snasibli/dpnp_work/tmp2/dpnp/tests/third_party/cupy/creation_tests/test_from_data.py", line 365, in test_asanyarray_with_order
E       b = xp.asanyarray(a, order=order)
E     File "/localdisk/work/snasibli/dpnp_work/tmp2/dpnp/dpnp/dpnp_iface_arraycreation.py", line 252, in asanyarray
E       checker_throw_value_error("asanyarray", "order", order, 'C')
E     File "dpnp/dpnp_utils/dpnp_algo_utils.pyx", line 189, in dpnp.dpnp_utils.dpnp_algo_utils.checker_throw_value_error
E       cpdef checker_throw_value_error(function_name, param_name, param, expected):
E     File "dpnp/dpnp_utils/dpnp_algo_utils.pyx", line 194, in dpnp.dpnp_utils.dpnp_algo_utils.checker_throw_value_error
E       raise ValueError(err_msg)
E   DPNP error: in function asanyarray() paramenter 'order' expected `C`, but 'None' provided
```

Now there are another fail on test:
```bash
tests/third_party/cupy/creation_tests/test_from_data.py:369: in test_asanyarray_with_order
    assert b.flags.c_contiguous
E   AssertionError: Only cupy raises error
E
E     File "/localdisk/work/snasibli/dpnp_work/tmp2/dpnp/tests/third_party/cupy/testing/helper.py", line 30, in _call_func
E       result = impl(self, *args, **kw)
E     File "/localdisk/work/snasibli/dpnp_work/tmp2/dpnp/tests/third_party/cupy/creation_tests/test_from_data.py", line 369, in test_asanyarray_with_order
E       assert b.flags.c_contiguous
E   'int' object has no attribute 'c_contiguous'
```

This fail happens due dpctl usm_ndarray, that have a bug for `flags`.
## Reproduce dpctl usm_array flags
```python
>>> a = dpnp.asanyarray([12,34], order='C')
>>> a = dpnp.asanyarray([12,34], order='K')
>>> a
<dpctl.tensor._usmarray.usm_ndarray object at 0x7fdec18e4130>
>>> a.flags
1
>>> import numpy
>>> b = numpy.asanyarray([12,34], order='K')
>>> b.flags
  C_CONTIGUOUS : True
  F_CONTIGUOUS : True
  OWNDATA : True
  WRITEABLE : True
  ALIGNED : True
  WRITEBACKIFCOPY : False
  UPDATEIFCOPY : False
```
'int' object has no attribute 'c_contiguous'
