### PR TITLE
Get rid of env var which handles dep on dpctl.tensor

### DIFF
--- a/dpnp/config.py
+++ b/dpnp/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # *****************************************************************************
-# Copyright (c) 2016-2020, Intel Corporation
+# Copyright (c) 2016-2022, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -41,11 +41,6 @@ Explicitly use GPU for SYCL queue
 __DPNP_OUTPUT_NUMPY__ = int(os.getenv('DPNP_OUTPUT_NUMPY', 0))
 '''
 Explicitly use NumPy.ndarray as return type for creation functions
-'''
-
-__DPNP_OUTPUT_DPCTL__ = int(os.getenv('DPNP_OUTPUT_DPCTL', 1))
-'''
-Explicitly use DPCtl package container as return type for creation functions
 '''
 
 __DPNP_OUTPUT_DPCTL_DEFAULT_SHARED__ = int(os.getenv('DPNP_OUTPUT_DPCTL_DEFAULT_SHARED', 0))

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -443,7 +443,9 @@ class dpnp_array:
 
         """
 
-        return dpnp.astype(self, dtype, order, casting, subok, copy)
+        new_array = self.__new__(dpnp_array)
+        new_array._array_obj = dpt.astype(self._array_obj, dtype, order=order, casting=casting, copy=copy)
+        return new_array
 
  # 'base',
  # 'byteswap',

--- a/dpnp/dpnp_iface.py
+++ b/dpnp/dpnp_iface.py
@@ -49,6 +49,7 @@ import collections
 import dpctl
 import dpctl.tensor as dpt
 
+from dpnp.dpnp_array import dpnp_array
 from dpnp.dpnp_algo import *
 from dpnp.dpnp_utils import *
 from dpnp.fft import *
@@ -137,24 +138,22 @@ def asnumpy(input, order='C'):
     This function works exactly the same as :obj:`numpy.asarray`.
 
     """
+    if isinstance(input, dpnp_array):
+        return dpt.to_numpy(input.get_array())
 
-    if isinstance(input, dpctl.tensor.usm_ndarray):
-        return dpctl.tensor.to_numpy(input)
-
-    if config.__DPNP_OUTPUT_DPCTL__ and hasattr(input, "__sycl_usm_array_interface__"):
-        return dpctl.tensor.to_numpy(input.get_array())
+    if isinstance(input, dpt.usm_ndarray):
+        return dpt.to_numpy(input)
 
     return numpy.asarray(input, order=order)
 
 
 def astype(x1, dtype, order='K', casting='unsafe', subok=True, copy=True):
     """Copy the array with data type casting."""
-    if config.__DPNP_OUTPUT_DPCTL__ and hasattr(x1, "__sycl_usm_array_interface__"):
-        import dpctl.tensor as dpt
-        # TODO: remove check dpctl.tensor has attribute "astype"
-        if hasattr(dpt, "astype"):
-            # return dpt.astype(x1, dtype, order=order, casting=casting, copy=copy)
-            return dpt.astype(x1.get_array(), dtype, order=order, casting=casting, copy=copy)
+    if isinstance(x1, dpnp_array):
+        return dpt.astype(x1.get_array(), dtype, order=order, casting=casting, copy=copy)
+
+    if isinstance(x1, dpt.usm_ndarray):
+        return dpt.astype(x1, dtype, order=order, casting=casting, copy=copy)
 
     x1_desc = get_dpnp_descriptor(x1)
     if not x1_desc:

--- a/dpnp/dpnp_iface.py
+++ b/dpnp/dpnp_iface.py
@@ -139,10 +139,10 @@ def asnumpy(input, order='C'):
 
     """
     if isinstance(input, dpnp_array):
-        return dpt.to_numpy(input.get_array())
+        return dpt.asnumpy(input.get_array())
 
     if isinstance(input, dpt.usm_ndarray):
-        return dpt.to_numpy(input)
+        return dpt.asnumpy(input)
 
     return numpy.asarray(input, order=order)
 
@@ -150,12 +150,12 @@ def asnumpy(input, order='C'):
 def astype(x1, dtype, order='K', casting='unsafe', subok=True, copy=True):
     """Copy the array with data type casting."""
     if isinstance(x1, dpnp_array):
-        return dpt.astype(x1.get_array(), dtype, order=order, casting=casting, copy=copy)
+        return x1.astype(dtype, order=order, casting=casting, copy=copy)
 
     if isinstance(x1, dpt.usm_ndarray):
         return dpt.astype(x1, dtype, order=order, casting=casting, copy=copy)
 
-    x1_desc = get_dpnp_descriptor(x1)
+    x1_desc = get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if not x1_desc:
         pass
     elif order != 'K':

--- a/dpnp/dpnp_utils/dpnp_algo_utils.pyx
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pyx
@@ -1,7 +1,7 @@
 # cython: language_level=3
 # -*- coding: utf-8 -*-
 # *****************************************************************************
-# Copyright (c) 2016-2020, Intel Corporation
+# Copyright (c) 2016-2022, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -100,9 +100,8 @@ def convert_list_args(input_list):
 
 def copy_from_origin(dst, src):
     """Copy origin result to output result."""
-    if config.__DPNP_OUTPUT_DPCTL__ and hasattr(dst, "__sycl_usm_array_interface__"):
+    if hasattr(dst, "__sycl_usm_array_interface__"):
         if src.size:
-            # dst.usm_data.copy_from_host(src.reshape(-1).view("|u1"))
             dpctl.tensor._copy_utils._copy_from_numpy_into(unwrap_array(dst), src)
     else:
         for i in range(dst.size):

--- a/dpnp/dpnp_utils/dpnp_algo_utils.pyx
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pyx
@@ -102,7 +102,8 @@ def copy_from_origin(dst, src):
     """Copy origin result to output result."""
     if hasattr(dst, "__sycl_usm_array_interface__"):
         if src.size:
-            dpctl.tensor._copy_utils._copy_from_numpy_into(unwrap_array(dst), src)
+            dst_dpt = unwrap_array(dst)
+            dst_dpt[...] = src
     else:
         for i in range(dst.size):
             dst.flat[i] = src.item(i)


### PR DESCRIPTION
DPNP has a run dependency on DPCTL from meta.yaml, assuming `dpctl.tensor` has to be deployed when DPNP is running.
There is no need to have an environment variable `__DPNP_OUTPUT_DPCTL__`, which controls if a function from `dpctl.tensor` module can be used.
This PR is some kind of clean up to remove code relating to the obsolete environment variable `__DPNP_OUTPUT_DPCTL__`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
