### PR TITLE
Add support of combining arrays with different USM types

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -10,6 +10,15 @@ env:
   PACKAGE_NAME: dpnp
   MODULE_NAME: dpnp
   CHANNELS: '-c dppy/label/dev -c intel -c defaults --override-channels'
+  TEST_SCOPE: >-
+      test_arraycreation.py
+      test_dparray.py
+      test_fft.py
+      test_linalg.py
+      test_mathematical.py
+      test_random_state.py
+      test_special.py
+      test_usm_type.py
   VER_JSON_NAME: 'version.json'
   VER_SCRIPT1: "import json; f = open('version.json', 'r'); j = json.load(f); f.close(); "
   VER_SCRIPT2: "d = j['dpnp'][0]; print('='.join((d[s] for s in ('version', 'build'))))"
@@ -235,7 +244,7 @@ jobs:
       # TODO: run the whole scope once the issues on CPU are resolved
       - name: Run tests
         run: |
-          python -m pytest -q -ra --disable-warnings -vv test_arraycreation.py test_dparray.py test_fft.py test_linalg.py test_mathematical.py test_random_state.py test_special.py
+          python -m pytest -q -ra --disable-warnings -vv ${{ env.TEST_SCOPE }}
         env:
           OCL_ICD_FILENAMES: 'libintelocl.so'
         working-directory: ${{ env.tests-path }}
@@ -410,7 +419,7 @@ jobs:
       # TODO: run the whole scope once the issues on CPU are resolved
       - name: Run tests
         run: |
-          python -m pytest -q -ra --disable-warnings -vv test_arraycreation.py test_dparray.py test_fft.py test_linalg.py test_mathematical.py test_random_state.py test_special.py
+          python -m pytest -q -ra --disable-warnings -vv ${{ env.TEST_SCOPE }}
         working-directory: ${{ env.tests-path }}
 
   upload_linux:

--- a/dpnp/dpnp_utils/dpnp_algo_utils.pyx
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pyx
@@ -540,22 +540,7 @@ cdef tuple get_common_usm_allocation(dpnp_descriptor x1, dpnp_descriptor x2):
     array1_obj = x1.get_array()
     array2_obj = x2.get_array()
 
-    def get_usm_type(usm_types):
-        if not isinstance(usm_types, (list, tuple)):
-            raise TypeError(
-                "Expected a list or a tuple, got {}".format(type(usm_types))
-            )
-        if len(usm_types) == 0:
-            return None
-        elif len(usm_types) == 1:
-            return usm_types[0]
-        for usm_type1, usm_type2 in zip(usm_types, usm_types[1:]):
-            if usm_type1 != usm_type2:
-                return None
-        return usm_types[0]
-
-    # TODO: use similar function from dpctl.utils instead of get_usm_type
-    common_usm_type = get_usm_type((array1_obj.usm_type, array2_obj.usm_type))
+    common_usm_type = dpctl.utils.get_coerced_usm_type((array1_obj.usm_type, array2_obj.usm_type))
     if common_usm_type is None:
         raise ValueError(
             "could not recognize common USM type for inputs of USM types {} and {}"

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -1,0 +1,36 @@
+import pytest
+
+import dpnp as dp
+
+import dpctl.utils as du
+
+list_of_usm_types = [
+    "device",
+    "shared",
+    "host"
+]
+
+
+@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+def test_coerced_usm_types_sum(usm_type):
+    x = dp.arange(10, usm_type = "device")
+    y = dp.arange(10, usm_type = usm_type)
+
+    z = x + y
+    
+    assert z.usm_type == x.usm_type
+    assert z.usm_type == "device"
+    assert y.usm_type == usm_type
+
+
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+def test_coerced_usm_types_mul(usm_type_x, usm_type_y):
+    x = dp.arange(10, usm_type = usm_type_x)
+    y = dp.arange(10, usm_type = usm_type_y)
+
+    z = x * y
+    
+    assert x.usm_type == usm_type_x
+    assert y.usm_type == usm_type_y
+    assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])


### PR DESCRIPTION
The PR implements a support of combining arrays with different USM types.
The change is mainly about to replace temporary dpnp call `get_usm_type()` with dpctl API call `dpctl.utils.get_coerced_usm_type()`, since it is available now.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
