### PR TITLE
Align normalize_queue_device call with CFD

### DIFF
--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # *****************************************************************************
-# Copyright (c) 2016-2020, Intel Corporation
+# Copyright (c) 2016-2022, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -25,10 +25,9 @@
 # *****************************************************************************
 
 import dpctl.tensor as dpt
-from dpctl.tensor._device import normalize_queue_device
-import dpnp
 import numpy
 
+import dpnp
 
 class dpnp_array:
     """
@@ -64,7 +63,7 @@ class dpnp_array:
                                           copy=False,
                                           order=order)
         else:
-            sycl_queue_normalized = normalize_queue_device(sycl_queue=sycl_queue, device=device)
+            sycl_queue_normalized = dpnp.get_normalized_queue_device(sycl_queue=sycl_queue, device=device)
             self._array_obj = dpt.usm_ndarray(shape,
                                               dtype=dtype,
                                               strides=strides,

--- a/dpnp/dpnp_container.py
+++ b/dpnp/dpnp_container.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # *****************************************************************************
-# Copyright (c) 2016-2020, Intel Corporation
+# Copyright (c) 2016-2022, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -34,28 +34,10 @@ This module contains code and dependency on diffrent containers used in DPNP
 """
 
 
-import dpnp.config as config
-# from dpnp.dparray import dparray
-from dpnp.dpnp_array import dpnp_array
-
-import numpy
-
 import dpctl.tensor as dpt
-from dpctl.tensor._device import normalize_queue_device
 
-
-if config.__DPNP_OUTPUT_DPCTL__:
-    try:
-        """
-        Detect DPCtl availability to use data container
-        """
-        import dpctl.tensor as dpctl
-
-    except ImportError:
-        """
-        No DPCtl data container available
-        """
-        config.__DPNP_OUTPUT_DPCTL__ = 0
+from dpnp.dpnp_array import dpnp_array
+import dpnp
 
 
 __all__ = [
@@ -77,14 +59,15 @@ def asarray(x1,
     else:
         x1_obj = x1
 
-    sycl_queue_normalized = normalize_queue_device(sycl_queue=sycl_queue, device=device)
+    sycl_queue_normalized = dpnp.get_normalized_queue_device(x1_obj, sycl_queue=sycl_queue, device=device)
+
+    """Converts incoming 'x1' object to 'dpnp_array'."""
     array_obj = dpt.asarray(x1_obj,
                             dtype=dtype,
                             copy=copy,
                             order=order,
                             usm_type=usm_type,
                             sycl_queue=sycl_queue_normalized)
-
     return dpnp_array(array_obj.shape, buffer=array_obj, order=order)
 
 
@@ -94,13 +77,12 @@ def empty(shape,
           device=None,
           usm_type="device",
           sycl_queue=None):
-    """Creates `dpnp_array` from uninitialized USM allocation."""
-    sycl_queue_normalized = normalize_queue_device(sycl_queue=sycl_queue, device=device)
+    sycl_queue_normalized = dpnp.get_normalized_queue_device(sycl_queue=sycl_queue, device=device)
 
+    """Creates `dpnp_array` from uninitialized USM allocation."""
     array_obj = dpt.empty(shape,
                           dtype=dtype,
                           order=order,
                           usm_type=usm_type,
                           sycl_queue=sycl_queue_normalized)
-
     return dpnp_array(array_obj.shape, buffer=array_obj, order=order)

--- a/dpnp/dpnp_iface.py
+++ b/dpnp/dpnp_iface.py
@@ -256,7 +256,7 @@ def get_normalized_queue_device(obj=None,
                                 device=None,
                                 sycl_queue=None):
     """
-    Utility to process exclusive keyword arguments 'device' and 'sycl_queue'
+    Utility to process complementary keyword arguments 'device' and 'sycl_queue'
     in subsequent calls of functions from `dpctl.tensor` module.
 
     If both arguments 'device' and 'sycl_queue' have default value `None`

--- a/dpnp/dpnp_iface.py
+++ b/dpnp/dpnp_iface.py
@@ -2,7 +2,7 @@
 # distutils: language = c++
 # -*- coding: utf-8 -*-
 # *****************************************************************************
-# Copyright (c) 2016-2020, Intel Corporation
+# Copyright (c) 2016-2022, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -47,6 +47,7 @@ import dpnp.config as config
 import collections
 
 import dpctl
+import dpctl.tensor as dpt
 
 from dpnp.dpnp_algo import *
 from dpnp.dpnp_utils import *
@@ -62,7 +63,8 @@ __all__ = [
     "dpnp_queue_initialize",
     "dpnp_queue_is_cpu",
     "get_dpnp_descriptor",
-    "get_include"
+    "get_include",
+    "get_normalized_queue_device"
 ]
 
 from dpnp.dpnp_iface_arraycreation import *
@@ -248,3 +250,50 @@ def get_include():
     dpnp_path = os.path.join(os.path.dirname(__file__), "backend", "include")
 
     return dpnp_path
+
+
+def get_normalized_queue_device(obj=None,
+                                device=None,
+                                sycl_queue=None):
+    """
+    Utility to process exclusive keyword arguments 'device' and 'sycl_queue'
+    in subsequent calls of functions from `dpctl.tensor` module.
+
+    If both arguments 'device' and 'sycl_queue' have default value `None`
+    and 'obj' has `sycl_queue` attribute, it assumes that Compute Follows Data
+    aproach has to be applied and so the resultuing SYCL queue will be normalized
+    based on the queue value from 'obj'.
+
+    Args:
+        obj (optional): A python object. Can be an instance of `dpnp_array`,
+            `dpctl.tensor.usm_ndarray`, an object representing SYCL USM allocation
+            and implementing `__sycl_usm_array_interface__` protocol,
+            an instance of `numpy.ndarray`, an object supporting Python buffer protocol,
+            a Python scalar, or a (possibly nested) sequence of Python scalars.
+        sycl_queue (:class:`dpctl.SyclQueue`, optional):
+            explicitly indicates where USM allocation is done
+            and the population code (if any) is executed.
+            Value `None` is interpreted as get the SYCL queue
+            from `obj` parameter if not None, from `device` keyword,
+            or use default queue.
+            Default: None
+        device (string, :class:`dpctl.SyclDevice`, :class:`dpctl.SyclQueue,
+            :class:`dpctl.tensor.Device`, optional):
+            array-API keyword indicating non-partitioned SYCL device
+            where array is allocated.
+    Returns
+        :class:`dpctl.SyclQueue` object normalized by `normalize_queue_device` call
+        of `dpctl.tensor` module invoked with 'device' and 'sycl_queue' values.
+        If both incoming 'device' and 'sycl_queue' are None and 'obj' has `sycl_queue` attribute,
+        the normalization will be performed for 'obj.sycl_queue' value.
+    Raises:
+        TypeError: if argument is not of the expected type, or keywords
+            imply incompatible queues.
+    """
+    if device is None and sycl_queue is None and obj is not None and hasattr(obj, 'sycl_queue'):
+        sycl_queue = obj.sycl_queue
+
+    # TODO: remove check dpt._device has attribute 'normalize_queue_device'
+    if hasattr(dpt._device, 'normalize_queue_device'):
+        return dpt._device.normalize_queue_device(sycl_queue=sycl_queue, device=device)
+    return sycl_queue

--- a/dpnp/dpnp_iface.py
+++ b/dpnp/dpnp_iface.py
@@ -261,7 +261,7 @@ def get_normalized_queue_device(obj=None,
 
     If both arguments 'device' and 'sycl_queue' have default value `None`
     and 'obj' has `sycl_queue` attribute, it assumes that Compute Follows Data
-    aproach has to be applied and so the resultuing SYCL queue will be normalized
+    approach has to be applied and so the resulting SYCL queue will be normalized
     based on the queue value from 'obj'.
 
     Args:


### PR DESCRIPTION
DPNP must adhere Compute Follows Data programming model, meaning among other things, that a copy of input array has to be created on the same device and with the same queue as the input array had unless either device or queue is passed explicitly and with different value.

To reproduce the issue:
```
import dpnp, dpctl

# list of GPU devices:
dpctl.get_devices()
Out:
[<dpctl.SyclDevice [backend_type.opencl, device_type.gpu,  Intel(R) UHD Graphics [0x9bca]] at 0x7fb5007d9070>,
 <dpctl.SyclDevice [backend_type.level_zero, device_type.gpu,  Intel(R) UHD Graphics [0x9bca]] at 0x7fb5006f0d30>]

# default GPU device:
dpctl.tensor.Device.create_device(None)
Out:
Device(level_zero:gpu:0)

# create DPNP array on OpenCL GPU device:
data = dpnp.empty((4, 4), device="opencl:gpu")
data.sycl_device
Out:
<dpctl.SyclDevice [backend_type.opencl, device_type.gpu,  Intel(R) UHD Graphics [0x9bca]] at 0x7fb56403c930>

# make a copy of the array:
copy_data = = dpnp.array(data)
copy_data.sycl_device
Out:
<dpctl.SyclDevice [backend_type.level_zero, device_type.gpu,  Intel(R) UHD Graphics [0x9bca]] at 0x7fb5b1d835f0>

# compute follows data concept is broken:
data.sycl_device == copy_data.sycl_device 
Out: False

data.sycl_queue== copy_data.sycl_queue
Out: False
```

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
