### PR TITLE
Map dtype to device in array creation functions

### DIFF
--- a/dpnp/backend/kernels/dpnp_krnl_arraycreation.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_arraycreation.cpp
@@ -58,6 +58,8 @@ DPCTLSyclEventRef dpnp_arange_c(DPCTLSyclQueueRef q_ref,
     sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
     sycl::event event;
 
+    validate_type_for_device<_DataType>(q);
+
     _DataType* result = reinterpret_cast<_DataType*>(result1);
 
     sycl::range<1> gws(size);
@@ -72,7 +74,6 @@ DPCTLSyclEventRef dpnp_arange_c(DPCTLSyclQueueRef q_ref,
     };
 
     event = q.submit(kernel_func);
-
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
 
     return DPCTLEvent_Copy(event_ref);
@@ -144,6 +145,8 @@ DPCTLSyclEventRef dpnp_diag_c(DPCTLSyclQueueRef q_ref,
     DPCTLSyclEventRef event_ref = nullptr;
     sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
 
+    validate_type_for_device<_DataType>(q);
+
     const size_t input1_size = std::accumulate(shape, shape + ndim, 1, std::multiplies<shape_elem_type>());
     const size_t result_size = std::accumulate(res_shape, res_shape + res_ndim, 1, std::multiplies<shape_elem_type>());
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref,v_in, input1_size, true);
@@ -194,6 +197,7 @@ void dpnp_diag_c(void* v_in,
                                                          res_ndim,
                                                          dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
@@ -240,6 +244,8 @@ DPCTLSyclEventRef dpnp_eye_c(DPCTLSyclQueueRef q_ref,
 
     sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
 
+    validate_type_for_device<_DataType>(q);
+
     size_t result_size = res_shape[0] * res_shape[1];
 
     DPNPC_ptr_adapter<_DataType> result_ptr(q_ref,result1, result_size, true, true);
@@ -280,6 +286,7 @@ void dpnp_eye_c(void* result1, int k, const shape_elem_type* res_shape)
                                                         res_shape,
                                                         dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
@@ -368,7 +375,9 @@ DPCTLSyclEventRef dpnp_identity_c(DPCTLSyclQueueRef q_ref,
     sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
     sycl::event event;
 
-    _DataType* result = reinterpret_cast<_DataType*>(result1);
+    validate_type_for_device<_DataType>(q);
+
+    _DataType* result = static_cast<_DataType *>(result1);
 
     sycl::range<2> gws(n, n);
     auto kernel_parallel_for_func = [=](sycl::id<2> global_id) {
@@ -382,10 +391,9 @@ DPCTLSyclEventRef dpnp_identity_c(DPCTLSyclQueueRef q_ref,
     };
 
     event = q.submit(kernel_func);
+    event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
 
-    event.wait();
-
-    return event_ref;
+    return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType>
@@ -398,6 +406,7 @@ void dpnp_identity_c(void* result1, const size_t n)
                                                              n,
                                                              dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
@@ -425,10 +434,11 @@ DPCTLSyclEventRef dpnp_ones_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = dpnp_initval_c<_DataType>(q_ref, result, fill_value, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 
     sycl::free(fill_value, q);
 
-    return event_ref;
+    return nullptr;
 }
 
 template <typename _DataType>
@@ -441,6 +451,7 @@ void dpnp_ones_c(void* result, size_t size)
                                                          size,
                                                          dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
@@ -471,6 +482,7 @@ void dpnp_ones_like_c(void* result, size_t size)
                                                               size,
                                                               dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
@@ -520,6 +532,8 @@ DPCTLSyclEventRef dpnp_ptp_c(DPCTLSyclQueueRef q_ref,
 
     sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
 
+    validate_type_for_device<_DataType>(q);
+
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref,input1_in, input_size, true);
     DPNPC_ptr_adapter<_DataType> result_ptr(q_ref,result1_out, result_size, false, true);
     _DataType* arr = input1_ptr.get_ptr();
@@ -563,7 +577,7 @@ DPCTLSyclEventRef dpnp_ptp_c(DPCTLSyclQueueRef q_ref,
     sycl::free(max_arr, q);
     sycl::free(_strides, q);
 
-    return event_ref;
+    return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType>
@@ -649,6 +663,9 @@ DPCTLSyclEventRef dpnp_vander_c(DPCTLSyclQueueRef q_ref,
 
     sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
 
+    validate_type_for_device<_DataType_input>(q);
+    validate_type_for_device<_DataType_output>(q);
+
     DPNPC_ptr_adapter<_DataType_input> input1_ptr(q_ref,array1_in, size_in, true);
     DPNPC_ptr_adapter<_DataType_output> result_ptr(q_ref,result1, size_in * N, true, true);
     const _DataType_input* array_in = input1_ptr.get_ptr();
@@ -693,7 +710,7 @@ DPCTLSyclEventRef dpnp_vander_c(DPCTLSyclQueueRef q_ref,
         }
     }
 
-    return event_ref;
+    return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType_input, typename _DataType_output>
@@ -709,6 +726,7 @@ void dpnp_vander_c(const void* array1_in, void* result1, const size_t size_in, c
                                                                                    increasing,
                                                                                    dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType_input, typename _DataType_output>
@@ -757,10 +775,11 @@ DPCTLSyclEventRef dpnp_trace_c(DPCTLSyclQueueRef q_ref,
 
     sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
 
-    DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref,array1_in, size * last_dim);
+    validate_type_for_device<_DataType>(q);
+    validate_type_for_device<_ResultType>(q);
 
-    const _DataType* input = input1_ptr.get_ptr();
-    _ResultType* result = reinterpret_cast<_ResultType*>(result_in);
+    const _DataType* input = static_cast<const _DataType *>(array1_in);
+    _ResultType* result = static_cast<_ResultType *>(result_in);
 
     sycl::range<1> gws(size);
     auto kernel_parallel_for_func = [=](auto index) {
@@ -780,7 +799,6 @@ DPCTLSyclEventRef dpnp_trace_c(DPCTLSyclQueueRef q_ref,
     };
 
     auto event = q.submit(kernel_func);
-
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
 
     return DPCTLEvent_Copy(event_ref);
@@ -798,6 +816,7 @@ void dpnp_trace_c(const void* array1_in, void* result_in, const shape_elem_type*
                                                                        ndim,
                                                                        dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType, typename _ResultType>
@@ -839,7 +858,9 @@ DPCTLSyclEventRef dpnp_tri_c(DPCTLSyclQueueRef q_ref,
 
     sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
 
-    _DataType* result = reinterpret_cast<_DataType*>(result1);
+    validate_type_for_device<_DataType>(q);
+
+    _DataType* result = static_cast<_DataType *>(result1);
 
     size_t idx = N * M;
     sycl::range<1> gws(idx);
@@ -867,7 +888,6 @@ DPCTLSyclEventRef dpnp_tri_c(DPCTLSyclQueueRef q_ref,
     };
 
     event = q.submit(kernel_func);
-
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
 
     return DPCTLEvent_Copy(event_ref);
@@ -885,6 +905,7 @@ void dpnp_tri_c(void* result1, const size_t N, const size_t M, const int k)
                                                         k,
                                                         dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
@@ -945,6 +966,8 @@ DPCTLSyclEventRef dpnp_tril_c(DPCTLSyclQueueRef q_ref,
     }
 
     sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+
+    validate_type_for_device<_DataType>(q);
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref,array_in, input_size, true);
     DPNPC_ptr_adapter<_DataType> result_ptr(q_ref,result1, res_size, true, true);
@@ -1015,7 +1038,7 @@ DPCTLSyclEventRef dpnp_tril_c(DPCTLSyclQueueRef q_ref,
             }
         }
     }
-    return event_ref;
+    return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType>
@@ -1039,6 +1062,7 @@ void dpnp_tril_c(void* array_in,
                                                          res_ndim,
                                                          dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
@@ -1106,6 +1130,8 @@ DPCTLSyclEventRef dpnp_triu_c(DPCTLSyclQueueRef q_ref,
 
     sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
 
+    validate_type_for_device<_DataType>(q);
+
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref,array_in, input_size, true);
     DPNPC_ptr_adapter<_DataType> result_ptr(q_ref,result1, res_size, true, true);
     _DataType* array_m = input1_ptr.get_ptr();
@@ -1175,7 +1201,7 @@ DPCTLSyclEventRef dpnp_triu_c(DPCTLSyclQueueRef q_ref,
             }
         }
     }
-    return event_ref;
+    return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType>
@@ -1199,6 +1225,7 @@ void dpnp_triu_c(void* array_in,
                                                          res_ndim,
                                                          dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
@@ -1234,10 +1261,11 @@ DPCTLSyclEventRef dpnp_zeros_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = dpnp_initval_c<_DataType>(q_ref, result, fill_value, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 
     sycl::free(fill_value, q);
 
-    return event_ref;
+    return nullptr;
 }
 
 template <typename _DataType>
@@ -1337,6 +1365,8 @@ void func_map_init_arraycreation(func_map_t& fmap)
     fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_identity_ext_c<float>};
     fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_identity_ext_c<double>};
     fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_identity_ext_c<bool>};
+    fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_C64][eft_C64] = {eft_C64,
+                                                                    (void*)dpnp_identity_ext_c<std::complex<float>>};
     fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_C128][eft_C128] = {eft_C128,
                                                                     (void*)dpnp_identity_ext_c<std::complex<double>>};
 
@@ -1392,9 +1422,11 @@ void func_map_init_arraycreation(func_map_t& fmap)
 
     fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_INT][eft_INT] = {eft_LNG, (void*)dpnp_vander_ext_c<int32_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_vander_ext_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_FLT][eft_FLT] = {eft_DBL, (void*)dpnp_vander_ext_c<float, double>};
+    fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_vander_ext_c<float, float>};
     fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_vander_ext_c<double, double>};
     fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_BLN][eft_BLN] = {eft_LNG, (void*)dpnp_vander_ext_c<bool, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_C64][eft_C64] = {
+        eft_C64, (void*)dpnp_vander_ext_c<std::complex<float>, std::complex<float>>};
     fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_C128][eft_C128] = {
         eft_C128, (void*)dpnp_vander_ext_c<std::complex<double>, std::complex<double>>};
 

--- a/dpnp/backend/src/dpnp_utils.hpp
+++ b/dpnp/backend/src/dpnp_utils.hpp
@@ -391,6 +391,58 @@ err:
 
 /**
  * @ingroup BACKEND_UTILS
+ * @brief check support of type T by SYCL device.
+ *
+ * To check if sycl::device may use templated type T.
+ *
+ * @param [in]  q  sycl::device which is examined for type support.
+ *
+ * @exception std::runtime_error    type T is out of suppport by the queue.
+ */
+template <typename T>
+void validate_type_for_device(const sycl::device &d)
+{
+    if constexpr (std::is_same_v<T, double>) {
+        if (!d.has(sycl::aspect::fp64)) {
+            throw std::runtime_error("Device " +
+                                     d.get_info<sycl::info::device::name>() +
+                                     " does not support type 'double'");
+        }
+    }
+    else if constexpr (std::is_same_v<T, std::complex<double>>) {
+        if (!d.has(sycl::aspect::fp64)) {
+            throw std::runtime_error("Device " +
+                                     d.get_info<sycl::info::device::name>() +
+                                     " does not support type 'complex<double>'");
+        }
+    }
+    else if constexpr (std::is_same_v<T, sycl::half>) {
+        if (!d.has(sycl::aspect::fp16)) {
+            throw std::runtime_error("Device " +
+                                     d.get_info<sycl::info::device::name>() +
+                                     " does not support type 'half'");
+        }
+    }
+}
+
+/**
+ * @ingroup BACKEND_UTILS
+ * @brief check support of type T by SYCL queue.
+ *
+ * To check if sycl::queue assigned to a device may use templated type T.
+ *
+ * @param [in]  q  sycl::queue which is examined for type support.
+ *
+ * @exception std::runtime_error    type T is out of suppport by the queue.
+ */
+template <typename T>
+void validate_type_for_device(const sycl::queue &q)
+{
+    validate_type_for_device<T>(q.get_device());
+}
+
+/**
+ * @ingroup BACKEND_UTILS
  * @brief print std::vector to std::ostream.
  *
  * To print std::vector with POD types to std::out.

--- a/dpnp/backend/src/dpnp_utils.hpp
+++ b/dpnp/backend/src/dpnp_utils.hpp
@@ -400,7 +400,7 @@ err:
  * @exception std::runtime_error    type T is out of suppport by the queue.
  */
 template <typename T>
-void validate_type_for_device(const sycl::device &d)
+static inline void validate_type_for_device(const sycl::device &d)
 {
     if constexpr (std::is_same_v<T, double>) {
         if (!d.has(sycl::aspect::fp64)) {
@@ -436,7 +436,7 @@ void validate_type_for_device(const sycl::device &d)
  * @exception std::runtime_error    type T is out of suppport by the queue.
  */
 template <typename T>
-void validate_type_for_device(const sycl::queue &q)
+static inline void validate_type_for_device(const sycl::queue &q)
 {
     validate_type_for_device<T>(q.get_device());
 }

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -392,7 +392,7 @@ cdef extern from "dpnp_iface.hpp":
 # C function pointer to the C library template functions
 ctypedef c_dpctl.DPCTLSyclEventRef(*fptr_1out_t)(c_dpctl.DPCTLSyclQueueRef,
                                                  void * , size_t,
-                                                 const c_dpctl.DPCTLEventVectorRef)
+                                                 const c_dpctl.DPCTLEventVectorRef) except +
 ctypedef c_dpctl.DPCTLSyclEventRef(*fptr_1in_1out_t)(c_dpctl.DPCTLSyclQueueRef,
                                                      void *, void * , size_t,
                                                      const c_dpctl.DPCTLEventVectorRef)

--- a/dpnp/dpnp_algo/dpnp_algo_arraycreation.pyx
+++ b/dpnp/dpnp_algo/dpnp_algo_arraycreation.pyx
@@ -65,7 +65,7 @@ ctypedef c_dpctl.DPCTLSyclEventRef(*custom_1in_1out_func_ptr_t)(c_dpctl.DPCTLSyc
                                                                 const c_dpctl.DPCTLEventVectorRef)
 ctypedef c_dpctl.DPCTLSyclEventRef(*ftpr_custom_vander_1in_1out_t)(c_dpctl.DPCTLSyclQueueRef,
                                                                    void * , void * , size_t, size_t, int,
-                                                                   const c_dpctl.DPCTLEventVectorRef)
+                                                                   const c_dpctl.DPCTLEventVectorRef) except +
 ctypedef c_dpctl.DPCTLSyclEventRef(*custom_arraycreation_1in_1out_func_ptr_t)(c_dpctl.DPCTLSyclQueueRef,
                                                                               void *,
                                                                               const size_t,
@@ -85,7 +85,7 @@ ctypedef c_dpctl.DPCTLSyclEventRef(*custom_indexing_1out_func_ptr_t)(c_dpctl.DPC
                                                                      const size_t ,
                                                                      const size_t ,
                                                                      const int,
-                                                                     const c_dpctl.DPCTLEventVectorRef)
+                                                                     const c_dpctl.DPCTLEventVectorRef) except +
 ctypedef c_dpctl.DPCTLSyclEventRef(*fptr_dpnp_eye_t)(c_dpctl.DPCTLSyclQueueRef,
                                                      void *, int , const shape_elem_type * ,
                                                      const c_dpctl.DPCTLEventVectorRef)
@@ -94,7 +94,7 @@ ctypedef c_dpctl.DPCTLSyclEventRef(*fptr_dpnp_trace_t)(c_dpctl.DPCTLSyclQueueRef
                                                        void * ,
                                                        const shape_elem_type * ,
                                                        const size_t,
-                                                       const c_dpctl.DPCTLEventVectorRef)
+                                                       const c_dpctl.DPCTLEventVectorRef) except +
 
 
 cpdef utils.dpnp_descriptor dpnp_copy(utils.dpnp_descriptor x1):
@@ -447,9 +447,6 @@ cpdef utils.dpnp_descriptor dpnp_trace(utils.dpnp_descriptor arr, offset=0, axis
 cpdef utils.dpnp_descriptor dpnp_tri(N, M=None, k=0, dtype=numpy.float):
     if M is None:
         M = N
-
-    if dtype == numpy.float:
-        dtype = numpy.float64
 
     cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(dtype)
 

--- a/dpnp/dpnp_container.py
+++ b/dpnp/dpnp_container.py
@@ -101,7 +101,7 @@ def asarray(x1,
 
 
 def empty(shape,
-          dtype="f8",
+          dtype="f4",
           order="C",
           device=None,
           usm_type="device",

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -839,7 +839,8 @@ def identity(n, dtype=None, *, like=None):
             pass
         else:
             if dtype is None:
-                dtype = dpnp.float64
+                sycl_queue = dpnp.get_normalized_queue_device(sycl_queue=None, device=None)
+                dtype = map_dtype_to_device(dpnp.float64, sycl_queue.sycl_device)
             return dpnp_identity(n, dtype).get_pyobj()
 
     return call_origin(numpy.identity, n, dtype=dtype, like=like)
@@ -1266,6 +1267,9 @@ def tri(N, M=None, k=0, dtype=numpy.float, **kwargs):
         elif not isinstance(k, int):
             pass
         else:
+            if dtype is numpy.float:
+                sycl_queue = dpnp.get_normalized_queue_device(sycl_queue=None, device=None)
+                dtype = map_dtype_to_device(dpnp.float64, sycl_queue.sycl_device)
             return dpnp_tri(N, M, k, dtype).get_pyobj()
 
     return call_origin(numpy.tri, N, M, k, dtype, **kwargs)

--- a/dpnp/dpnp_utils/dpnp_algo_utils.pyx
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pyx
@@ -61,6 +61,7 @@ __all__ = [
     "get_axis_indeces",
     "get_axis_offsets",
     "_get_linear_index",
+    "map_dtype_to_device",
     "normalize_axis",
     "_object_to_tuple",
     "unwrap_array",
@@ -170,11 +171,12 @@ def call_origin(function, *args, **kwargs):
                     arg[i] = val
 
     elif isinstance(result, numpy.ndarray):
-        if (kwargs_out is None):
-            result_dtype = result_origin.dtype
-            kwargs_dtype = kwargs.get("dtype", None)
-            if (kwargs_dtype is not None):
-                result_dtype = kwargs_dtype
+        if kwargs_out is None:
+            # use dtype from input arguments if present or from the result otherwise
+            result_dtype = kwargs.get("dtype", None) or result_origin.dtype
+
+            if exec_q is not None:
+                result_dtype = map_dtype_to_device(result_origin.dtype, exec_q.sycl_device)
 
             result = dpnp_container.empty(result_origin.shape, dtype=result_dtype, sycl_queue=exec_q)
         else:
@@ -203,6 +205,50 @@ def unwrap_array(x1):
         return x1.get_array()
 
     return x1
+
+
+def map_dtype_to_device(dtype, device):
+    """
+    Map an input ``dtype`` with type ``device`` may use
+    """
+
+    dtype = numpy.dtype(dtype)
+    if not hasattr(dtype, 'char'):
+        raise TypeError(f"Invalid type of input dtype={dtype}")
+    elif not isinstance(device, dpctl.SyclDevice):
+        raise TypeError(f"Invalid type of input device={device}")
+
+    dtc = dtype.char
+    if dtc == "?" or numpy.issubdtype(dtype, numpy.integer):
+        # bool or integer type
+        return dtype
+
+    if numpy.issubdtype(dtype, numpy.floating):
+        if dtc == "f":
+            # float32 type
+            return dtype
+        elif dtc == "d":
+            # float64 type
+            if device.has_aspect_fp64:
+                return dtype
+        elif dtc == "e":
+            # float16 type
+            if device.has_aspect_fp16:
+                return dtype
+        # float32 is default floating type
+        return dpnp.dtype("f4")
+
+    if numpy.issubdtype(dtype, numpy.complexfloating):
+        if dtc == "F":
+            # complex64 type
+            return dtype
+        elif dtc == "D":
+            # complex128 type
+            if device.has_aspect_fp64:
+                return dtype
+        # complex64 is default complex type
+        return dpnp.dtype("c8")
+    raise RuntimeError(f"Unrecognized type of input dtype={dtype}")
 
 
 cpdef checker_throw_axis_error(function_name, param_name, param, expected):

--- a/dpnp/random/dpnp_algo_random.pyx
+++ b/dpnp/random/dpnp_algo_random.pyx
@@ -353,9 +353,9 @@ cdef class MT19937:
 
     cdef bint is_integer(self, value):
         if isinstance(value, numbers.Number):
-            return isinstance(value, int) or isinstance(value, (numpy.int32, numpy.uint32))
+            return isinstance(value, int) or isinstance(value, numpy.integer)
         # cover an element of dpnp array:
-        return numpy.ndim(value) == 0 and hasattr(value, "dtype") and numpy.issubdtype(value, (numpy.int32, numpy.uint32))
+        return numpy.ndim(value) == 0 and hasattr(value, "dtype") and numpy.issubdtype(value, numpy.integer)
 
 
     cdef bint is_uint_range(self, value):

--- a/dpnp/random/dpnp_random_state.py
+++ b/dpnp/random/dpnp_random_state.py
@@ -41,6 +41,7 @@ import dpctl.utils as dpu
 import dpnp
 from dpnp.dpnp_utils.dpnp_algo_utils import (
     call_origin,
+    map_dtype_to_device,
     use_origin_backend
 )
 from dpnp.random.dpnp_algo_random import MT19937
@@ -61,27 +62,32 @@ class RandomState:
     def __init__(self, seed=None, device=None, sycl_queue=None):
         self._seed = 1 if seed is None else seed
         self._sycl_queue = dpnp.get_normalized_queue_device(device=device, sycl_queue=sycl_queue)
+        self._sycl_device = self._sycl_queue.sycl_device
 
-        self._def_float_type = dpnp.float32
-        if self._sycl_queue.get_sycl_device().has_aspect_fp64:
-            self._def_float_type = dpnp.float64
+        # 'float32' is default floating data type if device doesn't support 'float64'
+        self._def_float_type = map_dtype_to_device(dpnp.float64, self._sycl_device)
 
         self._random_state = MT19937(self._seed, self._sycl_queue)
         self._fallback_random_state = call_origin(numpy.random.RandomState, seed, allow_fallback=True)
 
 
+    def __repr__(self):
+        return self.__str__() + ' at 0x{:X}'.format(id(self))
+
+
+    def __str__(self):
+        _str = self.__class__.__name__
+        _str += '(' + self._random_state.__class__.__name__ + ')'
+        return _str
+
+
+    def __getstate__(self):
+        return self.get_state()
+
+
     def _is_finite_scalar(self, x):
         """
         Test a scalar for finiteness (not infinity and not Not a Number).
-
-        Parameters
-        -----------
-            x : input value for test, must be a scalar.
-
-        Returns
-        -------
-            True where ``x`` is not positive infinity, negative infinity, or NaN;
-            false otherwise.
         """
 
         # TODO: replace with dpnp.isfinite() once function is available in DPNP,
@@ -92,15 +98,6 @@ class RandomState:
     def _is_signbit_scalar(self, x):
         """
         Test a scalar if sign bit is set for it (less than zero).
-
-        Parameters
-        -----------
-            x : input value for test, must be a scalar.
-
-        Returns
-        -------
-            True where sign bit is set for ``x`` (that is ``x`` is less than zero);
-            false otherwise.
         """
 
         # TODO: replace with dpnp.signbit() once function is available in DPNP,
@@ -108,20 +105,60 @@ class RandomState:
         return numpy.signbit(x)
 
 
+    def _validate_float_dtype(self, dtype, supported_types):
+        """
+        Test an input floating type if it is listed in ``supported_types`` and
+        if it is supported by the used SYCL device.
+        If ``dtype`` is None, default floating type will be validating.
+        Return the examined floating type if it follows all validation checks.
+        """
+
+        if dtype is None:
+            dtype = self._def_float_type
+
+        if not dtype in supported_types:
+            raise TypeError(f"dtype={dtype} is unsupported.")
+        elif dtype != map_dtype_to_device(dtype, self._sycl_device):
+            raise RuntimeError(f"dtype={dtype} is not supported by SYCL device '{self._sycl_device}'")
+        return dtype
+
+
     def get_state(self):
         """
         Return an internal state of the generator.
 
         For full documentation refer to :obj:`numpy.random.RandomState.get_state`.
+
+        Returns
+        -------
+        out : object
+            An object representing the internal state of the generator.
         """
         return self._random_state
 
 
     def get_sycl_queue(self):
         """
-        Return a sycl queue used from the container.
+        Return an instance of of :class:`dpctl.SyclQueue` used within the generator for data allocation.
+
+        Returns
+        -------
+        queue : dpctl.SyclQueue
+            A SYCL queue used for data allocation.
         """
         return self._sycl_queue
+
+
+    def get_sycl_device(self):
+        """
+        Return an instance of of :class:`dpctl.SyclDevice` used within the generator to allocate data on.
+
+        Returns
+        -------
+        device : dpctl.SyclDevice
+            A SYCL device used to allocate data on.
+        """
+        return self._sycl_device
 
 
     def normal(self, loc=0.0, scale=1.0, size=None, dtype=None, usm_type="device"):
@@ -130,15 +167,23 @@ class RandomState:
 
         For full documentation refer to :obj:`numpy.random.RandomState.normal`.
 
+        Parameters
+        ----------
+        usm_type : ("device" | "shared" | "host"), optional
+            The type of SYCL USM allocation for the output array.
+
+        Returns
+        -------
+        out : dpnp.ndarray
+            Drawn samples from the parameterized normal distribution.
+            Output array data type is the same as input ``dtype``. If ``dtype`` is None (default),
+            :obj:`dpnp.float64` type will be used if device supports it or :obj:`dpnp.float32` otherwise.
+
         Limitations
         -----------
-        Parameters ``loc`` and ``scale`` are supported as scalar.
-        Otherwise, :obj:`numpy.random.RandomState.normal(loc, scale, size)` samples are drawn.
-
+        Parameters ``loc`` and ``scale`` are supported as scalar. Otherwise,
+        :obj:`numpy.random.RandomState.normal(loc, scale, size)` samples are drawn.
         Parameter ``dtype`` is supported only for :obj:`dpnp.float32`, :obj:`dpnp.float64` or `None`.
-        If ``dtype`` is None (default), :obj:`dpnp.float64` type will be used if device supports it
-        or :obj:`dpnp.float32` otherwise.
-        Output array data type is the same as ``dtype``.
 
         Examples
         --------
@@ -161,22 +206,18 @@ class RandomState:
             elif not dpnp.isscalar(scale):
                 pass
             else:
-                min_double = numpy.finfo('double').min
-                max_double = numpy.finfo('double').max
+                dtype = self._validate_float_dtype(dtype, (dpnp.float32, dpnp.float64))
+                min_floating = numpy.finfo(dtype).min
+                max_floating = numpy.finfo(dtype).max
 
-                if (loc >= max_double or loc <= min_double) and self._is_finite_scalar(loc):
+                if (loc >= max_floating or loc <= min_floating) and self._is_finite_scalar(loc):
                     raise OverflowError(f"Range of loc={loc} exceeds valid bounds")
 
-                if (scale >= max_double) and self._is_finite_scalar(scale):
+                if (scale >= max_floating) and self._is_finite_scalar(scale):
                     raise OverflowError(f"Range of scale={scale} exceeds valid bounds")
                 # scale = -0.0 is cosidered as negative
                 elif scale < 0 or scale == 0 and self._is_signbit_scalar(scale):
                     raise ValueError(f"scale={scale}, but must be non-negative.")
-
-                if dtype is None:
-                    dtype = self._def_float_type
-                elif not dtype in (dpnp.float32, dpnp.float64):
-                    raise TypeError(f"dtype={dtype} is unsupported.")
 
                 dpu.validate_usm_type(usm_type=usm_type, allow_none=False)
                 return self._random_state.normal(loc=loc,
@@ -198,9 +239,16 @@ class RandomState:
 
         For full documentation refer to :obj:`numpy.random.RandomState.rand`.
 
-        Limitations
-        -----------
-        Output array data type is :obj:`dpnp.float64`.
+        Parameters
+        ----------
+        usm_type : ("device" | "shared" | "host"), optional
+            The type of SYCL USM allocation for the output array.
+
+        Returns
+        -------
+        out : dpnp.ndarray
+            Random values in a given shape.
+            Output array data type is :obj:`dpnp.float64` if device supports it or :obj:`dpnp.float32` otherwise.
 
         Examples
         --------
@@ -233,6 +281,18 @@ class RandomState:
         in the “half-open” interval [low, high).
 
         For full documentation refer to :obj:`numpy.random.RandomState.randint`.
+
+        Parameters
+        ----------
+        usm_type : ("device" | "shared" | "host"), optional
+            The type of SYCL USM allocation for the output array.
+
+        Returns
+        -------
+        out : dpnp.ndarray
+            `size`-shaped array of random integers from the appropriate distribution,
+            or a single such random int if `size` not provided.
+            Output array data type is the same as input ``dtype``.
 
         Limitations
         -----------
@@ -297,10 +357,19 @@ class RandomState:
 
         For full documentation refer to :obj:`numpy.random.RandomState.randn`.
 
-        Limitations
-        -----------
-        Output array data type is :obj:`dpnp.float64` if device supports it
-        or :obj:`dpnp.float32` otherwise.
+        Parameters
+        ----------
+        usm_type : ("device" | "shared" | "host"), optional
+            The type of SYCL USM allocation for the output array.
+
+        Returns
+        -------
+        Z : dpnp.ndarray
+            A ``(d0, d1, ..., dn)``-shaped array of floating-point samples from
+            the standard normal distribution, or a single such float if
+            no parameters were supplied.
+            Output array data type is :obj:`dpnp.float64` if device supports it
+            or :obj:`dpnp.float32` otherwise.
 
         Examples
         --------
@@ -337,10 +406,18 @@ class RandomState:
 
         For full documentation refer to :obj:`numpy.random.RandomState.random_sample`.
 
-        Limitations
-        -----------
-        Output array data type is :obj:`dpnp.float64` if device supports it
-        or :obj:`dpnp.float32` otherwise.
+        Parameters
+        ----------
+        usm_type : ("device" | "shared" | "host"), optional
+            The type of SYCL USM allocation for the output array.
+
+        Returns
+        -------
+        out : dpnp.ndarray
+            Array of random floats of shape `size` (if ``size=None``,
+            zero dimension array with a single float is returned).
+            Output array data type is :obj:`dpnp.float64` if device supports it
+            or :obj:`dpnp.float32` otherwise.
 
         Examples
         --------
@@ -368,10 +445,18 @@ class RandomState:
 
         For full documentation refer to :obj:`numpy.random.RandomState.standard_normal`.
 
-        Limitations
-        -----------
-        Output array data type is :obj:`dpnp.float64` if device supports it
-        or :obj:`dpnp.float32` otherwise.
+        Parameters
+        ----------
+        usm_type : ("device" | "shared" | "host"), optional
+            The type of SYCL USM allocation for the output array.
+
+        Returns
+        -------
+        out : dpnp.ndarray
+            A floating-point array of shape ``size`` of drawn samples, or a
+            single sample if ``size`` was not specified.
+            Output array data type is :obj:`dpnp.float64` if device supports it
+            or :obj:`dpnp.float32` otherwise.
 
         Examples
         --------
@@ -405,14 +490,23 @@ class RandomState:
 
         For full documentation refer to :obj:`numpy.random.RandomState.uniform`.
 
+        Parameters
+        ----------
+        usm_type : ("device" | "shared" | "host"), optional
+            The type of SYCL USM allocation for the output array.
+
+        Returns
+        -------
+        out : dpnp.ndarray
+            Drawn samples from the parameterized uniform distribution.
+            Output array data type is the same as input ``dtype``. If ``dtype`` is None (default),
+            :obj:`dpnp.float64` type will be used if device supports it or :obj:`dpnp.float32` otherwise.
+
         Limitations
         -----------
-        Parameters ``low`` and ``high`` are supported as scalar.
-        Otherwise, :obj:`numpy.random.uniform(low, high, size)` samples are drawn.
+        Parameters ``low`` and ``high`` are supported as scalar. Otherwise,
+        :obj:`numpy.random.uniform(low, high, size)` samples are drawn.
         Parameter ``dtype`` is supported only for :obj:`dpnp.int32`, :obj:`dpnp.float32`, :obj:`dpnp.float64` or `None`.
-        If ``dtype`` is None (default), :obj:`dpnp.float64` type will be used if device supports it
-        or :obj:`dpnp.float32` otherwise.
-        Output array data type is the same as ``dtype``.
 
         Examples
         --------
@@ -450,12 +544,9 @@ class RandomState:
                 if low > high:
                     low, high = high, low
 
-                if dtype is None:
-                    dtype = self._def_float_type
-                elif not dtype in (dpnp.int32, dpnp.float32, dpnp.float64):
-                    raise TypeError(f"dtype={dtype} is unsupported.")
-
+                dtype = self._validate_float_dtype(dtype, (dpnp.int32, dpnp.float32, dpnp.float64))
                 dpu.validate_usm_type(usm_type, allow_none=False)
+
                 return self._random_state.uniform(low=low,
                                                   high=high,
                                                   size=size,

--- a/tests/test_arraycreation.py
+++ b/tests/test_arraycreation.py
@@ -1,11 +1,31 @@
 import pytest
 
 import dpnp
+
+import dpctl
 import dpctl.tensor as dpt
 
 import numpy
+from numpy.testing import (
+    assert_allclose,
+    assert_array_equal,
+    assert_raises
+)
 
 import tempfile
+
+
+# TODO: discuss with DPCTL why no exception on complex128
+def is_dtype_supported(dtype, no_complex_check=False):
+    device = dpctl.SyclQueue().sycl_device
+
+    if dtype is dpnp.float16 and not device.has_aspect_fp16:
+        return False
+    if dtype is dpnp.float64 and not device.has_aspect_fp64:
+        return False
+    if dtype is dpnp.complex128 and not device.has_aspect_fp64 and not no_complex_check:
+        return False
+    return True
 
 
 @pytest.mark.parametrize("start",
@@ -18,23 +38,40 @@ import tempfile
                          [None, 1, 2.7, -1.6, 100],
                          ids=['None', '1', '2.7', '-1.6', '100'])
 @pytest.mark.parametrize("dtype",
-                         [numpy.complex128, numpy.complex64, numpy.float64, numpy.float32, numpy.float16, numpy.int64, numpy.int32],
-                         ids=['complex128', 'complex64', 'float64', 'float32', 'float16', 'int64', 'int32'])
+                         [numpy.complex128, numpy.complex64, numpy.float64, numpy.float32,
+                          numpy.float16, numpy.int64, numpy.int32],
+                         ids=['complex128', 'complex64', 'float64', 'float32',
+                              'float16', 'int64', 'int32'])
 def test_arange(start, stop, step, dtype):
     rtol_mult = 2
     if numpy.issubdtype(dtype, numpy.float16):
         # numpy casts to float32 type when computes float16 data
         rtol_mult = 4
 
-    exp_array = numpy.arange(start, stop=stop, step=step, dtype=dtype)
+    func = lambda xp: xp.arange(start, stop=stop, step=step, dtype=dtype)
 
-    dpnp_array = dpnp.arange(start, stop=stop, step=step, dtype=dtype)
-    res_array = dpnp.asnumpy(dpnp_array)
+    if not is_dtype_supported(dtype):
+        if stop is None:
+            _stop, _start = start, 0
+        else:
+            _stop, _start = stop, start
+        _step = 1 if step is None else step
+
+        if _start == _stop:
+            pass
+        elif (_step < 0) ^ (_start < _stop):
+            # exception is raising when dpctl calls a kernel function,
+            # i.e. when resulting array is not empty
+            assert_raises(RuntimeError, func, dpnp)
+            return
+
+    exp_array = func(numpy)
+    res_array = func(dpnp).asnumpy()
 
     if numpy.issubdtype(dtype, numpy.floating) or numpy.issubdtype(dtype, numpy.complexfloating):
-        numpy.testing.assert_allclose(exp_array, res_array, rtol=rtol_mult*numpy.finfo(dtype).eps)
+        assert_allclose(exp_array, res_array, rtol=rtol_mult*numpy.finfo(dtype).eps)
     else:
-        numpy.testing.assert_array_equal(exp_array, res_array)
+        assert_array_equal(exp_array, res_array)
 
 
 @pytest.mark.parametrize("k",
@@ -60,7 +97,7 @@ def test_diag(v, k):
     ia = dpnp.array(a)
     expected = numpy.diag(a, k)
     result = dpnp.diag(ia, k)
-    numpy.testing.assert_array_equal(expected, result)
+    assert_array_equal(expected, result)
 
 
 @pytest.mark.parametrize("N",
@@ -78,137 +115,178 @@ def test_diag(v, k):
 def test_eye(N, M, k, dtype):
     expected = numpy.eye(N, M=M, k=k, dtype=dtype)
     result = dpnp.eye(N, M=M, k=k, dtype=dtype)
-    numpy.testing.assert_array_equal(expected, result)
+    assert_array_equal(expected, result)
 
 
 @pytest.mark.usefixtures("allow_fall_back_on_numpy")
-@pytest.mark.parametrize("type",
+@pytest.mark.parametrize("dtype",
                          [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
                          ids=['float64', 'float32', 'int64', 'int32'])
-def test_frombuffer(type):
+def test_frombuffer(dtype):
     buffer = b'12345678'
+    func = lambda xp: xp.frombuffer(buffer, dtype=dtype)
 
-    np_res = numpy.frombuffer(buffer, dtype=type)
-    dpnp_res = dpnp.frombuffer(buffer, dtype=type)
+    if not is_dtype_supported(dtype):
+        # dtpcl intercepts RuntimeError about 'double' type and raise ValueError instead
+        assert_raises(ValueError, func, dpnp)
+        return
 
-    numpy.testing.assert_array_equal(dpnp_res, np_res)
+    assert_array_equal(func(dpnp), func(numpy))
 
 
 @pytest.mark.usefixtures("allow_fall_back_on_numpy")
-@pytest.mark.parametrize("type",
+@pytest.mark.parametrize("dtype",
                          [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
                          ids=['float64', 'float32', 'int64', 'int32'])
-def test_fromfile(type):
+def test_fromfile(dtype):
     with tempfile.TemporaryFile() as fh:
         fh.write(b"\x00\x01\x02\x03\x04\x05\x06\x07\x08")
         fh.flush()
 
-        fh.seek(0)
-        np_res = numpy.fromfile(fh, dtype=type)
-        fh.seek(0)
-        dpnp_res = dpnp.fromfile(fh, dtype=type)
+        func = lambda xp: xp.fromfile(fh, dtype=dtype)
 
-        numpy.testing.assert_array_equal(dpnp_res, np_res)
+        if not is_dtype_supported(dtype):
+            fh.seek(0)
+            # dtpcl intercepts RuntimeError about 'double' type and raise ValueError instead
+            assert_raises(ValueError, func, dpnp)
+            return
+
+        fh.seek(0)
+        np_res = func(numpy)
+
+        fh.seek(0)
+        dpnp_res = func(dpnp)
+
+        assert_array_equal(dpnp_res, np_res)
 
 
 @pytest.mark.usefixtures("allow_fall_back_on_numpy")
-@pytest.mark.parametrize("type",
+@pytest.mark.parametrize("dtype",
                          [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
                          ids=['float64', 'float32', 'int64', 'int32'])
-def test_fromfunction(type):
+def test_fromfunction(dtype):
     def func(x, y):
         return x * y
 
     shape = (3, 3)
+    call_func = lambda xp: xp.fromfunction(func, shape=shape, dtype=dtype)
 
-    np_res = numpy.fromfunction(func, shape=shape, dtype=type)
-    dpnp_res = dpnp.fromfunction(func, shape=shape, dtype=type)
+    if not is_dtype_supported(dtype):
+        # dtpcl intercepts RuntimeError about 'double' type and raise ValueError instead
+        assert_raises(ValueError, call_func, dpnp)
+        return
 
-    numpy.testing.assert_array_equal(dpnp_res, np_res)
-
-
-@pytest.mark.usefixtures("allow_fall_back_on_numpy")
-@pytest.mark.parametrize("type",
-                         [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
-                         ids=['float64', 'float32', 'int64', 'int32'])
-def test_fromiter(type):
-    iter = [1, 2, 3, 4]
-
-    np_res = numpy.fromiter(iter, dtype=type)
-    dpnp_res = dpnp.fromiter(iter, dtype=type)
-
-    numpy.testing.assert_array_equal(dpnp_res, np_res)
+    assert_array_equal(call_func(dpnp), call_func(numpy))
 
 
 @pytest.mark.usefixtures("allow_fall_back_on_numpy")
-@pytest.mark.parametrize("type",
+@pytest.mark.parametrize("dtype",
                          [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
                          ids=['float64', 'float32', 'int64', 'int32'])
-def test_fromstring(type):
+def test_fromiter(dtype):
+    _iter = [1, 2, 3, 4]
+    func = lambda xp: xp.fromiter(_iter, dtype=dtype)
+
+    if not is_dtype_supported(dtype):
+        # dtpcl intercepts RuntimeError about 'double' type and raise ValueError instead
+        assert_raises(ValueError, func, dpnp)
+        return
+
+    assert_array_equal(func(dpnp), func(numpy))
+
+
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
+@pytest.mark.parametrize("dtype",
+                         [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
+                         ids=['float64', 'float32', 'int64', 'int32'])
+def test_fromstring(dtype):
     string = "1 2 3 4"
+    func = lambda xp: xp.fromstring(string, dtype=dtype, sep=' ')
 
-    np_res = numpy.fromstring(string, dtype=type, sep=' ')
-    dpnp_res = dpnp.fromstring(string, dtype=type, sep=' ')
+    if not is_dtype_supported(dtype):
+        # dtpcl intercepts RuntimeError about 'double' type and raise ValueError instead
+        assert_raises(ValueError, func, dpnp)
+        return
 
-    numpy.testing.assert_array_equal(dpnp_res, np_res)
+    assert_array_equal(func(dpnp), func(numpy))
 
 
 @pytest.mark.usefixtures("allow_fall_back_on_numpy")
-@pytest.mark.parametrize("type",
+@pytest.mark.parametrize("dtype",
                          [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
                          ids=['float64', 'float32', 'int64', 'int32'])
 @pytest.mark.parametrize("num",
                          [2, 4, 8, 3, 9, 27])
 @pytest.mark.parametrize("endpoint",
                          [True, False])
-def test_geomspace(type, num, endpoint):
+def test_geomspace(dtype, num, endpoint):
     start = 2
     stop = 256
 
-    np_res = numpy.geomspace(start, stop, num, endpoint, type)
-    dpnp_res = dpnp.geomspace(start, stop, num, endpoint, type)
+    func = lambda xp: xp.geomspace(start, stop, num, endpoint, dtype)
+
+    if not is_dtype_supported(dtype):
+        # dtpcl intercepts RuntimeError about 'double' type and raise ValueError instead
+        assert_raises(ValueError, func, dpnp)
+        return
+
+    np_res = func(numpy)
+    dpnp_res = func(dpnp)
 
     # Note that the above may not produce exact integers:
     # (c) https://numpy.org/doc/stable/reference/generated/numpy.geomspace.html
-    if type in [numpy.int64, numpy.int32]:
-        numpy.testing.assert_allclose(dpnp_res, np_res, atol=1)
+    if dtype in [numpy.int64, numpy.int32]:
+        assert_allclose(dpnp_res, np_res, atol=1)
     else:
-        numpy.testing.assert_allclose(dpnp_res, np_res)
+        assert_allclose(dpnp_res, np_res)
 
 
 @pytest.mark.parametrize("n",
                          [0, 1, 4],
                          ids=['0', '1', '4'])
-@pytest.mark.parametrize("type",
-                         [numpy.float64, numpy.float32, numpy.int64,
-                          numpy.int32, numpy.bool, numpy.complex128, None],
-                         ids=['float64', 'float32', 'int64', 'int32', 'bool', 'complex128', 'None'])
-def test_identity(n, type):
-    expected = numpy.identity(n, dtype=type)
-    result = dpnp.identity(n, dtype=type)
-    numpy.testing.assert_array_equal(expected, result)
+@pytest.mark.parametrize("dtype",
+                         [numpy.float64, numpy.float32, numpy.int64, numpy.int32,
+                          numpy.bool, numpy.complex64, numpy.complex128, None],
+                         ids=['float64', 'float32', 'int64', 'int32',
+                              'bool', 'complex64', 'complex128', 'None'])
+def test_identity(n, dtype):
+    func = lambda xp: xp.identity(n, dtype=dtype)
+
+    if n > 0 and not is_dtype_supported(dtype):
+        assert_raises(RuntimeError, func, dpnp)
+        return
+
+    assert_array_equal(func(numpy), func(dpnp))
 
 
 @pytest.mark.usefixtures("allow_fall_back_on_numpy")
-@pytest.mark.parametrize("type",
+@pytest.mark.parametrize("dtype",
                          [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
                          ids=['float64', 'float32', 'int64', 'int32'])
-def test_loadtxt(type):
+def test_loadtxt(dtype):
+    func = lambda xp: xp.loadtxt(fh, dtype=dtype)
+
     with tempfile.TemporaryFile() as fh:
         fh.write(b"1 2 3 4")
         fh.flush()
 
-        fh.seek(0)
-        np_res = numpy.loadtxt(fh, dtype=type)
-        fh.seek(0)
-        dpnp_res = dpnp.loadtxt(fh, dtype=type)
+        if not is_dtype_supported(dtype):
+            # dtpcl intercepts RuntimeError about 'double' type and raise ValueError instead
+            fh.seek(0)
+            assert_raises(ValueError, func, dpnp)
+            return
 
-        numpy.testing.assert_array_equal(dpnp_res, np_res)
+        fh.seek(0)
+        np_res = func(numpy)
+        fh.seek(0)
+        dpnp_res = func(dpnp)
+
+        assert_array_equal(dpnp_res, np_res)
 
 
 @pytest.mark.parametrize("dtype",
-                         [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
-                         ids=['float64', 'float32', 'int64', 'int32'])
+                         [numpy.float64, numpy.float32, numpy.int64, numpy.int32, None],
+                         ids=['float64', 'float32', 'int64', 'int32', 'None'])
 @pytest.mark.parametrize("type",
                          [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
                          ids=['float64', 'float32', 'int64', 'int32'])
@@ -236,11 +314,24 @@ def test_loadtxt(type):
                               '[[[[1, 2, 3], [3, 4, 5]], [[1, 2, 3], [2, 1, 0]]], [[[1, 3, 5], [3, 1, 0]], [[0, 1, 2], [1, 3, 4]]]]',
                               '[[[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]], [[[13, 14, 15], [16, 17, 18]], [[19, 20, 21], [22, 23, 24]]]]'])
 def test_trace(array, offset, type, dtype):
-    a = numpy.array(array, type)
-    ia = dpnp.array(array, type)
-    expected = numpy.trace(a, offset=offset, dtype=dtype)
-    result = dpnp.trace(ia, offset=offset, dtype=dtype)
-    numpy.testing.assert_array_equal(expected, result)
+    create_array = lambda xp: xp.array(array, type)
+    trace_func = lambda xp, x: xp.trace(x, offset=offset, dtype=dtype)
+
+    if not is_dtype_supported(type):
+        # dtpcl intercepts RuntimeError about 'double' type and raise ValueError instead
+        assert_raises(ValueError, create_array, dpnp)
+        return
+
+    a = create_array(numpy)
+    ia = create_array(dpnp)
+
+    if not is_dtype_supported(dtype):
+        assert_raises(RuntimeError, trace_func, dpnp, ia)
+        return
+
+    expected = trace_func(numpy, a)
+    result = trace_func(dpnp, ia)
+    assert_array_equal(expected, result)
 
 
 @pytest.mark.parametrize("N",
@@ -252,19 +343,23 @@ def test_trace(array, offset, type, dtype):
 @pytest.mark.parametrize("k",
                          [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5],
                          ids=['-5', '-4', '-3', '-2', '-1', '0', '1', '2', '3', '4', '5'])
-@pytest.mark.parametrize("type",
+@pytest.mark.parametrize("dtype",
                          [numpy.float64, numpy.float32, float, numpy.int64, numpy.int32, numpy.int, numpy.float, int],
                          ids=['float64', 'float32', 'numpy.float', 'float', 'int64', 'int32', 'numpy.int', 'int'])
-def test_tri(N, M, k, type):
-    expected = numpy.tri(N, M, k, dtype=type)
-    result = dpnp.tri(N, M, k, dtype=type)
-    numpy.testing.assert_array_equal(result, expected)
+def test_tri(N, M, k, dtype):
+    func = lambda xp: xp.tri(N, M, k, dtype=dtype)
+
+    if M > 0 and N > 0 and not is_dtype_supported(dtype):
+        assert_raises(RuntimeError, func, dpnp)
+        return
+
+    assert_array_equal(func(dpnp), func(numpy))
 
 
 def test_tri_default_dtype():
     expected = numpy.tri(3, 5, -1)
     result = dpnp.tri(3, 5, -1)
-    numpy.testing.assert_array_equal(result, expected)
+    assert_array_equal(result, expected)
 
 
 @pytest.mark.parametrize("k",
@@ -290,7 +385,7 @@ def test_tril(m, k):
     ia = dpnp.array(a)
     expected = numpy.tril(a, k)
     result = dpnp.tril(ia, k)
-    numpy.testing.assert_array_equal(expected, result)
+    assert_array_equal(expected, result)
 
 
 @pytest.mark.parametrize("k",
@@ -310,7 +405,7 @@ def test_triu(m, k):
     ia = dpnp.array(a)
     expected = numpy.triu(a, k)
     result = dpnp.triu(ia, k)
-    numpy.testing.assert_array_equal(expected, result)
+    assert_array_equal(expected, result)
 
 
 @pytest.mark.parametrize("k",
@@ -321,7 +416,7 @@ def test_triu_size_null(k):
     ia = dpnp.array(a)
     expected = numpy.triu(a, k)
     result = dpnp.triu(ia, k)
-    numpy.testing.assert_array_equal(expected, result)
+    assert_array_equal(expected, result)
 
 
 @pytest.mark.parametrize("array",
@@ -331,23 +426,34 @@ def test_triu_size_null(k):
                          ids=['[1, 2, 3, 4]',
                               '[]',
                               '[0, 3, 5]'])
-@pytest.mark.parametrize("type",
-                         [numpy.float64, numpy.float32, numpy.int64,
-                          numpy.int32, numpy.bool, numpy.complex128],
-                         ids=['float64', 'float32', 'int64', 'int32', 'bool', 'complex128'])
+@pytest.mark.parametrize("dtype",
+                         [numpy.float64, numpy.float32, numpy.int64, numpy.int32,
+                          numpy.bool, numpy.complex64, numpy.complex128],
+                         ids=['float64', 'float32', 'int64', 'int32',
+                              'bool', 'complex64', 'complex128'])
 @pytest.mark.parametrize("n",
                          [0, 1, 4, None],
                          ids=['0', '1', '4', 'None'])
 @pytest.mark.parametrize("increase",
                          [True, False],
                          ids=['True', 'False'])
-def test_vander(array, type, n, increase):
-    a_np = numpy.array(array, dtype=type)
-    a_dpnp = dpnp.array(array, dtype=type)
+def test_vander(array, dtype, n, increase):
+    create_array = lambda xp: xp.array(array, dtype=dtype)
+    vander_func = lambda xp, x: xp.vander(x, N=n, increasing=increase)
 
-    expected = numpy.vander(a_np, N=n, increasing=increase)
-    result = dpnp.vander(a_dpnp, N=n, increasing=increase)
-    numpy.testing.assert_array_equal(expected, result)
+    if array and not is_dtype_supported(dtype):
+        # dtpcl intercepts RuntimeError about 'double' type and raise ValueError instead
+        assert_raises(ValueError, create_array, dpnp)
+        return
+
+    a_np = numpy.array(array, dtype=dtype)
+    a_dpnp = dpnp.array(array, dtype=dtype)
+
+    if array and not is_dtype_supported(dtype):
+        assert_raises(RuntimeError, vander_func, dpnp, a_dpnp)
+        return
+
+    assert_array_equal(vander_func(numpy, a_np), vander_func(dpnp, a_dpnp))
 
 
 @pytest.mark.parametrize("shape",
@@ -357,17 +463,21 @@ def test_vander(array, type, n, increase):
                          [1.5, 2, 1.5+0.j],
                          ids=['1.5', '2', '1.5+0.j'])
 @pytest.mark.parametrize("dtype",
-                         [None, numpy.complex128, numpy.complex64, numpy.float64, numpy.float32, numpy.float16, numpy.int64, numpy.int32],
-                         ids=['None', 'complex128', 'complex64', 'float64', 'float32', 'float16', 'int64', 'int32'])
+                         [None, numpy.complex128, numpy.complex64, numpy.float64, numpy.float32,
+                          numpy.float16, numpy.int64, numpy.int32, numpy.bool],
+                         ids=['None', 'complex128', 'complex64', 'float64', 'float32',
+                              'float16', 'int64', 'int32', 'bool'])
 @pytest.mark.parametrize("order",
                          [None, "C", "F"],
                          ids=['None', 'C', 'F'])
 def test_full(shape, fill_value, dtype, order):
-    expected = numpy.full(shape, fill_value, dtype=dtype, order=order)
-    result = dpnp.full(shape, fill_value, dtype=dtype, order=order)
+    func = lambda xp: xp.full(shape, fill_value, dtype=dtype, order=order)
 
-    assert expected.dtype == result.dtype
-    numpy.testing.assert_array_equal(expected, result)
+    if shape != 0 and not 0 in shape and not is_dtype_supported(dtype, no_complex_check=True):
+        assert_raises(RuntimeError, func, dpnp)
+        return
+
+    assert_array_equal(func(numpy), func(dpnp))
 
 
 @pytest.mark.parametrize("array",
@@ -377,20 +487,23 @@ def test_full(shape, fill_value, dtype, order):
                          [1.5, 2, 1.5+0.j],
                          ids=['1.5', '2', '1.5+0.j'])
 @pytest.mark.parametrize("dtype",
-                         [None, numpy.complex128, numpy.complex64, numpy.float64, numpy.float32, numpy.float16, numpy.int64, numpy.int32],
-                         ids=['None', 'complex128', 'complex64', 'float64', 'float32', 'float16', 'int64', 'int32'])
+                         [None, numpy.complex128, numpy.complex64, numpy.float64, numpy.float32,
+                          numpy.float16, numpy.int64, numpy.int32, numpy.bool],
+                         ids=['None', 'complex128', 'complex64', 'float64', 'float32',
+                              'float16', 'int64', 'int32', 'bool'])
 @pytest.mark.parametrize("order",
                          [None, "C", "F"],
                          ids=['None', 'C', 'F'])
 def test_full_like(array, fill_value, dtype, order):
     a = numpy.array(array)
     ia = dpnp.array(array)
+    func = lambda xp, x: xp.full_like(x, fill_value, dtype=dtype, order=order)
 
-    expected = numpy.full_like(a, fill_value, dtype=dtype, order=order)
-    result = dpnp.full_like(ia, fill_value, dtype=dtype, order=order)
+    if ia.size and not is_dtype_supported(dtype, no_complex_check=True):
+        assert_raises(RuntimeError, func, dpnp, ia)
+        return
     
-    assert expected.dtype == result.dtype
-    numpy.testing.assert_array_equal(expected, result)
+    assert_array_equal(func(numpy, a), func(dpnp, ia))
 
 
 @pytest.mark.skip(reason="dpnp.ndarray.flags are not implemented")
@@ -414,12 +527,12 @@ def test_full_strides():
     a = numpy.full((3, 3), numpy.arange(3, dtype="i4"))
     ia = dpnp.full((3, 3), dpnp.arange(3, dtype="i4"))
     assert ia.strides == tuple(el // a.itemsize for el in a.strides)
-    numpy.testing.assert_array_equal(dpnp.asnumpy(ia), a)
+    assert_array_equal(dpnp.asnumpy(ia), a)
 
     a = numpy.full((3, 3), numpy.arange(6, dtype="i4")[::2])
     ia = dpnp.full((3, 3), dpnp.arange(6, dtype="i4")[::2])
     assert ia.strides == tuple(el // a.itemsize for el in a.strides)
-    numpy.testing.assert_array_equal(dpnp.asnumpy(ia), a)
+    assert_array_equal(dpnp.asnumpy(ia), a)
 
 
 @pytest.mark.parametrize("fill_value", [[], (), dpnp.full(0, 0)], ids=['[]', '()', 'dpnp.full(0, 0)'])
@@ -432,8 +545,10 @@ def test_full_invalid_fill_value(fill_value):
                          [(), 0, (0,), (2, 0, 3), (3, 2)],
                          ids=['()', '0', '(0,)', '(2, 0, 3)', '(3, 2)'])
 @pytest.mark.parametrize("dtype",
-                         [None, numpy.complex128, numpy.complex64, numpy.float64, numpy.float32, numpy.float16, numpy.int64, numpy.int32],
-                         ids=['None', 'complex128', 'complex64', 'float64', 'float32', 'float16', 'int64', 'int32'])
+                         [None, numpy.complex128, numpy.complex64, numpy.float64, numpy.float32,
+                          numpy.float16, numpy.int64, numpy.int32, numpy.bool],
+                         ids=['None', 'complex128', 'complex64', 'float64', 'float32',
+                              'float16', 'int64', 'int32', 'bool'])
 @pytest.mark.parametrize("order",
                          [None, "C", "F"],
                          ids=['None', 'C', 'F'])
@@ -441,16 +556,17 @@ def test_zeros(shape, dtype, order):
     expected = numpy.zeros(shape, dtype=dtype, order=order)
     result = dpnp.zeros(shape, dtype=dtype, order=order)
 
-    assert expected.dtype == result.dtype
-    numpy.testing.assert_array_equal(expected, result)
+    assert_array_equal(expected, result)
 
 
 @pytest.mark.parametrize("array",
                          [[], 0,  [1, 2, 3], [[1, 2], [3, 4]]],
                          ids=['[]', '0',  '[1, 2, 3]', '[[1, 2], [3, 4]]'])
 @pytest.mark.parametrize("dtype",
-                         [None, numpy.complex128, numpy.complex64, numpy.float64, numpy.float32, numpy.float16, numpy.int64, numpy.int32],
-                         ids=['None', 'complex128', 'complex64', 'float64', 'float32', 'float16', 'int64', 'int32'])
+                         [None, numpy.complex128, numpy.complex64, numpy.float64, numpy.float32,
+                          numpy.float16, numpy.int64, numpy.int32, numpy.bool],
+                         ids=['None', 'complex128', 'complex64', 'float64', 'float32',
+                              'float16', 'int64', 'int32', 'bool'])
 @pytest.mark.parametrize("order",
                          [None, "C", "F"],
                          ids=['None', 'C', 'F'])
@@ -461,5 +577,4 @@ def test_zeros_like(array, dtype, order):
     expected = numpy.zeros_like(a, dtype=dtype, order=order)
     result = dpnp.zeros_like(ia, dtype=dtype, order=order)
 
-    assert expected.dtype == result.dtype
-    numpy.testing.assert_array_equal(expected, result)
+    assert_array_equal(expected, result)

--- a/tests/test_random_state.py
+++ b/tests/test_random_state.py
@@ -552,13 +552,13 @@ class TestSeed:
                              [0.5, -1.5, [-0.3], (1.7, 3),
                               'text',
                               numpy.arange(0, 1, 0.5),
-                              dpnp.arange(3),
-                              dpnp.arange(3, dtype=numpy.float32)],
+                              dpnp.arange(3, dtype=numpy.float32),
+                              dpnp.arange(3, dtype=numpy.complex64)],
                              ids=['0.5', '-1.5', '[-0.3]', '(1.7, 3)',
                                   'text',
                                   'numpy.arange(0, 1, 0.5)',
-                                  'dpnp.arange(3)',
-                                  'dpnp.arange(3, dtype=numpy.float32)'])
+                                  'dpnp.arange(3, dtype=numpy.float32)',
+                                  'dpnp.arange(3, dtype=numpy.complex64)'])
     def test_invalid_type(self, seed):
         # seed must be an unsigned 32-bit integer
         assert_raises(TypeError, RandomState, seed)

--- a/tests/test_random_state.py
+++ b/tests/test_random_state.py
@@ -15,10 +15,21 @@ from numpy.testing import (
 )
 
 
+# aspects of default device:
+_def_device = dpctl.SyclQueue().sycl_device
+_def_dev_has_fp64 = _def_device.has_aspect_fp64
+
+
 def assert_cfd(data, exp_sycl_queue, exp_usm_type=None):
     assert exp_sycl_queue == data.sycl_queue
     if exp_usm_type:
         assert exp_usm_type == data.usm_type
+
+
+def get_default_floating():
+    if not _def_dev_has_fp64:
+        return dpnp.float32
+    return dpnp.float64
 
 
 class TestNormal:
@@ -31,17 +42,21 @@ class TestNormal:
     def test_distr(self, dtype, usm_type):
         seed = 1234567
         sycl_queue = dpctl.SyclQueue()
+        func = lambda: RandomState(seed, sycl_queue=sycl_queue).normal(loc=.12345,
+                                                                       scale=2.71,
+                                                                       size=(3, 2),
+                                                                       dtype=dtype,
+                                                                       usm_type=usm_type)
 
-        data = RandomState(seed, sycl_queue=sycl_queue).normal(loc=.12345,
-                                                               scale=2.71,
-                                                               size=(3, 2),
-                                                               dtype=dtype,
-                                                               usm_type=usm_type)
+        if dtype is dpnp.float64 and not _def_dev_has_fp64:
+            # default device doesn't support 'float64' type
+            assert_raises(RuntimeError, func)
+            return
 
-        if dtype is None:
-            # dtype depends on fp64 support by the device
-            dtype = dpnp.float64 if data.sycl_device.has_aspect_fp64 else dpnp.float32
+        dpnp_data = func()
 
+        # default dtype depends on fp64 support by the device
+        dtype = get_default_floating() if dtype is None else dtype
         desired = numpy.array([[0.428205496031286, -0.55383273779227 ],
                                [2.027017795643378,  4.318888073163015],
                                [2.69080893259102,  -1.047967253719708]], dtype=dtype)
@@ -50,10 +65,10 @@ class TestNormal:
         # generated samples since 9 digit while precision=15 for float64
         # precision = numpy.finfo(dtype=dtype).precision
         precision = 8 if dtype == dpnp.float64 else numpy.finfo(dtype=dtype).precision
-        assert_array_almost_equal(dpnp.asnumpy(data), desired, decimal=precision)
+        assert_array_almost_equal(dpnp_data.asnumpy(), desired, decimal=precision)
 
         # check if compute follows data isn't broken
-        assert_cfd(data, sycl_queue, usm_type)
+        assert_cfd(dpnp_data, sycl_queue, usm_type)
 
 
     @pytest.mark.parametrize("dtype",
@@ -63,27 +78,34 @@ class TestNormal:
                              ["host", "device", "shared"],
                              ids=['host', 'device', 'shared'])
     def test_scale(self, dtype, usm_type):
+        mean = 7
         rs = RandomState(39567)
+        func = lambda scale: rs.normal(loc=mean, scale=scale, dtype=dtype, usm_type=usm_type)
+
+        if dtype is dpnp.float64 and not _def_dev_has_fp64:
+            # default device doesn't support 'float64' type
+            assert_raises(RuntimeError, func, scale=0)
+            return
 
         # zero scale means full ndarray of mean values
-        assert_equal(rs.normal(loc=7, scale=0, dtype=dtype, usm_type=usm_type), 7)
+        assert_equal(func(scale=0), mean)
 
         # scale must be non-negative ('-0.0' is negative value)
-        assert_raises(ValueError, rs.normal, scale=-0., dtype=dtype, usm_type=usm_type)
-        assert_raises(ValueError, rs.normal, scale=-3.71, dtype=dtype, usm_type=usm_type)
+        assert_raises(ValueError, func, scale=-0.)
+        assert_raises(ValueError, func, scale=-3.71)
 
 
     @pytest.mark.parametrize("loc",
                              [numpy.inf, -numpy.inf,
-                              numpy.nextafter(numpy.finfo('double').max, 0),
-                              numpy.nextafter(numpy.finfo('double').min, 0)],
+                              numpy.nextafter(numpy.finfo(get_default_floating()).max, 0),
+                              numpy.nextafter(numpy.finfo(get_default_floating()).min, 0)],
                              ids=['numpy.inf', '-numpy.inf', 'nextafter(max, 0)', 'nextafter(min, 0)'])
     def test_inf_loc(self, loc):
-        assert_equal(RandomState(6531).normal(loc=loc, scale=1, size=1000), loc)
+        assert_equal(RandomState(6531).normal(loc=loc, scale=1, size=1000), get_default_floating()(loc))
 
 
     def test_inf_scale(self):
-        a = dpnp.asnumpy(RandomState().normal(0, numpy.inf, size=1000))
+        a = RandomState().normal(0, numpy.inf, size=1000).asnumpy()
         assert_equal(numpy.isnan(a).any(), False)
         assert_equal(numpy.isinf(a).all(), True)
         assert_equal(a.max(), numpy.inf)
@@ -94,15 +116,16 @@ class TestNormal:
                              [numpy.inf, -numpy.inf],
                              ids=['numpy.inf', '-numpy.inf'])
     def test_inf_loc_scale(self, loc):
-        a = dpnp.asnumpy(RandomState().normal(loc=loc, scale=numpy.inf, size=1000))
+        a = RandomState().normal(loc=loc, scale=numpy.inf, size=1000).asnumpy()
         assert_equal(numpy.isnan(a).all(), False)
         assert_equal(numpy.nanmin(a), loc)
         assert_equal(numpy.nanmax(a), loc)
 
 
     def test_extreme_bounds(self):
-        fmin = numpy.finfo('double').min
-        fmax = numpy.finfo('double').max
+        dtype = get_default_floating()
+        fmin = numpy.finfo(dtype).min
+        fmax = numpy.finfo(dtype).max
 
         size = 1000
         func = RandomState(34567).normal
@@ -138,10 +161,11 @@ class TestNormal:
         data = RandomState(seed, sycl_queue=sycl_queue).normal(loc=loc, scale=scale, size=size)
 
         # dpnp accepts only scalar as low and/or high, in other cases it will be a fallback to numpy
-        actual = dpnp.asnumpy(data)
+        actual = data.asnumpy()
         desired = numpy.random.RandomState(seed).normal(loc=loc, scale=scale, size=size)
 
-        precision = numpy.finfo(dtype=numpy.float64).precision
+        dtype = get_default_floating()
+        precision = numpy.finfo(dtype=dtype).precision
         assert_array_almost_equal(actual, desired, decimal=precision)
 
         # check if compute follows data isn't broken
@@ -173,24 +197,25 @@ class TestRand:
     def test_distr(self, usm_type):
         seed = 28042
         sycl_queue = dpctl.SyclQueue()
+        dtype = get_default_floating()
 
         data = RandomState(seed, sycl_queue=sycl_queue).rand(3, 2, usm_type=usm_type)
         desired = numpy.array([[0.7592552667483687, 0.5937560645397753],
                                [0.257010098779574 , 0.749422621447593 ],
-                               [0.6316644293256104, 0.7411410815548152]], dtype=numpy.float64)
+                               [0.6316644293256104, 0.7411410815548152]], dtype=dtype)
 
         precision = numpy.finfo(dtype=numpy.float64).precision
-        assert_array_almost_equal(dpnp.asnumpy(data), desired, decimal=precision)
+        assert_array_almost_equal(data.asnumpy(), desired, decimal=precision)
         assert_cfd(data, sycl_queue, usm_type)
 
         # call with the same seed has to draw the same values
         data = RandomState(seed, sycl_queue=sycl_queue).rand(3, 2, usm_type=usm_type)
-        assert_array_almost_equal(dpnp.asnumpy(data), desired, decimal=precision)
+        assert_array_almost_equal(data.asnumpy(), desired, decimal=precision)
         assert_cfd(data, sycl_queue, usm_type)
 
         # call with omitted dimensions has to draw the first element from desired
         data = RandomState(seed, sycl_queue=sycl_queue).rand(usm_type=usm_type)
-        assert_array_almost_equal(dpnp.asnumpy(data), desired[0, 0], decimal=precision)
+        assert_array_almost_equal(data.asnumpy(), desired[0, 0], decimal=precision)
         assert_cfd(data, sycl_queue, usm_type)
 
         # rand() is an alias on random_sample(), map arguments
@@ -251,7 +276,7 @@ class TestRandInt:
         desired = numpy.array([[4, 1],
                                [5, 3],
                                [5, 7]], dtype=numpy.int32)
-        assert_array_equal(dpnp.asnumpy(data), desired)
+        assert_array_equal(data.asnumpy(), desired)
         assert_cfd(data, sycl_queue, usm_type)
 
         # call with the same seed has to draw the same values
@@ -260,7 +285,7 @@ class TestRandInt:
                                                                 size=(3, 2),
                                                                 dtype=dtype,
                                                                 usm_type=usm_type)
-        assert_array_equal(dpnp.asnumpy(data), desired)
+        assert_array_equal(data.asnumpy(), desired)
         assert_cfd(data, sycl_queue, usm_type)
 
         # call with omitted dimensions has to draw the first element from desired
@@ -268,7 +293,7 @@ class TestRandInt:
                                                                 high=high,
                                                                 dtype=dtype,
                                                                 usm_type=usm_type)
-        assert_array_equal(dpnp.asnumpy(data), desired[0, 0])
+        assert_array_equal(data.asnumpy(), desired[0, 0])
         assert_cfd(data, sycl_queue, usm_type)
 
         # rand() is an alias on random_sample(), map arguments
@@ -282,13 +307,13 @@ class TestRandInt:
 
 
     def test_float_bounds(self):
-        actual = dpnp.asnumpy(RandomState(365852).randint(low=0.6, high=6.789102534, size=(7,)))
+        actual = RandomState(365852).randint(low=0.6, high=6.789102534, size=(7,)).asnumpy()
         desired = numpy.array([4, 4, 3, 3, 1, 0, 3], dtype=numpy.int32)
         assert_array_equal(actual, desired)
 
 
     def test_negative_bounds(self):
-        actual = dpnp.asnumpy(RandomState(5143).randint(low=-15.74, high=-3, size=(2, 7)))
+        actual = RandomState(5143).randint(low=-15.74, high=-3, size=(2, 7)).asnumpy()
         desired = numpy.array([[-9, -12, -4,  -12, -5, -13, -9],
                                [-4, -6,  -13, -9,  -9,  -6, -15]], dtype=numpy.int32)
         assert_array_equal(actual, desired)
@@ -333,6 +358,11 @@ class TestRandInt:
         func = RandomState().randint
         low = numpy.iinfo(dtype).min
         high = numpy.iinfo(dtype).max
+
+        sycl_device = dpctl.SyclQueue().sycl_device
+        if sycl_device.has_aspect_gpu and not sycl_device.has_aspect_fp64:
+            # TODO: discuss with opneMKL
+            pytest.skip(f"Due to some reason, oneMKL wrongly returns high value instead of low")
 
         tgt = high - 1
         assert_equal(func(tgt, tgt + 1, size=1000), tgt)
@@ -384,7 +414,7 @@ class TestRandInt:
         size = (3, 2, 5)
 
         # dpnp accepts only scalar as low and/or high, in other cases it will be a fallback to numpy
-        actual = dpnp.asnumpy(RandomState(seed).randint(low=low, high=high, size=size))
+        actual = RandomState(seed).randint(low=low, high=high, size=size).asnumpy()
         desired = numpy.random.RandomState(seed).randint(low=low, high=high, size=size)
         assert_equal(actual, desired)
 
@@ -403,7 +433,7 @@ class TestRandInt:
             pytest.skip("dpnp.integer is alias on dpnp.int32 on the target OS, so no fallback here")
 
         # dtype must be int or dpnp.int32, in other cases it will be a fallback to numpy
-        actual = dpnp.asnumpy(RandomState(seed).randint(low=low, high=high, size=size, dtype=dtype))
+        actual = RandomState(seed).randint(low=low, high=high, size=size, dtype=dtype).asnumpy()
         desired = numpy.random.RandomState(seed).randint(low=low, high=high, size=size, dtype=dtype)
         assert_equal(actual, desired)
         assert_raises(TypeError, RandomState().randint, dtype=dtype)
@@ -423,22 +453,23 @@ class TestRandN:
                              ids=['host', 'device', 'shared'])
     def test_distr(self, usm_type):
         seed = 3649
-
         sycl_queue = dpctl.SyclQueue()
+        dtype = get_default_floating()
+
         data = RandomState(seed, sycl_queue=sycl_queue).randn(3, 2, usm_type=usm_type)
         desired = numpy.array([[-0.862485623762009,  1.169492612490272],
                                 [-0.405876118480338,  0.939006537666719],
-                                [-0.615075625641019,  0.555260469834381]], dtype=numpy.float64)
+                                [-0.615075625641019,  0.555260469834381]], dtype=dtype)
 
         # TODO: discuss with opneMKL: there is a difference between CPU and GPU
         # generated samples since 9 digit while precision=15 for float64
         # precision = numpy.finfo(dtype=numpy.float64).precision
-        precision = 8
-        assert_array_almost_equal(dpnp.asnumpy(data), desired, decimal=precision)
+        precision = numpy.finfo(dtype=numpy.float32).precision
+        assert_array_almost_equal(data.asnumpy(), desired, decimal=precision)
 
         # call with the same seed has to draw the same values
         data = RandomState(seed, sycl_queue=sycl_queue).randn(3, 2, usm_type=usm_type)
-        assert_array_almost_equal(dpnp.asnumpy(data), desired, decimal=precision)
+        assert_array_almost_equal(data.asnumpy(), desired, decimal=precision)
 
         # TODO: discuss with oneMKL: return 0.0 instead of the 1st element
         # call with omitted dimensions has to draw the first element from desired
@@ -491,10 +522,10 @@ class TestSeed:
         size = (3, 2, 4)
 
         rs = RandomState(seed)
-        a1 = dpnp.asnumpy(getattr(rs, func)(size=size))
+        a1 = getattr(rs, func)(size=size).asnumpy()
 
         rs = RandomState(seed)
-        a2 = dpnp.asnumpy(getattr(rs, func)(size=size))
+        a2 = getattr(rs, func)(size=size).asnumpy()
 
         precision = numpy.finfo(dtype=numpy.float64).precision
         assert_array_almost_equal(a1, a2, decimal=precision)
@@ -512,8 +543,8 @@ class TestSeed:
                                   '[0]', '[4294967295]', '[2, 7, 15]', '(1,)', '(85, 6, 17)'])
     def test_array_range(self, seed):
         size = 15
-        a1 = dpnp.asnumpy(RandomState(seed).uniform(size=size))
-        a2 = dpnp.asnumpy(RandomState(seed).uniform(size=size))
+        a1 = RandomState(seed).uniform(size=size).asnumpy()
+        a2 = RandomState(seed).uniform(size=size).asnumpy()
         assert_allclose(a1, a2, rtol=1e-07, atol=0)
 
 
@@ -574,19 +605,20 @@ class TestStandardNormal:
                              ids=['host', 'device', 'shared'])
     def test_distr(self, usm_type):
         seed = 1234567
-
         sycl_queue = dpctl.SyclQueue()
+        dtype = get_default_floating()
+
         data = RandomState(seed, sycl_queue=sycl_queue).standard_normal(size=(4, 2), usm_type=usm_type)
         desired = numpy.array([[0.112455902594571, -0.249919829443642],
                                [0.702423540827815,  1.548132130318456],
                                [0.947364919775284, -0.432257289195464],
-                               [0.736848611436872,  1.557284323302839]], dtype=numpy.float64)
+                               [0.736848611436872,  1.557284323302839]], dtype=dtype)
 
         # TODO: discuss with opneMKL: there is a difference between CPU and GPU
         # generated samples since 9 digit while precision=15 for float64
         # precision = numpy.finfo(dtype=numpy.float64).precision
-        precision = 8
-        assert_array_almost_equal(dpnp.asnumpy(data), desired, decimal=precision)
+        precision = numpy.finfo(dtype=numpy.float32).precision
+        assert_array_almost_equal(data.asnumpy(), desired, decimal=precision)
 
         # TODO: discuss with oneMKL: return 0.0 instead of the 1st element
         # call with omitted dimensions has to draw the first element from desired
@@ -630,20 +662,21 @@ class TestRandSample:
                              ids=['host', 'device', 'shared'])
     def test_distr(self, usm_type):
         seed = 12657
-
         sycl_queue = dpctl.SyclQueue()
+        dtype = get_default_floating()
+
         data = RandomState(seed, sycl_queue=sycl_queue).random_sample(size=(4, 2), usm_type=usm_type)
         desired = numpy.array([[0.1887628440745175, 0.2763057765550911],
                                [0.3973943444434553, 0.2975987731479108],
                                [0.4144027342554182, 0.2636592474300414],
-                               [0.6129623607266694, 0.2596735346596688]], dtype=numpy.float64)
+                               [0.6129623607266694, 0.2596735346596688]], dtype=dtype)
         
-        precision = numpy.finfo(dtype=numpy.float64).precision
-        assert_array_almost_equal(dpnp.asnumpy(data), desired, decimal=precision)
+        precision = numpy.finfo(dtype=dtype).precision
+        assert_array_almost_equal(data.asnumpy(), desired, decimal=precision)
 
         # call with omitted dimensions has to draw the first element from desired
         data = RandomState(seed, sycl_queue=sycl_queue).random_sample(usm_type=usm_type)
-        assert_array_almost_equal(dpnp.asnumpy(data), desired[0, 0], decimal=precision)
+        assert_array_almost_equal(data.asnumpy(), desired[0, 0], decimal=precision)
 
         # random_sample() is an alias on uniform(), map arguments
         with mock.patch('dpnp.random.RandomState.uniform') as m:
@@ -692,29 +725,36 @@ class TestUniform:
         high = bounds[1]
 
         sycl_queue = dpctl.SyclQueue()
-        data = RandomState(seed, sycl_queue=sycl_queue).uniform(low=low,
-                                                                high=high,
-                                                                size=(3, 2),
-                                                                dtype=dtype,
-                                                                usm_type=usm_type)
+        func = lambda: RandomState(seed, sycl_queue=sycl_queue).uniform(low=low,
+                                                                        high=high,
+                                                                        size=(3, 2),
+                                                                        dtype=dtype,
+                                                                        usm_type=usm_type)
 
-        if dtype is None:
-            # dtype depends on fp64 support by the device
-            dtype = dpnp.float64 if data.sycl_device.has_aspect_fp64 else dpnp.float32
+        if dtype is dpnp.float64 and not _def_dev_has_fp64:
+            # default device doesn't support 'float64' type
+            assert_raises(RuntimeError, func)
+            return
 
+        # get drawn samples by dpnp
+        dpnp_data = func()
+        actual = dpnp_data.asnumpy()
+
+        # default dtype depends on fp64 support by the device
+        dtype = get_default_floating() if dtype is None else dtype
         if dtype != dpnp.int32:
             desired = numpy.array([[4.023770128630567, 8.87456423597643 ],
                                    [2.888630247435067, 4.823004481580574],
                                    [2.030351535445079, 4.533497077834326]])
-            assert_array_almost_equal(dpnp.asnumpy(data), desired, decimal=numpy.finfo(dtype=dtype).precision)
+            assert_array_almost_equal(actual, desired, decimal=numpy.finfo(dtype=dtype).precision)
         else:
             desired = numpy.array([[3, 8],
                                    [2, 4],
                                    [1, 4]])
-            assert_array_equal(dpnp.asnumpy(data), desired)
+            assert_array_equal(actual, desired)
 
         # check if compute follows data isn't broken
-        assert_cfd(data, sycl_queue, usm_type)
+        assert_cfd(dpnp_data, sycl_queue, usm_type)
 
 
     @pytest.mark.parametrize("dtype",
@@ -728,13 +768,18 @@ class TestUniform:
         low = high = 3.75
         shape = (7, 6, 20)
 
-        data = RandomState(seed).uniform(low=low, high=high, size=shape, dtype=dtype, usm_type=usm_type)
+        func = lambda: RandomState(seed).uniform(low=low, high=high, size=shape, dtype=dtype, usm_type=usm_type)
 
-        if dtype is None:
-            # dtype depends on fp64 support by the device
-            dtype = dpnp.float64 if data.sycl_device.has_aspect_fp64 else dpnp.float32
+        if dtype is dpnp.float64 and not _def_dev_has_fp64:
+            # default device doesn't support 'float64' type
+            assert_raises(RuntimeError, func)
+            return
 
-        actual = dpnp.asnumpy(data)
+        # get drawn samples by dpnp
+        actual = func().asnumpy()
+
+        # default dtype depends on fp64 support by the device
+        dtype = get_default_floating() if dtype is None else dtype
         desired = numpy.full(shape=shape, fill_value=low, dtype=dtype)
 
         if dtype == dpnp.int32:
@@ -774,10 +819,11 @@ class TestUniform:
         data = RandomState(seed, sycl_queue=sycl_queue).uniform(low=low, high=high, size=size)
 
         # dpnp accepts only scalar as low and/or high, in other cases it will be a fallback to numpy
-        actual = dpnp.asnumpy(data)
+        actual = data.asnumpy()
         desired = numpy.random.RandomState(seed).uniform(low=low, high=high, size=size)
 
-        precision = numpy.finfo(dtype=numpy.float64).precision
+        dtype = get_default_floating()
+        precision = numpy.finfo(dtype=dtype).precision
         assert_array_almost_equal(actual, desired, decimal=precision)
 
         # check if compute follows data isn't broken


### PR DESCRIPTION
The PR is to implement a dependency of default data type in creation functions on what is supported by target device.

The device may not support any of types: `dpnp.float16`, `dpnp.float64` or `dpnp.complex64`. Thus `dpnp` has to consider that when it's requested to create an array with default data type. The type should be selected only among supported ones by the device.

If a data type is passed explicitly in array creation function but the selected device doesn't support the type, an exception will be raise by `dpnp` indicating the issue.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
