### PR TITLE
replace deprecated sycl::vector_class with std::vector

### DIFF
--- a/dpnp/backend/kernels/dpnp_krnl_common.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_common.cpp
@@ -84,7 +84,7 @@ cl::sycl::event dot(cl::sycl::queue& queue,
                     size_t input1_strides,
                     size_t input2_strides,
                     size_t size,
-                    const cl::sycl::vector_class<cl::sycl::event>& dependencies = {})
+                    const std::vector<cl::sycl::event>& dependencies = {})
 {
     (void)dependencies;
 
@@ -322,9 +322,7 @@ void dpnp_dot_c(void* result_out,
         }
     }
 
-    // deprecated? can be replaced with std::vector<cl::sycl::event>
-    cl::sycl::vector_class<cl::sycl::event> dot_events;
-    // std::vector<cl::sycl::event> dot_events;
+    std::vector<cl::sycl::event> dot_events;
     dot_events.reserve(result_size);
 
     size_t dot_st1 = ext_input1_strides[ext_input1_ndim - 1];

--- a/dpnp/backend/kernels/dpnp_krnl_linalg.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_linalg.cpp
@@ -455,7 +455,7 @@ void dpnp_qr_c(void* array1_in, void* result1, void* result2, void* result3, siz
     _ComputeDT* geqrf_scratchpad =
         reinterpret_cast<_ComputeDT*>(dpnp_memory_alloc_c(geqrf_scratchpad_size * sizeof(_ComputeDT)));
 
-    cl::sycl::vector_class<cl::sycl::event> depends(1);
+    std::vector<cl::sycl::event> depends(1);
     set_barrier_event(DPNP_QUEUE, depends);
 
     event =

--- a/dpnp/backend/kernels/dpnp_krnl_random.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_random.cpp
@@ -202,7 +202,7 @@ void dpnp_rng_f_c(void* result, const _DataType df_num, const _DataType df_den, 
     {
         return;
     }
-    cl::sycl::vector_class<cl::sycl::event> no_deps;
+    std::vector<cl::sycl::event> no_deps;
 
     const _DataType d_zero = (_DataType(0.0));
 
@@ -875,7 +875,7 @@ void dpnp_rng_pareto_c(void* result, const double alpha, const size_t size)
     {
         return;
     }
-    cl::sycl::vector_class<cl::sycl::event> no_deps;
+    std::vector<cl::sycl::event> no_deps;
 
     const _DataType d_zero = _DataType(0.0);
     const _DataType d_one = _DataType(1.0);
@@ -913,7 +913,7 @@ void dpnp_rng_power_c(void* result, const double alpha, const size_t size)
     {
         return;
     }
-    cl::sycl::vector_class<cl::sycl::event> no_deps;
+    std::vector<cl::sycl::event> no_deps;
 
     const _DataType d_zero = _DataType(0.0);
     const _DataType d_one = _DataType(1.0);
@@ -937,7 +937,7 @@ void dpnp_rng_rayleigh_c(void* result, const _DataType scale, const size_t size)
         return;
     }
 
-    cl::sycl::vector_class<cl::sycl::event> no_deps;
+    std::vector<cl::sycl::event> no_deps;
 
     const _DataType a = 0.0;
     const _DataType beta = 2.0;

--- a/dpnp/backend/src/verbose.cpp
+++ b/dpnp/backend/src/verbose.cpp
@@ -46,7 +46,7 @@ bool is_verbose_mode()
 
 class barrierKernelClass;
 
-void set_barrier_event(cl::sycl::queue queue, sycl::vector_class<sycl::event>& depends)
+void set_barrier_event(cl::sycl::queue queue, std::vector<cl::sycl::event>& depends)
 {
     if (is_verbose_mode())
     {

--- a/dpnp/backend/src/verbose.hpp
+++ b/dpnp/backend/src/verbose.hpp
@@ -30,7 +30,7 @@
 #include <CL/sycl.hpp>
 
 bool is_verbose_mode();
-void set_barrier_event(cl::sycl::queue queue, sycl::vector_class<sycl::event>& depends);
+void set_barrier_event(cl::sycl::queue queue, std::vector<cl::sycl::event>& depends);
 void verbose_print(std::string header, cl::sycl::event first_event, cl::sycl::event last_event);
 
 #endif // VERBOSE_H


### PR DESCRIPTION
`cl::sycl::vector_class` is deprecated.
We should use `std::vector` instead of it.