### PR TITLE
Skip for two more tests till waiting fix

### DIFF
--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -1377,3 +1377,5 @@ tests/third_party/cupy/statistics_tests/test_order.py::TestOrder::test_percentil
 tests/third_party/cupy/statistics_tests/test_order.py::TestOrder::test_percentile_scalar_q
 tests/third_party/cupy/statistics_tests/test_order.py::TestOrder::test_percentile_tuple_axis
 tests/third_party/cupy/statistics_tests/test_order.py::TestOrder::test_percentile_uxpected_interpolation
+tests/third_party/cupy/statistics_tests/test_order.py::TestOrder::test_ptp_all_nan
+tests/third_party/cupy/statistics_tests/test_order.py::TestOrder::test_ptp_nan

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -1804,3 +1804,5 @@ tests/third_party/cupy/statistics_tests/test_order.py::TestOrder::test_percentil
 tests/third_party/cupy/statistics_tests/test_order.py::TestOrder::test_percentile_scalar_q
 tests/third_party/cupy/statistics_tests/test_order.py::TestOrder::test_percentile_tuple_axis
 tests/third_party/cupy/statistics_tests/test_order.py::TestOrder::test_percentile_uxpected_interpolation
+tests/third_party/cupy/statistics_tests/test_order.py::TestOrder::test_ptp_all_nan
+tests/third_party/cupy/statistics_tests/test_order.py::TestOrder::test_ptp_nan


### PR DESCRIPTION
tests/third_party/cupy/statistics_tests/test_order.py::TestOrder::test_ptp_all_nan
tests/third_party/cupy/statistics_tests/test_order.py::TestOrder::test_ptp_nan

Need to skip them because CI does not work due to this.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
