### PR TITLE
Fix github action for building docs

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Install dpnp dependencies
         run: |
-          conda install dpctl mkl-devel-dpcpp tbb-devel dpcpp_linux-64 cmake=3.19 cython pytest \
+          conda install dpctl mkl-devel-dpcpp tbb-devel dpcpp_linux-64 cmake cython pytest \
                         -c dppy/label/dev -c intel -c conda-forge
 
       - name: Install cuPy dependencies

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -3,16 +3,27 @@ on:
   push:
     branches:
       - master
+  pull_request:
 
 jobs:
   build-and-deploy:
     name: Build and Deploy Docs
+
     runs-on: ubuntu-20.04
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    env:
+      python-ver: '3.9'
+
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
+
       - name: Install Intel repository
         run: |
           wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
@@ -20,17 +31,20 @@ jobs:
           rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
           sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
           sudo apt-get update
+
       - name: Update libstdc++-dev
         run: |
           sudo apt remove -y gcc-7 g++-7 gcc-8 g++-8 gcc-10 g++-10
           sudo apt remove -y libstdc++-10-dev
           sudo apt autoremove
           sudo apt install --reinstall -y gcc-9 g++-9 libstdc++-9-dev
+
       - name: Install Intel OneAPI
         run: |
           sudo apt-get install intel-oneapi-mkl                \
                                intel-oneapi-mkl-devel          \
                                intel-oneapi-dpcpp-cpp-compiler
+
       # https://github.com/marketplace/actions/checkout
       - name: Install nvidia-cuda support drivers
         run: |
@@ -38,54 +52,60 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libnvidia-gl-450
           sudo apt-get install -y nvidia-cuda-toolkit clinfo
+
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
       # https://github.com/marketplace/actions/setup-miniconda
       - name: Setup miniconda
         uses: conda-incubator/setup-miniconda@v2
         with:
-          activate-environment: dpnp
-          python-version: 3.8
-          channels: intel,conda-forge
-          auto-activate-base: false
-      - name: Conda info
-        shell: bash -l {0}
-        run: |
-          conda info
-          conda list
+          auto-update-conda: true
+          python-version: ${{ env.python-ver }}
+          miniconda-version: 'latest'
+          activate-environment: 'docs'
+          channels: intel, conda-forge
+
       - name: Install sphinx dependencies
-        shell: bash -l {0}
-        run: |
-          conda install sphinx sphinx_rtd_theme
+        run: conda install sphinx sphinx_rtd_theme
+
       - name: Install dpnp dependencies
-        shell: bash -l {0}
         run: |
           conda install dpctl mkl-devel-dpcpp tbb-devel dpcpp_linux-64 cmake=3.19 cython pytest \
                         -c dppy/label/dev -c intel -c conda-forge
+
       - name: Install cuPy dependencies
-        shell: bash -l {0}
+        run: conda install -c conda-forge cupy cudatoolkit=10.0
+
+      - name: Conda info
         run: |
-          conda install -c conda-forge cupy cudatoolkit=10.0
+          conda info
+          conda list
+
       - name: Build library
-        shell: bash -l {0}
         run: |
           DPLROOT=/opt/intel/oneapi/dpl/latest python setup.py build_clib
           CC=dpcpp python setup.py build_ext --inplace
           python setup.py develop
+
       - name: Build docs
-        shell: bash -l {0}
-        run: |
-          make html
+        run: make html
         working-directory: doc
+
       # https://github.com/marketplace/actions/doxygen-action
       - name: Build backend docs
-        uses: mattnotmitt/doxygen-action@v1
+        uses: mattnotmitt/doxygen-action@v1.9.4
         with:
             working-directory: 'dpnp/backend/doc'
+
       - name: Copy backend docs
         run: cp -r dpnp/backend/doc/html doc/_build/html/backend_doc
+
       # https://github.com/marketplace/actions/github-pages-action
       - name: Deploy docs
+        if: |
+          !github.event.pull_request.head.repo.fork  &&
+          (github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/heads/release') == true) || github.event_name == 'push' && contains(github.ref, 'refs/tags/'))
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -31,6 +31,11 @@ jobs:
       conda-bld: '/usr/share/miniconda3/envs/build/conda-bld/linux-64/'
 
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.10.0
+        with:
+          access_token: ${{ github.token }}
+
       - name: Checkout DPNP repo
         uses: actions/checkout@v3
         with:
@@ -94,6 +99,11 @@ jobs:
       conda-bld: 'C:\Miniconda3\envs\build\conda-bld\win-64\'
 
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.10.0
+        with:
+          access_token: ${{ github.token }}
+
       - name: Checkout DPNP repo
         uses: actions/checkout@v3
         with:
@@ -416,7 +426,9 @@ jobs:
   upload_linux:
     needs: test_linux
 
-    if: ${{github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/heads/release') == true) || github.event_name == 'push' && contains(github.ref, 'refs/tags/')}}
+    if: |
+      !github.event.pull_request.head.repo.fork  &&
+      (github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/heads/release') == true) || github.event_name == 'push' && contains(github.ref, 'refs/tags/'))
 
     runs-on: ubuntu-latest
 
@@ -446,14 +458,16 @@ jobs:
         run: conda install anaconda-client
 
       - name: Upload
+        run: anaconda --token ${{ env.ANACONDA_TOKEN }} upload --user dppy --label dev ${{ env.PACKAGE_NAME }}-*.tar.bz2
         env:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-        run: anaconda --token ${{ env.ANACONDA_TOKEN }} upload --user dppy --label dev ${{ env.PACKAGE_NAME }}-*.tar.bz2
 
   upload_windows:
     needs: test_windows
 
-    if: ${{github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/heads/release') == true) || github.event_name == 'push' && contains(github.ref, 'refs/tags/')}}
+    if: |
+      !github.event.pull_request.head.repo.fork  &&
+      (github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/heads/release') == true) || github.event_name == 'push' && contains(github.ref, 'refs/tags/'))
 
     runs-on: windows-latest
 
@@ -482,6 +496,6 @@ jobs:
         run: conda install anaconda-client
 
       - name: Upload
+        run: anaconda --token ${{ env.ANACONDA_TOKEN }} upload --user dppy --label dev ${{ env.PACKAGE_NAME }}-*.tar.bz2
         env:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-        run: anaconda --token ${{ env.ANACONDA_TOKEN }} upload --user dppy --label dev ${{ env.PACKAGE_NAME }}-*.tar.bz2

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,12 @@ __pycache__/
 # Code project files
 .vscode
 
+# Files from test of code coverage
+coverage.xml
+
+# Backup files kept after git merge/rebase
+*.orig
+
 *dpnp_backend*
 dpnp/**/*.cpython*.so
 dpnp/**/*.pyd

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,7 +27,7 @@ with open('reference/comparison_table.rst.inc', 'w') as fd:
 # -- Project information -----------------------------------------------------
 
 project = 'dpnp'
-copyright = '2020, Intel'
+copyright = '2020-2022, Intel'
 author = 'Intel'
 
 # The short X.Y version
@@ -73,7 +73,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/doc/reference/fft.rst
+++ b/doc/reference/fft.rst
@@ -57,7 +57,9 @@ Helper routines
    dpnp.fft.rfftfreq
    dpnp.fft.fftshift
    dpnp.fft.ifftshift
-   dpnp.fft.config.set_cufft_callbacks
-   dpnp.fft.config.set_cufft_gpus
-   dpnp.fft.config.get_plan_cache
-   dpnp.fft.config.show_plan_cache_info
+
+   .. fft.config module is not implemented yet
+   .. dpnp.fft.config.set_cufft_callbacks
+   .. dpnp.fft.config.set_cufft_gpus
+   .. dpnp.fft.config.get_plan_cache
+   .. dpnp.fft.config.show_plan_cache_info

--- a/doc/reference/ndarray.rst
+++ b/doc/reference/ndarray.rst
@@ -11,4 +11,4 @@ For the basic concept of ``ndarray``\s, please refer to the `NumPy documentation
    :nosignatures:
 
    dpnp.ndarray
-   dpnp.dparray.dparray
+   dpnp.dpnp_array.dpnp_array

--- a/doc/reference/polynomials.rst
+++ b/doc/reference/polynomials.rst
@@ -13,8 +13,9 @@ Polynomial Module
    :toctree: generated/
    :nosignatures:
 
-   dpnp.polynomial.polynomial.polyvander
-   dpnp.polynomial.polynomial.polycompanion
+   .. polynomial module is not implemented yet
+   .. dpnp.polynomial.polynomial.polyvander
+   .. dpnp.polynomial.polynomial.polycompanion
 
 
 Polyutils
@@ -24,9 +25,10 @@ Polyutils
    :toctree: generated/
    :nosignatures:
 
-   dpnp.polynomial.polyutils.as_series
-   dpnp.polynomial.polyutils.trimseq
-   dpnp.polynomial.polyutils.trimcoef
+   .. polyutils module is not implemented yet
+   .. dpnp.polynomial.polyutils.as_series
+   .. dpnp.polynomial.polyutils.trimseq
+   .. dpnp.polynomial.polyutils.trimcoef
 
 
 Poly1d


### PR DESCRIPTION
Since spinx 5.0.0, autosummary extension will trigger an error if any input rst file includes unknown module.
Thus, as a fix. the modules which aren't currently implemented in DPNP have been commented in the rst files.

Additionally build docs action will be partly running on each push request (excluding deploy step) now. It should help to find an issue similar to the fault observing with a newer spinx version on early stage (previously the action was running on PR merge only).

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
