### PR TITLE
Set default shell in upload actions

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -45,7 +45,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          auto-activate-base: true
           python-version: ${{ matrix.python }}
           miniconda-version: 'latest'
           activate-environment: 'build'
@@ -107,7 +106,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          auto-activate-base: true
           python-version: ${{ matrix.python }}
           miniconda-version: 'latest'
           activate-environment: 'build'
@@ -146,6 +144,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    defaults:
+      run:
+        shell: bash -l {0}
+
     strategy:
       matrix:
         python: ['3.8', '3.9']
@@ -160,21 +162,17 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          auto-activate-base: true
           python-version: ${{ matrix.python }}
           miniconda-version: 'latest'
           activate-environment: 'upload'
 
-      - name: Install client and Upload
+      - name: Install anaconda-client
+        run: conda install anaconda-client
+
+      - name: Upload
         env:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-        run: |
-          source $CONDA/etc/profile.d/conda.sh
-          conda info
-          conda activate upload
-          ls -lF $CONDA_PREFIX/bin
-          conda install anaconda-client
-          anaconda --token ${{ env.ANACONDA_TOKEN }} upload --user dppy --label dev ${{ env.PACKAGE_NAME }}-*.tar.bz2
+        run: anaconda --token ${{ env.ANACONDA_TOKEN }} upload --user dppy --label dev ${{ env.PACKAGE_NAME }}-*.tar.bz2
 
   upload_windows:
     needs: build_windows
@@ -183,6 +181,10 @@ jobs:
 
     runs-on: windows-latest
 
+    defaults:
+      run:
+        shell: cmd /C CALL {0}
+
     strategy:
       matrix:
         python: ['3.8', '3.9']
@@ -196,15 +198,14 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          auto-activate-base: true
           python-version: ${{ matrix.python }}
           miniconda-version: 'latest'
           activate-environment: 'upload'
 
-      - name: Install client and Upload
+      - name: Install anaconda-client
+        run: conda install anaconda-client
+
+      - name: Upload
         env:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-        run: |
-          conda activate upload
-          conda install anaconda-client
-          anaconda --token ${{ env.ANACONDA_TOKEN }} upload --user dppy --label dev ${{ env.PACKAGE_NAME }}-*.tar.bz2
+        run: anaconda --token ${{ env.ANACONDA_TOKEN }} upload --user dppy --label dev ${{ env.PACKAGE_NAME }}-*.tar.bz2


### PR DESCRIPTION
It is required to explicitly define default shell when installing miniconda with "conda-incubator" action and "activate-environment: true" used. The action will update default shell to run each next step run inside created conda environment.
Otherwise (without shell option defined) it will require activate the environment inside each next run additionally.
No need to pass "auto-activate-base: true", since specific environment is created per each target step and so "base" environment is never used in the step runs.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
