### PR TITLE
Fix missing support of compute follows data in dpnp.erf

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -163,7 +163,7 @@ jobs:
       channel-path: '${{ github.workspace }}/channel/'
       pkg-path-in-channel: '${{ github.workspace }}/channel/linux-64/'
       extracted-pkg-path: '${{ github.workspace }}/pkg/'
-      tests-path: '${{ github.workspace }}/pkg/info/test/'
+      tests-path: '${{ github.workspace }}/pkg/info/test/tests/'
       ver-json-path: '${{ github.workspace }}/version.json'
 
     steps:
@@ -237,7 +237,7 @@ jobs:
 
       # TODO: run the whole scope once the issues on CPU are resolved
       - name: Run tests
-        run: python -m pytest -q -ra --disable-warnings -vv tests/test_arraycreation.py tests/test_dparray.py tests/test_mathematical.py
+        run: python -m pytest -q -ra --disable-warnings -vv test_arraycreation.py test_dparray.py test_mathematical.py test_special.py
         env:
           SYCL_ENABLE_HOST_DEVICE: '1'
         working-directory: ${{ env.tests-path }}
@@ -264,7 +264,7 @@ jobs:
       channel-path: '${{ github.workspace }}\channel\'
       pkg-path-in-channel: '${{ github.workspace }}\channel\win-64\'
       extracted-pkg-path: '${{ github.workspace }}\pkg'
-      tests-path: '${{ github.workspace }}\pkg\info\test\'
+      tests-path: '${{ github.workspace }}\pkg\info\test\tests\'
       ver-json-path: '${{ github.workspace }}\version.json'
       active-env-name: 'test'
       miniconda-lib-path: 'C:\Miniconda3\envs\test\Library\lib\'
@@ -410,7 +410,7 @@ jobs:
 
       # TODO: run the whole scope once the issues on CPU are resolved
       - name: Run tests
-        run: python -m pytest -q -ra --disable-warnings -vv tests\test_arraycreation.py tests\test_dparray.py tests\test_mathematical.py
+        run: python -m pytest -q -ra --disable-warnings -vv test_arraycreation.py test_dparray.py test_mathematical.py test_special.py
         working-directory: ${{ env.tests-path }}
 
   upload_linux:

--- a/dpnp/dpnp_iface_libmath.py
+++ b/dpnp/dpnp_iface_libmath.py
@@ -2,7 +2,7 @@
 # distutils: language = c++
 # -*- coding: utf-8 -*-
 # *****************************************************************************
-# Copyright (c) 2016-2020, Intel Corporation
+# Copyright (c) 2016-2022, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -77,7 +77,7 @@ def erf(in_array1):
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(in_array1, copy_when_strides=False)
+    x1_desc = dpnp.get_dpnp_descriptor(in_array1, copy_when_strides=False, copy_when_nondefault_queue=False)
     if x1_desc:
         return dpnp_erf(x1_desc).get_pyobj()
 


### PR DESCRIPTION
A missing part of compute follows data implementation was added for dpnp.erf function.

Tests for dpnp.erf validation was included into a scope of checks triggered on both Linux and Windows platforms by github action. It's enough to secure the fix is working, since the tests running on CPU device with the latest DPCtl from dppy/label/dev channel reproduce the same fault as reported in #1192.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
