### PR TITLE
Copy inputs if they have strides

### DIFF
--- a/dpnp/dpnp_iface.py
+++ b/dpnp/dpnp_iface.py
@@ -150,7 +150,7 @@ def convert_single_elem_array_to_scalar(obj, keepdims=False):
     return obj
 
 
-def get_dpnp_descriptor(ext_obj):
+def get_dpnp_descriptor(ext_obj, copy_when_strides=True):
     """
     Return True:
       never
@@ -168,6 +168,14 @@ def get_dpnp_descriptor(ext_obj):
 
     if use_origin_backend():
         return False
+
+    # while dpnp functions have no implementation with strides support
+    # we need to create a non-strided copy
+    # if function get implementation for strides case
+    # then this behavior can be disabled with setting "copy_when_strides"
+    if copy_when_strides and hasattr(ext_obj, "strides") and ext_obj.strides is not None:
+        # TODO: replace this workaround when usm_ndarray will provide such functionality
+        ext_obj = array(ext_obj)
 
     dpnp_desc = dpnp_descriptor(ext_obj)
     if dpnp_desc.is_valid:

--- a/dpnp/dpnp_iface.py
+++ b/dpnp/dpnp_iface.py
@@ -173,7 +173,7 @@ def get_dpnp_descriptor(ext_obj, copy_when_strides=True):
     # we need to create a non-strided copy
     # if function get implementation for strides case
     # then this behavior can be disabled with setting "copy_when_strides"
-    if copy_when_strides and hasattr(ext_obj, "strides") and ext_obj.strides is not None:
+    if copy_when_strides and getattr(ext_obj, "strides", None) is not None:
         # TODO: replace this workaround when usm_ndarray will provide such functionality
         ext_obj = array(ext_obj)
 

--- a/tests/test_strides.py
+++ b/tests/test_strides.py
@@ -11,7 +11,7 @@ def _getattr(ex, str_):
     return res
 
 @pytest.mark.parametrize("func_name",
-                         ['cos', 'sin'])
+                         ['abs',])
 @pytest.mark.parametrize("type",
                          [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
                          ids=['float64', 'float32', 'int64', 'int32'])

--- a/tests/test_strides.py
+++ b/tests/test_strides.py
@@ -1,0 +1,31 @@
+import pytest
+
+import dpnp
+import numpy
+
+def _getattr(ex, str_):
+    attrs = str_.split(".")
+    res = ex
+    for attr in attrs:
+        res = getattr(res, attr)
+    return res
+
+@pytest.mark.parametrize("func_name",
+                         ['cos', 'sin'])
+@pytest.mark.parametrize("type",
+                         [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
+                         ids=['float64', 'float32', 'int64', 'int32'])
+def test_strides(func_name, type):
+    shape = (4, 4)
+    a = numpy.arange(shape[0] * shape[1], dtype=type).reshape(shape)
+    a_strides = a[0::2, 0::2]
+    dpa = dpnp.array(a)
+    dpa_strides = dpa[0::2, 0::2]
+
+    dpnp_func = _getattr(dpnp, func_name)
+    result = dpnp_func(dpa_strides)
+
+    numpy_func = _getattr(numpy, func_name)
+    expected = numpy_func(a_strides)
+
+    numpy.testing.assert_allclose(expected, result)


### PR DESCRIPTION
We need a workaround for inputs with strides because current implementations of functions in dpnp assume that data is c-contiguous without strides.
