### PR TITLE
Raise not-implemented exception on numpy fallback

### DIFF
--- a/dpnp/config.py
+++ b/dpnp/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # *****************************************************************************
-# Copyright (c) 2016-2020, Intel Corporation
+# Copyright (c) 2016-2022, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -51,4 +51,9 @@ Explicitly use DPCtl package container as return type for creation functions
 __DPNP_OUTPUT_DPCTL_DEFAULT_SHARED__ = int(os.getenv('DPNP_OUTPUT_DPCTL_DEFAULT_SHARED', 0))
 '''
 Explicitly use SYCL shared memory parameter in DPCtl array constructor for creation functions
+'''
+
+__DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK__ = int(os.getenv('__DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK__', 1))
+'''
+Trigger non-implemented exception when DPNP fallbacks on NumPy implementation
 '''

--- a/dpnp/config.py
+++ b/dpnp/config.py
@@ -48,7 +48,7 @@ __DPNP_OUTPUT_DPCTL_DEFAULT_SHARED__ = int(os.getenv('DPNP_OUTPUT_DPCTL_DEFAULT_
 Explicitly use SYCL shared memory parameter in DPCtl array constructor for creation functions
 '''
 
-__DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK__ = int(os.getenv('__DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK__', 1))
+__DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK__ = int(os.getenv('DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK', 1))
 '''
 Trigger non-implemented exception when DPNP fallbacks on NumPy implementation
 '''

--- a/dpnp/dpnp_utils/dpnp_algo_utils.pyx
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pyx
@@ -114,9 +114,13 @@ def call_origin(function, *args, **kwargs):
     Call fallback function for unsupported cases
     """
 
-    if config.__DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK__:
+    allow_fallback = kwargs.pop("allow_fallback", False)
+
+    if not allow_fallback and config.__DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK__ == 1:
         raise NotImplementedError(f"Requested funtion={function.__name__} with args={args} and kwargs={kwargs} "
-                                  "isn't currently supported and would fall back on NumPy implementation.")
+                                   "isn't currently supported and would fall back on NumPy implementation. "
+                                   "Define enviroment variable `DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK` to `0` "
+                                   "if the fall back is required to be supported without rasing an exception.")
 
     dpnp_inplace = kwargs.pop("dpnp_inplace", False)
     sycl_queue = kwargs.pop("sycl_queue", None)

--- a/dpnp/dpnp_utils/dpnp_algo_utils.pyx
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pyx
@@ -1,7 +1,7 @@
 # cython: language_level=3
 # -*- coding: utf-8 -*-
 # *****************************************************************************
-# Copyright (c) 2016-2020, Intel Corporation
+# Copyright (c) 2016-2022, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -113,6 +113,10 @@ def call_origin(function, *args, **kwargs):
     """
     Call fallback function for unsupported cases
     """
+
+    if config.__DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK__:
+        raise NotImplementedError(f"Requested funtion={function.__name__} with args={args} and kwargs={kwargs} "
+                                  "isn't currently supported, fallback on NumPy implementation.")
 
     dpnp_inplace = kwargs.pop("dpnp_inplace", False)
     # print(f"DPNP call_origin(): Fallback called. \n\t function={function}, \n\t args={args}, \n\t kwargs={kwargs}, \n\t dpnp_inplace={dpnp_inplace}")

--- a/dpnp/dpnp_utils/dpnp_algo_utils.pyx
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pyx
@@ -116,7 +116,7 @@ def call_origin(function, *args, **kwargs):
 
     if config.__DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK__:
         raise NotImplementedError(f"Requested funtion={function.__name__} with args={args} and kwargs={kwargs} "
-                                  "isn't currently supported, fallback on NumPy implementation.")
+                                  "isn't currently supported and would fall back on NumPy implementation.")
 
     dpnp_inplace = kwargs.pop("dpnp_inplace", False)
     # print(f"DPNP call_origin(): Fallback called. \n\t function={function}, \n\t args={args}, \n\t kwargs={kwargs}, \n\t dpnp_inplace={dpnp_inplace}")

--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -1314,7 +1314,7 @@ def seed(seed=None):
             dpnp_rng_srand(seed)
 
     # always reseed numpy engine also
-    return call_origin(numpy.random.seed, seed)
+    return call_origin(numpy.random.seed, seed, allow_fallback=True)
 
 
 def standard_cauchy(size=None):

--- a/dpnp/random/dpnp_random_state.py
+++ b/dpnp/random/dpnp_random_state.py
@@ -67,7 +67,7 @@ class RandomState:
             self._def_float_type = dpnp.float64
 
         self._random_state = MT19937(self._seed, self._sycl_queue)
-        self._fallback_random_state = call_origin(numpy.random.RandomState, seed)
+        self._fallback_random_state = call_origin(numpy.random.RandomState, seed, allow_fallback=True)
 
 
     def get_state(self):
@@ -125,12 +125,15 @@ class RandomState:
             else:
                 min_double = numpy.finfo('double').min
                 max_double = numpy.finfo('double').max
-                if (loc >= max_double or loc <= min_double) and dpnp.isfinite(loc):
+
+                # TODO: switch to dpnp.isfinite() and dpnp.signbit() once functions are available,
+                # but for now use direct numpy calls without call_origin() wrapper, since data is a scalar
+                if (loc >= max_double or loc <= min_double) and numpy.isfinite(loc):
                     raise OverflowError(f"Range of loc={loc} exceeds valid bounds")
 
-                if (scale >= max_double) and dpnp.isfinite(scale):
+                if (scale >= max_double) and numpy.isfinite(scale):
                     raise OverflowError(f"Range of scale={scale} exceeds valid bounds")
-                # # scale = -0.0 is cosidered as negative
+                # scale = -0.0 is cosidered as negative
                 elif scale < 0 or scale == 0 and numpy.signbit(scale):
                     raise ValueError(f"scale={scale}, but must be non-negative.")
 
@@ -230,9 +233,12 @@ class RandomState:
 
                     min_int = numpy.iinfo('int32').min
                     max_int = numpy.iinfo('int32').max
-                    if not dpnp.isfinite(low) or low > max_int or low < min_int:
+
+                    # TODO: switch to dpnp.isfinite() once function is available,
+                    # but for now use direct numpy calls without call_origin() wrapper, since data is a scalar
+                    if not numpy.isfinite(low) or low > max_int or low < min_int:
                         raise OverflowError(f"Range of low={low} exceeds valid bounds")
-                    elif not dpnp.isfinite(high) or high > max_int or high < min_int:
+                    elif not numpy.isfinite(high) or high > max_int or high < min_int:
                         raise OverflowError(f"Range of high={high} exceeds valid bounds")
 
                     low = int(low)
@@ -400,9 +406,12 @@ class RandomState:
             else:
                 min_double = numpy.finfo('double').min
                 max_double = numpy.finfo('double').max
-                if not dpnp.isfinite(low) or low >= max_double or low <= min_double:
+
+                # TODO: switch to dpnp.isfinite() once function is available,
+                # but for now use direct numpy calls without call_origin() wrapper, since data is a scalar
+                if not numpy.isfinite(low) or low >= max_double or low <= min_double:
                     raise OverflowError(f"Range of low={low} exceeds valid bounds")
-                elif not dpnp.isfinite(high) or high >= max_double or high <= min_double:
+                elif not numpy.isfinite(high) or high >= max_double or high <= min_double:
                     raise OverflowError(f"Range of high={high} exceeds valid bounds")
 
                 if low > high:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,3 +73,7 @@ def pytest_collection_modifyitems(config, items):
             # exact match of the test name with items from excluded_list
             if test_name == item_tbl_str:
                 item.add_marker(skip_mark)
+
+@pytest.fixture
+def allow_fall_back_on_numpy(monkeypatch):
+    monkeypatch.setattr(dpnp.config, '__DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK__', 0)

--- a/tests/test_amin_amax.py
+++ b/tests/test_amin_amax.py
@@ -67,6 +67,7 @@ def _get_min_max_input(type, shape):
     return a.reshape(shape)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("type",
                          [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
                          ids=['float64', 'float32', 'int64', 'int32'])
@@ -87,6 +88,7 @@ def test_amax(type, shape):
     numpy.testing.assert_array_equal(dpnp_res, np_res)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("type",
                          [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
                          ids=['float64', 'float32', 'int64', 'int32'])

--- a/tests/test_arithmetic.py
+++ b/tests/test_arithmetic.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 
 from tests.third_party.cupy import testing
 
@@ -21,12 +22,14 @@ class TestArithmetic(unittest.TestCase):
 
         return c
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_float_dtypes()
     @testing.numpy_cupy_allclose()
     def test_nanprod(self, xp, dtype):
         a = xp.array([-2.5, -1.5, xp.nan, 10.5, 1.5, xp.nan], dtype=dtype)
         return xp.nanprod(a)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_float_dtypes()
     @testing.numpy_cupy_allclose()
     def test_nansum(self, xp, dtype):

--- a/tests/test_arraycreation.py
+++ b/tests/test_arraycreation.py
@@ -81,6 +81,7 @@ def test_eye(N, M, k, dtype):
     numpy.testing.assert_array_equal(expected, result)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("type",
                          [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
                          ids=['float64', 'float32', 'int64', 'int32'])
@@ -93,6 +94,7 @@ def test_frombuffer(type):
     numpy.testing.assert_array_equal(dpnp_res, np_res)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("type",
                          [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
                          ids=['float64', 'float32', 'int64', 'int32'])
@@ -109,6 +111,7 @@ def test_fromfile(type):
         numpy.testing.assert_array_equal(dpnp_res, np_res)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("type",
                          [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
                          ids=['float64', 'float32', 'int64', 'int32'])
@@ -124,6 +127,7 @@ def test_fromfunction(type):
     numpy.testing.assert_array_equal(dpnp_res, np_res)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("type",
                          [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
                          ids=['float64', 'float32', 'int64', 'int32'])
@@ -136,6 +140,7 @@ def test_fromiter(type):
     numpy.testing.assert_array_equal(dpnp_res, np_res)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("type",
                          [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
                          ids=['float64', 'float32', 'int64', 'int32'])
@@ -148,6 +153,7 @@ def test_fromstring(type):
     numpy.testing.assert_array_equal(dpnp_res, np_res)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("type",
                          [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
                          ids=['float64', 'float32', 'int64', 'int32'])
@@ -183,6 +189,7 @@ def test_identity(n, type):
     numpy.testing.assert_array_equal(expected, result)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("type",
                          [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
                          ids=['float64', 'float32', 'int64', 'int32'])

--- a/tests/test_arraymanipulation.py
+++ b/tests/test_arraymanipulation.py
@@ -4,6 +4,7 @@ import dpnp
 import numpy
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("dtype",
                          [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
                          ids=["float64", "float32", "int64", "int32"])
@@ -30,6 +31,7 @@ def test_asfarray2(dtype, data):
     numpy.testing.assert_array_equal(result, expected)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestConcatenate:
     def test_returns_copy(self):
         a = dpnp.array(numpy.eye(3))
@@ -91,9 +93,11 @@ class TestHstack:
     def test_non_iterable(self):
         numpy.testing.assert_raises(TypeError, dpnp.hstack, 1)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_empty_input(self):
         numpy.testing.assert_raises(ValueError, dpnp.hstack, ())
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_0D_array(self):
         b = dpnp.array(2)
         a = dpnp.array(1)
@@ -101,6 +105,7 @@ class TestHstack:
         desired = dpnp.array([1, 2])
         numpy.testing.assert_array_equal(res, desired)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_1D_array(self):
         a = dpnp.array([1])
         b = dpnp.array([2])
@@ -108,6 +113,7 @@ class TestHstack:
         desired = dpnp.array([1, 2])
         numpy.testing.assert_array_equal(res, desired)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_2D_array(self):
         a = dpnp.array([[1], [2]])
         b = dpnp.array([[1], [2]])
@@ -126,9 +132,11 @@ class TestVstack:
     def test_non_iterable(self):
         numpy.testing.assert_raises(TypeError, dpnp.vstack, 1)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_empty_input(self):
         numpy.testing.assert_raises(ValueError, dpnp.vstack, ())
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_0D_array(self):
         a = dpnp.array(1)
         b = dpnp.array(2)
@@ -136,6 +144,7 @@ class TestVstack:
         desired = dpnp.array([[1], [2]])
         numpy.testing.assert_array_equal(res, desired)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_1D_array(self):
         a = dpnp.array([1])
         b = dpnp.array([2])
@@ -143,6 +152,7 @@ class TestVstack:
         desired = dpnp.array([[1], [2]])
         numpy.testing.assert_array_equal(res, desired)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_2D_array(self):
         a = dpnp.array([[1], [2]])
         b = dpnp.array([[1], [2]])
@@ -150,6 +160,7 @@ class TestVstack:
         desired = dpnp.array([[1], [2], [1], [2]])
         numpy.testing.assert_array_equal(res, desired)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_2D_array2(self):
         a = dpnp.array([1, 2])
         b = dpnp.array([1, 2])

--- a/tests/test_bitwise.py
+++ b/tests/test_bitwise.py
@@ -37,20 +37,26 @@ class TestBitwise:
 
         numpy.testing.assert_array_equal(result, expected)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_bitwise_and(self, lhs, rhs, dtype):
         self._test_binary_int('bitwise_and', lhs, rhs, dtype)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_bitwise_or(self, lhs, rhs, dtype):
         self._test_binary_int('bitwise_or', lhs, rhs, dtype)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_bitwise_xor(self, lhs, rhs, dtype):
         self._test_binary_int('bitwise_xor', lhs, rhs, dtype)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_invert(self, lhs, rhs, dtype):
         self._test_unary_int('invert', lhs, dtype)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_left_shift(self, lhs, rhs, dtype):
         self._test_binary_int('left_shift', lhs, rhs, dtype)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_right_shift(self, lhs, rhs, dtype):
         self._test_binary_int('right_shift', lhs, rhs, dtype)

--- a/tests/test_histograms.py
+++ b/tests/test_histograms.py
@@ -13,6 +13,7 @@ class TestHistogram:
     def teardown(self):
         pass
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_simple(self):
         n = 100
         v = dpnp.random.rand(n)
@@ -24,6 +25,7 @@ class TestHistogram:
         (a, b) = dpnp.histogram(numpy.linspace(0, 10, 100))
         numpy.testing.assert_array_equal(a, 10)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_one_bin(self):
         # Ticket 632
         hist, edges = dpnp.histogram([1, 2, 3, 4], [1, 2])
@@ -66,6 +68,8 @@ class TestHistogram:
             [1, 2, 3, 4], [0.5, 1.5, numpy.inf], density=True)
         numpy.testing.assert_equal(counts, [.25, 0])
 
+
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_arr_weights_mismatch(self):
         a = dpnp.arange(10) + .5
         w = dpnp.arange(11) + .5

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -5,6 +5,7 @@ import dpnp
 import numpy
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 def test_choose():
     a = numpy.r_[:4]
     ia = dpnp.array(a)
@@ -109,6 +110,7 @@ def test_nonzero(array):
     numpy.testing.assert_array_equal(expected, result)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("vals",
                          [[100, 200],
                           (100, 200)],
@@ -138,6 +140,7 @@ def test_place1(arr, mask, vals):
     numpy.testing.assert_array_equal(a, ia)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("vals",
                          [[100, 200],
                           [100, 200, 300, 400, 500, 600],
@@ -161,6 +164,7 @@ def test_place2(arr, mask, vals):
     numpy.testing.assert_array_equal(a, ia)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("vals",
                          [[100, 200],
                           [100, 200, 300, 400, 500, 600],
@@ -243,6 +247,7 @@ def test_put3():
     numpy.testing.assert_array_equal(a, ia)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 def test_put_along_axis_val_int():
     a = numpy.arange(16).reshape(4, 4)
     ai = dpnp.array(a)
@@ -254,6 +259,7 @@ def test_put_along_axis_val_int():
         numpy.testing.assert_array_equal(a, ai)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 def test_put_along_axis1():
     a = numpy.arange(64).reshape(4, 4, 4)
     ai = dpnp.array(a)
@@ -265,6 +271,7 @@ def test_put_along_axis1():
         numpy.testing.assert_array_equal(a, ai)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 def test_put_along_axis2():
     a = numpy.arange(64).reshape(4, 4, 4)
     ai = dpnp.array(a)
@@ -411,6 +418,7 @@ def test_take(array, indices, array_type, indices_type):
     numpy.testing.assert_array_equal(expected, result)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 def test_take_along_axis():
     a = numpy.arange(16).reshape(4, 4)
     ai = dpnp.array(a)
@@ -422,6 +430,7 @@ def test_take_along_axis():
         numpy.testing.assert_array_equal(expected, result)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 def test_take_along_axis1():
     a = numpy.arange(64).reshape(4, 4, 4)
     ai = dpnp.array(a)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -85,6 +85,7 @@ def test_det(array):
     numpy.testing.assert_allclose(expected, result)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("type",
                          [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
                          ids=['float64', 'float32', 'int64', 'int32'])
@@ -179,6 +180,7 @@ def test_matrix_rank(type, tol, array):
     numpy.testing.assert_allclose(expected, result)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("array",
                          [[7], [1, 2], [1, 0]],
                          ids=['[7]', '[1, 2]', '[1, 0]'])
@@ -196,6 +198,7 @@ def test_norm1(array, ord, axis):
     numpy.testing.assert_allclose(expected, result)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("array",
                          [[[1, 0]], [[1, 2]], [[1, 0], [3, 0]], [[1, 2], [3, 4]]],
                          ids=['[[1, 0]]', '[[1, 2]]', '[[1, 0], [3, 0]]', '[[1, 2], [3, 4]]'])
@@ -213,6 +216,7 @@ def test_norm2(array, ord, axis):
     numpy.testing.assert_array_equal(expected, result)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("array",
                          [[[[1, 2], [3, 4]], [[5, 6], [7, 8]]], [[[1, 0], [3, 0]], [[5, 0], [7, 0]]]],
                          ids=['[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]', '[[[1, 0], [3, 0]], [[5, 0], [7, 0]]]'])
@@ -230,6 +234,7 @@ def test_norm3(array, ord, axis):
     numpy.testing.assert_array_equal(expected, result)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("type",
                          [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
                          ids=['float64', 'float32', 'int64', 'int32'])
@@ -273,6 +278,7 @@ def test_qr(type, shape, mode):
     numpy.testing.assert_allclose(dpnp_r, np_r, rtol=tol, atol=tol)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("type",
                          [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
                          ids=['float64', 'float32', 'int64', 'int32'])

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -95,6 +95,7 @@ def test_any(type, shape):
         numpy.testing.assert_allclose(dpnp_res, np_res)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 def test_greater():
     a = numpy.array([1, 2, 3, 4, 5, 6, 7, 8])
     ia = dpnp.array(a)
@@ -104,6 +105,7 @@ def test_greater():
         numpy.testing.assert_equal(dpnp_res, np_res)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 def test_greater_equal():
     a = numpy.array([1, 2, 3, 4, 5, 6, 7, 8])
     ia = dpnp.array(a)
@@ -113,6 +115,7 @@ def test_greater_equal():
         numpy.testing.assert_equal(dpnp_res, np_res)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 def test_less():
     a = numpy.array([1, 2, 3, 4, 5, 6, 7, 8])
     ia = dpnp.array(a)
@@ -122,6 +125,7 @@ def test_less():
         numpy.testing.assert_equal(dpnp_res, np_res)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 def test_less_equal():
     a = numpy.array([1, 2, 3, 4, 5, 6, 7, 8])
     ia = dpnp.array(a)
@@ -131,6 +135,7 @@ def test_less_equal():
         numpy.testing.assert_equal(dpnp_res, np_res)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 def test_not_equal():
     a = numpy.array([1, 2, 3, 4, 5, 6, 7, 8])
     ia = dpnp.array(a)

--- a/tests/test_manipulation.py
+++ b/tests/test_manipulation.py
@@ -23,6 +23,7 @@ def test_copyto_dtype(in_obj, out_dtype):
     numpy.testing.assert_array_equal(result, expected)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("arr",
                          [[], [1, 2, 3, 4], [[1, 2], [3, 4]], [[[1], [2]], [[3], [4]]]],
                          ids=['[]', '[1, 2, 3, 4]', '[[1, 2], [3, 4]]', '[[[1], [2]], [[3], [4]]]'])
@@ -34,6 +35,7 @@ def test_repeat(arr):
     numpy.testing.assert_array_equal(expected, result)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("array",
                          [[1, 2, 3],
                           [1, 2, 2, 1, 2, 4],

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -5,6 +5,7 @@ import dpnp
 import numpy
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestConvolve:
     def test_object(self):
         d = [1.] * 100
@@ -33,6 +34,7 @@ class TestConvolve:
             dpnp.convolve(d, k, mode=None)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("array",
                          [[[0, 0], [0, 0]],
                           [[1, 2], [1, 2]],
@@ -54,6 +56,7 @@ def test_diff(array):
     numpy.testing.assert_allclose(expected, result)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("dtype1",
                          [numpy.bool_, numpy.float64, numpy.float32, numpy.int64, numpy.int32, numpy.complex64, numpy.complex128],
                          ids=['numpy.bool_', 'numpy.float64', 'numpy.float32', 'numpy.int64', 'numpy.int32', 'numpy.complex64', 'numpy.complex128'])
@@ -98,46 +101,60 @@ class TestMathematical:
 
         numpy.testing.assert_allclose(result, expected, atol=1e-4)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_add(self, dtype, lhs, rhs):
         self._test_mathematical('add', dtype, lhs, rhs)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_arctan2(self, dtype, lhs, rhs):
         self._test_mathematical('arctan2', dtype, lhs, rhs)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_copysign(self, dtype, lhs, rhs):
         self._test_mathematical('copysign', dtype, lhs, rhs)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_divide(self, dtype, lhs, rhs):
         self._test_mathematical('divide', dtype, lhs, rhs)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_fmod(self, dtype, lhs, rhs):
         self._test_mathematical('fmod', dtype, lhs, rhs)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_floor_divide(self, dtype, lhs, rhs):
         self._test_mathematical('floor_divide', dtype, lhs, rhs)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_hypot(self, dtype, lhs, rhs):
         self._test_mathematical('hypot', dtype, lhs, rhs)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_maximum(self, dtype, lhs, rhs):
         self._test_mathematical('maximum', dtype, lhs, rhs)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_minimum(self, dtype, lhs, rhs):
         self._test_mathematical('minimum', dtype, lhs, rhs)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_multiply(self, dtype, lhs, rhs):
         self._test_mathematical('multiply', dtype, lhs, rhs)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_remainder(self, dtype, lhs, rhs):
         self._test_mathematical('remainder', dtype, lhs, rhs)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_power(self, dtype, lhs, rhs):
         self._test_mathematical('power', dtype, lhs, rhs)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_subtract(self, dtype, lhs, rhs):
         self._test_mathematical('subtract', dtype, lhs, rhs)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("val_type",
                          [bool, int, float],
                          ids=['bool', 'int', 'float'])
@@ -172,6 +189,7 @@ def test_multiply_scalar(array, val, data_type, val_type):
     numpy.testing.assert_array_equal(result, expected)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("shape",
                          [(), (3, 2)],
                          ids=['()', '(3, 2)'])
@@ -187,6 +205,7 @@ def test_multiply_scalar2(shape, dtype):
     numpy.testing.assert_array_equal(result, expected)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("array", [[1, 2, 3, 4, 5],
                                    [1, 2, numpy.nan, 4, 5],
                                    [[1, 2, numpy.nan], [3, -4, -5]]])
@@ -199,6 +218,7 @@ def test_nancumprod(array):
     numpy.testing.assert_array_equal(expected, result)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("array", [[1, 2, 3, 4, 5],
                                    [1, 2, numpy.nan, 4, 5],
                                    [[1, 2, numpy.nan], [3, -4, -5]]])
@@ -226,6 +246,7 @@ def test_negative(data, dtype):
     numpy.testing.assert_array_equal(result, expected)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("val_type",
                          [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
                          ids=['numpy.float64', 'numpy.float32', 'numpy.int64', 'numpy.int32'])
@@ -270,6 +291,8 @@ class TestEdiff1d:
         expected = numpy.ediff1d(np_a)
         numpy.testing.assert_array_equal(expected, result)
 
+    
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_ediff1d_args(self):
         np_a = numpy.array([1, 2, 4, 7, 0])
 
@@ -281,6 +304,7 @@ class TestEdiff1d:
         numpy.testing.assert_array_equal(expected, result)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestTrapz:
     @pytest.mark.parametrize("data_type",
                              [numpy.float64, numpy.float32, numpy.int64, numpy.int32])
@@ -336,6 +360,7 @@ class TestTrapz:
         numpy.testing.assert_array_equal(expected, result)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestCross:
 
     @pytest.mark.parametrize("axis", [None, 0],
@@ -370,32 +395,7 @@ class TestCross:
         numpy.testing.assert_array_equal(expected, result)
 
 
-class TestGradient:
-
-    @pytest.mark.parametrize("array", [[2, 3, 6, 8, 4, 9],
-                                       [3., 4., 7.5, 9.],
-                                       [2, 6, 8, 10]])
-    def test_gradient_y1(self, array):
-        np_y = numpy.array(array)
-        dpnp_y = dpnp.array(array)
-
-        result = dpnp.gradient(dpnp_y)
-        expected = numpy.gradient(np_y)
-        numpy.testing.assert_array_equal(expected, result)
-
-    @pytest.mark.parametrize("array", [[2, 3, 6, 8, 4, 9],
-                                       [3., 4., 7.5, 9.],
-                                       [2, 6, 8, 10]])
-    @pytest.mark.parametrize("dx", [2, 3.5])
-    def test_gradient_y1_dx(self, array, dx):
-        np_y = numpy.array(array)
-        dpnp_y = dpnp.array(array)
-
-        result = dpnp.gradient(dpnp_y, dx)
-        expected = numpy.gradient(np_y, dx)
-        numpy.testing.assert_array_equal(expected, result)
-
-
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestGradient:
 
     @pytest.mark.parametrize("array", [[2, 3, 6, 8, 4, 9],

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -75,6 +75,7 @@ def test_input_shape(func):
     assert shape == res.shape
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("func",
                          [dpnp.random.random,
                           dpnp.random.random_sample,
@@ -139,6 +140,7 @@ def test_randn_normal_distribution():
     assert math.isclose(mean, expected_mean, abs_tol=0.03)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsBeta(TestDistribution):
 
     def test_moments(self):
@@ -162,6 +164,7 @@ class TestDistributionsBeta(TestDistribution):
         self.check_seed('beta', {'a': a, 'b': b})
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsBinomial(TestDistribution):
 
     def test_extreme_value(self):
@@ -199,6 +202,7 @@ class TestDistributionsBinomial(TestDistribution):
         self.check_seed('binomial', {'n': n, 'p': p})
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsChisquare(TestDistribution):
 
     def test_invalid_args(self):
@@ -210,6 +214,7 @@ class TestDistributionsChisquare(TestDistribution):
         self.check_seed('chisquare', {'df': df})
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsExponential(TestDistribution):
 
     def test_invalid_args(self):
@@ -221,6 +226,7 @@ class TestDistributionsExponential(TestDistribution):
         self.check_seed('exponential', {'scale': scale})
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsF(TestDistribution):
 
     def test_moments(self):
@@ -248,6 +254,7 @@ class TestDistributionsF(TestDistribution):
         self.check_seed('f', {'dfnum': dfnum, 'dfden': dfden})
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsGamma(TestDistribution):
 
     def test_moments(self):
@@ -271,6 +278,7 @@ class TestDistributionsGamma(TestDistribution):
         self.check_seed('gamma', {'shape': shape})
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsGeometric(TestDistribution):
 
     def test_extreme_value(self):
@@ -294,6 +302,7 @@ class TestDistributionsGeometric(TestDistribution):
         self.check_seed('geometric', {'p': p})
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsGumbel(TestDistribution):
 
     def test_extreme_value(self):
@@ -323,6 +332,7 @@ class TestDistributionsGumbel(TestDistribution):
         self.check_seed('gumbel', {'loc': loc, 'scale': scale})
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsHypergeometric(TestDistribution):
 
     def test_extreme_value(self):
@@ -389,6 +399,7 @@ class TestDistributionsHypergeometric(TestDistribution):
                         {'ngood': ngood, 'nbad': nbad, 'nsample': nsample})
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsLaplace(TestDistribution):
 
     def test_extreme_value(self):
@@ -418,6 +429,7 @@ class TestDistributionsLaplace(TestDistribution):
         self.check_seed('laplace', {'loc': loc, 'scale': scale})
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsLogistic(TestDistribution):
 
     def test_moments(self):
@@ -440,6 +452,7 @@ class TestDistributionsLogistic(TestDistribution):
         self.check_seed('logistic', {'loc': loc, 'scale': scale})
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsLognormal(TestDistribution):
 
     def test_extreme_value(self):
@@ -468,6 +481,7 @@ class TestDistributionsLognormal(TestDistribution):
         self.check_seed('lognormal', {'mean': mean, 'sigma': sigma})
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsMultinomial(TestDistribution):
 
     def test_extreme_value(self):
@@ -514,6 +528,7 @@ class TestDistributionsMultinomial(TestDistribution):
         self.check_seed('multinomial', {'n': n, 'pvals': pvals})
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsMultivariateNormal(TestDistribution):
 
     def test_moments(self):
@@ -553,6 +568,7 @@ class TestDistributionsMultivariateNormal(TestDistribution):
         self.check_seed('multivariate_normal', {'mean': mean, 'cov': cov})
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsNegativeBinomial(TestDistribution):
 
     def test_extreme_value(self):
@@ -609,6 +625,7 @@ class TestDistributionsNormal(TestDistribution):
         self.check_seed('normal', {'loc': loc, 'scale': scale})
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsNoncentralChisquare:
 
     @pytest.mark.parametrize("df", [5.0, 1.0, 0.5], ids=['df_grt_1', 'df_eq_1', 'df_less_1'])
@@ -648,6 +665,7 @@ class TestDistributionsNoncentralChisquare:
         assert_allclose(a1, a2, rtol=1e-07, atol=0)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsPareto(TestDistribution):
 
     def test_moments(self):
@@ -667,6 +685,7 @@ class TestDistributionsPareto(TestDistribution):
         self.check_seed('pareto', {'a': a})
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsPoisson(TestDistribution):
 
     def test_extreme_value(self):
@@ -689,6 +708,7 @@ class TestDistributionsPoisson(TestDistribution):
         self.check_seed('poisson', {'lam': lam})
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsPower(TestDistribution):
 
     def test_moments(self):
@@ -709,6 +729,7 @@ class TestDistributionsPower(TestDistribution):
         self.check_seed('power', {'a': a})
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsRayleigh(TestDistribution):
 
     def test_extreme_value(self):
@@ -750,6 +771,7 @@ class TestDistributionsStandardExponential(TestDistribution):
         self.check_seed('standard_exponential', {})
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsStandardGamma(TestDistribution):
 
     def test_extreme_value(self):
@@ -782,6 +804,7 @@ class TestDistributionsStandardNormal(TestDistribution):
         self.check_seed('standard_normal', {})
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsStandardT(TestDistribution):
 
     def test_moments(self):
@@ -799,6 +822,7 @@ class TestDistributionsStandardT(TestDistribution):
         self.check_seed('standard_t', {'df': 10.0})
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsTriangular(TestDistribution):
 
     def test_moments(self):
@@ -851,6 +875,7 @@ class TestDistributionsUniform(TestDistribution):
         self.check_seed('uniform', {'low': low, 'high': high})
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsVonmises:
 
     @pytest.mark.parametrize("kappa", [5.0, 0.5], ids=['large_kappa', 'small_kappa'])
@@ -887,6 +912,7 @@ class TestDistributionsVonmises:
         assert_allclose(a1, a2, rtol=1e-07, atol=0)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsWald(TestDistribution):
 
     def test_moments(self):
@@ -913,6 +939,7 @@ class TestDistributionsWald(TestDistribution):
         self.check_seed('wald', {'mean': mean, 'scale': scale})
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsWeibull(TestDistribution):
 
     def test_extreme_value(self):
@@ -929,6 +956,7 @@ class TestDistributionsWeibull(TestDistribution):
         self.check_seed('weibull', {'a': a})
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestDistributionsZipf(TestDistribution):
 
     def test_invalid_args(self):
@@ -1018,6 +1046,8 @@ class TestPermutationsTestShuffle:
         desired = conv(dpnp_1d)
         assert_array_equal(actual, desired)
 
+
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @pytest.mark.parametrize("conv", [lambda x: x,
                                       lambda x: [(i, i) for i in x]],
                              ids=['lambda x: x',

--- a/tests/test_random_state.py
+++ b/tests/test_random_state.py
@@ -123,6 +123,7 @@ class TestNormal:
                                  "with the following message:\n\n%s" % str(e))
 
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @pytest.mark.parametrize("scale",
                              [dpnp.array([3]), numpy.array([3])],
                              ids=['dpnp.array([3])', 'numpy.array([3])'])
@@ -293,6 +294,7 @@ class TestRandInt:
         assert_array_equal(actual, desired)
 
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_negative_interval(self):
         rs = RandomState(3567)
 
@@ -354,6 +356,7 @@ class TestRandInt:
                                  "with the following message:\n\n%s" % str(e))
 
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_in_bounds_fuzz(self):
         for high in [4, 8, 16]:
             vals = RandomState().randint(2, high, size=2**16)
@@ -369,6 +372,7 @@ class TestRandInt:
         assert_equal(RandomState().randint(0, 10, size=zero_size).shape, exp_shape)
 
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @pytest.mark.parametrize("high",
                              [dpnp.array([3]), numpy.array([3])],
                              ids=['dpnp.array([3])', 'numpy.array([3])'])
@@ -385,6 +389,7 @@ class TestRandInt:
         assert_equal(actual, desired)
 
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @pytest.mark.parametrize("dtype",
                              [dpnp.int64, dpnp.integer, dpnp.bool, dpnp.bool_, bool],
                              ids=['dpnp.int64', 'dpnp.integer', 'dpnp.bool', 'dpnp.bool_', 'bool'])
@@ -495,6 +500,7 @@ class TestSeed:
         assert_array_almost_equal(a1, a2, decimal=precision)
 
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @pytest.mark.parametrize("seed",
                              [range(3),
                               numpy.arange(3, dtype=numpy.int32),
@@ -527,6 +533,7 @@ class TestSeed:
         assert_raises(TypeError, RandomState, seed)
 
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @pytest.mark.parametrize("seed",
                              [-1, [-3, 7], (17, 3, -5), [4, 3, 2, 1], (7, 6, 5, 1),
                               range(-1, -11, -1),
@@ -736,6 +743,7 @@ class TestUniform:
             assert_array_almost_equal(actual, desired, decimal=numpy.finfo(dtype=dtype).precision)
 
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_range_bounds(self):
         fmin = numpy.finfo('double').min
         fmax = numpy.finfo('double').max
@@ -751,6 +759,7 @@ class TestUniform:
         func(low=numpy.nextafter(fmin, 0), high=numpy.nextafter(fmax, 0))
 
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @pytest.mark.parametrize("high",
                              [dpnp.array([3]), numpy.array([3])],
                              ids=['dpnp.array([3])', 'numpy.array([3])'])

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -32,6 +32,7 @@ def test_partition(array, dtype, kth):
     numpy.testing.assert_array_equal(expected, result)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("side",
                          ["left", "right"],
                          ids=['"left"', '"right"'])

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -20,6 +20,7 @@ def test_median(type, size):
     numpy.testing.assert_allclose(dpnp_res, np_res)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("axis",
                          [0, 1, -1, 2, -2, (1, 2), (0, -2)])
 def test_max(axis):
@@ -32,6 +33,7 @@ def test_max(axis):
     numpy.testing.assert_allclose(dpnp_res, np_res)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("array",
                          [[2, 0, 6, 2],
                           [2, 0, 6, 2, 5, 6, 7, 8],
@@ -74,6 +76,7 @@ def test_nanvar(array):
     numpy.testing.assert_array_equal(expected, result)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestBincount:
 
     @pytest.mark.parametrize("array",

--- a/tests/test_strides.py
+++ b/tests/test_strides.py
@@ -190,6 +190,7 @@ def test_strides_copysign(dtype, shape):
     numpy.testing.assert_allclose(result, expected)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("dtype",
                          [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
                          ids=["float64", "float32", "int64", "int32"])
@@ -209,6 +210,7 @@ def test_strides_fmod(dtype, shape):
     numpy.testing.assert_allclose(result, expected)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("dtype",
                          [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
                          ids=["float64", "float32", "int64", "int32"])

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -93,6 +93,7 @@ def test_array_creation(func, arg, kwargs, device):
     assert dpnp_array.sycl_device == device
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize(
     "func,data",
     [
@@ -300,6 +301,7 @@ def test_rs_uniform(usm_type, seed):
     assert_sycl_queue_equal(res_sycl_queue, sycl_queue)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize(
     "func,data1,data2",
     [
@@ -460,6 +462,7 @@ def test_det(device):
     assert_sycl_queue_equal(result_queue, expected_queue)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("device",
                           valid_devices,
                           ids=[device.filter_string for device in valid_devices])
@@ -586,6 +589,7 @@ def test_qr(device):
     assert_sycl_queue_equal(dpnp_r_queue, expected_queue)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("device",
                         valid_devices,
                         ids=[device.filter_string for device in valid_devices])

--- a/tests/test_umath.py
+++ b/tests/test_umath.py
@@ -58,6 +58,7 @@ def get_id(val):
     return val.__str__()
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize('test_cases', test_cases, ids=get_id)
 def test_umaths(test_cases):
     umath, args_str = test_cases

--- a/tests/third_party/cupy/core_tests/test_ndarray_conversion.py
+++ b/tests/third_party/cupy/core_tests/test_ndarray_conversion.py
@@ -12,6 +12,7 @@ from tests.third_party.cupy import testing
     {'shape': (1,)},
     {'shape': (1, 1, 1)},
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestNdarrayItem(unittest.TestCase):
 
     @testing.for_all_dtypes()

--- a/tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py
@@ -159,12 +159,14 @@ class TestArrayCopyAndView(unittest.TestCase):
         return numpy.array(
             astype_without_warning(src, dst_dtype, order='K').strides)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_diagonal1(self, xp, dtype):
         a = testing.shaped_arange((3, 4, 5), xp, dtype)
         return a.diagonal(1, 2, 0)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_diagonal2(self, xp, dtype):

--- a/tests/third_party/cupy/core_tests/test_ndarray_math.py
+++ b/tests/third_party/cupy/core_tests/test_ndarray_math.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 
 import numpy
 
@@ -9,6 +10,7 @@ from tests.third_party.cupy import testing
 @testing.parameterize(*testing.product({
     'decimals': [-2, -1, 0, 1, 2],
 }))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestRound(unittest.TestCase):
 
     shape = (20,)

--- a/tests/third_party/cupy/core_tests/test_ndarray_reduction.py
+++ b/tests/third_party/cupy/core_tests/test_ndarray_reduction.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 
 import numpy
 
@@ -7,6 +8,7 @@ import dpnp as cupy
 from tests.third_party.cupy import testing
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestArrayReduction(unittest.TestCase):
 

--- a/tests/third_party/cupy/creation_tests/test_from_data.py
+++ b/tests/third_party/cupy/creation_tests/test_from_data.py
@@ -414,6 +414,7 @@ class TestFromData(unittest.TestCase):
         return xp.ascontiguousarray(a, dtype=numpy.int64)
 
     # @testing.for_CF_orders()
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_orders('C')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()

--- a/tests/third_party/cupy/creation_tests/test_matrix.py
+++ b/tests/third_party/cupy/creation_tests/test_matrix.py
@@ -60,16 +60,19 @@ class TestMatrix(unittest.TestCase):
         self.assertIsInstance(r, xp.ndarray)
         return r
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_diag_scaler(self):
         for xp in (numpy, cupy):
             with pytest.raises(ValueError):
                 xp.diag(1)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_diag_0dim(self):
         for xp in (numpy, cupy):
             with pytest.raises(ValueError):
                 xp.diag(xp.zeros(()))
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_diag_3dim(self):
         for xp in (numpy, cupy):
             with pytest.raises(ValueError):
@@ -90,14 +93,17 @@ class TestMatrix(unittest.TestCase):
         a = testing.shaped_arange((3, 3), xp)
         return xp.diagflat(a, -2)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_diagflat_from_scalar(self, xp):
         return xp.diagflat(3)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_diagflat_from_scalar_with_k0(self, xp):
         return xp.diagflat(3, 0)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_diagflat_from_scalar_with_k1(self, xp):
         return xp.diagflat(3, 1)
@@ -142,6 +148,7 @@ class TestTriLowerAndUpper(unittest.TestCase):
         m = testing.shaped_arange(self.shape, xp, dtype)
         return xp.tril(m)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_tril_array_like(self, xp):
         return xp.tril([[1, 2], [3, 4]])
@@ -164,6 +171,7 @@ class TestTriLowerAndUpper(unittest.TestCase):
         m = testing.shaped_arange(self.shape, xp, dtype)
         return xp.triu(m)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_triu_array_like(self, xp):
         return xp.triu([[1, 2], [3, 4]])

--- a/tests/third_party/cupy/creation_tests/test_ranges.py
+++ b/tests/third_party/cupy/creation_tests/test_ranges.py
@@ -206,11 +206,13 @@ class TestRanges(unittest.TestCase):
         stop = [100, 16]
         return xp.linspace(start, stop, num=50, dtype=dtype)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose()
     def test_logspace(self, xp, dtype):
         return xp.logspace(0, 2, 5, dtype=dtype)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose()
     def test_logspace2(self, xp, dtype):
@@ -221,24 +223,29 @@ class TestRanges(unittest.TestCase):
     def test_logspace_zero_num(self, xp, dtype):
         return xp.logspace(0, 2, 0, dtype=dtype)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose()
     def test_logspace_one_num(self, xp, dtype):
         return xp.logspace(0, 2, 1, dtype=dtype)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose()
     def test_logspace_no_endpoint(self, xp, dtype):
         return xp.logspace(0, 2, 5, dtype=dtype, endpoint=False)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_allclose()
     def test_logspace_no_dtype_int(self, xp):
         return xp.logspace(0, 2)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_allclose()
     def test_logspace_no_dtype_float(self, xp):
         return xp.logspace(0.0, 2.0)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_allclose()
     def test_logspace_float_args_with_int_dtype(self, xp):
         return xp.logspace(0.1, 2.1, 11, dtype=int)
@@ -248,6 +255,7 @@ class TestRanges(unittest.TestCase):
             with pytest.raises(ValueError):
                 xp.logspace(0, 10, -1)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose()
     def test_logspace_base(self, xp, dtype):

--- a/tests/third_party/cupy/fft_tests/test_fft.py
+++ b/tests/third_party/cupy/fft_tests/test_fft.py
@@ -14,6 +14,7 @@ from tests.third_party.cupy import testing
     'shape': [(0,), (10, 0), (10,), (10, 10)],
     'norm': [None, 'ortho', ''],
 }))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestFft(unittest.TestCase):
 
@@ -61,6 +62,7 @@ class TestFft(unittest.TestCase):
     {'shape': (3, 4), 's': (0, 5), 'axes': None, 'norm': None},
     {'shape': (3, 4), 's': (1, 0), 'axes': None, 'norm': None},
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestFft2(unittest.TestCase):
 
@@ -109,6 +111,7 @@ class TestFft2(unittest.TestCase):
     {'shape': (2, 0, 5), 's': None, 'axes': None, 'norm': None},
     {'shape': (0, 0, 5), 's': None, 'axes': None, 'norm': None},
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestFftn(unittest.TestCase):
 
@@ -136,6 +139,7 @@ class TestFftn(unittest.TestCase):
     'shape': [(10,), (10, 10)],
     'norm': [None, 'ortho'],
 }))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestRfft(unittest.TestCase):
 
@@ -160,6 +164,7 @@ class TestRfft(unittest.TestCase):
     {'shape': (3, 4), 's': None, 'axes': (), 'norm': None},
     {'shape': (2, 3, 4), 's': None, 'axes': (), 'norm': None},
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestRfft2EmptyAxes(unittest.TestCase):
 
@@ -182,6 +187,7 @@ class TestRfft2EmptyAxes(unittest.TestCase):
     {'shape': (3, 4), 's': None, 'axes': (), 'norm': None},
     {'shape': (2, 3, 4), 's': None, 'axes': (), 'norm': None},
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestRfftnEmptyAxes(unittest.TestCase):
 
@@ -205,6 +211,7 @@ class TestRfftnEmptyAxes(unittest.TestCase):
     'shape': [(10,), (10, 10)],
     'norm': [None, 'ortho'],
 }))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestHfft(unittest.TestCase):
 
@@ -230,6 +237,7 @@ class TestHfft(unittest.TestCase):
     {'n': 10, 'd': 0.5},
     {'n': 100, 'd': 2},
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestFftfreq(unittest.TestCase):
 
@@ -257,6 +265,7 @@ class TestFftfreq(unittest.TestCase):
     {'shape': (10, 10), 'axes': 0},
     {'shape': (10, 10), 'axes': (0, 1)},
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestFftshift(unittest.TestCase):
 

--- a/tests/third_party/cupy/indexing_tests/test_generate.py
+++ b/tests/third_party/cupy/indexing_tests/test_generate.py
@@ -7,6 +7,7 @@ import dpnp as cupy
 from tests.third_party.cupy import testing
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestIndices(unittest.TestCase):
 

--- a/tests/third_party/cupy/indexing_tests/test_indexing.py
+++ b/tests/third_party/cupy/indexing_tests/test_indexing.py
@@ -10,16 +10,19 @@ from tests.third_party.cupy import testing
 @testing.gpu
 class TestIndexing(unittest.TestCase):
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_take_by_scalar(self, xp):
         a = testing.shaped_arange((2, 4, 3), xp)
         return a.take(2, axis=1)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_external_take_by_scalar(self, xp):
         a = testing.shaped_arange((2, 4, 3), xp)
         return xp.take(a, 2, axis=1)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_take_by_array(self, xp):
         a = testing.shaped_arange((2, 4, 3), xp)
@@ -48,12 +51,14 @@ class TestIndexing(unittest.TestCase):
         b = xp.array([0], dtype=dtype)
         return a.take(b)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_take_along_axis(self, xp):
         a = testing.shaped_random((2, 4, 3), xp, dtype='float32')
         b = testing.shaped_random((2, 6, 3), xp, dtype='int64', scale=4)
         return xp.take_along_axis(a, b, axis=-2)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_take_along_axis_none_axis(self, xp):
         a = testing.shaped_random((2, 4, 3), xp, dtype='float32')
@@ -97,6 +102,7 @@ class TestIndexing(unittest.TestCase):
         a = testing.shaped_arange((3, 4, 5), xp, dtype)
         return a.diagonal(1, 2, 0)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_external_diagonal(self, xp, dtype):
@@ -189,6 +195,7 @@ class TestIndexing(unittest.TestCase):
         return xp.extract(b, a)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestChoose(unittest.TestCase):
 
@@ -339,6 +346,7 @@ class TestSelect(unittest.TestCase):
         with pytest.raises(AttributeError):
             cupy.select(condlist, choicelist)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes(no_bool=True)
     def test_select_type_error_choicelist(self, dtype):
         a, b = list(range(10)), list(range(-10, 0))

--- a/tests/third_party/cupy/indexing_tests/test_insert.py
+++ b/tests/third_party/cupy/indexing_tests/test_insert.py
@@ -64,6 +64,7 @@ class TestPlaceRaises(unittest.TestCase):
     'mode': ['raise', 'wrap', 'clip'],
     'n_vals': [0, 1, 3, 4, 5],
 }))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestPut(unittest.TestCase):
 
@@ -84,6 +85,7 @@ class TestPut(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'shape': [(7,), (2, 3), (4, 3, 2)],
 }))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestPutScalars(unittest.TestCase):
 
@@ -110,6 +112,7 @@ class TestPutScalars(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'shape': [(7,), (2, 3)],
 }))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestPutRaises(unittest.TestCase):
 
@@ -178,6 +181,7 @@ class TestPutmaskDifferentShapes(unittest.TestCase):
         return a
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestPutmask(unittest.TestCase):
 
@@ -232,6 +236,7 @@ class TestPutmaskDifferentDtypes(unittest.TestCase):
     'val': [1, 0, (2,), (2, 2)],
     'wrap': [True, False],
 }))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestFillDiagonal(unittest.TestCase):
 
@@ -308,6 +313,7 @@ class TestDiagIndicesFrom(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'shape': [(3, 5), (3, 3, 4), (5,), (0,), (-1,)],
 }))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDiagIndicesFromRaises(unittest.TestCase):
 

--- a/tests/third_party/cupy/linalg_tests/test_einsum.py
+++ b/tests/third_party/cupy/linalg_tests/test_einsum.py
@@ -13,6 +13,7 @@ def _dec_shape(shape, dec):
     return tuple(1 if s == 1 else max(0, s - dec) for s in shape)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestEinSumError(unittest.TestCase):
 
     def test_irregular_ellipsis1(self):
@@ -194,21 +195,25 @@ class TestListArgEinSumError(unittest.TestCase):
             with pytest.raises(ValueError):
                 xp.einsum(xp.arange(2), [None])
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_invalid_sub2(self):
         for xp in (numpy, cupy):
             with pytest.raises(ValueError):
                 xp.einsum(xp.arange(2), [0], [1])
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_invalid_sub3(self):
         for xp in (numpy, cupy):
             with pytest.raises(ValueError):
                 xp.einsum(xp.arange(2), [Ellipsis, 0, Ellipsis])
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_dim_mismatch1(self):
         for xp in (numpy, cupy):
             with pytest.raises(ValueError):
                 xp.einsum(xp.arange(2), [0], xp.arange(3), [0])
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_dim_mismatch2(self):
         for xp in (numpy, cupy):
             with pytest.raises(ValueError):
@@ -219,11 +224,13 @@ class TestListArgEinSumError(unittest.TestCase):
             with pytest.raises(ValueError):
                 xp.einsum(xp.arange(6).reshape(2, 3), [0, 0])
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_too_many_dims1(self):
         for xp in (numpy, cupy):
             with pytest.raises(ValueError):
                 xp.einsum(3, [0])
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_too_many_dims2(self):
         for xp in (numpy, cupy):
             with pytest.raises(ValueError):
@@ -298,6 +305,7 @@ class TestEinSumLarge(unittest.TestCase):
 
         self.operands = operands
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_einsum(self, xp):
         # TODO(kataoka): support memory efficient cupy.einsum

--- a/tests/third_party/cupy/linalg_tests/test_product.py
+++ b/tests/third_party/cupy/linalg_tests/test_product.py
@@ -31,6 +31,7 @@ from tests.third_party.cupy import testing
     'trans_a': [True, False],
     'trans_b': [True, False],
 }))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDot(unittest.TestCase):
 
@@ -89,6 +90,7 @@ class TestDot(unittest.TestCase):
         ((2, 4, 5, 2), (2, 4, 5, 2), 0, 0, -1),
     ],
 }))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestCrossProduct(unittest.TestCase):
 
@@ -224,6 +226,7 @@ class TestProduct(unittest.TestCase):
             (2, 2, 2, 3), xp, dtype).transpose(1, 3, 0, 2)
         return xp.vdot(a, b)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_inner(self, xp, dtype):
@@ -231,6 +234,7 @@ class TestProduct(unittest.TestCase):
         b = testing.shaped_reverse_arange((5,), xp, dtype)
         return xp.inner(a, b)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_reversed_inner(self, xp, dtype):
@@ -238,6 +242,7 @@ class TestProduct(unittest.TestCase):
         b = testing.shaped_reverse_arange((5,), xp, dtype)[::-1]
         return xp.inner(a, b)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_multidim_inner(self, xp, dtype):
@@ -273,6 +278,7 @@ class TestProduct(unittest.TestCase):
         b = testing.shaped_arange((4, 5), xp, dtype)
         return xp.outer(a, b)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_tensordot(self, xp, dtype):
@@ -287,6 +293,7 @@ class TestProduct(unittest.TestCase):
         b = testing.shaped_arange((4, 3, 2), xp, dtype).transpose(2, 0, 1)
         return xp.tensordot(a, b)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_tensordot_with_int_axes(self, xp, dtype):
@@ -316,6 +323,7 @@ class TestProduct(unittest.TestCase):
                 (5, 4, 3, 2), xp, dtype).transpose(3, 0, 2, 1)
             return xp.tensordot(a, b, axes=3)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_tensordot_with_list_axes(self, xp, dtype):
@@ -392,6 +400,7 @@ class TestProduct(unittest.TestCase):
         ((0, 0, 0), ([0, 2, 1], [1, 2, 0])),
     ],
 }))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestProductZeroLength(unittest.TestCase):
 
@@ -404,6 +413,7 @@ class TestProductZeroLength(unittest.TestCase):
 
 
 class TestMatrixPower(unittest.TestCase):
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_matrix_power_0(self, xp, dtype):
@@ -428,6 +438,7 @@ class TestMatrixPower(unittest.TestCase):
         a = testing.shaped_arange((3, 3), xp, dtype)
         return xp.linalg.matrix_power(a, 3)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1e-5)
     def test_matrix_power_inv1(self, xp, dtype):
@@ -435,6 +446,7 @@ class TestMatrixPower(unittest.TestCase):
         a = a * a % 30
         return xp.linalg.matrix_power(a, -1)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1e-5)
     def test_matrix_power_inv2(self, xp, dtype):
@@ -442,6 +454,7 @@ class TestMatrixPower(unittest.TestCase):
         a = a * a % 30
         return xp.linalg.matrix_power(a, -2)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1e-4)
     def test_matrix_power_inv3(self, xp, dtype):

--- a/tests/third_party/cupy/logic_tests/test_comparison.py
+++ b/tests/third_party/cupy/logic_tests/test_comparison.py
@@ -1,5 +1,6 @@
 import operator
 import unittest
+import pytest
 
 import numpy
 
@@ -7,6 +8,7 @@ import dpnp as cupy
 from tests.third_party.cupy import testing
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestComparison(unittest.TestCase):
 
@@ -36,6 +38,7 @@ class TestComparison(unittest.TestCase):
         self.check_binary('equal')
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestComparisonOperator(unittest.TestCase):
 
@@ -160,6 +163,7 @@ class TestAllclose(unittest.TestCase):
         return xp.allclose(a, b)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestIsclose(unittest.TestCase):
 
     @testing.for_all_dtypes(no_complex=True)

--- a/tests/third_party/cupy/logic_tests/test_content.py
+++ b/tests/third_party/cupy/logic_tests/test_content.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 
 import numpy
 
@@ -23,11 +24,14 @@ class TestContent(unittest.TestCase):
             dtype=dtype)
         return getattr(xp, name)(a)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_isfinite(self):
         self.check_unary_inf('isfinite')
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_isinf(self):
         self.check_unary_inf('isinf')
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_isnan(self):
         self.check_unary_nan('isnan')

--- a/tests/third_party/cupy/logic_tests/test_ops.py
+++ b/tests/third_party/cupy/logic_tests/test_ops.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 
 from tests.third_party.cupy import testing
 
@@ -19,14 +20,18 @@ class TestOps(unittest.TestCase):
         b = testing.shaped_reverse_arange((2, 3), xp, dtype)
         return getattr(xp, name)(a, b)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_logical_and(self):
         self.check_binary('logical_and')
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_logical_or(self):
         self.check_binary('logical_or')
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_logical_xor(self):
         self.check_binary('logical_xor')
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_logical_not(self):
         self.check_unary('logical_not')

--- a/tests/third_party/cupy/manipulation_tests/test_basic.py
+++ b/tests/third_party/cupy/manipulation_tests/test_basic.py
@@ -1,5 +1,6 @@
 import itertools
 import unittest
+import pytest
 
 import numpy
 
@@ -27,6 +28,7 @@ class TestBasic(unittest.TestCase):
         xp.copyto(b, a)
         return b
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_copyto_broadcast(self, xp, dtype):
@@ -35,6 +37,7 @@ class TestBasic(unittest.TestCase):
         xp.copyto(b, a)
         return b
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_copyto_where(self, xp, dtype):
@@ -107,6 +110,7 @@ class TestBasic(unittest.TestCase):
     *testing.product(
         {'src': [float(3.2), int(0), int(4), int(-4), True, False, 1 + 1j],
          'dst_shape': [(), (0,), (1,), (1, 1), (2, 2)]}))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestCopytoFromScalar(unittest.TestCase):
 

--- a/tests/third_party/cupy/manipulation_tests/test_dims.py
+++ b/tests/third_party/cupy/manipulation_tests/test_dims.py
@@ -19,15 +19,18 @@ class TestDims(unittest.TestCase):
         f = numpy.float32(1)
         return func(a, b, c, d, e, f)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_atleast_1d1(self, xp):
         return self.check_atleast(xp.atleast_1d, xp)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_atleast_1d2(self, xp):
         a = testing.shaped_arange((1, 3, 2), xp)
         return xp.atleast_1d(a)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_atleast_2d1(self, xp):
         return self.check_atleast(xp.atleast_2d, xp)
@@ -37,6 +40,7 @@ class TestDims(unittest.TestCase):
         a = testing.shaped_arange((1, 3, 2), xp)
         return xp.atleast_2d(a)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_atleast_3d1(self, xp):
         return self.check_atleast(xp.atleast_3d, xp)

--- a/tests/third_party/cupy/manipulation_tests/test_tiling.py
+++ b/tests/third_party/cupy/manipulation_tests/test_tiling.py
@@ -16,6 +16,7 @@ from tests.third_party.cupy import testing
     {'repeats': [1, 2, 3], 'axis': 1},
     {'repeats': [1, 2, 3], 'axis': -2},
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestRepeat(unittest.TestCase):
 
@@ -44,6 +45,7 @@ class TestRepeatRepeatsNdarray(unittest.TestCase):
     {'repeats': [2], 'axis': None},
     {'repeats': [2], 'axis': 1},
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestRepeatListBroadcast(unittest.TestCase):
 
@@ -65,6 +67,7 @@ class TestRepeatListBroadcast(unittest.TestCase):
     {'repeats': [1, 2, 3, 4], 'axis': None},
     {'repeats': [1, 2, 3, 4], 'axis': 0},
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestRepeat1D(unittest.TestCase):
 
@@ -97,6 +100,7 @@ class TestRepeat1DListBroadcast(unittest.TestCase):
     {'repeats': 2, 'axis': -4},
     {'repeats': 2, 'axis': 3},
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestRepeatFailure(unittest.TestCase):
 

--- a/tests/third_party/cupy/manipulation_tests/test_transpose.py
+++ b/tests/third_party/cupy/manipulation_tests/test_transpose.py
@@ -41,12 +41,14 @@ class TestTranspose(unittest.TestCase):
         return xp.moveaxis(a, [0, 2, 1], [3, 4, 0])
 
     # dim is too large
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_moveaxis_invalid1_1(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3, 4), xp)
             with pytest.raises(numpy.AxisError):
                 xp.moveaxis(a, [0, 1], [1, 3])
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_moveaxis_invalid1_2(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3, 4), xp)
@@ -54,12 +56,14 @@ class TestTranspose(unittest.TestCase):
                 xp.moveaxis(a, [0, 1], [1, 3])
 
     # dim is too small
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_moveaxis_invalid2_1(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3, 4), xp)
             with pytest.raises(numpy.AxisError):
                 xp.moveaxis(a, [0, -4], [1, 2])
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_moveaxis_invalid2_2(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3, 4), xp)
@@ -67,6 +71,7 @@ class TestTranspose(unittest.TestCase):
                 xp.moveaxis(a, [0, -4], [1, 2])
 
     # len(source) != len(destination)
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_moveaxis_invalid3(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3, 4), xp)
@@ -74,6 +79,7 @@ class TestTranspose(unittest.TestCase):
                 xp.moveaxis(a, [0, 1, 2], [1, 2])
 
     # len(source) != len(destination)
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_moveaxis_invalid4(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3, 4), xp)
@@ -81,6 +87,7 @@ class TestTranspose(unittest.TestCase):
                 xp.moveaxis(a, [0, 1], [1, 2, 0])
 
     # Use the same axis twice
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_moveaxis_invalid5_1(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3, 4), xp)
@@ -104,6 +111,7 @@ class TestTranspose(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), xp)
         return xp.rollaxis(a, 2)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_rollaxis_failure(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3, 4), xp)
@@ -115,6 +123,7 @@ class TestTranspose(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), xp)
         return xp.swapaxes(a, 2, 0)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_swapaxes_failure(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3, 4), xp)

--- a/tests/third_party/cupy/math_tests/test_arithmetic.py
+++ b/tests/third_party/cupy/math_tests/test_arithmetic.py
@@ -57,6 +57,7 @@ class TestArithmeticRaisesWithNumpyInput(unittest.TestCase):
         'name': ['reciprocal'],
     })
 ))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestArithmeticUnary(unittest.TestCase):
 
     @testing.numpy_cupy_allclose(atol=1e-5)
@@ -177,6 +178,7 @@ class ArithmeticBinaryBase:
         'name': ['divide', 'true_divide', 'subtract'],
     })
 ))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestArithmeticBinary(ArithmeticBinaryBase, unittest.TestCase):
 
     def test_binary(self):
@@ -226,6 +228,7 @@ class TestArithmeticBinary(ArithmeticBinaryBase, unittest.TestCase):
         'use_dtype': [True, False],
     })
 ))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestArithmeticBinary2(ArithmeticBinaryBase, unittest.TestCase):
 
     def test_binary(self):
@@ -252,6 +255,7 @@ class TestArithmeticModf(unittest.TestCase):
     'xp': [numpy, cupy],
     'shape': [(3, 2), (), (3, 0, 2)]
 }))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestBoolSubtract(unittest.TestCase):
 

--- a/tests/third_party/cupy/math_tests/test_matmul.py
+++ b/tests/third_party/cupy/math_tests/test_matmul.py
@@ -54,6 +54,7 @@ from tests.third_party.cupy import testing
             ((1, 3, 3), (10, 1, 3, 1)),
         ],
     }))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestMatmul(unittest.TestCase):
 
@@ -88,6 +89,7 @@ class TestMatmul(unittest.TestCase):
             ((6, 5, 3, 2), (2,)),
         ],
     }))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestMatmulLarge(unittest.TestCase):
 
@@ -138,6 +140,7 @@ class TestMatmulLarge(unittest.TestCase):
             ((0, 1, 1), (2, 1, 1)),
         ],
     }))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestMatmulInvalidShape(unittest.TestCase):
 

--- a/tests/third_party/cupy/math_tests/test_rounding.py
+++ b/tests/third_party/cupy/math_tests/test_rounding.py
@@ -77,6 +77,7 @@ class TestRounding(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'decimals': [-2, -1, 0, 1, 2],
 }))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestRound(unittest.TestCase):
 
     shape = (20,)
@@ -136,6 +137,7 @@ class TestRoundExtreme(unittest.TestCase):
         (1.6, 0),
     ]
 }))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestRoundBorder(unittest.TestCase):
 
     @testing.numpy_cupy_allclose(atol=1e-5)

--- a/tests/third_party/cupy/math_tests/test_sumprod.py
+++ b/tests/third_party/cupy/math_tests/test_sumprod.py
@@ -227,6 +227,7 @@ class TestNansumNanprodLong(unittest.TestCase):
         'shape': [(2, 3, 4), (20, 30, 40)],
     })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestNansumNanprodExtra(unittest.TestCase):
 
@@ -254,6 +255,7 @@ class TestNansumNanprodExtra(unittest.TestCase):
         'axis': [(1, 3), (0, 2, 3)],
     })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestNansumNanprodAxes(unittest.TestCase):
     @testing.for_all_dtypes(no_bool=True, no_float16=True)
@@ -269,6 +271,7 @@ axes = [0, 1, 2]
 
 
 @testing.parameterize(*testing.product({'axis': axes}))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestCumsum(unittest.TestCase):
 
@@ -387,6 +390,7 @@ class TestCumprod(unittest.TestCase):
         a = testing.shaped_arange((5,), xp, dtype)
         return xp.cumprod(a)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_cumprod_out(self, xp, dtype):
@@ -409,6 +413,7 @@ class TestCumprod(unittest.TestCase):
         a = testing.shaped_arange((4, 5), xp, dtype)
         return xp.cumprod(a)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_cumprod_2dim_with_axis(self, xp, dtype):
@@ -434,6 +439,7 @@ class TestCumprod(unittest.TestCase):
         del result
         cupy.get_default_memory_pool().free_all_blocks()
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     def test_invalid_axis_lower1(self, dtype):
         for xp in (numpy, cupy):
@@ -441,6 +447,7 @@ class TestCumprod(unittest.TestCase):
             with pytest.raises(numpy.AxisError):
                 xp.cumprod(a, axis=-a.ndim - 1)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     def test_invalid_axis_lower2(self, dtype):
         for xp in (numpy, cupy):
@@ -448,6 +455,7 @@ class TestCumprod(unittest.TestCase):
             with pytest.raises(numpy.AxisError):
                 xp.cumprod(a, axis=-a.ndim - 1)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     def test_invalid_axis_upper1(self, dtype):
         for xp in (numpy, cupy):
@@ -455,6 +463,7 @@ class TestCumprod(unittest.TestCase):
             with pytest.raises(numpy.AxisError):
                 return xp.cumprod(a, axis=a.ndim)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     def test_invalid_axis_upper2(self, dtype):
         a = testing.shaped_arange((4, 5), cupy, dtype)
@@ -521,6 +530,7 @@ class TestDiff(unittest.TestCase):
         b = testing.shaped_arange((1, 5), xp, dtype)
         return xp.diff(a, axis=0, append=b, n=2)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.with_requires('numpy>=1.16')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
@@ -528,6 +538,7 @@ class TestDiff(unittest.TestCase):
         a = testing.shaped_arange((4, 5), xp, dtype)
         return xp.diff(a, prepend=1, append=0)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.with_requires('numpy>=1.16')
     def test_diff_invalid_axis(self):
         for xp in (numpy, cupy):

--- a/tests/third_party/cupy/random_tests/test_distributions.py
+++ b/tests/third_party/cupy/random_tests/test_distributions.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 
 import numpy
 
@@ -31,6 +32,7 @@ class RandomDistributionsTestCase(unittest.TestCase):
     'b_shape': [(), (3, 2)],
 })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDistributionsBeta(RandomDistributionsTestCase):
 
@@ -68,6 +70,7 @@ class TestDistributionsBinomial(RandomDistributionsTestCase):
     'df_shape': [(), (3, 2)],
 })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDistributionsChisquare(unittest.TestCase):
 
@@ -88,6 +91,7 @@ class TestDistributionsChisquare(unittest.TestCase):
     'alpha_shape': [(3,)],
 })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDistributionsDirichlet(RandomDistributionsTestCase):
 
@@ -103,6 +107,7 @@ class TestDistributionsDirichlet(RandomDistributionsTestCase):
     'scale_shape': [(), (3, 2)],
 })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDistributionsExponential(RandomDistributionsTestCase):
 
@@ -112,6 +117,7 @@ class TestDistributionsExponential(RandomDistributionsTestCase):
         self.check_distribution('exponential', {'scale': scale})
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDistributionsExponentialError(RandomDistributionsTestCase):
 
@@ -127,6 +133,7 @@ class TestDistributionsExponentialError(RandomDistributionsTestCase):
     'dfden_shape': [(), (3, 2)],
 })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDistributionsF(unittest.TestCase):
 
@@ -151,6 +158,7 @@ class TestDistributionsF(unittest.TestCase):
     'scale_shape': [(), (3, 2)],
 })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDistributionsGamma(unittest.TestCase):
 
@@ -194,6 +202,7 @@ class TestDistributionsGeometric(unittest.TestCase):
     'scale_shape': [(), (3, 2)],
 })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDistributionsGumbel(RandomDistributionsTestCase):
 
@@ -239,6 +248,7 @@ class TestDistributionsHyperGeometric(unittest.TestCase):
     'scale_shape': [(), (3, 2)],
 })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDistributionsuLaplace(RandomDistributionsTestCase):
 
@@ -256,6 +266,7 @@ class TestDistributionsuLaplace(RandomDistributionsTestCase):
     'scale_shape': [(), (3, 2)],
 })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDistributionsLogistic(RandomDistributionsTestCase):
 
@@ -342,6 +353,7 @@ class TestDistributionsMultivariateNormal(unittest.TestCase):
     'p_shape': [(), (3, 2)],
 })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDistributionsNegativeBinomial(RandomDistributionsTestCase):
 
@@ -368,6 +380,7 @@ class TestDistributionsNegativeBinomial(RandomDistributionsTestCase):
     'nonc_shape': [(), (3, 2)],
 })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDistributionsNoncentralChisquare(RandomDistributionsTestCase):
 
@@ -401,6 +414,7 @@ class TestDistributionsNoncentralChisquare(RandomDistributionsTestCase):
     'nonc_shape': [(), (3, 2)],
 })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDistributionsNoncentralF(RandomDistributionsTestCase):
 
@@ -444,6 +458,7 @@ class TestDistributionsNoncentralF(RandomDistributionsTestCase):
     'scale_shape': [(), (3, 2)],
 })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDistributionsNormal(RandomDistributionsTestCase):
 
@@ -460,6 +475,7 @@ class TestDistributionsNormal(RandomDistributionsTestCase):
     'a_shape': [(), (3, 2)],
 })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDistributionsPareto(unittest.TestCase):
 
@@ -523,6 +539,7 @@ class TestDistributionsPower(RandomDistributionsTestCase):
     'scale_shape': [(), (3, 2)],
 })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDistributionsRayleigh(RandomDistributionsTestCase):
 
@@ -571,6 +588,7 @@ class TestDistributionsStandardExponential(RandomDistributionsTestCase):
     'shape_shape': [(), (3, 2)],
 })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDistributionsStandardGamma(RandomDistributionsTestCase):
 
@@ -597,6 +615,7 @@ class TestDistributionsStandardNormal(RandomDistributionsTestCase):
     'df_shape': [(), (3, 2)],
 })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDistributionsStandardT(unittest.TestCase):
 
@@ -619,6 +638,7 @@ class TestDistributionsStandardT(unittest.TestCase):
     'right_shape': [(), (3, 2)],
 })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDistributionsTriangular(RandomDistributionsTestCase):
 
@@ -662,6 +682,7 @@ class TestDistributionsTriangular(RandomDistributionsTestCase):
     'high_shape': [(), (3, 2)],
 })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDistributionsUniform(RandomDistributionsTestCase):
 
@@ -679,6 +700,7 @@ class TestDistributionsUniform(RandomDistributionsTestCase):
     'kappa_shape': [(), (3, 2)],
 })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDistributionsVonmises(unittest.TestCase):
 
@@ -703,6 +725,7 @@ class TestDistributionsVonmises(unittest.TestCase):
     'scale_shape': [(), (3, 2)],
 })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDistributionsWald(RandomDistributionsTestCase):
 
@@ -720,6 +743,7 @@ class TestDistributionsWald(RandomDistributionsTestCase):
     'a_shape': [(), (3, 2)],
 })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDistributionsWeibull(RandomDistributionsTestCase):
 
@@ -746,6 +770,7 @@ class TestDistributionsWeibull(RandomDistributionsTestCase):
     'a_shape': [(), (3, 2)],
 })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestDistributionsZipf(RandomDistributionsTestCase):
 

--- a/tests/third_party/cupy/random_tests/test_sample.py
+++ b/tests/third_party/cupy/random_tests/test_sample.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest import mock
+import pytest
 
 import numpy
 
@@ -32,6 +33,7 @@ class TestRandint(unittest.TestCase):
         a = random.randint(-1.1, -0.9, size=(2, 2))
         numpy.testing.assert_array_equal(a, cupy.full((2, 2), -1))
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_zero_sizes(self):
         a = random.randint(10, size=(0,))
         numpy.testing.assert_array_equal(a, cupy.array(()))
@@ -44,6 +46,7 @@ class TestRandint(unittest.TestCase):
 @testing.gpu
 class TestRandint2(unittest.TestCase):
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @condition.repeat(3, 10)
     def test_bound_1(self):
         vals = [random.randint(0, 10, (2, 3)) for _ in range(10)]
@@ -52,6 +55,7 @@ class TestRandint2(unittest.TestCase):
         self.assertEqual(min(_.min() for _ in vals), 0)
         self.assertEqual(max(_.max() for _ in vals), 9)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @condition.repeat(3, 10)
     def test_bound_2(self):
         vals = [random.randint(0, 2) for _ in range(20)]
@@ -60,6 +64,7 @@ class TestRandint2(unittest.TestCase):
         self.assertEqual(min(_.min() for _ in vals), 0)
         self.assertEqual(max(_.max() for _ in vals), 1)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @condition.repeat(3, 10)
     def test_bound_overflow(self):
         # 100 - (-100) exceeds the range of int8
@@ -68,6 +73,7 @@ class TestRandint2(unittest.TestCase):
         self.assertGreaterEqual(val.min(), -100)
         self.assertLess(val.max(), 100)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @condition.repeat(3, 10)
     def test_bound_float1(self):
         # generate floats s.t. int(low) < int(high)
@@ -80,6 +86,7 @@ class TestRandint2(unittest.TestCase):
         self.assertEqual(min(_.min() for _ in vals), int(low))
         self.assertEqual(max(_.max() for _ in vals), int(high) - 1)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_bound_float2(self):
         vals = [random.randint(-1.0, 1.0, (2, 3)) for _ in range(10)]
         for val in vals:
@@ -105,6 +112,7 @@ class TestRandint2(unittest.TestCase):
         self.assertTrue(hypothesis.chi_square_test(counts, expected))
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestRandintDtype(unittest.TestCase):
 

--- a/tests/third_party/cupy/sorting_tests/test_search.py
+++ b/tests/third_party/cupy/sorting_tests/test_search.py
@@ -29,30 +29,35 @@ class TestSearch(unittest.TestCase):
         a = xp.array([float('nan'), -1, 1], dtype)
         return a.argmax()
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_argmax_axis_large(self, xp, dtype):
         a = testing.shaped_random((3, 1000), xp, dtype)
         return a.argmax(axis=0)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_external_argmax_axis_large(self, xp, dtype):
         a = testing.shaped_random((3, 1000), xp, dtype)
         return xp.argmax(a, axis=0)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_argmax_axis0(self, xp, dtype):
         a = testing.shaped_random((2, 3, 4), xp, dtype)
         return a.argmax(axis=0)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_argmax_axis1(self, xp, dtype):
         a = testing.shaped_random((2, 3, 4), xp, dtype)
         return a.argmax(axis=1)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_argmax_axis2(self, xp, dtype):
@@ -72,6 +77,7 @@ class TestSearch(unittest.TestCase):
             with pytest.raises(ValueError):
                 a.argmax()
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes(no_complex=True)
     def test_argmax_zero_size_axis0(self, dtype):
         for xp in (numpy, cupy):
@@ -79,6 +85,7 @@ class TestSearch(unittest.TestCase):
             with pytest.raises(ValueError):
                 a.argmax(axis=0)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_argmax_zero_size_axis1(self, xp, dtype):
@@ -103,30 +110,35 @@ class TestSearch(unittest.TestCase):
         a = testing.shaped_random((2, 3), xp, dtype)
         return xp.argmin(a)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_argmin_axis_large(self, xp, dtype):
         a = testing.shaped_random((3, 1000), xp, dtype)
         return a.argmin(axis=0)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_external_argmin_axis_large(self, xp, dtype):
         a = testing.shaped_random((3, 1000), xp, dtype)
         return xp.argmin(a, axis=0)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_argmin_axis0(self, xp, dtype):
         a = testing.shaped_random((2, 3, 4), xp, dtype)
         return a.argmin(axis=0)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_argmin_axis1(self, xp, dtype):
         a = testing.shaped_random((2, 3, 4), xp, dtype)
         return a.argmin(axis=1)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_argmin_axis2(self, xp, dtype):
@@ -146,6 +158,7 @@ class TestSearch(unittest.TestCase):
             with pytest.raises(ValueError):
                 return a.argmin()
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes(no_complex=True)
     def test_argmin_zero_size_axis0(self, dtype):
         for xp in (numpy, cupy):
@@ -153,6 +166,7 @@ class TestSearch(unittest.TestCase):
             with pytest.raises(ValueError):
                 a.argmin(axis=0)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_argmin_zero_size_axis1(self, xp, dtype):
@@ -571,6 +585,7 @@ class TestNanArgMax(unittest.TestCase):
         'side': ['left', 'right'],
         'shape': [(), (10,), (6, 3, 3)]})
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestSearchSorted(unittest.TestCase):
 
     @testing.for_all_dtypes(no_bool=True)
@@ -586,6 +601,7 @@ class TestSearchSorted(unittest.TestCase):
 @testing.parameterize(
     {'side': 'left'},
     {'side': 'right'})
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestSearchSortedNanInf(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
@@ -648,6 +664,7 @@ class TestSearchSortedNanInf(unittest.TestCase):
         return y,
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestSearchSortedInvalid(unittest.TestCase):
 
@@ -662,6 +679,7 @@ class TestSearchSortedInvalid(unittest.TestCase):
                 xp.searchsorted(bins, x)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestSearchSortedWithSorter(unittest.TestCase):
 

--- a/tests/third_party/cupy/sorting_tests/test_sort.py
+++ b/tests/third_party/cupy/sorting_tests/test_sort.py
@@ -34,12 +34,14 @@ class TestSort(unittest.TestCase):
             with pytest.raises(numpy.AxisError):
                 xp.sort(a)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_sort_two_or_more_dim(self, xp):
         a = testing.shaped_random((2, 3, 3), xp)
         a.sort()
         return a
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_external_sort_two_or_more_dim(self, xp):
         a = testing.shaped_random((2, 3, 3), xp)
@@ -103,6 +105,7 @@ class TestSort(unittest.TestCase):
         a.sort(axis=2)
         return a
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_external_sort_axis(self, xp):
         a = testing.shaped_random((2, 3, 3), xp)
@@ -114,11 +117,13 @@ class TestSort(unittest.TestCase):
         a.sort(axis=-2)
         return a
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_external_sort_negative_axis(self, xp):
         a = testing.shaped_random((2, 3, 3), xp)
         return xp.sort(a, axis=-2)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_external_sort_none_axis(self, xp):
         a = testing.shaped_random((2, 3, 3), xp)
@@ -135,12 +140,14 @@ class TestSort(unittest.TestCase):
         with self.assertRaises(numpy.AxisError):
             a.sort(axis=3)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_external_sort_invalid_axis1(self):
         for xp in (numpy, cupy):
             a = testing.shaped_random((2, 3, 3), xp)
             with pytest.raises(numpy.AxisError):
                 xp.sort(a, axis=3)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_external_sort_invalid_axis2(self):
         a = testing.shaped_random((2, 3, 3), cupy)
         with self.assertRaises(numpy.AxisError):
@@ -157,12 +164,14 @@ class TestSort(unittest.TestCase):
         with self.assertRaises(numpy.AxisError):
             a.sort(axis=-4)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_external_sort_invalid_negative_axis1(self):
         for xp in (numpy, cupy):
             a = testing.shaped_random((2, 3, 3), xp)
             with pytest.raises(numpy.AxisError):
                 xp.sort(a, axis=-4)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_external_sort_invalid_negative_axis2(self):
         a = testing.shaped_random((2, 3, 3), cupy)
         with self.assertRaises(numpy.AxisError):
@@ -459,6 +468,7 @@ class TestSort_complex(unittest.TestCase):
     'external': [False, True],
     'length': [10, 20000],
 }))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestPartition(unittest.TestCase):
 

--- a/tests/third_party/cupy/statistics_tests/test_correlation.py
+++ b/tests/third_party/cupy/statistics_tests/test_correlation.py
@@ -70,6 +70,7 @@ class TestCov(unittest.TestCase):
             with pytest.raises(ValueError):
                 xp.cov(a, y, rowvar, bias, ddof)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_cov(self):
         self.check((2, 3))
         self.check((2,), (2,))
@@ -78,10 +79,12 @@ class TestCov(unittest.TestCase):
         self.check((2, 3), bias=True)
         self.check((2, 3), ddof=2)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_cov_warns(self):
         self.check_warns((2, 3), ddof=3)
         self.check_warns((2, 3), ddof=4)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_cov_raises(self):
         self.check_raises((2, 3), ddof=1.2)
         self.check_raises((3, 4, 2))
@@ -97,6 +100,7 @@ class TestCov(unittest.TestCase):
     'shape1': [(5,), (6,), (20,), (21,)],
     'shape2': [(5,), (6,), (20,), (21,)],
 }))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestCorrelateShapeCombination(unittest.TestCase):
 
     @testing.for_all_dtypes(no_float16=True)
@@ -111,6 +115,7 @@ class TestCorrelateShapeCombination(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'mode': ['valid', 'full', 'same']
 }))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestCorrelate(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -139,6 +144,7 @@ class TestCorrelate(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'mode': ['valid', 'same', 'full']
 }))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestCorrelateInvalid(unittest.TestCase):
 
     @testing.with_requires('numpy>=1.18')

--- a/tests/third_party/cupy/statistics_tests/test_histogram.py
+++ b/tests/third_party/cupy/statistics_tests/test_histogram.py
@@ -138,6 +138,7 @@ class TestHistogram(unittest.TestCase):
         assert xp.issubdtype(h.dtype, xp.floating)
         return h
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_histogram_weights_basic(self):
         v = cupy.random.rand(100)
         w = cupy.ones(100) * 5

--- a/tests/third_party/cupy/statistics_tests/test_meanvar.py
+++ b/tests/third_party/cupy/statistics_tests/test_meanvar.py
@@ -19,36 +19,42 @@ class TestMedian(unittest.TestCase):
         a = testing.shaped_random((3, 4, 5), xp, dtype)
         return xp.median(a)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_median_axis1(self, xp, dtype):
         a = testing.shaped_random((3, 4, 5), xp, dtype)
         return xp.median(a, axis=1)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_median_axis2(self, xp, dtype):
         a = testing.shaped_random((3, 4, 5), xp, dtype)
         return xp.median(a, axis=2)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_median_overwrite_input(self, xp, dtype):
         a = testing.shaped_random((3, 4, 5), xp, dtype)
         return xp.median(a, overwrite_input=True)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_median_keepdims_axis1(self, xp, dtype):
         a = testing.shaped_random((3, 4, 5), xp, dtype)
         return xp.median(a, axis=1, keepdims=True)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_median_keepdims_noaxis(self, xp, dtype):
         a = testing.shaped_random((3, 4, 5), xp, dtype)
         return xp.median(a, keepdims=True)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_median_invalid_axis(self):
         for xp in [numpy, cupy]:
             a = testing.shaped_random((3, 4, 5), xp)
@@ -72,6 +78,7 @@ class TestMedian(unittest.TestCase):
         'keepdims': [True, False]
     })
 )
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestMedianAxis(unittest.TestCase):
 
@@ -82,6 +89,7 @@ class TestMedianAxis(unittest.TestCase):
         return xp.median(a, self.axis, keepdims=self.keepdims)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestAverage(unittest.TestCase):
 
@@ -148,6 +156,7 @@ class TestMeanVar(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return xp.mean(a)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_mean_axis(self, xp, dtype):
@@ -160,18 +169,21 @@ class TestMeanVar(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return xp.mean(a, axis=1)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_mean_all_float64_dtype(self, xp, dtype):
         a = xp.full((2, 3, 4), 123456789, dtype=dtype)
         return xp.mean(a, dtype=numpy.float64)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_mean_all_int64_dtype(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return xp.mean(a, dtype=numpy.int64)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_mean_all_complex_dtype(self, xp, dtype):
@@ -202,24 +214,28 @@ class TestMeanVar(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return xp.var(a, ddof=1)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_var_axis(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return a.var(axis=1)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_external_var_axis(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return xp.var(a, axis=1)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_var_axis_ddof(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return a.var(axis=1, ddof=1)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_external_var_axis_ddof(self, xp, dtype):
@@ -250,24 +266,28 @@ class TestMeanVar(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return xp.std(a, ddof=1)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_std_axis(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return a.std(axis=1)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_external_std_axis(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return xp.std(a, axis=1)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_std_axis_ddof(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return a.std(axis=1, ddof=1)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_external_std_axis_ddof(self, xp, dtype):
@@ -454,6 +474,7 @@ class TestNanVarStdAdditional(unittest.TestCase):
     ],
     'func': ['mean', 'std', 'var'],
 }))
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestProductZeroLength(unittest.TestCase):
 


### PR DESCRIPTION
Previously DPNP fell back on NumPy implementation when a requested functionality isn't available and can't be provided by DPNP.
The PR is indented to raise `Non-implemented` exception in that scenario by default, rather than falling back.

It will be possible to keep old behavior with falling back on NumPy calls by setting a new environment variable `DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK = 0`.
In all other cases, the fallback is prohibited and lead to the exception.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
