### PR TITLE
[Build] setuptools 63.4.1 breaks build for Windows

### DIFF
--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -2,6 +2,11 @@ REM A workaround for activate-dpcpp.bat issue to be addressed in 2021.4
 set "LIB=%BUILD_PREFIX%\Library\lib;%BUILD_PREFIX%\compiler\lib;%LIB%"
 SET "INCLUDE=%BUILD_PREFIX%\include;%INCLUDE%"
 
+REM Since the 60.0.0 release, setuptools includes a local, vendored copy
+REM of distutils (from late copies of CPython) that is enabled by default.
+REM It breaks build for Windows, so use distutils from "stdlib" as before.
+SET "SETUPTOOLS_USE_DISTUTILS=stdlib"
+
 IF DEFINED DPLROOT (
     ECHO "Sourcing DPLROOT"
     SET "INCLUDE=%DPLROOT%\include;%INCLUDE%"

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -5,6 +5,8 @@ SET "INCLUDE=%BUILD_PREFIX%\include;%INCLUDE%"
 REM Since the 60.0.0 release, setuptools includes a local, vendored copy
 REM of distutils (from late copies of CPython) that is enabled by default.
 REM It breaks build for Windows, so use distutils from "stdlib" as before.
+REM @TODO: remove the setting, once transition to build backend on Windows
+REM to cmake is complete.
 SET "SETUPTOOLS_USE_DISTUTILS=stdlib"
 
 IF DEFINED DPLROOT (


### PR DESCRIPTION
DPNP build on Windows was previously successful in internal CI where setuptools=58.0.4. The same setuptools version is currently used in intel channel of Anaconda.
Switching to newer version setuptools=63.4.1 in internal CI broke the build flow due to non-backward compatible changed released in setuptools=60.0.0.
To prevent this and keep the legacy setuptools behavior, a workaround with setting environment variable SETUPTOOLS_USE_DISTUTILS="stdlib" is implemented.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
