### PR TITLE
Add support of DPNP backend linking with sycl6.lib on Win

### DIFF
--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -232,7 +232,7 @@ tests/third_party/cupy/creation_tests/test_matrix.py::TestMatrix::test_diag_cons
 tests/third_party/cupy/creation_tests/test_matrix.py::TestMatrix::test_diag_construction_from_tuple
 tests/third_party/cupy/creation_tests/test_matrix.py::TestMatrix::test_diag_extraction_from_nested_list
 tests/third_party/cupy/creation_tests/test_matrix.py::TestMatrix::test_diag_extraction_from_nested_tuple
-tests/third_party/cupy/creation_tests/test_ranges.py::TestRanges::test_logspace_zero_num
+
 tests/third_party/cupy/indexing_tests/test_insert.py::TestFillDiagonal_param_4_{shape=(3, 3), val=(2,), wrap=True}::test_1darray
 tests/third_party/cupy/indexing_tests/test_insert.py::TestFillDiagonal_param_4_{shape=(3, 3), val=(2,), wrap=True}::test_fill_diagonal
 tests/third_party/cupy/indexing_tests/test_insert.py::TestFillDiagonal_param_5_{shape=(3, 3), val=(2,), wrap=False}::test_1darray
@@ -664,6 +664,7 @@ tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asco
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asfortranarray_cuda_array_zero_dim
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_asfortranarray_cuda_array_zero_dim_dtype
 tests/third_party/cupy/creation_tests/test_from_data.py::TestFromData::test_fromfile
+
 tests/third_party/cupy/creation_tests/test_ranges.py::TestMeshgrid_param_0_{copy=False, indexing='xy', sparse=False}::test_meshgrid0
 tests/third_party/cupy/creation_tests/test_ranges.py::TestMeshgrid_param_0_{copy=False, indexing='xy', sparse=False}::test_meshgrid1
 tests/third_party/cupy/creation_tests/test_ranges.py::TestMeshgrid_param_0_{copy=False, indexing='xy', sparse=False}::test_meshgrid2
@@ -699,12 +700,18 @@ tests/third_party/cupy/creation_tests/test_ranges.py::TestMgrid::test_mgrid5
 tests/third_party/cupy/creation_tests/test_ranges.py::TestOgrid::test_ogrid3
 tests/third_party/cupy/creation_tests/test_ranges.py::TestOgrid::test_ogrid4
 tests/third_party/cupy/creation_tests/test_ranges.py::TestOgrid::test_ogrid5
+
 tests/third_party/cupy/creation_tests/test_ranges.py::TestRanges::test_linspace_array_start_stop
 tests/third_party/cupy/creation_tests/test_ranges.py::TestRanges::test_linspace_array_start_stop_axis1
+tests/third_party/cupy/creation_tests/test_ranges.py::TestRanges::test_arange_negative_size
+tests/third_party/cupy/creation_tests/test_ranges.py::TestRanges::test_arange_no_dtype_int
+
 tests/third_party/cupy/creation_tests/test_ranges.py::TestRanges::test_linspace_float_underflow
 tests/third_party/cupy/creation_tests/test_ranges.py::TestRanges::test_linspace_mixed_start_stop
 tests/third_party/cupy/creation_tests/test_ranges.py::TestRanges::test_linspace_mixed_start_stop2
 tests/third_party/cupy/creation_tests/test_ranges.py::TestRanges::test_linspace_start_stop_list
+
+tests/third_party/cupy/creation_tests/test_ranges.py::TestRanges::test_logspace_zero_num
 
 tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_1_{axes=None, norm=None, s=(1, None), shape=(3, 4)}::test_fft2
 tests/third_party/cupy/fft_tests/test_fft.py::TestFft2_param_7_{axes=(), norm=None, s=None, shape=(3, 4)}::test_fft2

--- a/utils/command_build_clib.py
+++ b/utils/command_build_clib.py
@@ -36,6 +36,7 @@ This modification add:
 import os
 import sys
 
+from ctypes.util import find_library as find_shared_lib
 from setuptools.command import build_clib
 from distutils import log
 from distutils.dep_util import newer_group
@@ -151,7 +152,14 @@ if IS_LIN:
     _mathlibs = ["mkl_sycl", "mkl_intel_ilp64", "mkl_sequential",
                  "mkl_core", "sycl", "OpenCL", "pthread", "m", "dl"]
 elif IS_WIN:
-    _mathlibs = ["mkl_sycl_dll", "mkl_intel_ilp64_dll", "mkl_tbb_thread_dll", "mkl_core_dll", "sycl", "OpenCL", "tbb"]
+    _sycl_lib = None
+    for lib in {"sycl", "sycl6", "sycl7"}:
+        if find_shared_lib(lib):
+            _sycl_lib = lib
+    if not _sycl_lib:
+        raise EnvironmentError("DPNP: sycl library is not found")
+
+    _mathlibs = ["mkl_sycl_dll", "mkl_intel_ilp64_dll", "mkl_tbb_thread_dll", "mkl_core_dll", _sycl_lib, "OpenCL", "tbb"]
 
 """
 Final set of arguments for extentions


### PR DESCRIPTION
SYCL DPC++ 2023 compiler introduces alternative names for sycl.lib on Win OS.
The PR adds a support of this while building DPNP backend.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
