### PR TITLE
Use main channel instead of defaults

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -9,7 +9,7 @@ on:
 env:
   PACKAGE_NAME: dpnp
   MODULE_NAME: dpnp
-  CHANNELS: '-c dppy/label/dev -c intel -c defaults --override-channels'
+  CHANNELS: '-c dppy/label/dev -c intel -c main --override-channels'
   TEST_SCOPE: >-
       test_arraycreation.py
       test_dparray.py


### PR DESCRIPTION
It's proper to explicitly define `main` channel when installing packages from conda rather than to rely on a value of `defaults` channel in conda configuration.
This is because `main` channel is what exactly required for building and testing dpnp and also because conda is configured by `conda-incubator/setup-miniconda` github action and we have no control on that (can't guarantee `defaults` channel is the same as `main` one).

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
