### PR TITLE
Remove temporary pinning of 'dpcpp'

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
       - wheel
     build:
       - {{ compiler('cxx') }}
-      - {{ compiler('dpcpp') }}  <2023a0  # [not osx]
+      - {{ compiler('dpcpp') }}  >=2022.1  # [not osx]
     run:
       - python
       - dpctl >=0.13

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -12,13 +12,12 @@ requirements:
       - cython
       - cmake >=3.19
       - dpctl >=0.13
-      - dpcpp-cpp-rt 2022.2.0
       - mkl-devel-dpcpp {{ environ.get('MKL_VER', '>=2021.1.1') }}
       - tbb-devel
       - wheel
     build:
       - {{ compiler('cxx') }}
-      - {{ compiler('dpcpp') }}  >=2022.1  # [not osx]
+      - {{ compiler('dpcpp') }}  <2023a0  # [not osx]
     run:
       - python
       - dpctl >=0.13


### PR DESCRIPTION
Remove a temporary pinning of `dpcpp-cpp-rt` on `2022.2.0` version.
It safely to update configs of internal CI to be able to build DPNP release `0.10.3`, rather than modifying `meta.yaml`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
