### PR TITLE
Import of deprecated dpnp.dparray class caused exception

### DIFF
--- a/dpnp/dparray.pyx
+++ b/dpnp/dparray.pyx
@@ -1,7 +1,7 @@
 # cython: language_level=3
 # -*- coding: utf-8 -*-
 # *****************************************************************************
-# Copyright (c) 2016-2020, Intel Corporation
+# Copyright (c) 2016-2022, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -33,23 +33,26 @@ using USB interface for an Intel GPU device.
 
 """
 
+import warnings
 
 from libcpp cimport bool as cpp_bool
 
 from dpnp.dpnp_iface_types import *
-from dpnp.dpnp_iface import *
 
 # to avoid interference with Python internal functions
 from dpnp.dpnp_iface import sum as iface_sum
 from dpnp.dpnp_iface import prod as iface_prod
 from dpnp.dpnp_iface import get_dpnp_descriptor as iface_get_dpnp_descriptor
 
-from dpnp.dpnp_algo cimport *
 from dpnp.dpnp_iface_statistics import min, max  # TODO do the same as for iface_sum
 from dpnp.dpnp_iface_logic import all, any  # TODO do the same as for iface_sum
 import numpy
 cimport numpy
 
+from dpnp.dpnp_algo cimport (
+    dpnp_memory_alloc_c,
+    dpnp_memory_free_c
+)
 cimport dpnp.dpnp_utils as utils
 
 
@@ -123,6 +126,12 @@ cdef class dparray:
             .. seealso:: :attr:`numpy.ndarray.size`
 
     """
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("default", category=DeprecationWarning)
+        warnings.warn("dpnp.dparray class is deprecated, use dpnp.dpnp_array class instead",
+                      DeprecationWarning,
+                      stacklevel=2)
 
     def __init__(self, shape, dtype=float64, memptr=None, strides=None, order=b'C'):
         cdef Py_ssize_t shape_it = 0


### PR DESCRIPTION
A `dpnp.dparray` class is actually obsolete and needs to be declared as deprecated. There is `dpnp.dpnp_array` class which has to be used instead. So the PR implements a deprecation warning for `dpnp.dparray` class.
Another issue which is fixed by the PR is an exception raised during import of `dpnp.dparray`, like in below example:
```
> python -c "import dpnp; import dpnp.dparray"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "dpnp/dparray.pyx", line 40, in init dpnp.dparray
    from dpnp.dpnp_iface import *
TypeError: Cannot overwrite C type array
```
- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
