### PR TITLE
Leave is_host() call with old compiler only

### DIFF
--- a/dpnp/backend/src/dpnp_utils.hpp
+++ b/dpnp/backend/src/dpnp_utils.hpp
@@ -1,5 +1,5 @@
 //*****************************************************************************
-// Copyright (c) 2016-2020, Intel Corporation
+// Copyright (c) 2016-2022, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -39,6 +39,13 @@
 #define LIBSYCL_VERSION_GREATER(major, minor, patch)                                                                   \
     (__LIBSYCL_MAJOR_VERSION > major) || (__LIBSYCL_MAJOR_VERSION == major and __LIBSYCL_MINOR_VERSION > minor) ||     \
         (__LIBSYCL_MAJOR_VERSION == major and __LIBSYCL_MINOR_VERSION == minor and __LIBSYCL_PATCH_VERSION >= patch)
+
+/**
+ * Version of SYCL DPC++ 2023 compiler at which transition to SYCL 2020 occurs
+ */
+#ifndef __SYCL_COMPILER_2023_SWITCHOVER
+#define __SYCL_COMPILER_2023_SWITCHOVER 20221020L
+#endif
 
 /**
  * @defgroup BACKEND_UTILS Backend C++ library utilities

--- a/dpnp/backend/src/dpnp_utils.hpp
+++ b/dpnp/backend/src/dpnp_utils.hpp
@@ -41,10 +41,12 @@
         (__LIBSYCL_MAJOR_VERSION == major and __LIBSYCL_MINOR_VERSION == minor and __LIBSYCL_PATCH_VERSION >= patch)
 
 /**
- * Version of SYCL DPC++ 2023 compiler at which transition to SYCL 2020 occurs
+ * Version of SYCL DPC++ 2023 compiler at which transition to SYCL 2020 occurs.
+ * Intel(R) oneAPI DPC++ 2022.2.1 compiler has version 20221020L on Linux and
+ * 20221101L on Windows.
  */
 #ifndef __SYCL_COMPILER_2023_SWITCHOVER
-#define __SYCL_COMPILER_2023_SWITCHOVER 20221020L
+#define __SYCL_COMPILER_2023_SWITCHOVER 20221102L
 #endif
 
 /**

--- a/dpnp/backend/src/dpnpc_memory_adapter.hpp
+++ b/dpnp/backend/src/dpnpc_memory_adapter.hpp
@@ -1,5 +1,5 @@
 //*****************************************************************************
-// Copyright (c) 2016-2020, Intel Corporation
+// Copyright (c) 2016-2022, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,7 @@
 #define DPNP_MEMORY_ADAPTER_H
 
 #include "queue_sycl.hpp"
+#include "dpnp_utils.hpp"
 
 /**
  * @ingroup BACKEND_UTILS
@@ -84,7 +85,9 @@ public:
             std::cerr << "\n\t size_in_bytes=" << size_in_bytes;
             std::cerr << "\n\t pointer type=" << (long)src_ptr_type;
             std::cerr << "\n\t queue inorder=" << queue.is_in_order();
+#if __SYCL_COMPILER_VERSION < __SYCL_COMPILER_2023_SWITCHOVER
             std::cerr << "\n\t queue is_host=" << queue.is_host();
+#endif
             std::cerr << "\n\t queue device is_host=" << queue.get_device().is_host();
             std::cerr << "\n\t queue device is_cpu=" << queue.get_device().is_cpu();
             std::cerr << "\n\t queue device is_gpu=" << queue.get_device().is_gpu();


### PR DESCRIPTION
Since SYCL DPC++ 2023 compiler the function is_host() is deprecated as the host device is no longer supported.
The PR excludes is_host() call from the code when the new compiler is used, i.e. when `__SYCL_COMPILER_VERSION < 20221102L`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
