### PR TITLE
Complete support of python 3.10 in external CI

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -29,11 +29,8 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.8', '3.9']
+        python: ['3.8', '3.9', '3.10']
         os: [ubuntu-20.04, windows-latest]
-        include:
-          - python: '3.10'
-            os: ubuntu-20.04
 
     runs-on: ${{ matrix.os }}
 
@@ -110,7 +107,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.8', '3.9']
+        python: ['3.8', '3.9', '3.10']
         os: [ubuntu-20.04, ubuntu-latest]
 
         experimental: [false]
@@ -215,7 +212,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.8', '3.9']
+        python: ['3.8', '3.9', '3.10']
         experimental: [false]
 
     continue-on-error: ${{ matrix.experimental }}
@@ -384,7 +381,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.8', '3.9']
+        python: ['3.8', '3.9', '3.10']
         os: [ubuntu-20.04, windows-latest]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Extended github actions flow to complete validation support of `dpnp` build on Windows and Linux and with python 3.10 in public CI (completed work started in #1244).

Th PR includes steps with python 3.10 and
1. build on Windows
2. test on both Linux and Windows 
3. publishing `dpnp` for python 3.10 in `dppy/label/dev` channel, once test step is done

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
