### PR TITLE
remove conda list command from test section in meta.yaml

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -46,7 +46,6 @@ test:
         - setup.cfg
     commands:
       - python -c "import dpnp"
-      - conda list
       - pytest -s
 
 about:


### PR DESCRIPTION
For some reason on Windows `conda list` command in test section in recipe finish testing and prevent execution of other commands below in this section.