### PR TITLE
Fix take

### DIFF
--- a/dpnp/backend/kernels/dpnp_krnl_bitwise.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_bitwise.cpp
@@ -148,16 +148,16 @@ static void func_map_init_bitwise_1arg_1type(func_map_t& fmap)
                                                                                                                        \
         sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));                                                      \
                                                                                                                        \
-        DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, input1_in, input1_size);                                            \
-        DPNPC_ptr_adapter<shape_elem_type> input1_shape_ptr(q_ref, input1_shape, input1_ndim, true);                       \
-        DPNPC_ptr_adapter<shape_elem_type> input1_strides_ptr(q_ref, input1_strides, input1_ndim, true);                   \
+        DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, input1_in, input1_size);                                        \
+        DPNPC_ptr_adapter<shape_elem_type> input1_shape_ptr(q_ref, input1_shape, input1_ndim, true);                   \
+        DPNPC_ptr_adapter<shape_elem_type> input1_strides_ptr(q_ref, input1_strides, input1_ndim, true);               \
                                                                                                                        \
-        DPNPC_ptr_adapter<_DataType> input2_ptr(q_ref, input2_in, input2_size);                                            \
-        DPNPC_ptr_adapter<shape_elem_type> input2_shape_ptr(q_ref, input2_shape, input2_ndim, true);                       \
-        DPNPC_ptr_adapter<shape_elem_type> input2_strides_ptr(q_ref, input2_strides, input2_ndim, true);                   \
+        DPNPC_ptr_adapter<_DataType> input2_ptr(q_ref, input2_in, input2_size);                                        \
+        DPNPC_ptr_adapter<shape_elem_type> input2_shape_ptr(q_ref, input2_shape, input2_ndim, true);                   \
+        DPNPC_ptr_adapter<shape_elem_type> input2_strides_ptr(q_ref, input2_strides, input2_ndim, true);               \
                                                                                                                        \
-        DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result_out, result_size, false, true);                              \
-        DPNPC_ptr_adapter<shape_elem_type> result_strides_ptr(q_ref, result_strides, result_ndim);                         \
+        DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result_out, result_size, false, true);                          \
+        DPNPC_ptr_adapter<shape_elem_type> result_strides_ptr(q_ref, result_strides, result_ndim);                     \
                                                                                                                        \
         _DataType* input1_data = input1_ptr.get_ptr();                                                                 \
         shape_elem_type* input1_shape_data = input1_shape_ptr.get_ptr();                                               \
@@ -226,6 +226,14 @@ static void func_map_init_bitwise_1arg_1type(func_map_t& fmap)
             };                                                                                                         \
             event = q.submit(kernel_func);                                                                             \
         }                                                                                                              \
+        input1_ptr.depends_on(event);                                                                                  \
+        input1_shape_ptr.depends_on(event);                                                                            \
+        input1_strides_ptr.depends_on(event);                                                                          \
+        input2_ptr.depends_on(event);                                                                                  \
+        input2_shape_ptr.depends_on(event);                                                                            \
+        input2_strides_ptr.depends_on(event);                                                                          \
+        result_ptr.depends_on(event);                                                                                  \
+        result_strides_ptr.depends_on(event);                                                                          \
         event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);                                                       \
                                                                                                                        \
         return DPCTLEvent_Copy(event_ref);                                                                             \

--- a/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
@@ -143,6 +143,12 @@
             }                                                                                                          \
         }                                                                                                              \
                                                                                                                        \
+        input1_ptr.depends_on(event);                                                                                  \
+        input1_shape_ptr.depends_on(event);                                                                            \
+        input1_strides_ptr.depends_on(event);                                                                          \
+        result_ptr.depends_on(event);                                                                                  \
+        result_strides_ptr.depends_on(event);                                                                          \
+                                                                                                                       \
         event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);                                                       \
                                                                                                                        \
         return DPCTLEvent_Copy(event_ref);                                                                             \
@@ -644,6 +650,12 @@ static void func_map_init_elemwise_1arg_2type(func_map_t& fmap)
             }                                                                                                          \
         }                                                                                                              \
                                                                                                                        \
+        input1_ptr.depends_on(event);                                                                                  \
+        input1_shape_ptr.depends_on(event);                                                                            \
+        input1_strides_ptr.depends_on(event);                                                                          \
+        result_ptr.depends_on(event);                                                                                  \
+        result_strides_ptr.depends_on(event);                                                                          \
+                                                                                                                       \
         event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);                                                       \
                                                                                                                        \
         return DPCTLEvent_Copy(event_ref);                                                                             \
@@ -998,6 +1010,17 @@ static void func_map_init_elemwise_1arg_1type(func_map_t& fmap)
                 event = q.submit(kernel_func);                                                                         \
             }                                                                                                          \
         }                                                                                                              \
+                                                                                                                       \
+        input1_ptr.depends_on(event);                                                                                  \
+        input1_shape_ptr.depends_on(event);                                                                            \
+        input1_strides_ptr.depends_on(event);                                                                          \
+        input2_ptr.depends_on(event);                                                                                  \
+        input2_shape_ptr.depends_on(event);                                                                            \
+        input2_strides_ptr.depends_on(event);                                                                          \
+        result_ptr.depends_on(event);                                                                                  \
+        result_shape_ptr.depends_on(event);                                                                            \
+        result_strides_ptr.depends_on(event);                                                                          \
+                                                                                                                       \
         event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);                                                       \
                                                                                                                        \
         return DPCTLEvent_Copy(event_ref);                                                                             \

--- a/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
@@ -901,7 +901,7 @@ DPCTLSyclEventRef dpnp_take_c(DPCTLSyclQueueRef q_ref,
     DPCTLSyclEventRef event_ref = nullptr;
     sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
 
-    DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, array1_size, true);
+    DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, array1_size);
     DPNPC_ptr_adapter<_IndecesType> input2_ptr(q_ref, indices1, size);
     _DataType* array_1 = input1_ptr.get_ptr();
     _IndecesType* indices = input2_ptr.get_ptr();

--- a/dpnp/backend/kernels/dpnp_krnl_mathematical.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_mathematical.cpp
@@ -170,6 +170,8 @@ DPCTLSyclEventRef dpnp_elemwise_absolute_c(DPCTLSyclQueueRef q_ref,
         event = q.submit(kernel_func);
     }
 
+    input1_ptr.depends_on(event);
+    result1_ptr.depends_on(event);
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
 
     return DPCTLEvent_Copy(event_ref);
@@ -483,6 +485,8 @@ DPCTLSyclEventRef dpnp_ediff1d_c(DPCTLSyclQueueRef q_ref,
     };
     event = q.submit(kernel_func);
 
+    input1_ptr.depends_on(event);
+    result_ptr.depends_on(event);
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
 
     return DPCTLEvent_Copy(event_ref);
@@ -676,6 +680,7 @@ void dpnp_floor_divide_c(void* result_out,
         where,
         dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
@@ -770,6 +775,7 @@ void dpnp_modf_c(void* array1_in, void* result1_out, void* result2_out, size_t s
                                                                                  size,
                                                                                  dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType_input, typename _DataType_output>
@@ -911,6 +917,7 @@ void dpnp_remainder_c(void* result_out,
         where,
         dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
@@ -1041,6 +1048,7 @@ void dpnp_trapz_c(
                                                                                                      array2_size,
                                                                                                      dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType_input1, typename _DataType_input2, typename _DataType_output>

--- a/dpnp/backend/kernels/dpnp_krnl_reduction.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_reduction.cpp
@@ -162,6 +162,7 @@ void dpnp_sum_c(void* result_out,
                                                                                 where,
                                                                                 dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType_output, typename _DataType_input>
@@ -278,6 +279,7 @@ void dpnp_prod_c(void* result_out,
                                                                                  where,
                                                                                  dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType_output, typename _DataType_input>

--- a/dpnp/backend/kernels/dpnp_krnl_sorting.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_sorting.cpp
@@ -91,6 +91,7 @@ void dpnp_argsort_c(void* array1_in, void* result1, size_t size)
                                                                            size,
                                                                            dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType, typename _idx_DataType>
@@ -242,6 +243,7 @@ void dpnp_partition_c(
                                                               ndim,
                                                               dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
@@ -394,6 +396,7 @@ void dpnp_searchsorted_c(
                                                                                 v_size,
                                                                                 dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType, typename _IndexingType>
@@ -459,6 +462,7 @@ void dpnp_sort_c(void* array1_in, void* result1, size_t size)
                                                          size,
                                                          dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>

--- a/dpnp/backend/kernels/dpnp_krnl_statistics.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_statistics.cpp
@@ -101,6 +101,7 @@ void dpnp_correlate_c(void* result_out,
         where,
         dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
@@ -298,6 +299,7 @@ void dpnp_count_nonzero_c(void* array1_in, void* result1_out, size_t size)
                                                                                           size,
                                                                                           dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType_input, typename _DataType_output>
@@ -539,6 +541,7 @@ void dpnp_max_c(void* array1_in,
                                                         naxis,
                                                         dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
@@ -636,6 +639,7 @@ void dpnp_mean_c(void* array1_in,
                                                                       naxis,
                                                                       dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType, typename _ResultType>
@@ -721,6 +725,7 @@ void dpnp_median_c(void* array1_in,
                                                                         naxis,
                                                                         dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType, typename _ResultType>
@@ -963,6 +968,7 @@ void dpnp_min_c(void* array1_in,
                                                         naxis,
                                                         dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
@@ -1044,6 +1050,7 @@ void dpnp_nanvar_c(void* array1_in, void* mask_arr1, void* result1, const size_t
                                                            arr_size,
                                                            dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
@@ -1100,17 +1107,20 @@ DPCTLSyclEventRef dpnp_std_c(DPCTLSyclQueueRef q_ref,
                                                                       q));
     *var_strides = 1;
 
-    dpnp_sqrt_c<_ResultType, _ResultType>(result1,
-                                          result1_size,
-                                          result1_ndim,
-                                          result1_shape,
-                                          result1_strides,
-                                          var,
-                                          var_size,
-                                          var_ndim,
-                                          var_shape,
-                                          var_strides,
-                                          NULL);
+    DPCTLSyclEventRef e_sqrt_ref =
+	dpnp_sqrt_c<_ResultType, _ResultType>(q_ref, result1,
+					      result1_size,
+					      result1_ndim,
+					      result1_shape,
+					      result1_strides,
+					      var,
+					      var_size,
+					      var_ndim,
+					      var_shape,
+					      var_strides,
+					      NULL, NULL);
+    DPCTLEvent_WaitAndThrow(e_sqrt_ref);
+    DPCTLEvent_Delete(e_sqrt_ref);
 
     sycl::free(var, q);
     sycl::free(result1_shape, q);
@@ -1142,6 +1152,7 @@ void dpnp_std_c(void* array1_in,
                                                                      ddof,
                                                                      dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType, typename _ResultType>
@@ -1253,6 +1264,7 @@ void dpnp_var_c(void* array1_in,
                                                                      ddof,
                                                                      dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType, typename _ResultType>

--- a/dpnp/backend/src/dpnpc_memory_adapter.hpp
+++ b/dpnp/backend/src/dpnpc_memory_adapter.hpp
@@ -52,7 +52,7 @@ class DPNPC_ptr_adapter final
     bool target_no_queue = false; /**< Indicates that original memory will be accessed from non SYCL environment */
     bool copy_back = false;       /**< If the memory is 'result' it needs to be copied back to original */
     const bool verbose = false;
-    std::vector<sycl::event> deps{};
+    std::vector<sycl::event> deps;
 
 public:
     DPNPC_ptr_adapter() = delete;
@@ -164,10 +164,12 @@ public:
     }
 
     void depends_on(const std::vector<sycl::event> &new_deps) {
+	assert(allocated);
         deps.insert(std::end(deps), std::begin(new_deps), std::end(new_deps));
     }
 
     void depends_on(const sycl::event &new_dep) {
+	assert(allocated);
         deps.push_back(new_dep);
     }
 

--- a/dpnp/backend/src/dpnpc_memory_adapter.hpp
+++ b/dpnp/backend/src/dpnpc_memory_adapter.hpp
@@ -52,6 +52,7 @@ class DPNPC_ptr_adapter final
     bool target_no_queue = false; /**< Indicates that original memory will be accessed from non SYCL environment */
     bool copy_back = false;       /**< If the memory is 'result' it needs to be copied back to original */
     const bool verbose = false;
+    std::vector<sycl::event> deps{};
 
 public:
     DPNPC_ptr_adapter() = delete;
@@ -68,6 +69,7 @@ public:
         copy_back = copy_back_request;
         orig_ptr = const_cast<void*>(src_ptr);
         size_in_bytes = size * sizeof(_DataType);
+        deps = std::vector<sycl::event>{};
 
         // enum class alloc { host = 0, device = 1, shared = 2, unknown = 3 };
         sycl::usm::alloc src_ptr_type = sycl::usm::alloc::unknown;
@@ -117,6 +119,8 @@ public:
                 std::cerr << "DPNPC_ptr_converter::free_memory at=" << aux_ptr << std::endl;
             }
 
+            sycl::event::wait(deps);
+
             if (copy_back)
             {
                 copy_data_back();
@@ -158,6 +162,15 @@ public:
 
         dpnp_memory_memcpy_c(queue_ref, orig_ptr, aux_ptr, size_in_bytes);
     }
+
+    void depends_on(const std::vector<sycl::event> &new_deps) {
+        deps.insert(std::end(deps), std::begin(new_deps), std::end(new_deps));
+    }
+
+    void depends_on(const sycl::event &new_dep) {
+        deps.push_back(new_dep);
+    }
+
 };
 
 #endif // DPNP_MEMORY_ADAPTER_H


### PR DESCRIPTION
The following script:

```python
# crash.py
import dpctl
import dpnp, numpy as np
x = np.array([[0,1,2,3,4],[5,6,7,8,9]])
idx = np.array([[0,0],[0,0]])

q = dpctl.SyclQueue(property="in_order")

dp_x = dpnp.array(x, sycl_queue=q)
dp_idx = dpnp.array(idx, sycl_queue=q)
dp_res = dpnp.take(dp_x, dp_idx)
print(dpnp.asnumpy(dp_res))
```

executed using `$ SYCL_DEVICE_FILTER=cpu python crash.py` would consistently crash on Linux. 

The reason was use `DPNPC_ptr_adapter` in `dpnp_take_c` code. The adapter class instance would allocate USM-shared temporary, populate it with input data. The SYCL kernel is then submitted to work on this kernel asynchronously. 

At the `return` line of thr `dpnp_take_c` the adapter goes out of scope and frees the USM-shared temporary without making sure that the kernel has completed its execution. Failure to do that causes a crash on Linux, and explains sporadic test failures on Windows.

This PR modifies arguments of `DPNPC_ptr_adapter` constructor in `dpnp_take_c` as it does not need to allocate USM-shared temporary, but also introduces `DPNPC_ptr_adapter::depends_on` method that records events that should be waited upon before the destructor can free temporary allocations. 



- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
