### PR TITLE
Use zeros() function from dpctl.tensor.

### DIFF
--- a/dpnp/backend/include/dpnp_iface_fptr.hpp
+++ b/dpnp/backend/include/dpnp_iface_fptr.hpp
@@ -373,9 +373,7 @@ enum class DPNPFuncName : size_t
     DPNP_FN_VAR,                          /**< Used in numpy.var() impl  */
     DPNP_FN_VAR_EXT,                      /**< Used in numpy.var() impl, requires extra parameters */
     DPNP_FN_ZEROS,                        /**< Used in numpy.zeros() impl */
-    DPNP_FN_ZEROS_EXT,                    /**< Used in numpy.zeros() impl, requires extra parameters */
     DPNP_FN_ZEROS_LIKE,                   /**< Used in numpy.zeros_like() impl */
-    DPNP_FN_ZEROS_LIKE_EXT,               /**< Used in numpy.zeros_like() impl, requires extra parameters */
     DPNP_FN_LAST,                         /**< The latest element of the enumeration */
 };
 

--- a/dpnp/backend/kernels/dpnp_krnl_arraycreation.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_arraycreation.cpp
@@ -1250,16 +1250,11 @@ void dpnp_zeros_c(void* result, size_t size)
                                                           size,
                                                           dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
 void (*dpnp_zeros_default_c)(void*, size_t) = dpnp_zeros_c<_DataType>;
-
-template <typename _DataType>
-DPCTLSyclEventRef (*dpnp_zeros_ext_c)(DPCTLSyclQueueRef,
-                                      void*,
-                                      size_t,
-                                      const DPCTLEventVectorRef) = dpnp_zeros_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_zeros_like_c(DPCTLSyclQueueRef q_ref,
@@ -1280,16 +1275,11 @@ void dpnp_zeros_like_c(void* result, size_t size)
                                                                size,
                                                                dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
 void (*dpnp_zeros_like_default_c)(void*, size_t) = dpnp_zeros_like_c<_DataType>;
-
-template <typename _DataType>
-DPCTLSyclEventRef (*dpnp_zeros_like_ext_c)(DPCTLSyclQueueRef,
-                                           void*,
-                                           size_t,
-                                           const DPCTLEventVectorRef) = dpnp_zeros_like_c<_DataType>;
 
 void func_map_init_arraycreation(func_map_t& fmap)
 {
@@ -1480,14 +1470,6 @@ void func_map_init_arraycreation(func_map_t& fmap)
     fmap[DPNPFuncName::DPNP_FN_ZEROS][eft_C128][eft_C128] = {eft_C128,
                                                              (void*)dpnp_zeros_default_c<std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_zeros_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_zeros_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_zeros_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_zeros_ext_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_EXT][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_zeros_ext_c<bool>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_EXT][eft_C128][eft_C128] = {eft_C128,
-                                                                 (void*)dpnp_zeros_ext_c<std::complex<double>>};
-
     fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_zeros_like_default_c<int32_t>};
     fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_zeros_like_default_c<int64_t>};
     fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_zeros_like_default_c<float>};
@@ -1495,14 +1477,6 @@ void func_map_init_arraycreation(func_map_t& fmap)
     fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_zeros_like_default_c<bool>};
     fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE][eft_C128][eft_C128] = {
         eft_C128, (void*)dpnp_zeros_like_default_c<std::complex<double>>};
-
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_zeros_like_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_zeros_like_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_zeros_like_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_zeros_like_ext_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE_EXT][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_zeros_like_ext_c<bool>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE_EXT][eft_C128][eft_C128] = {
-        eft_C128, (void*)dpnp_zeros_like_ext_c<std::complex<double>>};
 
     return;
 }

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -349,9 +349,7 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_VAR
         DPNP_FN_VAR_EXT
         DPNP_FN_ZEROS
-        DPNP_FN_ZEROS_EXT
         DPNP_FN_ZEROS_LIKE
-        DPNP_FN_ZEROS_LIKE_EXT
 
 cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncType":  # need this namespace for Enum import
     cdef enum DPNPFuncType "DPNPFuncType":

--- a/dpnp/dpnp_algo/dpnp_algo_arraycreation.pyx
+++ b/dpnp/dpnp_algo/dpnp_algo_arraycreation.pyx
@@ -51,8 +51,6 @@ __all__ += [
     "dpnp_tril",
     "dpnp_triu",
     "dpnp_vander",
-    "dpnp_zeros",
-    "dpnp_zeros_like"
 ]
 
 
@@ -120,8 +118,7 @@ cpdef utils.dpnp_descriptor dpnp_diag(utils.dpnp_descriptor v, int k):
 
     v_obj = v.get_array()
 
-    # TODO need to call dpnp_container.zeros instead
-    result_obj = dpnp.zeros(result_shape, dtype=v.dtype).to_device(v_obj.sycl_device)
+    result_obj = dpnp_container.zeros(result_shape, dtype=v.dtype, device=v_obj.sycl_device)
     cdef utils.dpnp_descriptor result = dpnp_descriptor(result_obj)
 
     cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(v.dtype)
@@ -597,11 +594,3 @@ cpdef utils.dpnp_descriptor dpnp_vander(utils.dpnp_descriptor x1, int N, int inc
     c_dpctl.DPCTLEvent_Delete(event_ref)
 
     return result
-
-
-cpdef utils.dpnp_descriptor dpnp_zeros(result_shape, result_dtype):
-    return call_fptr_1out(DPNP_FN_ZEROS_EXT, utils._object_to_tuple(result_shape), result_dtype)
-
-
-cpdef utils.dpnp_descriptor dpnp_zeros_like(result_shape, result_dtype):
-    return call_fptr_1out(DPNP_FN_ZEROS_LIKE_EXT, utils._object_to_tuple(result_shape), result_dtype)

--- a/dpnp/dpnp_container.py
+++ b/dpnp/dpnp_container.py
@@ -46,6 +46,7 @@ __all__ = [
     "asarray",
     "empty",
     "full",
+    "zeros",
 ]
 
 
@@ -136,4 +137,26 @@ def full(shape,
                          order=order,
                          usm_type=usm_type,
                          sycl_queue=sycl_queue_normalized)
+    return dpnp_array(array_obj.shape, buffer=array_obj, order=order)
+
+
+def zeros(shape,
+          *,
+          dtype=None,
+          order="C",
+          device=None,
+          usm_type="device",
+          sycl_queue=None):
+    """Validate input parameters before passing them into `dpctl.tensor` module"""
+    dpu.validate_usm_type(usm_type, allow_none=False)
+    sycl_queue_normalized = dpnp.get_normalized_queue_device(sycl_queue=sycl_queue, device=device)
+    if order is None:
+        order = 'C'
+
+    """Creates `dpnp_array` with zero elements."""
+    array_obj = dpt.zeros(shape,
+                          dtype=dtype,
+                          order=order,
+                          usm_type=usm_type,
+                          sycl_queue=sycl_queue_normalized)
     return dpnp_array(array_obj.shape, buffer=array_obj, order=order)

--- a/dpnp/dpnp_container.py
+++ b/dpnp/dpnp_container.py
@@ -87,6 +87,8 @@ def asarray(x1,
         x1_obj = x1
 
     sycl_queue_normalized = dpnp.get_normalized_queue_device(x1_obj, device=device, sycl_queue=sycl_queue)
+    if order is None:
+        order = 'C'
 
     """Converts incoming 'x1' object to 'dpnp_array'."""
     array_obj = dpt.asarray(x1_obj,
@@ -126,6 +128,8 @@ def full(shape,
     """Validate input parameters before passing them into `dpctl.tensor` module"""
     dpu.validate_usm_type(usm_type, allow_none=True)
     sycl_queue_normalized = dpnp.get_normalized_queue_device(fill_value, sycl_queue=sycl_queue, device=device)
+    if order is None:
+        order = 'C'
 
     if isinstance(fill_value, dpnp_array):
         fill_value = fill_value.get_array()
@@ -153,7 +157,7 @@ def zeros(shape,
     if order is None:
         order = 'C'
 
-    """Creates `dpnp_array` with zero elements."""
+    """Creates `dpnp_array` of zeros with the given shape, dtype, and order."""
     array_obj = dpt.zeros(shape,
                           dtype=dtype,
                           order=order,

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -697,7 +697,7 @@ def full(shape,
     """
     if like is not None:
         pass
-    elif not isinstance(order, str) or len(order) != 1 or order not in "CcFf":
+    elif order not in ('C', 'c', 'F', 'f', None):
         pass
     else:
         return dpnp_container.full(shape,
@@ -752,14 +752,14 @@ def full_like(x1,
     """
     if not isinstance(x1, dpnp.ndarray):
         pass
-    elif not isinstance(order, str) or len(order) != 1 or order not in "CcFf":
+    elif order not in ('C', 'c', 'F', 'f', None):
         pass
     elif subok is not False:
         pass
     else:
-        _shape = shape if shape is not None else x1.shape
-        _dtype = dtype if dtype is not None else x1.dtype
-        _usm_type = usm_type if usm_type is not None else x1.usm_type
+        _shape = x1.shape if shape is None else shape
+        _dtype = x1.dtype if dtype is None else dtype
+        _usm_type = x1.usm_type if usm_type is None else usm_type
         _sycl_queue = dpnp.get_normalized_queue_device(x1, sycl_queue=sycl_queue, device=device)
 
         return dpnp_container.full(_shape,
@@ -1374,7 +1374,7 @@ def vander(x1, N=None, increasing=False):
 
 def zeros(shape,
           *,
-          dtype=numpy.float64,
+          dtype=None,
           order="C",
           like=None,
           device=None,
@@ -1463,16 +1463,16 @@ def zeros_like(x1,
     [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
 
 """
-    if subok is not False:
-        pass
-    elif not isinstance(x1, dpnp.ndarray):
+    if not isinstance(x1, dpnp.ndarray):
         pass
     elif order not in ('C', 'c', 'F', 'f', None):
         pass
+    elif subok is not False:
+        pass
     else:
-        _shape = shape if shape is not None else x1.shape
-        _dtype = dtype if dtype is not None else x1.dtype
-        _usm_type = usm_type if usm_type is not None else x1.usm_type
+        _shape = x1.shape if shape is None else shape
+        _dtype = x1.dtype if dtype is None else dtype
+        _usm_type = x1.usm_type if usm_type is None else usm_type
         _sycl_queue = dpnp.get_normalized_queue_device(x1, sycl_queue=sycl_queue, device=device)
         return dpnp_container.zeros(_shape,
                                     dtype=_dtype,

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -1372,7 +1372,14 @@ def vander(x1, N=None, increasing=False):
     return call_origin(numpy.vander, x1, N=N, increasing=increasing)
 
 
-def zeros(shape, dtype=None, order='C'):
+def zeros(shape,
+          *,
+          dtype=numpy.float64,
+          order="C",
+          like=None,
+          device=None,
+          usm_type="device",
+          sycl_queue=None):
     """
     Return a new array of given shape and type, filled with zeros.
 
@@ -1380,7 +1387,9 @@ def zeros(shape, dtype=None, order='C'):
 
     Limitations
     -----------
-    Parameter ``order`` is supported only with default value ``"C"``.
+    Parameter ``order`` is supported only with values ``"C"`` and ``"F"``.
+    Parameter ``like`` is supported only with default value ``None``.
+    Otherwise the function will be executed sequentially on CPU.
 
     See Also
     --------
@@ -1401,21 +1410,30 @@ def zeros(shape, dtype=None, order='C'):
     [0.0, 0.0]
 
     """
+    if like is not None:
+        pass
+    elif order not in ('C', 'c', 'F', 'f', None):
+        pass
+    else:
+        return dpnp_container.zeros(shape,
+                                    dtype=dtype,
+                                    order=order,
+                                    device=device,
+                                    usm_type=usm_type,
+                                    sycl_queue=sycl_queue)
 
-    if (not use_origin_backend()):
-        if order not in ('C', 'c', None):
-            pass
-        else:
-            _dtype = dtype if dtype is not None else dpnp.float64
-            result = dpnp_zeros(shape, _dtype).get_pyobj()
-
-            return result
-
-    return call_origin(numpy.zeros, shape, dtype=dtype, order=order)
+    return call_origin(numpy.zeros, shape, dtype=dtype, order=order, like=like)
 
 
-# numpy.zeros_like(a, dtype=None, order='K', subok=True, shape=None)
-def zeros_like(x1, dtype=None, order='C', subok=False, shape=None):
+def zeros_like(x1,
+               *,
+               dtype=None,
+               order="C",
+               subok=False,
+               shape=None,
+               device=None,
+               usm_type=None,
+               sycl_queue=None):
     """
     Return an array of zeros with the same shape and type as a given array.
 
@@ -1423,8 +1441,10 @@ def zeros_like(x1, dtype=None, order='C', subok=False, shape=None):
 
     Limitations
     -----------
-    Parameter ``order`` is supported only with default value ``"C"``.
+    Parameters ``x1`` is supported only as :class:`dpnp.dpnp_array`.
+    Parameter ``order`` is supported with values ``"C"`` or ``"F"``.
     Parameter ``subok`` is supported only with default value ``False``.
+    Otherwise the function will be executed sequentially on CPU.
 
     See Also
     --------
@@ -1442,19 +1462,22 @@ def zeros_like(x1, dtype=None, order='C', subok=False, shape=None):
     >>> [i for i in np.zeros_like(x)]
     [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
 
-    """
-
-    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
-    if x1_desc:
-        if order not in ('C', 'c', None):
-            pass
-        elif subok is not False:
-            pass
-        else:
-            _shape = shape if shape is not None else x1_desc.shape
-            _dtype = dtype if dtype is not None else x1_desc.dtype
-            result = dpnp_zeros_like(_shape, _dtype).get_pyobj()
-
-            return result
+"""
+    if subok is not False:
+        pass
+    elif not isinstance(x1, dpnp.ndarray):
+        pass
+    elif order not in ('C', 'c', 'F', 'f', None):
+        pass
+    else:
+        _shape = shape if shape is not None else x1.shape
+        _dtype = dtype if dtype is not None else x1.dtype
+        _usm_type = usm_type if usm_type is not None else x1.usm_type
+        _sycl_queue = dpnp.get_normalized_queue_device(x1, sycl_queue=sycl_queue, device=device)
+        return dpnp_container.zeros(_shape,
+                                    dtype=_dtype,
+                                    order=order,
+                                    usm_type=_usm_type,
+                                    sycl_queue=_sycl_queue)
 
     return call_origin(numpy.zeros_like, x1, dtype, order, subok, shape)

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -289,7 +289,6 @@ tests/third_party/cupy/creation_tests/test_basic.py::TestBasic::test_empty_int
 tests/third_party/cupy/creation_tests/test_basic.py::TestBasic::test_empty_like
 tests/third_party/cupy/creation_tests/test_basic.py::TestBasic::test_empty_like_contiguity
 tests/third_party/cupy/creation_tests/test_basic.py::TestBasic::test_empty_scalar
-tests/third_party/cupy/creation_tests/test_basic.py::TestBasic::test_zeros_scalar
 tests/third_party/cupy/creation_tests/test_basic.py::TestBasicReshape_param_0_{shape=4}::test_empty_like_reshape
 tests/third_party/cupy/creation_tests/test_basic.py::TestBasicReshape_param_0_{shape=4}::test_empty_like_reshape_contiguity
 tests/third_party/cupy/creation_tests/test_basic.py::TestBasicReshape_param_1_{shape=(4,)}::test_empty_like_reshape

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -517,7 +517,6 @@ tests/third_party/cupy/creation_tests/test_basic.py::TestBasic::test_empty_int
 tests/third_party/cupy/creation_tests/test_basic.py::TestBasic::test_empty_like
 tests/third_party/cupy/creation_tests/test_basic.py::TestBasic::test_empty_like_contiguity
 tests/third_party/cupy/creation_tests/test_basic.py::TestBasic::test_empty_scalar
-tests/third_party/cupy/creation_tests/test_basic.py::TestBasic::test_zeros_scalar
 tests/third_party/cupy/creation_tests/test_basic.py::TestBasicReshape_param_0_{shape=4}::test_empty_like_reshape
 tests/third_party/cupy/creation_tests/test_basic.py::TestBasicReshape_param_0_{shape=4}::test_empty_like_reshape_contiguity
 tests/third_party/cupy/creation_tests/test_basic.py::TestBasicReshape_param_1_{shape=(4,)}::test_empty_like_reshape

--- a/tests/test_arraycreation.py
+++ b/tests/test_arraycreation.py
@@ -352,7 +352,7 @@ def test_vander(array, type, n, increase):
 
 @pytest.mark.parametrize("shape",
                          [(), 0, (0,), (2, 0, 3), (3, 2)],
-                         ids=['()', '0', '(0,)', '(2, 0, 3)', '(1, 2)'])
+                         ids=['()', '0', '(0,)', '(2, 0, 3)', '(3, 2)'])
 @pytest.mark.parametrize("fill_value",
                          [1.5, 2, 1.5+0.j],
                          ids=['1.5', '2', '1.5+0.j'])
@@ -418,3 +418,32 @@ def test_full_strides():
 def test_full_invalid_fill_value(fill_value):
     with pytest.raises(ValueError):
         dpnp.full(10, fill_value=fill_value)
+
+
+@pytest.mark.parametrize("shape",
+                         [(), 0, (0,), (2, 0, 3), (3, 2)],
+                         ids=['()', '0', '(0,)', '(2, 0, 3)', '(3, 2)'])
+@pytest.mark.parametrize("dtype",
+                         [numpy.complex128, numpy.complex64, numpy.float64, numpy.float32, numpy.float16, numpy.int64, numpy.int32],
+                         ids=['complex128', 'complex64', 'float64', 'float32', 'float16', 'int64', 'int32'])
+def test_zeros(shape, dtype):
+    expected = numpy.zeros(shape, dtype=dtype)
+    result = dpnp.zeros(shape, dtype=dtype)
+
+    assert expected.dtype == result.dtype
+    numpy.testing.assert_array_equal(expected, result)
+
+
+@pytest.mark.parametrize("array",
+                         [[], 0,  [1, 2, 3], [[1, 2], [3, 4]]],
+                         ids=['[]', '0',  '[1, 2, 3]', '[[1, 2], [3, 4]]'])
+@pytest.mark.parametrize("dtype",
+                         [numpy.complex128, numpy.complex64, numpy.float64, numpy.float32, numpy.float16, numpy.int64, numpy.int32],
+                         ids=['complex128', 'complex64', 'float64', 'float32', 'float16', 'int64', 'int32'])
+def test_zeros_like(array, dtype):
+    a = numpy.array(array)
+    ia = dpnp.array(array)
+
+    expected = numpy.zeros_like(a, dtype=dtype)
+    result = dpnp.zeros_like(ia, dtype=dtype)
+    numpy.testing.assert_array_equal(expected, result)

--- a/tests/test_arraycreation.py
+++ b/tests/test_arraycreation.py
@@ -357,11 +357,14 @@ def test_vander(array, type, n, increase):
                          [1.5, 2, 1.5+0.j],
                          ids=['1.5', '2', '1.5+0.j'])
 @pytest.mark.parametrize("dtype",
-                         [numpy.complex128, numpy.complex64, numpy.float64, numpy.float32, numpy.float16, numpy.int64, numpy.int32],
-                         ids=['complex128', 'complex64', 'float64', 'float32', 'float16', 'int64', 'int32'])
-def test_full(shape, fill_value, dtype):
-    expected = numpy.full(shape, fill_value, dtype=dtype)
-    result = dpnp.full(shape, fill_value, dtype=dtype)
+                         [None, numpy.complex128, numpy.complex64, numpy.float64, numpy.float32, numpy.float16, numpy.int64, numpy.int32],
+                         ids=['None', 'complex128', 'complex64', 'float64', 'float32', 'float16', 'int64', 'int32'])
+@pytest.mark.parametrize("order",
+                         [None, "C", "F"],
+                         ids=['None', 'C', 'F'])
+def test_full(shape, fill_value, dtype, order):
+    expected = numpy.full(shape, fill_value, dtype=dtype, order=order)
+    result = dpnp.full(shape, fill_value, dtype=dtype, order=order)
 
     assert expected.dtype == result.dtype
     numpy.testing.assert_array_equal(expected, result)
@@ -374,14 +377,19 @@ def test_full(shape, fill_value, dtype):
                          [1.5, 2, 1.5+0.j],
                          ids=['1.5', '2', '1.5+0.j'])
 @pytest.mark.parametrize("dtype",
-                         [numpy.complex128, numpy.complex64, numpy.float64, numpy.float32, numpy.float16, numpy.int64, numpy.int32],
-                         ids=['complex128', 'complex64', 'float64', 'float32', 'float16', 'int64', 'int32'])
-def test_full_like(array, fill_value, dtype):
+                         [None, numpy.complex128, numpy.complex64, numpy.float64, numpy.float32, numpy.float16, numpy.int64, numpy.int32],
+                         ids=['None', 'complex128', 'complex64', 'float64', 'float32', 'float16', 'int64', 'int32'])
+@pytest.mark.parametrize("order",
+                         [None, "C", "F"],
+                         ids=['None', 'C', 'F'])
+def test_full_like(array, fill_value, dtype, order):
     a = numpy.array(array)
     ia = dpnp.array(array)
 
-    expected = numpy.full_like(a, fill_value, dtype=dtype)
-    result = dpnp.full_like(ia, fill_value, dtype=dtype)
+    expected = numpy.full_like(a, fill_value, dtype=dtype, order=order)
+    result = dpnp.full_like(ia, fill_value, dtype=dtype, order=order)
+    
+    assert expected.dtype == result.dtype
     numpy.testing.assert_array_equal(expected, result)
 
 
@@ -424,11 +432,14 @@ def test_full_invalid_fill_value(fill_value):
                          [(), 0, (0,), (2, 0, 3), (3, 2)],
                          ids=['()', '0', '(0,)', '(2, 0, 3)', '(3, 2)'])
 @pytest.mark.parametrize("dtype",
-                         [numpy.complex128, numpy.complex64, numpy.float64, numpy.float32, numpy.float16, numpy.int64, numpy.int32],
-                         ids=['complex128', 'complex64', 'float64', 'float32', 'float16', 'int64', 'int32'])
-def test_zeros(shape, dtype):
-    expected = numpy.zeros(shape, dtype=dtype)
-    result = dpnp.zeros(shape, dtype=dtype)
+                         [None, numpy.complex128, numpy.complex64, numpy.float64, numpy.float32, numpy.float16, numpy.int64, numpy.int32],
+                         ids=['None', 'complex128', 'complex64', 'float64', 'float32', 'float16', 'int64', 'int32'])
+@pytest.mark.parametrize("order",
+                         [None, "C", "F"],
+                         ids=['None', 'C', 'F'])
+def test_zeros(shape, dtype, order):
+    expected = numpy.zeros(shape, dtype=dtype, order=order)
+    result = dpnp.zeros(shape, dtype=dtype, order=order)
 
     assert expected.dtype == result.dtype
     numpy.testing.assert_array_equal(expected, result)
@@ -438,12 +449,17 @@ def test_zeros(shape, dtype):
                          [[], 0,  [1, 2, 3], [[1, 2], [3, 4]]],
                          ids=['[]', '0',  '[1, 2, 3]', '[[1, 2], [3, 4]]'])
 @pytest.mark.parametrize("dtype",
-                         [numpy.complex128, numpy.complex64, numpy.float64, numpy.float32, numpy.float16, numpy.int64, numpy.int32],
-                         ids=['complex128', 'complex64', 'float64', 'float32', 'float16', 'int64', 'int32'])
-def test_zeros_like(array, dtype):
+                         [None, numpy.complex128, numpy.complex64, numpy.float64, numpy.float32, numpy.float16, numpy.int64, numpy.int32],
+                         ids=['None', 'complex128', 'complex64', 'float64', 'float32', 'float16', 'int64', 'int32'])
+@pytest.mark.parametrize("order",
+                         [None, "C", "F"],
+                         ids=['None', 'C', 'F'])
+def test_zeros_like(array, dtype, order):
     a = numpy.array(array)
     ia = dpnp.array(array)
 
-    expected = numpy.zeros_like(a, dtype=dtype)
-    result = dpnp.zeros_like(ia, dtype=dtype)
+    expected = numpy.zeros_like(a, dtype=dtype, order=order)
+    result = dpnp.zeros_like(ia, dtype=dtype, order=order)
+
+    assert expected.dtype == result.dtype
     numpy.testing.assert_array_equal(expected, result)

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -80,7 +80,10 @@ def vvsort(val, vec, size, xp):
                      {'stop': 10**8, 'step': 15}),
         pytest.param("full",
                      (2,2),
-                     {'fill_value': 5})
+                     {'fill_value': 5}),
+        pytest.param("zeros",
+                     (2,2),
+                     {})
     ])
 @pytest.mark.parametrize("device",
                           valid_devices,
@@ -100,7 +103,9 @@ def test_array_creation(func, arg, kwargs, device):
     "func, kwargs",
     [
         pytest.param("full_like",
-                     {'fill_value': 5})
+                     {'fill_value': 5}),
+        pytest.param("zeros_like",
+                     {})
     ])
 @pytest.mark.parametrize("device_x",
                           valid_devices,

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -50,3 +50,8 @@ def test_array_creation(usm_type_x, usm_type_y):
     y = dp.full_like(x0, 4, usm_type=usm_type_y)
     assert x.usm_type == usm_type_x
     assert y.usm_type == usm_type_y
+
+    x = dp.zeros_like(x0)
+    y = dp.zeros_like(x0, usm_type=usm_type_y)
+    assert x.usm_type == usm_type_x
+    assert y.usm_type == usm_type_y

--- a/tests/third_party/cupy/creation_tests/test_basic.py
+++ b/tests/third_party/cupy/creation_tests/test_basic.py
@@ -181,7 +181,7 @@ class TestBasic(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_zeros_scalar(self, xp, dtype, order):
-        return xp.zeros(None, dtype=dtype, order=order)
+        return xp.zeros((), dtype=dtype, order=order)
 
     @testing.for_CF_orders()
     @testing.for_all_dtypes()

--- a/tests/third_party/cupy/statistics_tests/test_correlation.py
+++ b/tests/third_party/cupy/statistics_tests/test_correlation.py
@@ -151,7 +151,7 @@ class TestCorrelateInvalid(unittest.TestCase):
     @testing.for_all_dtypes()
     def test_correlate_empty(self, dtype):
         for xp in (numpy, cupy):
-            a = xp.zeros((0,), dtype)
+            a = xp.zeros((0,), dtype=dtype)
             with pytest.raises(ValueError):
                 xp.correlate(a, a, mode=self.mode)
 


### PR DESCRIPTION
Use zeros() function from dpctl.tensor module instead of DPNP backend implementation.
A cython code relating to zeros() call is cleaned up.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
