### PR TITLE
Use Python 3.9 [public CI]

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -8,6 +8,11 @@ env:
 jobs:
   build:
     runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        python: [3.8, 3.9]
+
     steps:
       - name: Install Intel repository
         run: |
@@ -41,7 +46,7 @@ jobs:
           . /opt/intel/oneapi/setvars.sh
           . ./scripts/install_cmake_lin.sh
           CHANNELS="-c dppy/label/dev -c intel -c defaults --override-channels"
-          VERSIONS="--python 3.8"
+          VERSIONS="--python ${{ matrix.python }}"
           TEST="--no-test"
           conda build \
             $TEST \
@@ -52,18 +57,23 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: dpnp ${{ runner.os }}
+          name: dpnp ${{ runner.os }} ${{ matrix.python }}
           path: /usr/share/miniconda/conda-bld/linux-64/dpnp-*.tar.bz2
 
   upload:
     needs: build
     if: ${{ github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python: [3.8, 3.9]
+
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:
-          name: dpnp ${{ runner.os }}
+          name: dpnp ${{ runner.os }} ${{ matrix.python }}
 
       - name: Install anaconda-client
         run: conda install anaconda-client

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -8,7 +8,7 @@ requirements:
     host:
       - python
       - setuptools
-      - numpy >=1.15                    # [win or osx or py==38]
+      - numpy >=1.15                    # [win or osx or py>=38]
       - numpy 1.17                      # [linux and py==37]
       - cython
       - cmake >=3.16.5


### PR DESCRIPTION
- [x] Update GitHub CI for building development package
- [x] Update conda recipe
- [x] Dependencies
  - [x] https://github.com/IntelPython/dpctl/pull/599
- [x] Install oneAPI 2021.3 via APT
 
Closes #984. 