### PR TITLE
Add asnumpy() method for dpnp_array

### DIFF
--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -278,17 +278,22 @@ class dpnp_array:
  # '__setstate__',
  # '__sizeof__',
 
-    def __str__(self):
-        """ Output values from the array to standard output
 
-        Example:
-          [[ 136.  136.  136.]
-           [ 272.  272.  272.]
-           [ 408.  408.  408.]]
+    def __str__(self):
+        """
+        Output values from the array to standard output.
+
+        Examples
+        --------
+        >>> print(a)
+        [[ 136.  136.  136.]
+         [ 272.  272.  272.]
+         [ 408.  408.  408.]]
 
         """
 
-        return str(dpnp.asnumpy(self._array_obj))
+        return str(self.asnumpy())
+
 
     def __sub__(self, other):
         return dpnp.subtract(self, other)
@@ -424,6 +429,20 @@ class dpnp_array:
 
         """
         return dpnp.argsort(self, axis, kind, order)
+
+
+    def asnumpy(self):
+        """
+        Copy content of the array into :class:`numpy.ndarray` instance of the same shape and data type.
+
+        Returns
+        -------
+            An instance of :class:`numpy.ndarray` populated with the array content.
+
+        """
+
+        return dpt.asnumpy(self._array_obj)
+
 
     def astype(self, dtype, order='K', casting='unsafe', subok=True, copy=True):
         """Copy the array with data type casting.

--- a/dpnp/dpnp_iface.py
+++ b/dpnp/dpnp_iface.py
@@ -139,7 +139,7 @@ def asnumpy(input, order='C'):
 
     """
     if isinstance(input, dpnp_array):
-        return dpt.asnumpy(input.get_array())
+        return input.asnumpy()
 
     if isinstance(input, dpt.usm_ndarray):
         return dpt.asnumpy(input)


### PR DESCRIPTION
The TR is about to implement an enhancement suggested in issue #1245.

New `asnumpy()` method of `dpnp_array` class is an equivalent of `dpnp.asnumpy()` call.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
