### PR TITLE
Relax build dependency to numpy

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -8,7 +8,7 @@ requirements:
     host:
       - python
       - setuptools
-      - numpy 1.19.5
+      - numpy 1.19
       - cython
       - cmake 3.19
       - dpctl >=0.10


### PR DESCRIPTION
The workflow uses following channels for build:
https://github.com/IntelPython/dpnp/blob/457a5984712d28e73531fd70e482c099fe87d2c8/.github/workflows/conda-package.yml#L48

At the same time recipe requires concrete numpy version:
https://github.com/IntelPython/dpnp/blob/457a5984712d28e73531fd70e482c099fe87d2c8/conda-recipe/meta.yaml#L11 

I have relaxed requirements for numpy version in conda recipe because `defaults` channel does not have `numpy 1.19.5` (only `1.19.2`).