### PR TITLE
Define OneDPL package as a host dependency in meta.yaml

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -71,8 +71,8 @@ jobs:
 
       - name: Install dpnp dependencies
         run: |
-          conda install dpctl mkl-devel-dpcpp tbb-devel dpcpp_linux-64 cmake cython pytest \
-                        -c dppy/label/dev -c intel -c conda-forge
+          conda install dpctl mkl-devel-dpcpp onedpl-devel tbb-devel dpcpp_linux-64 \
+              cmake cython pytest -c dppy/label/dev -c intel -c conda-forge
 
       - name: Install cuPy dependencies
         run: conda install -c conda-forge cupy cudatoolkit=10.0
@@ -84,7 +84,7 @@ jobs:
 
       - name: Build library
         run: |
-          DPLROOT=/opt/intel/oneapi/dpl/latest python setup.py build_clib
+          python setup.py build_clib
           CC=dpcpp python setup.py build_ext --inplace
           python setup.py develop
 

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -40,13 +40,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Checkout oneDPL
-        uses: actions/checkout@v3.1.0
-        with:
-          repository: oneapi-src/oneDPL
-          path: oneDPL
-          ref: oneDPL-2021.7.0-release
-
       - name: Setup miniconda
         uses: conda-incubator/setup-miniconda@v2.1.1
         with:
@@ -76,8 +69,6 @@ jobs:
 
       - name: Build conda package
         run: conda build --no-test --python ${{ matrix.python }} ${{ env.CHANNELS }} conda-recipe
-        env:
-          DPLROOT: '${{ github.workspace }}/oneDPL'
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3.1.0
@@ -110,13 +101,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Checkout oneDPL
-        uses: actions/checkout@v3.1.0
-        with:
-          repository: oneapi-src/oneDPL
-          path: oneDPL
-          ref: oneDPL-2021.7.0-release
-
       - name: Setup miniconda
         uses: conda-incubator/setup-miniconda@v2.1.1
         with:
@@ -148,8 +132,6 @@ jobs:
 
       - name: Build conda package
         run: conda build --no-test --python ${{ matrix.python }} ${{ env.CHANNELS }} conda-recipe
-        env:
-          DPLROOT: '%GITHUB_WORKSPACE%\oneDPL'
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3.1.0

--- a/0.build.sh
+++ b/0.build.sh
@@ -7,7 +7,7 @@ cd ${THEDIR}
 export DPNP_DEBUG=1
 
 python setup.py clean
-DPLROOT=/opt/intel/oneapi/dpl/latest python setup.py build_clib
+python setup.py build_clib
 
 # inplace build
 CC=dpcpp python setup.py build_ext --inplace

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -13,6 +13,7 @@ requirements:
       - cmake >=3.19
       - dpctl >=0.13
       - mkl-devel-dpcpp {{ environ.get('MKL_VER', '>=2021.1.1') }}
+      - onedpl-devel
       - tbb-devel
       - wheel
     build:


### PR DESCRIPTION
DPNP requires OneDPL headers during the build step.

Previously the headers fetch from OneDPL github repo prior the build in external CI or alternatively there was a shared folder where the headers located on the host. In both cases a path towards the files location is handled through DPLROOT environment variable. The variable needs to be defined/added to the environment prior the build.

The new solution proposed to install a package with OneDPL files required for build. The package is available on both external (`intel` on Anaconda) and internal channels. Thus it's only required to define a host dependency on `onedpl-devel` package in `meta.yaml` file of DPNP. The files will be installed following by default `$CONDA_PREFIX` root, so no additional include path is required to define for the build.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
