### PR TITLE
Exclude running upload steps for forked repo

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -417,7 +417,7 @@ jobs:
     needs: test_linux
 
     if: |
-      !github.event.pull_request.head.repo.fork  &&
+      (github.repository == 'IntelPython/dpnp') &&
       (github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/heads/release') == true) || github.event_name == 'push' && contains(github.ref, 'refs/tags/'))
 
     runs-on: ubuntu-latest
@@ -456,7 +456,7 @@ jobs:
     needs: test_windows
 
     if: |
-      !github.event.pull_request.head.repo.fork  && !github.event.push.repository.fork &&
+      (github.repository == 'IntelPython/dpnp') &&
       (github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/heads/release') == true) || github.event_name == 'push' && contains(github.ref, 'refs/tags/'))
 
     runs-on: windows-latest


### PR DESCRIPTION
Upload steps shan't be running when merging in forked repositories.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
