### PR TITLE
dpctl arranges an array with elements of long type by default

### DIFF
--- a/tests/test_random_state.py
+++ b/tests/test_random_state.py
@@ -521,13 +521,13 @@ class TestSeed:
                              [0.5, -1.5, [-0.3], (1.7, 3),
                               'text',
                               numpy.arange(0, 1, 0.5),
-                              dpnp.arange(3),
-                              dpnp.arange(3, dtype=numpy.float32)],
+                              dpnp.arange(3, dtype=dpnp.int64),
+                              dpnp.arange(3, dtype=dpnp.float32)],
                              ids=['0.5', '-1.5', '[-0.3]', '(1.7, 3)',
                                   'text',
                                   'numpy.arange(0, 1, 0.5)',
-                                  'dpnp.arange(3)',
-                                  'dpnp.arange(3, dtype=numpy.float32)'])
+                                  'dpnp.arange(3, dtype=dpnp.int64)',
+                                  'dpnp.arange(3, dtype=dpnp.float32)'])
     def test_invalid_type(self, seed):
         # seed must be an unsigned 32-bit integer
         assert_raises(TypeError, RandomState, seed)


### PR DESCRIPTION
`dpctl` changed default integer type used to arrange an array in [#1017](https://github.com/IntelPython/dpctl/pull/1017). Now it returns the array with elements of long type.
This PR is to update failing `dpnp` tests due to introduced change in `dpctl`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
