### PR TITLE
Replace std::vector() with sycl::span() by prompt from OneMKL

### DIFF
--- a/dpnp/backend/kernels/dpnp_krnl_random.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_random.cpp
@@ -973,11 +973,11 @@ DPCTLSyclEventRef dpnp_rng_multinomial_c(DPCTLSyclQueueRef q_ref,
     else
     {
         DPNPC_ptr_adapter<double> p_ptr(q_ref, p_in, p_size, true);
-        double* p = p_ptr.get_ptr();
+        double* p_data = p_ptr.get_ptr();
 
         // size = size
         // `result` is a array for random numbers
-        // `size` is a `result`'s len. `size = n * p.size()`
+        // `size` is a `result`'s len. `size = n * p_size`
         // `n` is a number of random values to be generated.
         size_t n = size / p_size;
 
@@ -990,8 +990,12 @@ DPCTLSyclEventRef dpnp_rng_multinomial_c(DPCTLSyclQueueRef q_ref,
             DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result, size, true, true);
             _DataType* result1 = result_ptr.get_ptr();
 
-            auto p_span = sycl::span<double>{p, p_size};
-            mkl_rng::multinomial<_DataType> distribution(ntrial, p_span);
+#if (INTEL_MKL_VERSION < __INTEL_MKL_2023_SWITCHOVER)
+            std::vector<double> p(p_data, p_data + p_size);
+#else
+            auto p = sycl::span<double>{p_data, p_size};
+#endif
+            mkl_rng::multinomial<_DataType> distribution(ntrial, p);
 
             // perform generation
             event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, n, result1);
@@ -1005,7 +1009,7 @@ DPCTLSyclEventRef dpnp_rng_multinomial_c(DPCTLSyclQueueRef q_ref,
             DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result, size, true, true);
             _DataType* result1 = result_ptr.get_ptr();
             int errcode = viRngMultinomial(
-                VSL_RNG_METHOD_MULTINOMIAL_MULTPOISSON, get_rng_stream(), n, result1, ntrial, p_size, p);
+                VSL_RNG_METHOD_MULTINOMIAL_MULTPOISSON, get_rng_stream(), n, result1, ntrial, p_size, p_data);
             if (errcode != VSL_STATUS_OK)
             {
                 throw std::runtime_error("DPNP RNG Error: dpnp_rng_multinomial_c() failed.");
@@ -1072,21 +1076,26 @@ DPCTLSyclEventRef dpnp_rng_multivariate_normal_c(DPCTLSyclQueueRef q_ref,
     sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
 
     DPNPC_ptr_adapter<double> mean_ptr(q_ref, mean_in, mean_size, true);
-    double* mean = mean_ptr.get_ptr();
+    double* mean_data = mean_ptr.get_ptr();
     DPNPC_ptr_adapter<double> cov_ptr(q_ref, cov_in, cov_size, true);
-    double* cov = cov_ptr.get_ptr();
+    double* cov_data = cov_ptr.get_ptr();
 
     _DataType* result1 = static_cast<_DataType *>(result);
 
-    auto mean_span = sycl::span<double>{mean, mean_size};
-    auto cov_span = sycl::span<double>{cov, cov_size};
+#if (INTEL_MKL_VERSION < __INTEL_MKL_2023_SWITCHOVER)
+    std::vector<double> mean(mean_data, mean_data + mean_size);
+    std::vector<double> cov(cov_data, cov_data + cov_size);
+#else
+    auto mean = sycl::span<double>{mean_data, mean_size};
+    auto cov = sycl::span<double>{cov_data, cov_size};
+#endif
 
     // `result` is a array for random numbers
     // `size` is a `result`'s len.
     // `size1` is a number of random values to be generated for each dimension.
     size_t size1 = size / dimen;
 
-    mkl_rng::gaussian_mv<_DataType> distribution(dimen, mean_span, cov_span);
+    mkl_rng::gaussian_mv<_DataType> distribution(dimen, mean, cov);
     auto event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size1, result1);
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event_out);
 

--- a/dpnp/backend/kernels/dpnp_krnl_random.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_random.cpp
@@ -973,13 +973,13 @@ DPCTLSyclEventRef dpnp_rng_multinomial_c(DPCTLSyclQueueRef q_ref,
     else
     {
         DPNPC_ptr_adapter<double> p_ptr(q_ref, p_in, p_size, true);
-        const double* p = p_ptr.get_ptr();
-        std::vector<double> p_vec(p, p + p_size);
+        double* p = p_ptr.get_ptr();
+
         // size = size
         // `result` is a array for random numbers
         // `size` is a `result`'s len. `size = n * p.size()`
         // `n` is a number of random values to be generated.
-        size_t n = size / p_vec.size();
+        size_t n = size / p_size;
 
         size_t is_cpu_queue = dpnp_queue_is_cpu_c();
 
@@ -987,17 +987,23 @@ DPCTLSyclEventRef dpnp_rng_multinomial_c(DPCTLSyclQueueRef q_ref,
         // which follow the condition
         if (is_cpu_queue || (!is_cpu_queue && (p_size >= ((size_t)ntrial * 16)) && (ntrial <= 16)))
         {
-            DPNPC_ptr_adapter<std::int32_t> result_ptr(q_ref, result, size, false, true);
-            std::int32_t* result1 = result_ptr.get_ptr();
-            mkl_rng::multinomial<std::int32_t> distribution(ntrial, p_vec);
+            DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result, size, true, true);
+            _DataType* result1 = result_ptr.get_ptr();
+
+            auto p_span = sycl::span<double>{p, p_size};
+            mkl_rng::multinomial<_DataType> distribution(ntrial, p_span);
+
             // perform generation
             event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, n, result1);
             event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event_out);
+
+            p_ptr.depends_on(event_out);
+            result_ptr.depends_on(event_out);
         }
         else
         {
-            DPNPC_ptr_adapter<std::int32_t> result_ptr(q_ref, result, size, true, true);
-            std::int32_t* result1 = result_ptr.get_ptr();
+            DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result, size, true, true);
+            _DataType* result1 = result_ptr.get_ptr();
             int errcode = viRngMultinomial(
                 VSL_RNG_METHOD_MULTINOMIAL_MULTPOISSON, get_rng_stream(), n, result1, ntrial, p_size, p);
             if (errcode != VSL_STATUS_OK)
@@ -1023,6 +1029,7 @@ void dpnp_rng_multinomial_c(
                                                                     size,
                                                                     dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
@@ -1065,23 +1072,26 @@ DPCTLSyclEventRef dpnp_rng_multivariate_normal_c(DPCTLSyclQueueRef q_ref,
     sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
 
     DPNPC_ptr_adapter<double> mean_ptr(q_ref, mean_in, mean_size, true);
-    const double* mean = mean_ptr.get_ptr();
+    double* mean = mean_ptr.get_ptr();
     DPNPC_ptr_adapter<double> cov_ptr(q_ref, cov_in, cov_size, true);
-    const double* cov = cov_ptr.get_ptr();
+    double* cov = cov_ptr.get_ptr();
 
-    _DataType* result1 = reinterpret_cast<_DataType*>(result);
+    _DataType* result1 = static_cast<_DataType *>(result);
 
-    std::vector<double> mean_vec(mean, mean + mean_size);
-    std::vector<double> cov_vec(cov, cov + cov_size);
+    auto mean_span = sycl::span<double>{mean, mean_size};
+    auto cov_span = sycl::span<double>{cov, cov_size};
 
     // `result` is a array for random numbers
     // `size` is a `result`'s len.
     // `size1` is a number of random values to be generated for each dimension.
     size_t size1 = size / dimen;
 
-    mkl_rng::gaussian_mv<_DataType> distribution(dimen, mean_vec, cov_vec);
+    mkl_rng::gaussian_mv<_DataType> distribution(dimen, mean_span, cov_span);
     auto event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size1, result1);
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event_out);
+
+    mean_ptr.depends_on(event_out);
+    cov_ptr.depends_on(event_out);
 
     return DPCTLEvent_Copy(event_ref);
 }
@@ -1107,6 +1117,7 @@ void dpnp_rng_multivariate_normal_c(void* result,
                                                                             size,
                                                                             dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>

--- a/dpnp/backend/src/dpnp_utils.hpp
+++ b/dpnp/backend/src/dpnp_utils.hpp
@@ -50,6 +50,13 @@
 #endif
 
 /**
+ * Version of Intel MKL at which transition to OneMKL release 2023.0.0 occurs.
+ */
+#ifndef __INTEL_MKL_2023_SWITCHOVER
+#define __INTEL_MKL_2023_SWITCHOVER 20230000
+#endif
+
+/**
  * @defgroup BACKEND_UTILS Backend C++ library utilities
  * @{
  * This section describes utilities used in Backend API.

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -199,9 +199,12 @@ tests/test_linalg.py::test_svd[(5,3)-float64]
 tests/test_linalg.py::test_svd[(16,16)-float64]
 
 tests/test_mathematical.py::TestGradient::test_gradient_y1_dx[3.5-array1]
+
+tests/test_random.py::TestPermutationsTestShuffle::test_shuffle1[lambda x: dpnp.asarray([[i, i] for i in x])]
 tests/test_random.py::TestPermutationsTestShuffle::test_shuffle1[lambda x: (dpnp.asarray([(i, i) for i in x], [("a", int), ("b", int)]).view(dpnp.recarray))]
 tests/test_random.py::TestPermutationsTestShuffle::test_shuffle1[lambda x: dpnp.asarray([(i, i) for i in x], [("a", object), ("b", dpnp.int32)])]]
 tests/test_random.py::TestPermutationsTestShuffle::test_shuffle1[lambda x: dpnp.asarray(x).astype(dpnp.int8)]
+
 tests/test_sort.py::test_partition[[[1, 0], [3, 0]]-float32-1]
 tests/third_party/cupy/binary_tests/test_elementwise.py::TestElementwise::test_bitwise_and
 tests/third_party/cupy/binary_tests/test_elementwise.py::TestElementwise::test_bitwise_or

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -1,5 +1,3 @@
-tests/test_random.py::TestDistributionsMultinomial::test_extreme_value
-tests/test_random.py::TestDistributionsMultinomial::test_seed1
 tests/test_random.py::TestDistributionsMultivariateNormal::test_moments
 tests/test_random.py::TestDistributionsMultivariateNormal::test_output_shape_check
 tests/test_random.py::TestDistributionsMultivariateNormal::test_seed
@@ -219,9 +217,7 @@ tests/test_mathematical.py::TestGradient::test_gradient_y1[array2]
 tests/test_mathematical.py::TestGradient::test_gradient_y1_dx[2-array0]
 tests/test_mathematical.py::TestGradient::test_gradient_y1_dx[2-array1]
 tests/test_mathematical.py::TestGradient::test_gradient_y1_dx[2-array2]
-tests/test_random.py::TestDistributionsMultinomial::test_check_sum
-tests/test_random.py::TestDistributionsMultinomial::test_moments
-tests/test_random.py::TestDistributionsMultinomial::test_seed
+
 tests/test_random.py::TestPermutationsTestShuffle::test_shuffle1[lambda x: dpnp.astype(dpnp.asarray(x), dpnp.int8)]
 tests/test_random.py::TestPermutationsTestShuffle::test_shuffle1[lambda x: dpnp.astype(dpnp.asarray(x), object)]
 tests/test_random.py::TestPermutationsTestShuffle::test_shuffle1[lambda x: dpnp.vstack([x, x]).T]


### PR DESCRIPTION
The PR is intended to get rid of deprecation warnings while compiling with the latest OneMKL.
The warnings advise to replace `std::vector()` with `sycl::span()` when `oneapi::mkl::rng::multinomial` and `oneapi::mkl::rng::gaussian_mv` constructors are called.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
