### PR TITLE
Enable Compute Follows Data in Cython in fft and linalg

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -248,12 +248,14 @@ jobs:
 
       - name: Smoke test
         run: python -c "import dpnp, dpctl; dpctl.lsplatform()"
+        env:
+          OCL_ICD_FILENAMES: 'libintelocl.so'
 
       # TODO: run the whole scope once the issues on CPU are resolved
       - name: Run tests
-        run: python -m pytest -q -ra --disable-warnings -vv test_arraycreation.py test_dparray.py test_mathematical.py test_special.py
+        run: python -m pytest -q -ra --disable-warnings -vv test_arraycreation.py test_dparray.py test_fft.py test_linalg.py test_mathematical.py test_special.py
         env:
-          SYCL_ENABLE_HOST_DEVICE: '1'
+          OCL_ICD_FILENAMES: 'libintelocl.so'
         working-directory: ${{ env.tests-path }}
 
   test_windows:
@@ -426,7 +428,7 @@ jobs:
 
       # TODO: run the whole scope once the issues on CPU are resolved
       - name: Run tests
-        run: python -m pytest -q -ra --disable-warnings -vv test_arraycreation.py test_dparray.py test_mathematical.py test_special.py
+        run: python -m pytest -q -ra --disable-warnings -vv test_arraycreation.py test_dparray.py test_fft.py test_linalg.py test_mathematical.py test_special.py
         working-directory: ${{ env.tests-path }}
 
   upload_linux:

--- a/dpnp/backend/kernels/dpnp_krnl_common.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_common.cpp
@@ -1,5 +1,5 @@
 //*****************************************************************************
-// Copyright (c) 2016-2020, Intel Corporation
+// Copyright (c) 2016-2022, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -97,6 +97,7 @@ void dpnp_astype_c(const void* array1_in, void* result1, const size_t size)
                                                                         size,
                                                                         dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType, typename _ResultType>
@@ -477,6 +478,7 @@ void dpnp_dot_c(void* result_out,
                                                                                                    input2_strides,
                                                                                                    dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
@@ -614,6 +616,7 @@ void dpnp_eig_c(const void* array_in, void* result1, void* result2, size_t size)
                                                                      size,
                                                                      dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType, typename _ResultType>
@@ -707,6 +710,7 @@ void dpnp_eigvals_c(const void* array_in, void* result1, size_t size)
                                                                          size,
                                                                          dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType, typename _ResultType>
@@ -774,7 +778,7 @@ void dpnp_initval_c(void* result1, void* value, size_t size)
                                                             size,
                                                             dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
-
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
@@ -941,6 +945,7 @@ void dpnp_matmul_c(void* result_out,
                                                            input2_strides,
                                                            dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
@@ -1112,10 +1117,24 @@ void func_map_init_linalg(func_map_t& fmap)
     fmap[DPNPFuncName::DPNP_FN_EIG][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_eig_default_c<float, float>};
     fmap[DPNPFuncName::DPNP_FN_EIG][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_eig_default_c<double, double>};
 
+    fmap[DPNPFuncName::DPNP_FN_EIG_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_eig_ext_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_EIG_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_eig_ext_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_EIG_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_eig_ext_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_EIG_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_eig_ext_c<double, double>};
+
     fmap[DPNPFuncName::DPNP_FN_EIGVALS][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_eigvals_default_c<int32_t, double>};
     fmap[DPNPFuncName::DPNP_FN_EIGVALS][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_eigvals_default_c<int64_t, double>};
     fmap[DPNPFuncName::DPNP_FN_EIGVALS][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_eigvals_default_c<float, float>};
     fmap[DPNPFuncName::DPNP_FN_EIGVALS][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_eigvals_default_c<double, double>};
+
+    fmap[DPNPFuncName::DPNP_FN_EIGVALS_EXT][eft_INT][eft_INT] = {eft_DBL,
+                                                                 (void*)dpnp_eigvals_ext_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_EIGVALS_EXT][eft_LNG][eft_LNG] = {eft_DBL,
+                                                                 (void*)dpnp_eigvals_ext_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_EIGVALS_EXT][eft_FLT][eft_FLT] = {eft_FLT,
+                                                                 (void*)dpnp_eigvals_ext_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_EIGVALS_EXT][eft_DBL][eft_DBL] = {eft_DBL,
+                                                                 (void*)dpnp_eigvals_ext_c<double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_INITVAL][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_initval_default_c<bool>};
     fmap[DPNPFuncName::DPNP_FN_INITVAL][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_initval_default_c<int32_t>};

--- a/dpnp/backend/kernels/dpnp_krnl_linalg.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_linalg.cpp
@@ -1,5 +1,5 @@
 //*****************************************************************************
-// Copyright (c) 2016-2020, Intel Corporation
+// Copyright (c) 2016-2022, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -122,6 +122,7 @@ void dpnp_cholesky_c(void* array1_in, void* result1, const size_t size, const si
                                                              data_size,
                                                              dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
@@ -263,6 +264,7 @@ void dpnp_det_c(void* array1_in, void* result1, shape_elem_type* shape, size_t n
                                                         ndim,
                                                         dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
@@ -405,6 +407,7 @@ void dpnp_inv_c(void* array1_in, void* result1, shape_elem_type* shape, size_t n
                                                                      ndim,
                                                                      dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType, typename _ResultType>
@@ -528,6 +531,7 @@ void dpnp_kron_c(void* array1_in,
                                                                                    ndim,
                                                                                    dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType1, typename _DataType2, typename _ResultType>
@@ -616,6 +620,7 @@ void dpnp_matrix_rank_c(void* array1_in, void* result1, shape_elem_type* shape, 
                                                                 ndim,
                                                                 dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
@@ -753,6 +758,7 @@ void dpnp_qr_c(void* array1_in, void* result1, void* result2, void* result3, siz
                                                                   size_n,
                                                                   dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _InputDT, typename _ComputeDT>
@@ -852,6 +858,7 @@ void dpnp_svd_c(void* array1_in, void* result1, void* result2, void* result3, si
                                                                           size_n,
                                                                           dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _InputDT, typename _ComputeDT, typename _SVDT>
@@ -872,15 +879,28 @@ void func_map_init_linalg_func(func_map_t& fmap)
     fmap[DPNPFuncName::DPNP_FN_CHOLESKY][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_cholesky_default_c<float>};
     fmap[DPNPFuncName::DPNP_FN_CHOLESKY][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_cholesky_default_c<double>};
 
+    fmap[DPNPFuncName::DPNP_FN_CHOLESKY_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_cholesky_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_CHOLESKY_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_cholesky_ext_c<double>};
+
     fmap[DPNPFuncName::DPNP_FN_DET][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_det_default_c<int32_t>};
     fmap[DPNPFuncName::DPNP_FN_DET][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_det_default_c<int64_t>};
     fmap[DPNPFuncName::DPNP_FN_DET][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_det_default_c<float>};
     fmap[DPNPFuncName::DPNP_FN_DET][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_det_default_c<double>};
 
+    fmap[DPNPFuncName::DPNP_FN_DET_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_det_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_DET_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_det_ext_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_DET_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_det_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_DET_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_det_ext_c<double>};
+
     fmap[DPNPFuncName::DPNP_FN_INV][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_inv_default_c<int32_t, double>};
     fmap[DPNPFuncName::DPNP_FN_INV][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_inv_default_c<int64_t, double>};
     fmap[DPNPFuncName::DPNP_FN_INV][eft_FLT][eft_FLT] = {eft_DBL, (void*)dpnp_inv_default_c<float, double>};
     fmap[DPNPFuncName::DPNP_FN_INV][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_inv_default_c<double, double>};
+
+    fmap[DPNPFuncName::DPNP_FN_INV_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_inv_ext_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_INV_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_inv_ext_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_INV_EXT][eft_FLT][eft_FLT] = {eft_DBL, (void*)dpnp_inv_ext_c<float, double>};
+    fmap[DPNPFuncName::DPNP_FN_INV_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_inv_ext_c<double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_KRON][eft_INT][eft_INT] = {eft_INT,
                                                           (void*)dpnp_kron_default_c<int32_t, int32_t, int32_t>};
@@ -989,6 +1009,11 @@ void func_map_init_linalg_func(func_map_t& fmap)
     fmap[DPNPFuncName::DPNP_FN_MATRIX_RANK][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_matrix_rank_default_c<float>};
     fmap[DPNPFuncName::DPNP_FN_MATRIX_RANK][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_matrix_rank_default_c<double>};
 
+    fmap[DPNPFuncName::DPNP_FN_MATRIX_RANK_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_matrix_rank_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_MATRIX_RANK_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_matrix_rank_ext_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_MATRIX_RANK_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_matrix_rank_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_MATRIX_RANK_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_matrix_rank_ext_c<double>};
+
     fmap[DPNPFuncName::DPNP_FN_QR][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_qr_default_c<int32_t, double>};
     fmap[DPNPFuncName::DPNP_FN_QR][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_qr_default_c<int64_t, double>};
     fmap[DPNPFuncName::DPNP_FN_QR][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_qr_default_c<float, float>};
@@ -996,12 +1021,34 @@ void func_map_init_linalg_func(func_map_t& fmap)
     // fmap[DPNPFuncName::DPNP_FN_QR][eft_C128][eft_C128] = {
     // eft_C128, (void*)dpnp_qr_c<std::complex<double>, std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_SVD][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_svd_default_c<int32_t, double, double>};
-    fmap[DPNPFuncName::DPNP_FN_SVD][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_svd_default_c<int64_t, double, double>};
-    fmap[DPNPFuncName::DPNP_FN_SVD][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_svd_default_c<float, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_SVD][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_svd_default_c<double, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_QR_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_qr_ext_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_QR_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_qr_ext_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_QR_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_qr_ext_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_QR_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_qr_ext_c<double, double>};
+    // fmap[DPNPFuncName::DPNP_FN_QR_EXT][eft_C128][eft_C128] = {
+    // eft_C128, (void*)dpnp_qr_c<std::complex<double>, std::complex<double>>};
+
+    fmap[DPNPFuncName::DPNP_FN_SVD][eft_INT][eft_INT] = {eft_DBL,
+                                                         (void*)dpnp_svd_default_c<int32_t, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_SVD][eft_LNG][eft_LNG] = {eft_DBL,
+                                                         (void*)dpnp_svd_default_c<int64_t, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_SVD][eft_FLT][eft_FLT] = {eft_FLT,
+                                                         (void*)dpnp_svd_default_c<float, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_SVD][eft_DBL][eft_DBL] = {eft_DBL,
+                                                         (void*)dpnp_svd_default_c<double, double, double>};
     fmap[DPNPFuncName::DPNP_FN_SVD][eft_C128][eft_C128] = {
         eft_C128, (void*)dpnp_svd_default_c<std::complex<double>, std::complex<double>, double>};
+    
+    fmap[DPNPFuncName::DPNP_FN_SVD_EXT][eft_INT][eft_INT] = {eft_DBL,
+                                                             (void*)dpnp_svd_ext_c<int32_t, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_SVD_EXT][eft_LNG][eft_LNG] = {eft_DBL,
+                                                             (void*)dpnp_svd_ext_c<int64_t, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_SVD_EXT][eft_FLT][eft_FLT] = {eft_FLT,
+                                                             (void*)dpnp_svd_ext_c<float, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_SVD_EXT][eft_DBL][eft_DBL] = {eft_DBL,
+                                                             (void*)dpnp_svd_ext_c<double, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_SVD_EXT][eft_C128][eft_C128] = {
+        eft_C128, (void*)dpnp_svd_ext_c<std::complex<double>, std::complex<double>, double>};
 
     return;
 }

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -1,7 +1,7 @@
 # cython: language_level=3
 # -*- coding: utf-8 -*-
 # *****************************************************************************
-# Copyright (c) 2016-2020, Intel Corporation
+# Copyright (c) 2016-2022, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 # THE POSSIBILITY OF SUCH DAMAGE.
 # *****************************************************************************
-cimport dpctl as c_dpctl
-
 cimport dpctl as c_dpctl
 
 from libcpp cimport bool as cpp_bool
@@ -145,6 +143,7 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_FFT_FFT
         DPNP_FN_FFT_FFT_EXT
         DPNP_FN_FFT_RFFT
+        DPNP_FN_FFT_RFFT_EXT
         DPNP_FN_FILL_DIAGONAL
         DPNP_FN_FILL_DIAGONAL_EXT
         DPNP_FN_FLATTEN

--- a/dpnp/fft/dpnp_iface_fft.py
+++ b/dpnp/fft/dpnp_iface_fft.py
@@ -2,7 +2,7 @@
 # distutils: language = c++
 # -*- coding: utf-8 -*-
 # *****************************************************************************
-# Copyright (c) 2016-2020, Intel Corporation
+# Copyright (c) 2016-2022, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -100,7 +100,7 @@ def fft(x1, n=None, axis=-1, norm=None):
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1)
+    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if x1_desc:
         norm_ = get_validated_norm(norm)
 
@@ -144,7 +144,7 @@ def fft2(x1, s=None, axes=(-2, -1), norm=None):
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1)
+    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if x1_desc:
         if norm is not None:
             pass
@@ -185,7 +185,7 @@ def fftn(x1, s=None, axes=None, norm=None):
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1)
+    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if x1_desc:
         if s is None:
             boundaries = tuple([x1_desc.shape[i] for i in range(x1_desc.ndim)])
@@ -231,7 +231,7 @@ def fftshift(x1, axes=None):
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1)
+    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if x1_desc and 0:
 
         norm_= Norm.backward
@@ -263,7 +263,7 @@ def hfft(x1, n=None, axis=-1, norm=None):
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1)
+    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if x1_desc and 0:
         norm_ = get_validated_norm(norm)
 
@@ -305,7 +305,7 @@ def ifft(x1, n=None, axis=-1, norm=None):
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1)
+    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if x1_desc:
         norm_ = get_validated_norm(norm)
 
@@ -348,7 +348,7 @@ def ifft2(x1, s=None, axes=(-2, -1), norm=None):
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1)
+    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if x1_desc:
         if norm is not None:
             pass
@@ -372,7 +372,7 @@ def ifftshift(x1, axes=None):
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1)
+    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if x1_desc and 0:
 
         norm_ = Norm.backward
@@ -385,7 +385,7 @@ def ifftshift(x1, axes=None):
         if x1_desc.size < 1:
             pass                 # let fallback to handle exception
         else:
-            return dpnp_fft(x1_desc, input_boundarie, output_boundarie, axis_param, False, norm_.value).get_pyobj()
+            return dpnp_fft(x1_desc, input_boundarie, output_boundarie, axis_param, True, norm_.value).get_pyobj()
 
     return call_origin(numpy.fft.ifftshift, x1, axes)
 
@@ -406,7 +406,7 @@ def ifftn(x1, s=None, axes=None, norm=None):
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1)
+    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if x1_desc and 0:
         if s is None:
             boundaries = tuple([x1_desc.shape[i] for i in range(x1_desc.ndim)])
@@ -453,7 +453,7 @@ def ihfft(x1, n=None, axis=-1, norm=None):
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1)
+    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if x1_desc and 0:
         norm_ = get_validated_norm(norm)
 
@@ -478,7 +478,7 @@ def ihfft(x1, n=None, axis=-1, norm=None):
         else:
             output_boundarie = input_boundarie
 
-            return dpnp_fft(x1_desc, input_boundarie, output_boundarie, axis_param, False, norm_.value).get_pyobj()
+            return dpnp_fft(x1_desc, input_boundarie, output_boundarie, axis_param, True, norm_.value).get_pyobj()
 
     return call_origin(numpy.fft.ihfft, x1, n, axis, norm)
 
@@ -497,7 +497,7 @@ def irfft(x1, n=None, axis=-1, norm=None):
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1)
+    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if x1_desc and 0:
         norm_ = get_validated_norm(norm)
 
@@ -548,7 +548,7 @@ def irfft2(x1, s=None, axes=(-2, -1), norm=None):
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1)
+    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if x1_desc:
         if norm is not None:
             pass
@@ -574,7 +574,7 @@ def irfftn(x1, s=None, axes=None, norm=None):
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1)
+    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if x1_desc and 0:
         if s is None:
             boundaries = tuple([x1_desc.shape[i] for i in range(x1_desc.ndim)])
@@ -621,7 +621,7 @@ def rfft(x1, n=None, axis=-1, norm=None):
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1)
+    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if x1_desc:
         norm_ = get_validated_norm(norm)
 
@@ -670,7 +670,7 @@ def rfft2(x1, s=None, axes=(-2, -1), norm=None):
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1)
+    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if x1_desc:
         if norm is not None:
             pass
@@ -711,7 +711,7 @@ def rfftn(x1, s=None, axes=None, norm=None):
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1)
+    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if x1_desc and 0:
         if s is None:
             boundaries = tuple([x1_desc.shape[i] for i in range(x1_desc.ndim)])
@@ -738,7 +738,7 @@ def rfftn(x1, s=None, axes=None, norm=None):
                 except IndexError:
                     checker_throw_axis_error("fft.rfftn", "is out of bounds", param_axis, f"< {len(boundaries)}")
 
-                x1_iter_desc = dpnp.get_dpnp_descriptor(x1_iter)
+                x1_iter_desc = dpnp.get_dpnp_descriptor(x1_iter, copy_when_nondefault_queue=False)
                 x1_iter = rfft(x1_iter_desc.get_pyobj(), n=param_n, axis=param_axis, norm=norm)
 
             return x1_iter

--- a/dpnp/linalg/dpnp_iface_linalg.py
+++ b/dpnp/linalg/dpnp_iface_linalg.py
@@ -88,14 +88,14 @@ def cholesky(input):
         matrix object if `input` is a matrix object.
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(input)
+    x1_desc = dpnp.get_dpnp_descriptor(input, copy_when_nondefault_queue=False)
     if x1_desc:
         if x1_desc.shape[-1] != x1_desc.shape[-2]:
             pass
         else:
             if input.dtype == dpnp.int32 or input.dtype == dpnp.int64:
                 # TODO memory copy. needs to move into DPNPC
-                input_ = dpnp.get_dpnp_descriptor(dpnp.astype(input, dpnp.float64))
+                input_ = dpnp.get_dpnp_descriptor(dpnp.astype(input, dpnp.float64), copy_when_nondefault_queue=False)
             else:
                 input_ = x1_desc
             return dpnp_cholesky(input_).get_pyobj()
@@ -145,7 +145,7 @@ def det(input):
         Determinant of `input`.
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(input)
+    x1_desc = dpnp.get_dpnp_descriptor(input, copy_when_nondefault_queue=False)
     if x1_desc:
         if x1_desc.shape[-1] == x1_desc.shape[-2]:
             result_obj = dpnp_det(x1_desc).get_pyobj()
@@ -164,7 +164,7 @@ def eig(x1):
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1)
+    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if x1_desc:
         if (x1_desc.size > 0):
             return dpnp_eig(x1_desc)
@@ -191,7 +191,7 @@ def eigvals(input):
         real for real matrices.
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(input)
+    x1_desc = dpnp.get_dpnp_descriptor(input, copy_when_nondefault_queue=False)
     if x1_desc:
         if x1_desc.size > 0:
             return dpnp_eigvals(x1_desc).get_pyobj()
@@ -213,7 +213,7 @@ def inv(input):
         Otherwise the function will be executed sequentially on CPU.
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(input)
+    x1_desc = dpnp.get_dpnp_descriptor(input, copy_when_nondefault_queue=False)
     if x1_desc:
         if x1_desc.ndim == 2 and x1_desc.shape[0] == x1_desc.shape[1] and x1_desc.shape[0] >= 2:
             return dpnp_inv(x1_desc).get_pyobj()
@@ -277,7 +277,7 @@ def matrix_rank(input, tol=None, hermitian=False):
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(input)
+    x1_desc = dpnp.get_dpnp_descriptor(input, copy_when_nondefault_queue=False)
     if x1_desc:
         if tol is not None:
             pass
@@ -362,7 +362,7 @@ def norm(x1, ord=None, axis=None, keepdims=False):
         Norm of the matrix or vector(s).
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1)
+    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if x1_desc:
         if not isinstance(axis, int) and not isinstance(axis, tuple) and axis is not None:
             pass
@@ -395,7 +395,7 @@ def qr(x1, mode='reduced'):
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1)
+    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if x1_desc:
         if mode != 'reduced':
             pass
@@ -464,7 +464,7 @@ def svd(x1, full_matrices=True, compute_uv=True, hermitian=False):
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1)
+    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if x1_desc:
         if not x1_desc.ndim == 2:
             pass

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -5,60 +5,29 @@ tests/test_sycl_queue.py::test_broadcasting[opencl:gpu:0-remainder-data15-data25
 tests/test_sycl_queue.py::test_broadcasting[opencl:cpu:0-floor_divide-data12-data22]
 tests/test_sycl_queue.py::test_broadcasting[opencl:cpu:0-remainder-data15-data25]
 
+tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_1_{axes=None, norm=None, s=(1, None), shape=(3, 4)}::test_fft2
+tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_7_{axes=(), norm=None, s=None, shape=(3, 4)}::test_fft2
+tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_7_{axes=(), norm=None, s=None, shape=(3, 4)}::test_ifft2
+tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_9_{axes=None, norm=None, s=(1, 4, None), shape=(2, 3, 4)}::test_fft2
 tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_15_{axes=(), norm=None, s=None, shape=(2, 3, 4)}::test_fft2
 tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_15_{axes=(), norm=None, s=None, shape=(2, 3, 4)}::test_ifft2
 tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_16_{axes=(0, 1, 2), norm='ortho', s=(2, 3), shape=(2, 3, 4)}::test_fft2
 tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_16_{axes=(0, 1, 2), norm='ortho', s=(2, 3), shape=(2, 3, 4)}::test_ifft2
 tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_18_{axes=None, norm=None, s=None, shape=(0, 5)}::test_fft2
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_18_{axes=None, norm=None, s=None, shape=(0, 5)}::test_ifft2
 tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_19_{axes=None, norm=None, s=None, shape=(2, 0, 5)}::test_fft2
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_19_{axes=None, norm=None, s=None, shape=(2, 0, 5)}::test_ifft2
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_1_{axes=None, norm=None, s=(1, None), shape=(3, 4)}::test_fft2
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_1_{axes=None, norm=None, s=(1, None), shape=(3, 4)}::test_ifft2
 tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_20_{axes=None, norm=None, s=None, shape=(0, 0, 5)}::test_fft2
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_20_{axes=None, norm=None, s=None, shape=(0, 0, 5)}::test_ifft2
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_7_{axes=(), norm=None, s=None, shape=(3, 4)}::test_fft2
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_7_{axes=(), norm=None, s=None, shape=(3, 4)}::test_ifft2
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_9_{axes=None, norm=None, s=(1, 4, None), shape=(2, 3, 4)}::test_fft2
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_9_{axes=None, norm=None, s=(1, 4, None), shape=(2, 3, 4)}::test_ifft2
-tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_10_{axes=None, norm=None, s=(1, 4, None), shape=(2, 3, 4)}::test_fftn
-tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_10_{axes=None, norm=None, s=(1, 4, None), shape=(2, 3, 4)}::test_ifftn
+
+tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_1_{axes=None, norm=None, s=(1, None), shape=(3, 4)}::test_fftn
+tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_7_{axes=(), norm=None, s=None, shape=(3, 4)}::test_fftn
+tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_7_{axes=(), norm=None, s=None, shape=(3, 4)}::test_ifftn
 tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_17_{axes=(), norm='ortho', s=None, shape=(2, 3, 4)}::test_fftn
 tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_17_{axes=(), norm='ortho', s=None, shape=(2, 3, 4)}::test_ifftn
 tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_18_{axes=(0, 1, 2), norm='ortho', s=(2, 3), shape=(2, 3, 4)}::test_fftn
 tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_18_{axes=(0, 1, 2), norm='ortho', s=(2, 3), shape=(2, 3, 4)}::test_ifftn
-tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_1_{axes=None, norm=None, s=(1, None), shape=(3, 4)}::test_fftn
-tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_1_{axes=None, norm=None, s=(1, None), shape=(3, 4)}::test_ifftn
+tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_10_{axes=None, norm=None, s=(1, 4, None), shape=(2, 3, 4)}::test_fftn
 tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_21_{axes=None, norm=None, s=None, shape=(0, 5)}::test_fftn
-tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_21_{axes=None, norm=None, s=None, shape=(0, 5)}::test_ifftn
 tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_22_{axes=None, norm=None, s=None, shape=(2, 0, 5)}::test_fftn
-tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_22_{axes=None, norm=None, s=None, shape=(2, 0, 5)}::test_ifftn
 tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_23_{axes=None, norm=None, s=None, shape=(0, 0, 5)}::test_fftn
-tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_23_{axes=None, norm=None, s=None, shape=(0, 0, 5)}::test_ifftn
-tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_7_{axes=(), norm=None, s=None, shape=(3, 4)}::test_fftn
-tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_7_{axes=(), norm=None, s=None, shape=(3, 4)}::test_ifftn
-
-tests/test_linalg.py::test_eig_arange[2-float64]
-tests/test_linalg.py::test_eig_arange[2-float32]
-tests/test_linalg.py::test_eig_arange[2-int64]
-tests/test_linalg.py::test_eig_arange[2-int32]
-tests/test_linalg.py::test_eig_arange[4-float64]
-tests/test_linalg.py::test_eig_arange[4-float32]
-tests/test_linalg.py::test_eig_arange[4-int64]
-tests/test_linalg.py::test_eig_arange[4-int32]
-tests/test_linalg.py::test_eig_arange[8-float64]
-tests/test_linalg.py::test_eig_arange[8-float32]
-tests/test_linalg.py::test_eig_arange[8-int64]
-tests/test_linalg.py::test_eig_arange[8-int32]
-tests/test_linalg.py::test_eig_arange[16-float64]
-tests/test_linalg.py::test_eig_arange[16-float32]
-tests/test_linalg.py::test_eig_arange[16-int64]
-tests/test_linalg.py::test_eig_arange[16-int32]
-tests/test_linalg.py::test_eig_arange[300-float64]
-tests/test_linalg.py::test_eig_arange[300-float32]
-tests/test_linalg.py::test_eig_arange[300-int64]
-tests/test_linalg.py::test_eig_arange[300-int32]
-tests/test_linalg.py::test_eigvals
 
 tests/third_party/intel/test_zero_copy_test1.py::test_dpnp_interaction_with_dpctl_memory
 
@@ -113,22 +82,120 @@ tests/test_dparray.py::test_astype[[]-complex-int32]
 tests/test_dparray.py::test_astype[[]-complex-bool]
 tests/test_dparray.py::test_astype[[]-complex-bool_]
 tests/test_dparray.py::test_astype[[]-complex-complex]
-tests/test_linalg.py::test_cond[-1-[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]
-tests/test_linalg.py::test_cond[1-[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]
-tests/test_linalg.py::test_cond[-2-[[1, 0, -1], [0, 1, 0], [1, 0, 1]]]
-tests/test_linalg.py::test_cond[2-[[1, 0, -1], [0, 1, 0], [1, 0, 1]]]
-tests/test_linalg.py::test_cond[-2-[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]
-tests/test_linalg.py::test_cond[2-[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]
-tests/test_linalg.py::test_cond["fro"-[[1, 0, -1], [0, 1, 0], [1, 0, 1]]]
-tests/test_linalg.py::test_cond["fro"-[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]
+
 tests/test_linalg.py::test_cond[None-[[1, 0, -1], [0, 1, 0], [1, 0, 1]]]
 tests/test_linalg.py::test_cond[None-[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]
-tests/test_linalg.py::test_cond[-numpy.inf-[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]
+tests/test_linalg.py::test_cond[1-[[1, 0, -1], [0, 1, 0], [1, 0, 1]]]
+tests/test_linalg.py::test_cond[1-[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]
+tests/test_linalg.py::test_cond[-1-[[1, 0, -1], [0, 1, 0], [1, 0, 1]]]
+tests/test_linalg.py::test_cond[-1-[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]
+tests/test_linalg.py::test_cond[2-[[1, 0, -1], [0, 1, 0], [1, 0, 1]]]
+tests/test_linalg.py::test_cond[2-[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]
+tests/test_linalg.py::test_cond[-2-[[1, 0, -1], [0, 1, 0], [1, 0, 1]]]
+tests/test_linalg.py::test_cond[-2-[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]
+tests/test_linalg.py::test_cond[numpy.inf-[[1, 0, -1], [0, 1, 0], [1, 0, 1]]]
 tests/test_linalg.py::test_cond[numpy.inf-[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]
-tests/test_linalg.py::test_svd[(2,2)-complex128]
-tests/test_linalg.py::test_svd[(3,4)-complex128]
-tests/test_linalg.py::test_svd[(5,3)-complex128]
-tests/test_linalg.py::test_svd[(16,16)-complex128]
+tests/test_linalg.py::test_cond[-numpy.inf-[[1, 0, -1], [0, 1, 0], [1, 0, 1]]]
+tests/test_linalg.py::test_cond[-numpy.inf-[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]
+tests/test_linalg.py::test_cond["fro"-[[1, 0, -1], [0, 1, 0], [1, 0, 1]]]
+tests/test_linalg.py::test_cond["fro"-[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]
+
+tests/test_linalg.py::test_matrix_rank[None-[0, 1]-float64]
+tests/test_linalg.py::test_matrix_rank[None-[0, 1]-float32]
+tests/test_linalg.py::test_matrix_rank[None-[0, 1]-int64]
+tests/test_linalg.py::test_matrix_rank[None-[0, 1]-int32]
+tests/test_linalg.py::test_matrix_rank[None-[[1, 2], [1, 2]]-float64]
+tests/test_linalg.py::test_matrix_rank[None-[[1, 2], [1, 2]]-float32]
+tests/test_linalg.py::test_matrix_rank[None-[[1, 2], [1, 2]]-int64]
+tests/test_linalg.py::test_matrix_rank[None-[[1, 2], [1, 2]]-int32]
+tests/test_linalg.py::test_matrix_rank[None-[[1, 2], [3, 4]]-float64]
+tests/test_linalg.py::test_matrix_rank[None-[[1, 2], [3, 4]]-float32]
+tests/test_linalg.py::test_matrix_rank[None-[[1, 2], [3, 4]]-int64]
+tests/test_linalg.py::test_matrix_rank[None-[[1, 2], [3, 4]]-int32]
+
+tests/test_linalg.py::test_norm1[0-None-[7]]
+tests/test_linalg.py::test_norm1[0-None-[1, 2]]
+tests/test_linalg.py::test_norm1[0-None-[1, 0]]
+tests/test_linalg.py::test_norm1[0-3-[7]]
+tests/test_linalg.py::test_norm1[0-3-[1, 2]]
+tests/test_linalg.py::test_norm1[0-3-[1, 0]]
+tests/test_linalg.py::test_norm1[None-3-[7]]
+tests/test_linalg.py::test_norm1[None-3-[1, 2]]
+tests/test_linalg.py::test_norm1[None-3-[1, 0]]
+
+tests/test_linalg.py::test_norm2[(0, 1)-None-[[1, 0]]]
+tests/test_linalg.py::test_norm2[(0, 1)-None-[[1, 2]]]
+tests/test_linalg.py::test_norm2[(0, 1)-None-[[1, 0], [3, 0]]]
+tests/test_linalg.py::test_norm2[(0, 1)-None-[[1, 2], [3, 4]]]
+tests/test_linalg.py::test_norm2[(0, 1)-"fro"-[[1, 0]]]
+tests/test_linalg.py::test_norm2[(0, 1)-"fro"-[[1, 2]]]
+tests/test_linalg.py::test_norm2[(0, 1)-"fro"-[[1, 0], [3, 0]]]
+tests/test_linalg.py::test_norm2[(0, 1)-"fro"-[[1, 2], [3, 4]]]
+tests/test_linalg.py::test_norm2[None-None-[[1, 2]]]
+tests/test_linalg.py::test_norm2[None-None-[[1, 0], [3, 0]]]
+tests/test_linalg.py::test_norm2[None-None-[[1, 2], [3, 4]]]
+tests/test_linalg.py::test_norm2[None-"fro"-[[1, 2]]]
+tests/test_linalg.py::test_norm2[None-"fro"-[[1, 0], [3, 0]]]
+tests/test_linalg.py::test_norm2[None-"fro"-[[1, 2], [3, 4]]]
+
+tests/test_linalg.py::test_norm3[0-None-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
+tests/test_linalg.py::test_norm3[0-None-[[[1, 0], [3, 0]], [[5, 0], [7, 0]]]]
+tests/test_linalg.py::test_norm3[0--2-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
+tests/test_linalg.py::test_norm3[0--2-[[[1, 0], [3, 0]], [[5, 0], [7, 0]]]]
+tests/test_linalg.py::test_norm3[0--1-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
+tests/test_linalg.py::test_norm3[0--1-[[[1, 0], [3, 0]], [[5, 0], [7, 0]]]]
+tests/test_linalg.py::test_norm3[0-2-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
+tests/test_linalg.py::test_norm3[0-2-[[[1, 0], [3, 0]], [[5, 0], [7, 0]]]]
+tests/test_linalg.py::test_norm3[1-None-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
+tests/test_linalg.py::test_norm3[1-None-[[[1, 0], [3, 0]], [[5, 0], [7, 0]]]]
+tests/test_linalg.py::test_norm3[1--2-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
+tests/test_linalg.py::test_norm3[1--2-[[[1, 0], [3, 0]], [[5, 0], [7, 0]]]]
+tests/test_linalg.py::test_norm3[1--1-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
+tests/test_linalg.py::test_norm3[1--1-[[[1, 0], [3, 0]], [[5, 0], [7, 0]]]]
+tests/test_linalg.py::test_norm3[1-2-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
+tests/test_linalg.py::test_norm3[1-2-[[[1, 0], [3, 0]], [[5, 0], [7, 0]]]]
+tests/test_linalg.py::test_norm3[2-None-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
+tests/test_linalg.py::test_norm3[2-None-[[[1, 0], [3, 0]], [[5, 0], [7, 0]]]]
+tests/test_linalg.py::test_norm3[2--2-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
+tests/test_linalg.py::test_norm3[2--1-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
+tests/test_linalg.py::test_norm3[2-2-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
+tests/test_linalg.py::test_norm3[(0, 1)-None-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
+tests/test_linalg.py::test_norm3[(0, 1)-None-[[[1, 0], [3, 0]], [[5, 0], [7, 0]]]]
+tests/test_linalg.py::test_norm3[(0, 1)--2-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
+tests/test_linalg.py::test_norm3[(0, 1)--2-[[[1, 0], [3, 0]], [[5, 0], [7, 0]]]]
+tests/test_linalg.py::test_norm3[(0, 1)-2-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
+tests/test_linalg.py::test_norm3[(0, 1)-2-[[[1, 0], [3, 0]], [[5, 0], [7, 0]]]]
+tests/test_linalg.py::test_norm3[(0, 2)-None-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
+tests/test_linalg.py::test_norm3[(0, 2)-None-[[[1, 0], [3, 0]], [[5, 0], [7, 0]]]]
+tests/test_linalg.py::test_norm3[(0, 2)--2-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
+tests/test_linalg.py::test_norm3[(0, 2)-2-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
+tests/test_linalg.py::test_norm3[(0, 2)-2-[[[1, 0], [3, 0]], [[5, 0], [7, 0]]]]
+tests/test_linalg.py::test_norm3[(1, 2)-None-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
+tests/test_linalg.py::test_norm3[(1, 2)-None-[[[1, 0], [3, 0]], [[5, 0], [7, 0]]]]
+tests/test_linalg.py::test_norm3[(1, 2)--2-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
+tests/test_linalg.py::test_norm3[(1, 2)-2-[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
+tests/test_linalg.py::test_norm3[(1, 2)-2-[[[1, 0], [3, 0]], [[5, 0], [7, 0]]]]
+
+tests/test_linalg.py::test_qr[complete-(2,2)-float64]
+tests/test_linalg.py::test_qr[complete-(3,4)-float64]
+tests/test_linalg.py::test_qr[complete-(3,4)-int64]
+tests/test_linalg.py::test_qr[complete-(3,4)-int32]
+tests/test_linalg.py::test_qr[complete-(5,3)-float64]
+tests/test_linalg.py::test_qr[complete-(5,3)-int64]
+tests/test_linalg.py::test_qr[complete-(5,3)-int32]
+tests/test_linalg.py::test_qr[complete-(16,16)-float64]
+tests/test_linalg.py::test_qr[complete-(16,16)-int64]
+tests/test_linalg.py::test_qr[complete-(16,16)-int32]
+tests/test_linalg.py::test_qr[reduced-(2,2)-float64]
+tests/test_linalg.py::test_qr[reduced-(3,4)-float64]
+tests/test_linalg.py::test_qr[reduced-(5,3)-float64]
+tests/test_linalg.py::test_qr[reduced-(16,16)-float64]
+
+tests/test_linalg.py::test_svd[(2,2)-float64]
+tests/test_linalg.py::test_svd[(3,4)-float64]
+tests/test_linalg.py::test_svd[(5,3)-float64]
+tests/test_linalg.py::test_svd[(16,16)-float64]
+
 tests/test_mathematical.py::TestGradient::test_gradient_y1_dx[3.5-array1]
 tests/test_random.py::TestPermutationsTestShuffle::test_shuffle1[lambda x: (dpnp.asarray([(i, i) for i in x], [("a", int), ("b", int)]).view(dpnp.recarray))]
 tests/test_random.py::TestPermutationsTestShuffle::test_shuffle1[lambda x: dpnp.asarray([(i, i) for i in x], [("a", object), ("b", dpnp.int32)])]]

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -91,47 +91,6 @@ tests/test_sycl_queue.py::test_broadcasting[opencl:gpu:0-remainder-data15-data25
 tests/test_sycl_queue.py::test_broadcasting[opencl:cpu:0-floor_divide-data12-data22]
 tests/test_sycl_queue.py::test_broadcasting[opencl:cpu:0-remainder-data15-data25]
 
-tests/test_fft.py::test_fft_ndim[None-shape3-float32]
-tests/test_fft.py::test_fft_ndim[None-shape3-float64]
-tests/test_fft.py::test_fft_ndim[None-shape3-int32]
-tests/test_fft.py::test_fft_ndim[None-shape3-int64]
-tests/test_fft.py::test_fft_ndim[forward-shape3-float32]
-tests/test_fft.py::test_fft_ndim[forward-shape3-float64]
-tests/test_fft.py::test_fft_ndim[forward-shape3-int32]
-tests/test_fft.py::test_fft_ndim[forward-shape3-int64]
-tests/test_fft.py::test_fft_ndim[ortho-shape3-float32]
-tests/test_fft.py::test_fft_ndim[ortho-shape3-float64]
-tests/test_fft.py::test_fft_ndim[ortho-shape3-int32]
-tests/test_fft.py::test_fft_ndim[ortho-shape3-int64]
-tests/test_fft.py::test_fft_ifft[None-shape4-float32]
-tests/test_fft.py::test_fft_ifft[None-shape4-float64]
-tests/test_fft.py::test_fft_ifft[None-shape4-int32]
-tests/test_fft.py::test_fft_ifft[None-shape4-int64]
-tests/test_fft.py::test_fft_ifft[forward-shape4-float32]
-tests/test_fft.py::test_fft_ifft[forward-shape4-float64]
-tests/test_fft.py::test_fft_ifft[forward-shape4-int32]
-tests/test_fft.py::test_fft_ifft[forward-shape4-int64]
-tests/test_fft.py::test_fft_ifft[ortho-shape4-float32]
-tests/test_fft.py::test_fft_ifft[ortho-shape4-float64]
-tests/test_fft.py::test_fft_ifft[ortho-shape4-int32]
-tests/test_fft.py::test_fft_ifft[ortho-shape4-int64]
-tests/test_fft.py::test_fft_rfft[shape1-float32]
-tests/test_fft.py::test_fft_rfft[shape1-float64]
-tests/test_fft.py::test_fft_rfft[shape1-int32]
-tests/test_fft.py::test_fft_rfft[shape1-int64]
-tests/test_fft.py::test_fft_rfft[shape2-float32]
-tests/test_fft.py::test_fft_rfft[shape2-float64]
-tests/test_fft.py::test_fft_rfft[shape2-int32]
-tests/test_fft.py::test_fft_rfft[shape2-int64]
-tests/test_fft.py::test_fft_rfft[shape3-float32]
-tests/test_fft.py::test_fft_rfft[shape3-float64]
-tests/test_fft.py::test_fft_rfft[shape3-int32]
-tests/test_fft.py::test_fft_rfft[shape3-int64]
-tests/test_fft.py::test_fft_rfft[shape4-float32]
-tests/test_fft.py::test_fft_rfft[shape4-float64]
-tests/test_fft.py::test_fft_rfft[shape4-int32]
-tests/test_fft.py::test_fft_rfft[shape4-int64]
-
 tests/test_indexing.py::test_nonzero[[[1, 0], [1, 0]]]
 tests/test_indexing.py::test_nonzero[[[1, 2], [3, 4]]]
 tests/test_indexing.py::test_nonzero[[[0, 1, 2], [3, 0, 5], [6, 7, 0]]]
@@ -380,10 +339,6 @@ tests/third_party/cupy/sorting_tests/test_sort.py::TestPartition_param_2_{extern
 tests/third_party/cupy/statistics_tests/test_correlation.py::TestCov::test_cov_empty
 tests/third_party/cupy/statistics_tests/test_meanvar.py::TestMeanVar::test_external_mean_axis
 
-tests/test_linalg.py::test_eig_arange[16-float64]
-tests/test_linalg.py::test_eig_arange[16-float32]
-tests/test_linalg.py::test_eig_arange[16-int64]
-tests/test_linalg.py::test_eig_arange[16-int32]
 tests/test_random.py::test_randn_normal_distribution
 tests/third_party/cupy/linalg_tests/test_product.py::TestProduct::test_multidim_outer
 tests/third_party/cupy/random_tests/test_sample.py::TestRandintDtype::test_dtype
@@ -445,6 +400,7 @@ tests/test_dparray.py::test_astype[[]-complex-int32]
 tests/test_dparray.py::test_astype[[]-complex-bool]
 tests/test_dparray.py::test_astype[[]-complex-bool_]
 tests/test_dparray.py::test_astype[[]-complex-complex]
+
 tests/test_linalg.py::test_cond[-1-[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]
 tests/test_linalg.py::test_cond[1-[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]
 tests/test_linalg.py::test_cond[-2-[[1, 0, -1], [0, 1, 0], [1, 0, 1]]]
@@ -457,10 +413,20 @@ tests/test_linalg.py::test_cond[None-[[1, 0, -1], [0, 1, 0], [1, 0, 1]]]
 tests/test_linalg.py::test_cond[None-[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]
 tests/test_linalg.py::test_cond[-numpy.inf-[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]
 tests/test_linalg.py::test_cond[numpy.inf-[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]
-tests/test_linalg.py::test_eig_arange[300-float32]
-tests/test_linalg.py::test_eig_arange[300-float64]
-tests/test_linalg.py::test_eig_arange[300-int32]
-tests/test_linalg.py::test_eig_arange[300-int64]
+
+tests/test_linalg.py::test_matrix_rank[None-[0, 1]-float64]
+tests/test_linalg.py::test_matrix_rank[None-[0, 1]-float32]
+tests/test_linalg.py::test_matrix_rank[None-[0, 1]-int64]
+tests/test_linalg.py::test_matrix_rank[None-[0, 1]-int32]
+tests/test_linalg.py::test_matrix_rank[None-[[1, 2], [1, 2]]-float64]
+tests/test_linalg.py::test_matrix_rank[None-[[1, 2], [1, 2]]-float32]
+tests/test_linalg.py::test_matrix_rank[None-[[1, 2], [1, 2]]-int64]
+tests/test_linalg.py::test_matrix_rank[None-[[1, 2], [1, 2]]-int32]
+tests/test_linalg.py::test_matrix_rank[None-[[1, 2], [3, 4]]-float64]
+tests/test_linalg.py::test_matrix_rank[None-[[1, 2], [3, 4]]-float32]
+tests/test_linalg.py::test_matrix_rank[None-[[1, 2], [3, 4]]-int64]
+tests/test_linalg.py::test_matrix_rank[None-[[1, 2], [3, 4]]-int32]
+
 tests/test_random.py::TestPermutationsTestShuffle::test_shuffle1[lambda x: (dpnp.asarray([(i, i) for i in x], [("a", int), ("b", int)]).view(dpnp.recarray))]
 tests/test_random.py::TestPermutationsTestShuffle::test_shuffle1[lambda x: dpnp.asarray([(i, i) for i in x], [("a", object), ("b", dpnp.int32)])]]
 tests/test_random.py::TestPermutationsTestShuffle::test_shuffle1[lambda x: dpnp.asarray(x).astype(dpnp.int8)]
@@ -739,54 +705,30 @@ tests/third_party/cupy/creation_tests/test_ranges.py::TestRanges::test_linspace_
 tests/third_party/cupy/creation_tests/test_ranges.py::TestRanges::test_linspace_mixed_start_stop
 tests/third_party/cupy/creation_tests/test_ranges.py::TestRanges::test_linspace_mixed_start_stop2
 tests/third_party/cupy/creation_tests/test_ranges.py::TestRanges::test_linspace_start_stop_list
+
+tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_1_{axes=None, norm=None, s=(1, None), shape=(3, 4)}::test_fft2
+tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_7_{axes=(), norm=None, s=None, shape=(3, 4)}::test_fft2
+tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_7_{axes=(), norm=None, s=None, shape=(3, 4)}::test_ifft2
+tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_9_{axes=None, norm=None, s=(1, 4, None), shape=(2, 3, 4)}::test_fft2
 tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_15_{axes=(), norm=None, s=None, shape=(2, 3, 4)}::test_fft2
 tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_15_{axes=(), norm=None, s=None, shape=(2, 3, 4)}::test_ifft2
 tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_16_{axes=(0, 1, 2), norm='ortho', s=(2, 3), shape=(2, 3, 4)}::test_fft2
 tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_16_{axes=(0, 1, 2), norm='ortho', s=(2, 3), shape=(2, 3, 4)}::test_ifft2
 tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_18_{axes=None, norm=None, s=None, shape=(0, 5)}::test_fft2
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_18_{axes=None, norm=None, s=None, shape=(0, 5)}::test_ifft2
 tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_19_{axes=None, norm=None, s=None, shape=(2, 0, 5)}::test_fft2
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_19_{axes=None, norm=None, s=None, shape=(2, 0, 5)}::test_ifft2
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_1_{axes=None, norm=None, s=(1, None), shape=(3, 4)}::test_fft2
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_1_{axes=None, norm=None, s=(1, None), shape=(3, 4)}::test_ifft2
 tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_20_{axes=None, norm=None, s=None, shape=(0, 0, 5)}::test_fft2
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_20_{axes=None, norm=None, s=None, shape=(0, 0, 5)}::test_ifft2
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_7_{axes=(), norm=None, s=None, shape=(3, 4)}::test_fft2
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_7_{axes=(), norm=None, s=None, shape=(3, 4)}::test_ifft2
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_9_{axes=None, norm=None, s=(1, 4, None), shape=(2, 3, 4)}::test_fft2
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_9_{axes=None, norm=None, s=(1, 4, None), shape=(2, 3, 4)}::test_ifft2
-tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_10_{axes=None, norm=None, s=(1, 4, None), shape=(2, 3, 4)}::test_fftn
-tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_10_{axes=None, norm=None, s=(1, 4, None), shape=(2, 3, 4)}::test_ifftn
+
+tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_1_{axes=None, norm=None, s=(1, None), shape=(3, 4)}::test_fftn
+tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_7_{axes=(), norm=None, s=None, shape=(3, 4)}::test_fftn
+tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_7_{axes=(), norm=None, s=None, shape=(3, 4)}::test_ifftn
 tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_17_{axes=(), norm='ortho', s=None, shape=(2, 3, 4)}::test_fftn
 tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_17_{axes=(), norm='ortho', s=None, shape=(2, 3, 4)}::test_ifftn
 tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_18_{axes=(0, 1, 2), norm='ortho', s=(2, 3), shape=(2, 3, 4)}::test_fftn
 tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_18_{axes=(0, 1, 2), norm='ortho', s=(2, 3), shape=(2, 3, 4)}::test_ifftn
-tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_1_{axes=None, norm=None, s=(1, None), shape=(3, 4)}::test_fftn
-tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_1_{axes=None, norm=None, s=(1, None), shape=(3, 4)}::test_ifftn
+tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_10_{axes=None, norm=None, s=(1, 4, None), shape=(2, 3, 4)}::test_fftn
 tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_21_{axes=None, norm=None, s=None, shape=(0, 5)}::test_fftn
-tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_21_{axes=None, norm=None, s=None, shape=(0, 5)}::test_ifftn
 tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_22_{axes=None, norm=None, s=None, shape=(2, 0, 5)}::test_fftn
-tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_22_{axes=None, norm=None, s=None, shape=(2, 0, 5)}::test_ifftn
 tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_23_{axes=None, norm=None, s=None, shape=(0, 0, 5)}::test_fftn
-tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_23_{axes=None, norm=None, s=None, shape=(0, 0, 5)}::test_ifftn
-tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_7_{axes=(), norm=None, s=None, shape=(3, 4)}::test_fftn
-tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_7_{axes=(), norm=None, s=None, shape=(3, 4)}::test_ifftn
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft_param_2_{n=None, norm=None, shape=(10,)}::test_fft
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft_param_2_{n=None, norm=None, shape=(10,)}::test_ifft
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft_param_2_{n=None, norm=None, shape=(10,)}::test_fftn
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft_param_2_{n=None, norm=None, shape=(10,)}::test_ifftn
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft_param_6_{n=None, norm='ortho', shape=(10,)}::test_fft
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft_param_6_{n=None, norm='ortho', shape=(10,)}::test_ifft
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft_param_6_{n=None, norm='ortho', shape=(10,)}::test_fftn
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft_param_6_{n=None, norm='ortho', shape=(10,)}::test_ifftn
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft_param_3_{n=None, norm=None, shape=(10, 10)}::test_fft
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft_param_3_{n=None, norm=None, shape=(10, 10)}::test_ifft
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft_param_7_{n=None, norm='ortho', shape=(10, 10)}::test_fft
-tests/third_party/cupy/fft_tests/test_fft.py::TestFft_param_7_{n=None, norm='ortho', shape=(10, 10)}::test_ifft
-tests/third_party/cupy/fft_tests/test_fft.py::TestRfft_param_0_{n=None, norm=None, shape=(10,)}::test_irfft
-tests/third_party/cupy/fft_tests/test_fft.py::TestRfft_param_0_{n=None, norm=None, shape=(10,)}::test_rfft
-tests/third_party/cupy/fft_tests/test_fft.py::TestRfft_param_1_{n=None, norm=None, shape=(10, 10)}::test_irfft
-tests/third_party/cupy/fft_tests/test_fft.py::TestRfft_param_1_{n=None, norm=None, shape=(10, 10)}::test_rfft
 
 tests/third_party/cupy/indexing_tests/test_generate.py::TestAxisConcatenator::test_AxisConcatenator_init1
 tests/third_party/cupy/indexing_tests/test_generate.py::TestAxisConcatenator::test_len

--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -10,9 +10,6 @@ import numpy
 def test_fft(type, norm):
     # 1 dim array
     data = numpy.arange(100, dtype=numpy.dtype(type))
-    # TODO:
-    # doesn't work correct with `complex64` (not supported)
-    # dpnp_data = dpnp.arange(100, dtype=dpnp.dtype(type))
     dpnp_data = dpnp.array(data)
 
     np_res = numpy.fft.fft(data, norm=norm)

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -41,6 +41,37 @@ def assert_sycl_queue_equal(result, expected):
     assert exec_queue is not None
 
 
+def vvsort(val, vec, size, xp):
+    val_kwargs = dict()
+    if hasattr(val, 'sycl_queue'):
+        val_kwargs['sycl_queue'] = getattr(val, "sycl_queue", None)
+
+    vec_kwargs = dict()
+    if hasattr(vec, 'sycl_queue'):
+        vec_kwargs['sycl_queue'] = getattr(vec, "sycl_queue", None)
+
+    for i in range(size):
+        imax = i
+        for j in range(i + 1, size):
+            unravel_imax = numpy.unravel_index(imax, val.shape)
+            unravel_j = numpy.unravel_index(j, val.shape)
+            if xp.abs(val[unravel_imax]) < xp.abs(val[unravel_j]):
+                imax = j
+
+        unravel_i = numpy.unravel_index(i, val.shape)
+        unravel_imax = numpy.unravel_index(imax, val.shape)
+
+        # swap elements in val array
+        temp = xp.array(val[unravel_i], dtype=vec.dtype, **val_kwargs)
+        val[unravel_i] = val[unravel_imax]
+        val[unravel_imax] = temp
+
+        # swap corresponding columns in vec matrix
+        temp = xp.array(vec[:, i], dtype=val.dtype, **vec_kwargs)
+        vec[:, i] = vec[:, imax]
+        vec[:, imax] = temp
+
+
 @pytest.mark.parametrize(
     "func,data",
     [
@@ -104,7 +135,6 @@ def test_1in_1out(func, data, device):
     result_queue = result.get_array().sycl_queue
 
     assert_sycl_queue_equal(result_queue, expected_queue)
-    assert result_queue.sycl_device == expected_queue.sycl_device
 
 
 @pytest.mark.parametrize(
@@ -169,7 +199,6 @@ def test_2in_1out(func, data1, data2, device):
     result_queue = result.get_array().sycl_queue
 
     assert_sycl_queue_equal(result_queue, expected_queue)
-    assert result_queue.sycl_device == expected_queue.sycl_device
 
 
 @pytest.mark.parametrize(
@@ -216,7 +245,6 @@ def test_broadcasting(func, data1, data2, device):
     result_queue = result.get_array().sycl_queue
 
     assert_sycl_queue_equal(result_queue, expected_queue)
-    assert result_queue.sycl_device == expected_queue.sycl_device
 
 
 @pytest.mark.parametrize(
@@ -277,7 +305,6 @@ def test_out(func, data1, data2, device):
     result_queue = result.get_array().sycl_queue
 
     assert_sycl_queue_equal(result_queue, expected_queue)
-    assert result_queue.sycl_device == expected_queue.sycl_device
 
 
 @pytest.mark.parametrize("device",
@@ -302,8 +329,255 @@ def test_modf(device):
     assert_sycl_queue_equal(result1_queue, expected_queue)
     assert_sycl_queue_equal(result2_queue, expected_queue)
 
-    assert result1_queue.sycl_device == expected_queue.sycl_device
-    assert result2_queue.sycl_device == expected_queue.sycl_device
+
+@pytest.mark.parametrize("type", ['complex128'])
+@pytest.mark.parametrize("device",
+                         valid_devices,
+                         ids=[device.filter_string for device in valid_devices])
+def test_fft(type, device):
+    data = numpy.arange(100, dtype=numpy.dtype(type))
+
+    dpnp_data = dpnp.array(data, device=device)
+
+    expected = numpy.fft.fft(data)
+    result = dpnp.fft.fft(dpnp_data)
+
+    numpy.testing.assert_allclose(result, expected, rtol=1e-4, atol=1e-7)
+
+    expected_queue = dpnp_data.get_array().sycl_queue
+    result_queue = result.get_array().sycl_queue
+
+    assert_sycl_queue_equal(result_queue, expected_queue)
+
+
+@pytest.mark.parametrize("type", ['float32'])
+@pytest.mark.parametrize("shape", [(8,8)])
+@pytest.mark.parametrize("device",
+                         valid_devices,
+                         ids=[device.filter_string for device in valid_devices])
+def test_fft_rfft(type, shape, device):
+    np_data = numpy.arange(64, dtype=numpy.dtype(type)).reshape(shape)
+    dpnp_data = dpnp.array(np_data, device=device)
+
+    np_res = numpy.fft.rfft(np_data)
+    dpnp_res = dpnp.fft.rfft(dpnp_data)
+
+    numpy.testing.assert_allclose(dpnp_res, np_res, rtol=1e-4, atol=1e-7)
+    assert dpnp_res.dtype == np_res.dtype
+
+    expected_queue = dpnp_data.get_array().sycl_queue
+    result_queue = dpnp_res.get_array().sycl_queue
+
+    assert_sycl_queue_equal(result_queue, expected_queue)
+
+
+@pytest.mark.parametrize("device",
+                          valid_devices,
+                          ids=[device.filter_string for device in valid_devices])
+def test_cholesky(device):
+    data = [[[1., -2.], [2., 5.]], [[1., -2.], [2., 5.]]]
+    numpy_data = numpy.array(data)
+    dpnp_data = dpnp.array(data, device=device)
+
+    result = dpnp.linalg.cholesky(dpnp_data)
+    expected = numpy.linalg.cholesky(numpy_data)
+    numpy.testing.assert_array_equal(expected, result)
+
+    expected_queue = dpnp_data.get_array().sycl_queue
+    result_queue = result.get_array().sycl_queue
+
+    assert_sycl_queue_equal(result_queue, expected_queue)
+
+
+@pytest.mark.parametrize("device",
+                          valid_devices,
+                          ids=[device.filter_string for device in valid_devices])
+def test_det(device):
+    data = [[[1, 2], [3, 4]], [[1, 2], [2, 1]], [[1, 3], [3, 1]]]
+    numpy_data = numpy.array(data)
+    dpnp_data = dpnp.array(data, device=device)
+
+    result = dpnp.linalg.det(dpnp_data)
+    expected = numpy.linalg.det(numpy_data)
+    numpy.testing.assert_allclose(expected, result)
+
+    expected_queue = dpnp_data.get_array().sycl_queue
+    result_queue = result.get_array().sycl_queue
+
+    assert_sycl_queue_equal(result_queue, expected_queue)
+
+
+@pytest.mark.parametrize("device",
+                          valid_devices,
+                          ids=[device.filter_string for device in valid_devices])
+def test_eig(device):
+    if device.device_type != dpctl.device_type.gpu:
+        pytest.skip("eig function doesn\'t work on CPU: https://github.com/IntelPython/dpnp/issues/1005")
+
+    size = 4
+    a = numpy.arange(size * size, dtype='float64').reshape((size, size))
+    symm_orig = numpy.tril(a) + numpy.tril(a, -1).T + numpy.diag(numpy.full((size,), size * size, dtype='float64'))
+    numpy_data = symm_orig
+    dpnp_symm_orig = dpnp.array(numpy_data, device=device)
+    dpnp_data = dpnp_symm_orig
+
+    dpnp_val, dpnp_vec = dpnp.linalg.eig(dpnp_data)
+    numpy_val, numpy_vec = numpy.linalg.eig(numpy_data)
+
+    # DPNP sort val/vec by abs value
+    vvsort(dpnp_val, dpnp_vec, size, dpnp)
+
+    # NP sort val/vec by abs value
+    vvsort(numpy_val, numpy_vec, size, numpy)
+
+    # NP change sign of vectors
+    for i in range(numpy_vec.shape[1]):
+        if numpy_vec[0, i] * dpnp_vec[0, i] < 0:
+            numpy_vec[:, i] = -numpy_vec[:, i]
+
+    numpy.testing.assert_allclose(dpnp_val, numpy_val, rtol=1e-05, atol=1e-05)
+    numpy.testing.assert_allclose(dpnp_vec, numpy_vec, rtol=1e-05, atol=1e-05)
+
+    assert (dpnp_val.dtype == numpy_val.dtype)
+    assert (dpnp_vec.dtype == numpy_vec.dtype)
+    assert (dpnp_val.shape == numpy_val.shape)
+    assert (dpnp_vec.shape == numpy_vec.shape)
+
+    expected_queue = dpnp_data.get_array().sycl_queue
+    dpnp_val_queue = dpnp_val.get_array().sycl_queue
+    dpnp_vec_queue = dpnp_vec.get_array().sycl_queue
+
+    # compare queue and device    
+    assert_sycl_queue_equal(dpnp_val_queue, expected_queue)
+    assert_sycl_queue_equal(dpnp_vec_queue, expected_queue)
+
+
+@pytest.mark.parametrize("device",
+                          valid_devices,
+                          ids=[device.filter_string for device in valid_devices])
+def test_eigvals(device):
+    if device.device_type != dpctl.device_type.gpu:
+        pytest.skip("eigvals function doesn\'t work on CPU: https://github.com/IntelPython/dpnp/issues/1005")
+
+    data = [[0, 0], [0, 0]]
+    numpy_data = numpy.array(data)
+    dpnp_data = dpnp.array(data, device=device)
+
+    result = dpnp.linalg.eigvals(dpnp_data)
+    expected = numpy.linalg.eigvals(numpy_data)
+    numpy.testing.assert_allclose(expected, result, atol=0.5)
+
+    expected_queue = dpnp_data.get_array().sycl_queue
+    result_queue = result.get_array().sycl_queue
+
+    assert_sycl_queue_equal(result_queue, expected_queue)
+
+
+@pytest.mark.parametrize("device",
+                          valid_devices,
+                          ids=[device.filter_string for device in valid_devices])
+def test_inv(device):
+    data = [[1., 2.], [3., 4.]]
+    numpy_data = numpy.array(data)
+    dpnp_data = dpnp.array(data, device=device)
+
+    result = dpnp.linalg.inv(dpnp_data)
+    expected = numpy.linalg.inv(numpy_data)
+    numpy.testing.assert_allclose(expected, result)
+
+    expected_queue = dpnp_data.get_array().sycl_queue
+    result_queue = result.get_array().sycl_queue
+
+    assert_sycl_queue_equal(result_queue, expected_queue)
+
+
+@pytest.mark.parametrize("device",
+                          valid_devices,
+                          ids=[device.filter_string for device in valid_devices])
+def test_matrix_rank(device):
+    data = [[0, 0], [0, 0]]
+    numpy_data = numpy.array(data)
+    dpnp_data = dpnp.array(data, device=device)
+
+    result = dpnp.linalg.matrix_rank(dpnp_data)
+    expected = numpy.linalg.matrix_rank(numpy_data)
+    numpy.testing.assert_array_equal(expected, result)
+
+
+@pytest.mark.parametrize("device",
+                          valid_devices,
+                          ids=[device.filter_string for device in valid_devices])
+def test_qr(device):
+    tol = 1e-11
+    data = [[1,2,3], [1,2,3]]
+    numpy_data = numpy.array(data)
+    dpnp_data = dpnp.array(data, device=device)
+
+    np_q, np_r = numpy.linalg.qr(numpy_data, "reduced")
+    dpnp_q, dpnp_r = dpnp.linalg.qr(dpnp_data, "reduced")
+
+    assert (dpnp_q.dtype == np_q.dtype)
+    assert (dpnp_r.dtype == np_r.dtype)
+    assert (dpnp_q.shape == np_q.shape)
+    assert (dpnp_r.shape == np_r.shape)
+
+    numpy.testing.assert_allclose(dpnp_q, np_q, rtol=tol, atol=tol)
+    numpy.testing.assert_allclose(dpnp_r, np_r, rtol=tol, atol=tol)
+
+    expected_queue = dpnp_data.get_array().sycl_queue
+    dpnp_q_queue = dpnp_q.get_array().sycl_queue
+    dpnp_r_queue = dpnp_r.get_array().sycl_queue
+
+    # compare queue and device
+    assert_sycl_queue_equal(dpnp_q_queue, expected_queue)
+    assert_sycl_queue_equal(dpnp_r_queue, expected_queue)
+
+
+@pytest.mark.parametrize("device",
+                        valid_devices,
+                        ids=[device.filter_string for device in valid_devices])
+def test_svd(device):
+    tol = 1e-12
+    shape = (2,2)
+    numpy_data = numpy.arange(shape[0] * shape[1]).reshape(shape)
+    dpnp_data = dpnp.arange(shape[0] * shape[1]).reshape(shape)
+    np_u, np_s, np_vt = numpy.linalg.svd(numpy_data)
+    dpnp_u, dpnp_s, dpnp_vt = dpnp.linalg.svd(dpnp_data)
+
+    assert (dpnp_u.dtype == np_u.dtype)
+    assert (dpnp_s.dtype == np_s.dtype)
+    assert (dpnp_vt.dtype == np_vt.dtype)
+    assert (dpnp_u.shape == np_u.shape)
+    assert (dpnp_s.shape == np_s.shape)
+    assert (dpnp_vt.shape == np_vt.shape)
+
+    # check decomposition
+    dpnp_diag_s = dpnp.zeros(shape, dtype=dpnp_s.dtype)
+    for i in range(dpnp_s.size):
+        dpnp_diag_s[i, i] = dpnp_s[i]
+
+    # check decomposition
+    numpy.testing.assert_allclose(dpnp_data, dpnp.dot(dpnp_u, dpnp.dot(dpnp_diag_s, dpnp_vt)), rtol=tol, atol=tol)
+
+    for i in range(min(shape[0], shape[1])):
+        if np_u[0, i] * dpnp_u[0, i] < 0:
+            np_u[:, i] = -np_u[:, i]
+            np_vt[i, :] = -np_vt[i, :]
+
+    # compare vectors for non-zero values
+    for i in range(numpy.count_nonzero(np_s > tol)):
+        numpy.testing.assert_allclose(dpnp.asnumpy(dpnp_u)[:, i], np_u[:, i], rtol=tol, atol=tol)
+        numpy.testing.assert_allclose(dpnp.asnumpy(dpnp_vt)[i, :], np_vt[i, :], rtol=tol, atol=tol)
+
+    expected_queue = dpnp_data.get_array().sycl_queue
+    dpnp_u_queue = dpnp_u.get_array().sycl_queue
+    dpnp_s_queue = dpnp_s.get_array().sycl_queue
+    dpnp_vt_queue = dpnp_vt.get_array().sycl_queue
+
+    # compare queue and device
+    assert_sycl_queue_equal(dpnp_u_queue, expected_queue)
+    assert_sycl_queue_equal(dpnp_s_queue, expected_queue)
+    assert_sycl_queue_equal(dpnp_vt_queue, expected_queue)
 
 
 @pytest.mark.parametrize("device_from",


### PR DESCRIPTION
The PR is intended to apply Compute Follows Data approach for all supported DPNP functions of `fft` and `linalg` libraries.
- The implemented changes include an adaptation in python, cython and backend parts associated with `fft` and `linalg` functionality.
- Additional tests are introduced in `test_sycl_queue.py` to secure Compute Follows Data support for `fft` and `linalg` in DPNP. The new tests assume running checks for equality of underlying `backend`, `sycl_device`, `sycl_context` and properties of argument sycl queues at the end of verifying sequence.
- The tests from `test_fft.py`, `test_linalg.py` and `test_sycl_queue.py` (covering `fft` and `linalg` functionality) are added to a validation jobs running as github actions per each commit in DPNP.