### PR TITLE
Pin mkl version with hash

### DIFF
--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,3 +1,6 @@
+mkl_dpcpp:
+  - 2021.4
+
 pin_run_as_build:
     mkl-dpcpp:
       max_pin: x.x

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,0 +1,3 @@
+pin_run_as_build:
+    mkl-dpcpp:
+      max_pin: x.x

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,7 +21,6 @@ requirements:
       - python
       - dpctl >=0.10
       - dpcpp_cpp_rt >=2021.1.1
-      - mkl >=2021.1.1
       - mkl-dpcpp >=2021.1.1
       - numpy >=1.15
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -12,7 +12,7 @@ requirements:
       - cython
       - cmake 3.19
       - dpctl >=0.10
-      - mkl-devel-dpcpp
+      - mkl-devel-dpcpp {{ mkl_dpcpp }}
       - tbb-devel
       - wheel
     build:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
       - python
       - dpctl >=0.10
       - dpcpp_cpp_rt >=2021.1.1
-      - mkl-dpcpp >=2021.1.1
+      - mkl-dpcpp
       - numpy >=1.15
 
 build:


### PR DESCRIPTION
Based on #1082.
This PR adds:
- [x] Package have hash (i.e. `dpnp-0.9.0rc1-py39h4188336_38.tar.bz2`) as variable from conda_build_config.yml used in recipe. The same variable name used in internal CI. It is possible to built the same dpnp version but different mkl version.

Fixes #1079.