### PR TITLE
Use icpx instead of dpcpp on Linux

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Build library
         run: |
           python setup.py build_clib
-          CC=dpcpp python setup.py build_ext --inplace
+          CC=icpx python setup.py build_ext --inplace
           python setup.py develop
 
       - name: Build docs

--- a/0.build.sh
+++ b/0.build.sh
@@ -10,14 +10,14 @@ python setup.py clean
 python setup.py build_clib
 
 # inplace build
-CC=dpcpp python setup.py build_ext --inplace
+CC=icpx python setup.py build_ext --inplace
 
 # development build. Root privileges needed
 # python setup.py develop
 
 echo
 echo =========example3==============
-dpcpp -g -fPIC dpnp/backend/examples/example3.cpp -Idpnp -Idpnp/backend/include -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o example3
+icpx -fsycl -g -fPIC dpnp/backend/examples/example3.cpp -Idpnp -Idpnp/backend/include -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o example3
 # LD_DEBUG=libs,bindings,symbols ./example3
 ./example3
 

--- a/dpnp/backend/CMakeLists.txt
+++ b/dpnp/backend/CMakeLists.txt
@@ -99,10 +99,10 @@ string(CONCAT COMMON_LINK_FLAGS
   "-fsycl-device-code-split=per_kernel "
 )
 if(UNIX)
-  set(CMAKE_CXX_COMPILER "dpcpp")
+  set(CMAKE_CXX_COMPILER "icpx")
   # add_compile_options(-fPIC)
 elseif(WIN32)
-  set(CMAKE_CXX_COMPILER "dpcpp")
+  set(CMAKE_CXX_COMPILER "icx")
   # set(CMAKE_SHARED_LINKER_FLAGS_INIT "-fuse-ld=lld-link")
   # set(CMAKE_LINKER "lld-link")
   # include (Platform/Windows-Clang)

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
       conda activate CondaCodeCov
       echo ============================================ build DPNP ============================================
       python setup.py build_clib
-      CC=dpcpp python setup.py build_ext --inplace
+      CC=icpx python setup.py build_ext --inplace
       echo ============================================ run code coverage =====================================
       export OCL_ICD_FILENAMES=libintelocl.so
       pytest --cov-report xml:coverage.xml --cov-report term-missing --cov=dpnp

--- a/utils/command_build_clib.py
+++ b/utils/command_build_clib.py
@@ -61,8 +61,8 @@ else:
 Set compiler for the project
 """
 # default variables (for Linux)
-_project_compiler = "dpcpp"
-_project_linker = "dpcpp"
+_project_compiler = "icpx"
+_project_linker = "icpx"
 _project_cmplr_flag_sycl_devel = ["-fsycl-device-code-split=per_kernel", "-fno-approx-func"]
 _project_cmplr_flag_sycl = ["-fsycl"]
 _project_cmplr_flag_stdcpp_static = []  # This brakes TBB ["-static-libstdc++", "-static-libgcc"]


### PR DESCRIPTION
Since SYCL DPC++ 2023 compiler use of `dpcpp` is deprecated and will be removed in a future release.
The PR replaces `dpcpp` with use of 'icpx -fsycl' in case of building for Linux OS.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
