### PR TITLE
Setting version to 0.11.0

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -31,9 +31,9 @@ copyright = '2020-2022, Intel'
 author = 'Intel'
 
 # The short X.Y version
-version = '0.10'
+version = '0.11'
 # The full version, including alpha/beta/rc tags
-release = '0.10.3'
+release = '0.11.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/dpnp/backend/CMakeLists.txt
+++ b/dpnp/backend/CMakeLists.txt
@@ -27,8 +27,8 @@
 
 cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
-# set(DPNP_VERSION 0.10.3)
-# set(DPNP_API_VERSION 0.10)
+# set(DPNP_VERSION 0.11.0)
+# set(DPNP_API_VERSION 0.11)
 
 # set directory where the custom finders live
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules")

--- a/dpnp/backend/doc/Doxyfile
+++ b/dpnp/backend/doc/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "DPNP C++ backend kernel library"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.10.3
+PROJECT_NUMBER         = 0.11.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/dpnp/version.py
+++ b/dpnp/version.py
@@ -29,6 +29,6 @@
 DPNP version module
 """
 
-__version__: str = '0.10.3'
+__version__: str = '0.11.0'
 
 version: str = __version__


### PR DESCRIPTION
Switch DPNP version to `0.11.0` for upcoming 2023.0 release

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
