### PR TITLE
Use zeros() function from dpctl.tensor.

### DIFF
--- a/dpnp/backend/include/dpnp_iface_fptr.hpp
+++ b/dpnp/backend/include/dpnp_iface_fptr.hpp
@@ -376,9 +376,7 @@ enum class DPNPFuncName : size_t
     DPNP_FN_VAR,                          /**< Used in numpy.var() impl  */
     DPNP_FN_VAR_EXT,                      /**< Used in numpy.var() impl, requires extra parameters */
     DPNP_FN_ZEROS,                        /**< Used in numpy.zeros() impl */
-    DPNP_FN_ZEROS_EXT,                    /**< Used in numpy.zeros() impl, requires extra parameters */
     DPNP_FN_ZEROS_LIKE,                   /**< Used in numpy.zeros_like() impl */
-    DPNP_FN_ZEROS_LIKE_EXT,               /**< Used in numpy.zeros_like() impl, requires extra parameters */
     DPNP_FN_LAST,                         /**< The latest element of the enumeration */
 };
 

--- a/dpnp/backend/kernels/dpnp_krnl_arraycreation.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_arraycreation.cpp
@@ -1262,16 +1262,11 @@ void dpnp_zeros_c(void* result, size_t size)
                                                           size,
                                                           dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
 void (*dpnp_zeros_default_c)(void*, size_t) = dpnp_zeros_c<_DataType>;
-
-template <typename _DataType>
-DPCTLSyclEventRef (*dpnp_zeros_ext_c)(DPCTLSyclQueueRef,
-                                      void*,
-                                      size_t,
-                                      const DPCTLEventVectorRef) = dpnp_zeros_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_zeros_like_c(DPCTLSyclQueueRef q_ref,
@@ -1292,16 +1287,11 @@ void dpnp_zeros_like_c(void* result, size_t size)
                                                                size,
                                                                dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
 void (*dpnp_zeros_like_default_c)(void*, size_t) = dpnp_zeros_like_c<_DataType>;
-
-template <typename _DataType>
-DPCTLSyclEventRef (*dpnp_zeros_like_ext_c)(DPCTLSyclQueueRef,
-                                           void*,
-                                           size_t,
-                                           const DPCTLEventVectorRef) = dpnp_zeros_like_c<_DataType>;
 
 void func_map_init_arraycreation(func_map_t& fmap)
 {
@@ -1508,14 +1498,6 @@ void func_map_init_arraycreation(func_map_t& fmap)
     fmap[DPNPFuncName::DPNP_FN_ZEROS][eft_C128][eft_C128] = {eft_C128,
                                                              (void*)dpnp_zeros_default_c<std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_zeros_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_zeros_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_zeros_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_zeros_ext_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_EXT][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_zeros_ext_c<bool>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_EXT][eft_C128][eft_C128] = {eft_C128,
-                                                                 (void*)dpnp_zeros_ext_c<std::complex<double>>};
-
     fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_zeros_like_default_c<int32_t>};
     fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_zeros_like_default_c<int64_t>};
     fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_zeros_like_default_c<float>};
@@ -1523,14 +1505,6 @@ void func_map_init_arraycreation(func_map_t& fmap)
     fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_zeros_like_default_c<bool>};
     fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE][eft_C128][eft_C128] = {
         eft_C128, (void*)dpnp_zeros_like_default_c<std::complex<double>>};
-
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_zeros_like_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_zeros_like_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_zeros_like_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_zeros_like_ext_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE_EXT][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_zeros_like_ext_c<bool>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE_EXT][eft_C128][eft_C128] = {
-        eft_C128, (void*)dpnp_zeros_like_ext_c<std::complex<double>>};
 
     return;
 }

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -352,9 +352,7 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_VAR
         DPNP_FN_VAR_EXT
         DPNP_FN_ZEROS
-        DPNP_FN_ZEROS_EXT
         DPNP_FN_ZEROS_LIKE
-        DPNP_FN_ZEROS_LIKE_EXT
 
 cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncType":  # need this namespace for Enum import
     cdef enum DPNPFuncType "DPNPFuncType":

--- a/dpnp/dpnp_algo/dpnp_algo_arraycreation.pyx
+++ b/dpnp/dpnp_algo/dpnp_algo_arraycreation.pyx
@@ -52,9 +52,7 @@ __all__ += [
     "dpnp_tri",
     "dpnp_tril",
     "dpnp_triu",
-    "dpnp_vander",
-    "dpnp_zeros",
-    "dpnp_zeros_like"
+    "dpnp_vander"
 ]
 
 
@@ -672,11 +670,3 @@ cpdef utils.dpnp_descriptor dpnp_vander(utils.dpnp_descriptor x1, int N, int inc
     c_dpctl.DPCTLEvent_Delete(event_ref)
 
     return result
-
-
-cpdef utils.dpnp_descriptor dpnp_zeros(result_shape, result_dtype):
-    return call_fptr_1out(DPNP_FN_ZEROS_EXT, utils._object_to_tuple(result_shape), result_dtype)
-
-
-cpdef utils.dpnp_descriptor dpnp_zeros_like(result_shape, result_dtype):
-    return call_fptr_1out(DPNP_FN_ZEROS_LIKE_EXT, utils._object_to_tuple(result_shape), result_dtype)

--- a/dpnp/dpnp_algo/dpnp_algo_arraycreation.pyx
+++ b/dpnp/dpnp_algo/dpnp_algo_arraycreation.pyx
@@ -1,7 +1,7 @@
 # cython: language_level=3
 # -*- coding: utf-8 -*-
 # *****************************************************************************
-# Copyright (c) 2016-2020, Intel Corporation
+# Copyright (c) 2016-2022, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/dpnp/dpnp_container.py
+++ b/dpnp/dpnp_container.py
@@ -45,6 +45,7 @@ __all__ = [
     "arange",
     "asarray",
     "empty",
+    "zeros",
 ]
 
 
@@ -106,6 +107,26 @@ def empty(shape,
 
     """Creates `dpnp_array` from uninitialized USM allocation."""
     array_obj = dpt.empty(shape,
+                          dtype=dtype,
+                          order=order,
+                          usm_type=usm_type,
+                          sycl_queue=sycl_queue_normalized)
+    return dpnp_array(array_obj.shape, buffer=array_obj, order=order)
+
+
+def zeros(shape,
+          *,
+          dtype=None,
+          order="C",
+          device=None,
+          usm_type="device",
+          sycl_queue=None):
+    """Validate input parameters before passing them into `dpctl.tensor` module"""
+    dpu.validate_usm_type(usm_type, allow_none=True)
+    sycl_queue_normalized = dpnp.get_normalized_queue_device(sycl_queue=sycl_queue, device=device)
+
+    """Creates `dpnp_array` with zero elements."""
+    array_obj = dpt.zeros(shape,
                           dtype=dtype,
                           order=order,
                           usm_type=usm_type,

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -1343,7 +1343,7 @@ def vander(x1, N=None, increasing=False):
 
 def zeros(shape,
           *,
-          dtype=dpnp.float64,
+          dtype=numpy.float64,
           order="C",
           like=None,
           device=None,

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -1343,7 +1343,7 @@ def vander(x1, N=None, increasing=False):
 
 def zeros(shape,
           *,
-          dtype=None,
+          dtype=dpnp.float64,
           order="C",
           like=None,
           device=None,
@@ -1379,9 +1379,8 @@ def zeros(shape,
 
     """
     if like is None:
-        _dtype = dtype if dtype is not None else dpnp.float64
         return dpnp_container.zeros(shape,
-                                    dtype=_dtype,
+                                    dtype=dtype,
                                     order=order,
                                     device=device,
                                     usm_type=usm_type,
@@ -1390,7 +1389,6 @@ def zeros(shape,
     return call_origin(numpy.zeros, shape, dtype=dtype, order=order, like=like)
 
 
-# numpy.zeros_like(a, dtype=None, order='K', subok=True, shape=None)
 def zeros_like(x1,
                *,
                dtype=None,
@@ -1407,6 +1405,7 @@ def zeros_like(x1,
 
     Limitations
     -----------
+    Parameter ``order`` is supported with values ``"C"`` or ``"F"``.
     Parameter ``subok`` is supported only with default value ``False``.
 
     See Also
@@ -1425,13 +1424,10 @@ def zeros_like(x1,
     >>> [i for i in np.zeros_like(x)]
     [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
 
-    """
-
-    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
-    if x1_desc:
-        if subok is not False:
-            pass
-        else:
+"""
+    if subok is False:
+        x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
+        if x1_desc:
             _shape = shape if shape is not None else x1_desc.shape
             _dtype = dtype if dtype is not None else x1_desc.dtype
             return zeros(_shape,


### PR DESCRIPTION
Use zeros() function from dpctl.tensor module instead of DPNP backend implementation.
A cython code relating to zeros() call is cleaned up.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
