### PR TITLE
Fix import dpnp on Win & python 3.10

### DIFF
--- a/dpnp/__init__.py
+++ b/dpnp/__init__.py
@@ -39,8 +39,7 @@ if system() == 'Windows':
     if hasattr(os, "add_dll_directory"):
         os.add_dll_directory(mypath)
         os.add_dll_directory(dpctlpath)
-    else:
-        os.environ["PATH"] += os.pathsep + mypath + os.pathsep + dpctlpath
+    os.environ["PATH"] += os.pathsep + mypath + os.pathsep + dpctlpath
 
 
 from dpnp.dpnp_array import dpnp_array as ndarray

--- a/dpnp/__init__.py
+++ b/dpnp/__init__.py
@@ -30,10 +30,10 @@ mypath = os.path.dirname(os.path.realpath(__file__))
 import dpctl
 dpctlpath = os.path.dirname(dpctl.__file__)
 
-# For Windows OS, with Python >3.7, it is required to explicitly define a path where to search
-# for DLLs towards both DPNP backend and DPCTL Sycl interface, otherwise
-# DPNP import will be failing. This is because the libraries are not installed
-# under any of default paths where Python is searching.
+# For Windows OS with Python >= 3.7, it is required to explicitly define a path
+# where to search for DLLs towards both DPNP backend and DPCTL Sycl interface,
+# otherwise DPNP import will be failing. This is because the libraries
+# are not installed under any of default paths where Python is searching.
 from platform import system
 if system() == 'Windows':
     if hasattr(os, "add_dll_directory"):

--- a/dpnp/__init__.py
+++ b/dpnp/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # *****************************************************************************
-# Copyright (c) 2016-2020, Intel Corporation
+# Copyright (c) 2016-2022, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -30,7 +30,17 @@ mypath = os.path.dirname(os.path.realpath(__file__))
 import dpctl
 dpctlpath = os.path.dirname(dpctl.__file__)
 
-os.environ["PATH"] += os.pathsep + mypath + os.pathsep + dpctlpath
+# For Windows OS it is required to explicitly define a path where to search
+# for DLLs towards both DPNP backand and DPCTL Sycl interface, otherwise
+# DPNP import will be failing. This is because the libraries are not installed
+# under any of default paths where Python is looking for.
+from platform import system
+if system() == 'Windows':
+    if hasattr(os, "add_dll_directory"):
+        os.add_dll_directory(mypath)
+        os.add_dll_directory(dpctlpath)
+    else:
+        os.environ["PATH"] += os.pathsep + mypath + os.pathsep + dpctlpath
 
 
 from dpnp.dpnp_array import dpnp_array as ndarray

--- a/dpnp/__init__.py
+++ b/dpnp/__init__.py
@@ -31,7 +31,7 @@ import dpctl
 dpctlpath = os.path.dirname(dpctl.__file__)
 
 # For Windows OS it is required to explicitly define a path where to search
-# for DLLs towards both DPNP backand and DPCTL Sycl interface, otherwise
+# for DLLs towards both DPNP backend and DPCTL Sycl interface, otherwise
 # DPNP import will be failing. This is because the libraries are not installed
 # under any of default paths where Python is looking for.
 from platform import system

--- a/dpnp/__init__.py
+++ b/dpnp/__init__.py
@@ -39,7 +39,7 @@ if system() == 'Windows':
     if hasattr(os, "add_dll_directory"):
         os.add_dll_directory(mypath)
         os.add_dll_directory(dpctlpath)
-    os.environ["PATH"] += os.pathsep + mypath + os.pathsep + dpctlpath
+    os.environ["PATH"] = os.pathsep.join([os.getenv("PATH", ""), mypath, dpctlpath])
 
 
 from dpnp.dpnp_array import dpnp_array as ndarray

--- a/dpnp/__init__.py
+++ b/dpnp/__init__.py
@@ -33,7 +33,7 @@ dpctlpath = os.path.dirname(dpctl.__file__)
 # For Windows OS it is required to explicitly define a path where to search
 # for DLLs towards both DPNP backend and DPCTL Sycl interface, otherwise
 # DPNP import will be failing. This is because the libraries are not installed
-# under any of default paths where Python is looking for.
+# under any of default paths where Python is searching.
 from platform import system
 if system() == 'Windows':
     if hasattr(os, "add_dll_directory"):

--- a/dpnp/__init__.py
+++ b/dpnp/__init__.py
@@ -30,7 +30,7 @@ mypath = os.path.dirname(os.path.realpath(__file__))
 import dpctl
 dpctlpath = os.path.dirname(dpctl.__file__)
 
-# For Windows OS it is required to explicitly define a path where to search
+# For Windows OS, with Python >3.7, it is required to explicitly define a path where to search
 # for DLLs towards both DPNP backend and DPCTL Sycl interface, otherwise
 # DPNP import will be failing. This is because the libraries are not installed
 # under any of default paths where Python is searching.


### PR DESCRIPTION
In case of Windows OS t is required to explicitly define a path where to search for DLLs towards both DPNP backend and DPCTL Sycl interface, otherwise the DPNP import will fail. This is because the libraries are not installed under any of default paths where Python is looking for.

Python 3.10 modifies the behavior on how it looks for DLLs to make it more secure. An environment variable PATH isn't longer used as default DLL search location. Library provides must add it to DLL search path using 'add_dll_directory' utility for Python's internal dynamic library opener to be able to find it.

The solution working with all supported pythons is supposed to be a combination of two approaches with extending PATH env variable and with calling os.add_dll_directory() if available.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
