### PR TITLE
Remove numpy from host dependencies

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -8,7 +8,6 @@ requirements:
     host:
       - python
       - setuptools
-      - numpy 1.19
       - cython
       - cmake 3.19
       - dpctl >=0.12


### PR DESCRIPTION
This is how I want to enable building with public packages.