### PR TITLE
Pin `mkl-dpcpp` version in run as in build

### DIFF
--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,0 +1,3 @@
+pin_run_as_build:
+    mkl-dpcpp:
+      max_pin: x.x

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,7 +21,6 @@ requirements:
       - python
       - dpctl >=0.10
       - dpcpp_cpp_rt >=2021.1.1
-      - mkl >=2021.1.1
       - mkl-dpcpp >=2021.1.1
       - numpy >=1.15
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
       - python
       - dpctl >=0.10
       - dpcpp_cpp_rt >=2021.1.1
-      - mkl-dpcpp >=2021.1.1
+      - mkl-dpcpp
       - numpy >=1.15
 
 build:


### PR DESCRIPTION
I tried several variants. This is less intrusive.
It will build `dpnp` with mkl-dpcpp 2021.4.0 and make `dpnp` conda package with run dependency `mkl-dpcpp >=2021.4.0,<2021.5.0a0`.
- [x] Use conda_build_config.yml
- [x] Remove mkl from runtime as mkl-dpcpp depends on it. It eliminates duplications.
- [x] Pinning with `x.x` (i.e. 2021.4.*) as I faced that DPNP built with mkl 2021.3 does not work with mkl 2021.4.
- [x] Package does not have hash as no one variable used in recipe from conda_build_config.yml. If need to control different packages built with the same dpnp version but different mkl version then see #1083.

Fixes #1079.