### PR TITLE
prep for dpctl/include reorg (IntelPython/dpctl#685)

### DIFF
--- a/dpnp/backend/src/queue_sycl.hpp
+++ b/dpnp/backend/src/queue_sycl.hpp
@@ -41,7 +41,13 @@
 #include <ctime>
 
 #if !defined(DPNP_LOCAL_QUEUE)
-#include <dpctl_sycl_queue_manager.h>
+#  if defined __has_include
+#    if __has_include(<dpctl_sycl_interface.h>)
+#       include <dpctl_sycl_interface.h>
+#    else
+#       include <dpctl_sycl_queue_manager.h>
+#    endif
+#  endif
 #endif
 
 #include "dpnp_pstl.hpp" // this header must be included after <mkl.hpp>


### PR DESCRIPTION
Use `__has_include` to minimize disruption that the said reorg may cause.