### PR TITLE
Fix precision issues with single precision transcendentals

### DIFF
--- a/dpnp/backend/CMakeLists.txt
+++ b/dpnp/backend/CMakeLists.txt
@@ -113,6 +113,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # SYCL related compile options
 add_compile_options(-fsycl)
 add_compile_options(-fsycl-device-code-split=per_kernel)
+add_compile_options(-fno-fast-math)
 add_link_options(-fsycl)
 add_link_options(-fsycl-device-code-split=per_kernel)
 


### PR DESCRIPTION
Use `-fno-fast-math` to ensure that device code uses accurate transcendentals

Use of this compiler option ensures that accurate code for computing transcendental functions in single precision is used.
This ensures that `dpnp.cos(dpnp.asarray([2], 'float32'))` is close to NumPy's result.

- [X] Have you provided a meaningful PR description?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
