### PR TITLE
Revert merge gold/2021 to master

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -8,7 +8,7 @@ requirements:
     host:
       - python
       - setuptools
-      - numpy 1.19
+      - numpy >=1.19,<1.23a0
       - cython
       - cmake >=3.19
       - dpctl >=0.13


### PR DESCRIPTION
Revert merge branch 'gold/2021' into `master` done by a [commit](https://github.com/IntelPython/dpnp/commit/a9f45e3111684e56848472e309eea93f46359d38).

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
