### PR TITLE
Roll back pinning on NumPy for 'gold/2021' branch

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -8,7 +8,7 @@ requirements:
     host:
       - python
       - setuptools
-      - numpy >=1.19,<1.23a0
+      - numpy 1.19
       - cython
       - cmake >=3.19
       - dpctl >=0.13


### PR DESCRIPTION
The branch `gold/2021` is intended for internal CI needs, where it is required to explicitly take NumPy 1.19 during the build in upcoming release. The change mustn't aligned with `master` branch and it requires to be controlled every next push/merge on `gold/2021` branch.

Alternative solution might be to update run dependencies with `max_pin` on `x.x` instead of `x`, like:
```
{{ pin_compatible('numpy', min_pin='x.x', max_pin='x.x') }}
```
but it can produce another unwanted consequences which has to be properly analyzed firstly and needs to be implemented in dpctl also.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
