### PR TITLE
REPRODUCER: shuffle as an example

### DIFF
--- a/dpnp/backend/examples/example11.cpp
+++ b/dpnp/backend/examples/example11.cpp
@@ -1,5 +1,32 @@
-/*
- * dpcpp -g -fPIC -fsycl dpnp/backend/examples/example11.cpp  -o example11 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_tbb_thread -lmkl_core
+//*****************************************************************************
+// Copyright (c) 2016-2020, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//*****************************************************************************
+
+/**
+ * Example 11.
+ *
+ * Possible compile line:
  * dpcpp -g -fPIC   -W -Wextra -Wshadow -Wall -Wstrict-prototypes -Wformat -Wformat-security -fsycl -fsycl-device-code-split=per_kernel -O0 -fno-delete-null-pointer-checks -fstack-protector-strong -fno-strict-overflow -std=gnu++17 dpnp/backend/examples/example11.cpp -Idpnp -Idpnp/backend/include -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o example11 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_core
  */
 #include <iostream>
@@ -35,7 +62,8 @@ void init(T* x, size_t size)
     }
 }
 
-// For 1dim array
+#if 0
+/* For 1dim array */
 template <typename _DataType>
 void shuffle_c(
     void* result, const size_t itemsize, const size_t ndim, const size_t high_dim_size, const size_t size, cl::sycl::queue& queue, size_t seed)
@@ -98,47 +126,59 @@ void shuffle_c(
     free(Uvec, queue);
     return;
 }
+#endif
 
 int main(int, char**)
 {
-    cl::sycl::queue queue{cl::sycl::gpu_selector()};
+    // Two cases:
+    // 1) array size = 100, ndim = 1, high_dim_size = 10 (aka ndarray with shape (100,) )
+    // 2) array size = 100, ndim = 2, high_dim_size = 20 (aka ndarray with shape (20, 5) and len(array) = 20 )
+    const size_t ndim_cases = 2;
     const size_t itemsize = sizeof(double);
-    const size_t ndim = 1;
-    const size_t high_dim_size = 100;
+    const size_t ndim[ndim_cases] = {1, 2};
+    const size_t high_dim_size[ndim_cases] = {100, 20};
     const size_t size = 100;
     const size_t seed = 1234;
 
-    // reproducer for shuffling array (as is in dpnp_rng_shuffle_c)
-    // using mathlib interface
+#if 0
+    /*
+      reproducer for shuffling array (as is in dpnp_rng_shuffle_c)
+      for 1dim array
+      the same logic for ndim arrays
+      using mathlib interface
+    */
+    std::cout << "\n///////////////////////////////////////////////\n";
+    cl::sycl::queue queue{cl::sycl::gpu_selector()};
     std::cout << "\nREPRODUCE: logic as is in DPNPC dpnp_rng_shuffle_c:";
+    std::cout << "\nDIMS: " << ndim[0] <<std::endl;
     double* array_1 = reinterpret_cast<double*>(malloc_shared(size * sizeof(double), queue));
     std::cout << "\nINPUT array 1:";
     init<double>(array_1, size);
     print_dpnp_array(array_1, size);
-    shuffle_c<double>(array_1, itemsize, ndim, high_dim_size, size, queue, seed);
+    shuffle_c<double>(array_1, itemsize, ndim[0], high_dim_size[0], size, queue, seed);
     std::cout << "\nSHUFFLE INPUT array:";
     print_dpnp_array(array_1, size);
     free(array_1, queue);
+#endif
 
     std::cout << "\n///////////////////////////////////////////////\n";
-
     // DPNPC dpnp_rng_shuffle_c
     // DPNPC interface
-    std::cout << "\nREPRODUCE: DPNPC dpnp_rng_shuffle_c:";
     double* array_2 = reinterpret_cast<double*>(dpnp_memory_alloc_c(size * sizeof(double)));
-    // init array
-    init<double>(array_2, size);
-    // print before shuffle
-    std::cout << "\nINPUT array 2:";
-    print_dpnp_array(array_2, size);
-
-    dpnp_rng_srand_c(seed);
-
-    dpnp_rng_shuffle_c<double>(array_2, itemsize, ndim, high_dim_size, size);
-
-    // print shuffle result
-    std::cout << "\nSHUFFLE INPUT array 2:";
-    print_dpnp_array(array_2, size);
-
+    for (size_t i = 0; i < ndim_cases; i++)
+    {
+        std::cout << "\nREPRODUCE: DPNPC dpnp_rng_shuffle_c:";
+        std::cout << "\nDIMS: " << ndim[i] <<std::endl;
+        // init array 0, 1, 2, 3, 4, 5, 6, ....
+        init<double>(array_2, size);
+        // print before shuffle
+        std::cout << "\nINPUT array 2:";
+        print_dpnp_array(array_2, size);
+        dpnp_rng_srand_c(seed);
+        dpnp_rng_shuffle_c<double>(array_2, itemsize, ndim[i], high_dim_size[i], size);
+        // print shuffle result
+        std::cout << "\nSHUFFLE INPUT array 2:";
+        print_dpnp_array(array_2, size); 
+    }
     dpnp_memory_free_c(array_2);
 }

--- a/dpnp/backend/examples/example11.cpp
+++ b/dpnp/backend/examples/example11.cpp
@@ -1,0 +1,121 @@
+/*
+ * dpcpp -g -fPIC -fsycl dpnp/backend/examples/example11.cpp  -o example11 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_tbb_thread -lmkl_core
+ */
+#include <iostream>
+#include <time.h>
+
+// #include <dpnp_iface.hpp>
+
+#include <CL/sycl.hpp>
+#include <oneapi/mkl.hpp>
+
+namespace mkl_dft = oneapi::mkl::dft;
+namespace mkl_rng = oneapi::mkl::rng;
+namespace mkl_vm = oneapi::mkl::vm;
+
+template <typename T>
+void print_dpnp_array(T* arr, size_t size)
+{
+    std::cout << std::endl;
+    for (size_t i = 0; i < size; ++i)
+    {
+        std::cout << arr[i] << ", ";
+    }
+    std::cout << std::endl;
+}
+
+template <typename T>
+void init(T* x, size_t size)
+{
+    for (size_t i = 0; i < size; ++i)
+    {
+        x[i] = static_cast<T>(i);
+    }
+}
+
+// For 1dim array
+template <typename _DataType>
+void shuffle_c(
+    void* result, const size_t itemsize, const size_t ndim, const size_t high_dim_size, const size_t size, cl::sycl::queue& queue)
+{
+    if (!result)
+    {
+        return;
+    }
+
+    if (!size || !ndim || !(high_dim_size > 1))
+    {
+        return;
+    }
+
+    // cl::sycl::queue queue{cl::sycl::gpu_selector()};
+    size_t seed = 1234;
+
+    mkl_rng::mt19937 rng_engine = mkl_rng::mt19937(queue, seed);
+
+    // DPNPC_ptr_adapter<char> result1_ptr(result, size * itemsize, true, true);
+    // char* result1 = result1_ptr.get_ptr();
+    char* result1 = reinterpret_cast<char*>(result);
+
+    size_t uvec_size = high_dim_size - 1;
+    // double* array_1 = reinterpret_cast<double*>(malloc_shared(result_size * sizeof(double), queue));
+    // double* Uvec = reinterpret_cast<double*>(dpnp_memory_alloc_c(uvec_size * sizeof(double)));
+
+    double* Uvec = reinterpret_cast<double*>(malloc_shared(uvec_size * sizeof(double), queue));
+
+    mkl_rng::uniform<double> uniform_distribution(0.0, 1.0);
+
+    auto uniform_event = mkl_rng::generate(uniform_distribution, rng_engine, uvec_size, Uvec);
+    uniform_event.wait();
+    // just for debug
+    // print_dpnp_array(Uvec, uvec_size);
+
+
+    // Fast, statically typed path: shuffle the underlying buffer.
+    // Only for non-empty, 1d objects of class ndarray (subclasses such
+    // as MaskedArrays may not support this approach).
+    char* buf = reinterpret_cast<char*>(malloc_shared(sizeof(char), queue));
+    for (size_t i = uvec_size; i > 0; i--)
+    {
+        size_t j = (size_t)(floor((i + 1) * Uvec[i - 1]));
+        if (i != j)
+        {
+            auto memcpy1 =
+                queue.submit([&](cl::sycl::handler& h) { h.memcpy(buf, result1 + j * itemsize, itemsize); });
+            auto memcpy2 = queue.submit([&](cl::sycl::handler& h) {
+                h.depends_on({memcpy1});
+                h.memcpy(result1 + j * itemsize, result1 + i * itemsize, itemsize);
+            });
+            auto memcpy3 = queue.submit([&](cl::sycl::handler& h) {
+                h.depends_on({memcpy2});
+                h.memcpy(result1 + i * itemsize, buf, itemsize);
+            });
+            memcpy3.wait();
+        }
+    }
+    free(buf, queue);
+    free(Uvec, queue);
+    return;
+}
+
+int main(int, char**)
+{
+    // reproducer for shuffling array (as is in dpnp_rng_shuffle_c)
+    cl::sycl::queue queue{cl::sycl::gpu_selector()};
+    const size_t itemsize = sizeof(double);
+    const size_t ndim = 1;
+    const size_t high_dim_size = 100;
+    const size_t size = 100;
+    double* array_1 = reinterpret_cast<double*>(malloc_shared(size * sizeof(double), queue));
+    std::cout << "\nINPUT array:"; // << std::endl;
+    init<double>(array_1, size);
+    print_dpnp_array(array_1, size);
+    shuffle_c<double>(array_1, itemsize, ndim, high_dim_size, size, queue);
+    std::cout << "\nSHUFFLE INPUT array:"; // << std::endl;
+    print_dpnp_array(array_1, size);
+
+    free(array_1, queue);
+
+    // TODO
+    // add using dpnpc dpnp_rng_shuffle_c
+}

--- a/dpnp/backend/examples/example11.cpp
+++ b/dpnp/backend/examples/example11.cpp
@@ -1,10 +1,12 @@
 /*
  * dpcpp -g -fPIC -fsycl dpnp/backend/examples/example11.cpp  -o example11 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_tbb_thread -lmkl_core
+ * dpcpp -g -fPIC   -W -Wextra -Wshadow -Wall -Wstrict-prototypes -Wformat -Wformat-security -fsycl -fsycl-device-code-split=per_kernel -O0 -fno-delete-null-pointer-checks -fstack-protector-strong -fno-strict-overflow -std=gnu++17 dpnp/backend/examples/example11.cpp -Idpnp -Idpnp/backend/include -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o example11 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_core
  */
 #include <iostream>
 #include <time.h>
 
-// #include <dpnp_iface.hpp>
+#include <dpnp_iface.hpp>
+#include <dpnp_iface_fptr.hpp>
 
 #include <CL/sycl.hpp>
 #include <oneapi/mkl.hpp>
@@ -36,7 +38,7 @@ void init(T* x, size_t size)
 // For 1dim array
 template <typename _DataType>
 void shuffle_c(
-    void* result, const size_t itemsize, const size_t ndim, const size_t high_dim_size, const size_t size, cl::sycl::queue& queue)
+    void* result, const size_t itemsize, const size_t ndim, const size_t high_dim_size, const size_t size, cl::sycl::queue& queue, size_t seed)
 {
     if (!result)
     {
@@ -49,7 +51,6 @@ void shuffle_c(
     }
 
     // cl::sycl::queue queue{cl::sycl::gpu_selector()};
-    size_t seed = 1234;
 
     mkl_rng::mt19937 rng_engine = mkl_rng::mt19937(queue, seed);
 
@@ -100,22 +101,44 @@ void shuffle_c(
 
 int main(int, char**)
 {
-    // reproducer for shuffling array (as is in dpnp_rng_shuffle_c)
     cl::sycl::queue queue{cl::sycl::gpu_selector()};
     const size_t itemsize = sizeof(double);
     const size_t ndim = 1;
     const size_t high_dim_size = 100;
     const size_t size = 100;
+    const size_t seed = 1234;
+
+    // reproducer for shuffling array (as is in dpnp_rng_shuffle_c)
+    // using mathlib interface
+    std::cout << "\nREPRODUCE: logic as is in DPNPC dpnp_rng_shuffle_c:";
     double* array_1 = reinterpret_cast<double*>(malloc_shared(size * sizeof(double), queue));
-    std::cout << "\nINPUT array:"; // << std::endl;
+    std::cout << "\nINPUT array 1:";
     init<double>(array_1, size);
     print_dpnp_array(array_1, size);
-    shuffle_c<double>(array_1, itemsize, ndim, high_dim_size, size, queue);
-    std::cout << "\nSHUFFLE INPUT array:"; // << std::endl;
+    shuffle_c<double>(array_1, itemsize, ndim, high_dim_size, size, queue, seed);
+    std::cout << "\nSHUFFLE INPUT array:";
     print_dpnp_array(array_1, size);
-
     free(array_1, queue);
 
-    // TODO
-    // add using dpnpc dpnp_rng_shuffle_c
+    std::cout << "\n///////////////////////////////////////////////\n";
+
+    // DPNPC dpnp_rng_shuffle_c
+    // DPNPC interface
+    std::cout << "\nREPRODUCE: DPNPC dpnp_rng_shuffle_c:";
+    double* array_2 = reinterpret_cast<double*>(dpnp_memory_alloc_c(size * sizeof(double)));
+    // init array
+    init<double>(array_2, size);
+    // print before shuffle
+    std::cout << "\nINPUT array 2:";
+    print_dpnp_array(array_2, size);
+
+    dpnp_rng_srand_c(seed);
+
+    dpnp_rng_shuffle_c<double>(array_2, itemsize, ndim, high_dim_size, size);
+
+    // print shuffle result
+    std::cout << "\nSHUFFLE INPUT array 2:";
+    print_dpnp_array(array_2, size);
+
+    dpnp_memory_free_c(array_2);
 }

--- a/dpnp/backend/examples/example11.cpp
+++ b/dpnp/backend/examples/example11.cpp
@@ -30,17 +30,13 @@
  * for one and ndim arrays.
  *
  * Possible compile line:
- * dpcpp -g -fPIC   -W -Wextra -Wshadow -Wall -Wstrict-prototypes -Wformat -Wformat-security -fsycl
- * -fsycl-device-code-split=per_kernel -O0 -fno-delete-null-pointer-checks -fstack-protector-strong
- * -fno-strict-overflow -std=gnu++17 dpnp/backend/examples/example11.cpp -Idpnp -Idpnp/backend/include
- * -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o example11 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_core
+ * g++ -g dpnp/backend/examples/example11.cpp -Idpnp -Idpnp/backend/include -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o example11
+ *
  */
 
 #include <iostream>
 
 #include <dpnp_iface.hpp>
-
-namespace mkl_rng = oneapi::mkl::rng;
 
 template <typename T>
 void print_dpnp_array(T* arr, size_t size)
@@ -51,15 +47,6 @@ void print_dpnp_array(T* arr, size_t size)
         std::cout << arr[i] << ", ";
     }
     std::cout << std::endl;
-}
-
-template <typename T>
-void init(T* x, size_t size)
-{
-    for (size_t i = 0; i < size; ++i)
-    {
-        x[i] = static_cast<T>(i);
-    }
 }
 
 int main(int, char**)
@@ -76,21 +63,21 @@ int main(int, char**)
 
     // DPNPC dpnp_rng_shuffle_c
     // DPNPC interface
-    double* array_2 = reinterpret_cast<double*>(dpnp_memory_alloc_c(size * sizeof(double)));
+    double* array_1 = reinterpret_cast<double*>(dpnp_memory_alloc_c(size * sizeof(double)));
     for (size_t i = 0; i < ndim_cases; i++)
     {
         std::cout << "\nREPRODUCE: DPNPC dpnp_rng_shuffle_c:";
         std::cout << "\nDIMS: " << ndim[i] <<std::endl;
         // init array 0, 1, 2, 3, 4, 5, 6, ....
-        init<double>(array_2, size);
+        dpnp_arange_c<double>(0, 1, array_1, size);
         // print before shuffle
-        std::cout << "\nINPUT array 2:";
-        print_dpnp_array(array_2, size);
+        std::cout << "\nINPUT array:";
+        print_dpnp_array(array_1, size);
         dpnp_rng_srand_c(seed);
-        dpnp_rng_shuffle_c<double>(array_2, itemsize, ndim[i], high_dim_size[i], size);
+        dpnp_rng_shuffle_c<double>(array_1, itemsize, ndim[i], high_dim_size[i], size);
         // print shuffle result
-        std::cout << "\nSHUFFLE INPUT array 2:";
-        print_dpnp_array(array_2, size); 
+        std::cout << "\nSHUFFLE INPUT array:";
+        print_dpnp_array(array_1, size); 
     }
-    dpnp_memory_free_c(array_2);
+    dpnp_memory_free_c(array_1);
 }

--- a/dpnp/backend/examples/example11.cpp
+++ b/dpnp/backend/examples/example11.cpp
@@ -26,21 +26,21 @@
 /**
  * Example 11.
  *
+ * This example shows simple usage of the DPNP C++ Backend library RNG shuffle function
+ * for one and ndim arrays.
+ *
  * Possible compile line:
- * dpcpp -g -fPIC   -W -Wextra -Wshadow -Wall -Wstrict-prototypes -Wformat -Wformat-security -fsycl -fsycl-device-code-split=per_kernel -O0 -fno-delete-null-pointer-checks -fstack-protector-strong -fno-strict-overflow -std=gnu++17 dpnp/backend/examples/example11.cpp -Idpnp -Idpnp/backend/include -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o example11 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_core
+ * dpcpp -g -fPIC   -W -Wextra -Wshadow -Wall -Wstrict-prototypes -Wformat -Wformat-security -fsycl
+ * -fsycl-device-code-split=per_kernel -O0 -fno-delete-null-pointer-checks -fstack-protector-strong
+ * -fno-strict-overflow -std=gnu++17 dpnp/backend/examples/example11.cpp -Idpnp -Idpnp/backend/include
+ * -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o example11 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_core
  */
+
 #include <iostream>
-#include <time.h>
 
 #include <dpnp_iface.hpp>
-#include <dpnp_iface_fptr.hpp>
 
-#include <CL/sycl.hpp>
-#include <oneapi/mkl.hpp>
-
-namespace mkl_dft = oneapi::mkl::dft;
 namespace mkl_rng = oneapi::mkl::rng;
-namespace mkl_vm = oneapi::mkl::vm;
 
 template <typename T>
 void print_dpnp_array(T* arr, size_t size)
@@ -62,77 +62,11 @@ void init(T* x, size_t size)
     }
 }
 
-#if 0
-/* For 1dim array */
-template <typename _DataType>
-void shuffle_c(
-    void* result, const size_t itemsize, const size_t ndim, const size_t high_dim_size, const size_t size, cl::sycl::queue& queue, size_t seed)
-{
-    if (!result)
-    {
-        return;
-    }
-
-    if (!size || !ndim || !(high_dim_size > 1))
-    {
-        return;
-    }
-
-    // cl::sycl::queue queue{cl::sycl::gpu_selector()};
-
-    mkl_rng::mt19937 rng_engine = mkl_rng::mt19937(queue, seed);
-
-    // DPNPC_ptr_adapter<char> result1_ptr(result, size * itemsize, true, true);
-    // char* result1 = result1_ptr.get_ptr();
-    char* result1 = reinterpret_cast<char*>(result);
-
-    size_t uvec_size = high_dim_size - 1;
-    // double* array_1 = reinterpret_cast<double*>(malloc_shared(result_size * sizeof(double), queue));
-    // double* Uvec = reinterpret_cast<double*>(dpnp_memory_alloc_c(uvec_size * sizeof(double)));
-
-    double* Uvec = reinterpret_cast<double*>(malloc_shared(uvec_size * sizeof(double), queue));
-
-    mkl_rng::uniform<double> uniform_distribution(0.0, 1.0);
-
-    auto uniform_event = mkl_rng::generate(uniform_distribution, rng_engine, uvec_size, Uvec);
-    uniform_event.wait();
-    // just for debug
-    // print_dpnp_array(Uvec, uvec_size);
-
-
-    // Fast, statically typed path: shuffle the underlying buffer.
-    // Only for non-empty, 1d objects of class ndarray (subclasses such
-    // as MaskedArrays may not support this approach).
-    char* buf = reinterpret_cast<char*>(malloc_shared(sizeof(char), queue));
-    for (size_t i = uvec_size; i > 0; i--)
-    {
-        size_t j = (size_t)(floor((i + 1) * Uvec[i - 1]));
-        if (i != j)
-        {
-            auto memcpy1 =
-                queue.submit([&](cl::sycl::handler& h) { h.memcpy(buf, result1 + j * itemsize, itemsize); });
-            auto memcpy2 = queue.submit([&](cl::sycl::handler& h) {
-                h.depends_on({memcpy1});
-                h.memcpy(result1 + j * itemsize, result1 + i * itemsize, itemsize);
-            });
-            auto memcpy3 = queue.submit([&](cl::sycl::handler& h) {
-                h.depends_on({memcpy2});
-                h.memcpy(result1 + i * itemsize, buf, itemsize);
-            });
-            memcpy3.wait();
-        }
-    }
-    free(buf, queue);
-    free(Uvec, queue);
-    return;
-}
-#endif
-
 int main(int, char**)
 {
     // Two cases:
     // 1) array size = 100, ndim = 1, high_dim_size = 10 (aka ndarray with shape (100,) )
-    // 2) array size = 100, ndim = 2, high_dim_size = 20 (aka ndarray with shape (20, 5) and len(array) = 20 )
+    // 2) array size = 100, ndim = 2, high_dim_size = 20 (e.g. ndarray with shape (20, 5) and len(array) = 20 )
     const size_t ndim_cases = 2;
     const size_t itemsize = sizeof(double);
     const size_t ndim[ndim_cases] = {1, 2};
@@ -140,28 +74,6 @@ int main(int, char**)
     const size_t size = 100;
     const size_t seed = 1234;
 
-#if 0
-    /*
-      reproducer for shuffling array (as is in dpnp_rng_shuffle_c)
-      for 1dim array
-      the same logic for ndim arrays
-      using mathlib interface
-    */
-    std::cout << "\n///////////////////////////////////////////////\n";
-    cl::sycl::queue queue{cl::sycl::gpu_selector()};
-    std::cout << "\nREPRODUCE: logic as is in DPNPC dpnp_rng_shuffle_c:";
-    std::cout << "\nDIMS: " << ndim[0] <<std::endl;
-    double* array_1 = reinterpret_cast<double*>(malloc_shared(size * sizeof(double), queue));
-    std::cout << "\nINPUT array 1:";
-    init<double>(array_1, size);
-    print_dpnp_array(array_1, size);
-    shuffle_c<double>(array_1, itemsize, ndim[0], high_dim_size[0], size, queue, seed);
-    std::cout << "\nSHUFFLE INPUT array:";
-    print_dpnp_array(array_1, size);
-    free(array_1, queue);
-#endif
-
-    std::cout << "\n///////////////////////////////////////////////\n";
     // DPNPC dpnp_rng_shuffle_c
     // DPNPC interface
     double* array_2 = reinterpret_cast<double*>(dpnp_memory_alloc_c(size * sizeof(double)));


### PR DESCRIPTION
## Descriptor
Merging this is not necessary.
This PR is just for reproducing DPNPC backend lib shuffle logic for 1dim and 2dim (ndim) arrays.
1) array size = 100, ndim = 1, high_dim_size = 100 (aka `ndarray` with shape `(100,)` )
2) array size = 100, ndim = 2, high_dim_size = 20 (for example `ndarray` with shape `(20, 5)` and len(array) = 20 )
