### PR TITLE
Add property flags to dpnp_array

### DIFF
--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -578,7 +578,14 @@ class dpnp_array:
         for i in range(self.size):
             self.flat[i] = value
 
- # 'flags',
+    @property
+    def flags(self):
+        """
+        Return information about the memory layout of the array.
+
+        """
+
+        return self._array_obj.flags
 
     @property
     def flat(self):

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -282,12 +282,6 @@ tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestCubReduction_pa
 tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestCubReduction_param_6_{order='F', shape=(10, 20, 30)}::test_cub_min
 tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestCubReduction_param_7_{order='F', shape=(10, 20, 30, 40)}::test_cub_max
 tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestCubReduction_param_7_{order='F', shape=(10, 20, 30, 40)}::test_cub_min
-tests/third_party/cupy/creation_tests/test_basic.py::TestBasic::test_empty_like_contiguity
-tests/third_party/cupy/creation_tests/test_basic.py::TestBasicReshape_param_0_{shape=4}::test_empty_like_reshape_contiguity
-tests/third_party/cupy/creation_tests/test_basic.py::TestBasicReshape_param_1_{shape=(4,)}::test_empty_like_reshape_contiguity
-tests/third_party/cupy/creation_tests/test_basic.py::TestBasicReshape_param_2_{shape=(4, 2)}::test_empty_like_reshape_contiguity
-tests/third_party/cupy/creation_tests/test_basic.py::TestBasicReshape_param_3_{shape=(4, 2, 3)}::test_empty_like_reshape_contiguity
-tests/third_party/cupy/creation_tests/test_basic.py::TestBasicReshape_param_4_{shape=(5, 4, 2, 3)}::test_empty_like_reshape_contiguity
 tests/third_party/cupy/creation_tests/test_basic.py::TestBasicReshape_param_0_{shape=4}::test_empty_like_K_strides_reshape
 tests/third_party/cupy/creation_tests/test_basic.py::TestBasicReshape_param_0_{shape=4}::test_empty_like_reshape_contiguity2
 tests/third_party/cupy/creation_tests/test_basic.py::TestBasicReshape_param_0_{shape=4}::test_empty_like_reshape_contiguity2_cupy_only

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -458,12 +458,6 @@ tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestCubReduction_pa
 tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestCubReduction_param_6_{order='F', shape=(10, 20, 30)}::test_cub_min
 tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestCubReduction_param_7_{order='F', shape=(10, 20, 30, 40)}::test_cub_max
 tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestCubReduction_param_7_{order='F', shape=(10, 20, 30, 40)}::test_cub_min
-tests/third_party/cupy/creation_tests/test_basic.py::TestBasic::test_empty_like_contiguity
-tests/third_party/cupy/creation_tests/test_basic.py::TestBasicReshape_param_0_{shape=4}::test_empty_like_reshape_contiguity
-tests/third_party/cupy/creation_tests/test_basic.py::TestBasicReshape_param_1_{shape=(4,)}::test_empty_like_reshape_contiguity
-tests/third_party/cupy/creation_tests/test_basic.py::TestBasicReshape_param_2_{shape=(4, 2)}::test_empty_like_reshape_contiguity
-tests/third_party/cupy/creation_tests/test_basic.py::TestBasicReshape_param_3_{shape=(4, 2, 3)}::test_empty_like_reshape_contiguity
-tests/third_party/cupy/creation_tests/test_basic.py::TestBasicReshape_param_4_{shape=(5, 4, 2, 3)}::test_empty_like_reshape_contiguity
 tests/third_party/cupy/creation_tests/test_basic.py::TestBasicReshape_param_0_{shape=4}::test_empty_like_K_strides_reshape
 tests/third_party/cupy/creation_tests/test_basic.py::TestBasicReshape_param_0_{shape=4}::test_empty_like_reshape_contiguity2
 tests/third_party/cupy/creation_tests/test_basic.py::TestBasicReshape_param_0_{shape=4}::test_empty_like_reshape_contiguity2_cupy_only

--- a/tests/test_arraycreation.py
+++ b/tests/test_arraycreation.py
@@ -506,7 +506,6 @@ def test_full_like(array, fill_value, dtype, order):
     assert_array_equal(func(numpy, a), func(dpnp, ia))
 
 
-@pytest.mark.skip(reason="dpnp.ndarray.flags are not implemented")
 @pytest.mark.parametrize("order1",
                          ["F", "C"],
                          ids=['F', 'C'])

--- a/tests/test_dparray.py
+++ b/tests/test_dparray.py
@@ -50,19 +50,21 @@ def test_flags(shape, order):
     assert numpy_array.flags.f_contiguous == dpnp_array.flags.f_contiguous
 
 
+@pytest.mark.parametrize("dtype",
+                         [numpy.complex64, numpy.float32, numpy.int64, numpy.int32, numpy.bool],
+                         ids=['complex64', 'float32', 'int64', 'int32', 'bool'])
 @pytest.mark.parametrize("strides",
                          [(1, 4) , (4, 1)],
                          ids=['(1, 4)', '(4, 1)'])
 @pytest.mark.parametrize("order",
                          ["C", "F"],
                          ids=['C', 'F'])
-def test_flags_strides(order, strides):
-    dtype = numpy.int64
+def test_flags_strides(dtype, order, strides):
     itemsize = numpy.dtype(dtype).itemsize
     numpy_strides = tuple([el * itemsize for el in strides])
-    usm_array = dpt.usm_ndarray((4, 4), order=order, strides=strides)
-    numpy_array = numpy.ndarray((4, 4), order=order, strides=numpy_strides)
-    dpnp_array = dpnp.ndarray((4, 4), order=order, strides=strides)
+    usm_array = dpt.usm_ndarray((4, 4), dtype=dtype, order=order, strides=strides)
+    numpy_array = numpy.ndarray((4, 4), dtype=dtype, order=order, strides=numpy_strides)
+    dpnp_array = dpnp.ndarray((4, 4), dtype=dtype, order=order, strides=strides)
     assert usm_array.flags == dpnp_array.flags
     assert numpy_array.flags.c_contiguous == dpnp_array.flags.c_contiguous
     assert numpy_array.flags.f_contiguous == dpnp_array.flags.f_contiguous

--- a/tests/test_dparray.py
+++ b/tests/test_dparray.py
@@ -42,6 +42,27 @@ def test_flatten(arr, arr_dtype):
                          ["C", "F"],
                          ids=['C', 'F'])
 def test_flags(shape, order):
-    expected = dpt.usm_ndarray(shape, order=order)
-    result = dpnp.ndarray(shape, order=order)
-    assert expected.flags == result.flags
+    usm_array = dpt.usm_ndarray(shape, order=order)
+    numpy_array = numpy.ndarray(shape, order=order)
+    dpnp_array = dpnp.ndarray(shape, order=order)
+    assert usm_array.flags == dpnp_array.flags
+    assert numpy_array.flags.c_contiguous == dpnp_array.flags.c_contiguous
+    assert numpy_array.flags.f_contiguous == dpnp_array.flags.f_contiguous
+
+
+@pytest.mark.parametrize("strides",
+                         [(1, 4) , (4, 1)],
+                         ids=['(1, 4)', '(4, 1)'])
+@pytest.mark.parametrize("order",
+                         ["C", "F"],
+                         ids=['C', 'F'])
+def test_flags_strides(order, strides):
+    dtype = numpy.int64
+    itemsize = numpy.dtype(dtype).itemsize
+    numpy_strides = tuple([el * itemsize for el in strides])
+    usm_array = dpt.usm_ndarray((4, 4), order=order, strides=strides)
+    numpy_array = numpy.ndarray((4, 4), order=order, strides=numpy_strides)
+    dpnp_array = dpnp.ndarray((4, 4), order=order, strides=strides)
+    assert usm_array.flags == dpnp_array.flags
+    assert numpy_array.flags.c_contiguous == dpnp_array.flags.c_contiguous
+    assert numpy_array.flags.f_contiguous == dpnp_array.flags.f_contiguous

--- a/tests/test_dparray.py
+++ b/tests/test_dparray.py
@@ -1,6 +1,7 @@
 import dpnp
 import numpy
 import pytest
+import dpctl.tensor as dpt
 
 
 @pytest.mark.parametrize("res_dtype",
@@ -32,3 +33,15 @@ def test_flatten(arr, arr_dtype):
     expected = numpy_array.flatten()
     result = dpnp_array.flatten()
     numpy.testing.assert_array_equal(expected, result)
+
+
+@pytest.mark.parametrize("shape",
+                         [(), 0, (0,), (2), (5, 2), (5, 0, 2), (5, 3, 2)],
+                         ids=['()', '0', '(0,)', '(2)', '(5, 2)', '(5, 0, 2)', '(5, 3, 2)'])
+@pytest.mark.parametrize("order",
+                         ["C", "F"],
+                         ids=['C', 'F'])
+def test_flags(shape, order):
+    expected = dpt.usm_ndarray(shape, order=order)
+    result = dpnp.ndarray(shape, order=order)
+    assert expected.flags == result.flags


### PR DESCRIPTION
Added property flags to dpnp_array by using dpctl.tensor.usm_ndarray.flags.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
