### PR TITLE
update numpy restriction by adding numpy 1.22

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -8,7 +8,7 @@ requirements:
     host:
       - python
       - setuptools
-      - numpy >=1.19,<1.22a0
+      - numpy >=1.19,<1.23
       - cython
       - cmake >=3.19
       - dpctl >=0.13

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -8,7 +8,7 @@ requirements:
     host:
       - python
       - setuptools
-      - numpy >=1.19,<1.23
+      - numpy >=1.19,<1.23a0
       - cython
       - cmake >=3.19
       - dpctl >=0.13


### PR DESCRIPTION
Update numpy restrictions because now dpnp is still building with numpy 1.21 instead 1.22
- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
