### PR TITLE
Set minimum required versions & fix debug building

### DIFF
--- a/0.build.sh
+++ b/0.build.sh
@@ -4,6 +4,14 @@ THEDIR=$(dirname $(readlink -e ${BASH_SOURCE[0]}))
 # . ${THEDIR}/0.env.sh
 cd ${THEDIR}
 
+# Assign $TMP env varibale to a directory where the script locates.
+# The env variable is used by compiler as a path to temporary folder,
+# where it can store a temporary files generated during compilation and linkage phases.
+# By default the compiler uses /tmp folder, but it is limited by the size and
+# there might be not enough space to temporary keep all generated data.
+export TMP=${THEDIR}
+
+
 export DPNP_DEBUG=1
 
 python setup.py clean

--- a/0.build.sh
+++ b/0.build.sh
@@ -4,7 +4,7 @@ THEDIR=$(dirname $(readlink -e ${BASH_SOURCE[0]}))
 # . ${THEDIR}/0.env.sh
 cd ${THEDIR}
 
-# Assign $TMP env varibale to a directory where the script locates.
+# Assign $TMP env variable to a directory where the script locates.
 # The env variable is used by compiler as a path to temporary folder,
 # where it can store a temporary files generated during compilation and linkage phases.
 # By default the compiler uses /tmp folder, but it is limited by the size and

--- a/dpnp/backend/CMakeLists.txt
+++ b/dpnp/backend/CMakeLists.txt
@@ -1,5 +1,5 @@
 # *****************************************************************************
-# Copyright (c) 2016-2022, Intel Corporation
+# Copyright (c) 2016-2023, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -111,7 +111,7 @@ elseif(WIN32)
   # set(CMAKE_RANLIB "llvm-ranlib")
   # set(CMAKE_CXX_FLAGS "/EHsc")
 
-  string(APPEND COMMON_COMPILER_FLAGS
+  string(APPEND COMMON_COMPILE_FLAGS
     "/EHsc "
 #    "/Ox "
 #    "/W3 "
@@ -133,23 +133,29 @@ string(CONCAT DPNP_WARNING_FLAGS
   "-Wextra "
   "-Wshadow "
   "-Wall "
-  "-Wstring-prototypes "
+  "-Wstrict-prototypes "
   "-Wformat "
   "-Wformat-security "
 )
-string(APPEND COMMON_COMPILER_FLAGS
+string(APPEND COMMON_COMPILE_FLAGS
   "${DPNP_WARNING_FLAGS}"
 )
 
 # debug/release compile definitions
 if(DPNP_DEBUG_ENABLE)
   set(CMAKE_BUILD_TYPE "Debug")
-  string(APPEND COMMON_COMPILER_FLAGS
+  string(APPEND COMMON_COMPILE_FLAGS
     "-O0 "
+    "-ggdb3 "
+  )
+  string(APPEND COMMON_LINK_FLAGS
+    "-O0 "
+    "-ggdb3 "
+    "-fsycl-link-huge-device-code "
   )
 else()
   set(CMAKE_BUILD_TYPE "Release")
-  string(APPEND COMMON_COMPILER_FLAGS
+  string(APPEND COMMON_COMPILE_FLAGS
     "-O3 "
   )
 endif()
@@ -162,7 +168,7 @@ string(CONCAT DPNP_DEFS
   "-D_FORTIFY_SOURCE=2 "
 )
 if(NOT WIN32)
-  string(APPEND COMMON_COMPILER_FLAGS
+  string(APPEND COMMON_COMPILE_FLAGS
     "-fno-delete-null-pointer-checks "
     "-fstack-protector-strong "
     "-fno-strict-overflow "

--- a/dpnp/backend/include/dpnp_iface.hpp
+++ b/dpnp/backend/include/dpnp_iface.hpp
@@ -1,5 +1,5 @@
 //*****************************************************************************
-// Copyright (c) 2016-2020, Intel Corporation
+// Copyright (c) 2016-2023, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -95,7 +95,7 @@ INP_DLLEXPORT void dpnp_queue_initialize_c(QueueOptions selector = QueueOptions:
  * @ingroup BACKEND_API
  * @brief SYCL queue device status.
  *
- * Return 1 if current @ref queue is related to cpu or host device. return 0 otherwise.
+ * Return 1 if current @ref queue is related to cpu device. return 0 otherwise.
  */
 INP_DLLEXPORT size_t dpnp_queue_is_cpu_c();
 

--- a/dpnp/backend/kernels/dpnp_krnl_fft.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_fft.cpp
@@ -1,5 +1,5 @@
 //*****************************************************************************
-// Copyright (c) 2016-2022, Intel Corporation
+// Copyright (c) 2016-2023, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -182,7 +182,10 @@ static void dpnp_fft_fft_mathlib_cmplx_to_cmplx_c(DPCTLSyclQueueRef q_ref,
                                                   size_t inverse,
                                                   const size_t norm)
 {
+    // avoid warning unused variable
     (void)result_shape;
+    (void)input_size;
+    (void)result_size;
 
     if (!shape_size) {
         return;
@@ -253,6 +256,9 @@ static DPCTLSyclEventRef dpnp_fft_fft_mathlib_real_to_cmplx_c(DPCTLSyclQueueRef 
                                                               const size_t norm,
                                                               const size_t real)
 {
+    // avoid warning unused variable
+    (void)input_size;
+
     DPCTLSyclEventRef event_ref = nullptr;
     if (!shape_size) {
         return event_ref;

--- a/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
@@ -1,5 +1,5 @@
 //*****************************************************************************
-// Copyright (c) 2016-2020, Intel Corporation
+// Copyright (c) 2016-2023, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -896,6 +896,7 @@ DPCTLSyclEventRef dpnp_take_c(DPCTLSyclQueueRef q_ref,
                               const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
+    (void)array1_size;
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;

--- a/dpnp/backend/kernels/dpnp_krnl_random.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_random.cpp
@@ -1,5 +1,5 @@
 //*****************************************************************************
-// Copyright (c) 2016-2022, Intel Corporation
+// Copyright (c) 2016-2023, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -36,6 +36,9 @@
 #include "dpnpc_memory_adapter.hpp"
 #include "queue_sycl.hpp"
 #include "dpnp_random_state.hpp"
+
+static_assert(INTEL_MKL_VERSION >= __INTEL_MKL_2023_VERSION_REQUIRED,
+              "MKL does not meet minimum version requirement");
 
 namespace mkl_blas = oneapi::mkl::blas;
 namespace mkl_rng = oneapi::mkl::rng;
@@ -990,11 +993,7 @@ DPCTLSyclEventRef dpnp_rng_multinomial_c(DPCTLSyclQueueRef q_ref,
             DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result, size, true, true);
             _DataType* result1 = result_ptr.get_ptr();
 
-#if (INTEL_MKL_VERSION < __INTEL_MKL_2023_SWITCHOVER)
-            std::vector<double> p(p_data, p_data + p_size);
-#else
             auto p = sycl::span<double>{p_data, p_size};
-#endif
             mkl_rng::multinomial<_DataType> distribution(ntrial, p);
 
             // perform generation
@@ -1082,13 +1081,8 @@ DPCTLSyclEventRef dpnp_rng_multivariate_normal_c(DPCTLSyclQueueRef q_ref,
 
     _DataType* result1 = static_cast<_DataType *>(result);
 
-#if (INTEL_MKL_VERSION < __INTEL_MKL_2023_SWITCHOVER)
-    std::vector<double> mean(mean_data, mean_data + mean_size);
-    std::vector<double> cov(cov_data, cov_data + cov_size);
-#else
     auto mean = sycl::span<double>{mean_data, mean_size};
     auto cov = sycl::span<double>{cov_data, cov_size};
-#endif
 
     // `result` is a array for random numbers
     // `size` is a `result`'s len.

--- a/dpnp/backend/src/dpnp_utils.hpp
+++ b/dpnp/backend/src/dpnp_utils.hpp
@@ -1,5 +1,5 @@
 //*****************************************************************************
-// Copyright (c) 2016-2022, Intel Corporation
+// Copyright (c) 2016-2023, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -45,15 +45,15 @@
  * Intel(R) oneAPI DPC++ 2022.2.1 compiler has version 20221020L on Linux and
  * 20221101L on Windows.
  */
-#ifndef __SYCL_COMPILER_2023_SWITCHOVER
-#define __SYCL_COMPILER_2023_SWITCHOVER 20221102L
+#ifndef __SYCL_COMPILER_VERSION_REQUIRED
+#define __SYCL_COMPILER_VERSION_REQUIRED 20221102L
 #endif
 
 /**
  * Version of Intel MKL at which transition to OneMKL release 2023.0.0 occurs.
  */
-#ifndef __INTEL_MKL_2023_SWITCHOVER
-#define __INTEL_MKL_2023_SWITCHOVER 20230000
+#ifndef __INTEL_MKL_2023_VERSION_REQUIRED
+#define __INTEL_MKL_2023_VERSION_REQUIRED 20230000
 #endif
 
 /**

--- a/dpnp/backend/src/dpnpc_memory_adapter.hpp
+++ b/dpnp/backend/src/dpnpc_memory_adapter.hpp
@@ -1,5 +1,5 @@
 //*****************************************************************************
-// Copyright (c) 2016-2022, Intel Corporation
+// Copyright (c) 2016-2023, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -85,10 +85,6 @@ public:
             std::cerr << "\n\t size_in_bytes=" << size_in_bytes;
             std::cerr << "\n\t pointer type=" << (long)src_ptr_type;
             std::cerr << "\n\t queue inorder=" << queue.is_in_order();
-#if (__SYCL_COMPILER_VERSION < __SYCL_COMPILER_2023_SWITCHOVER)
-            std::cerr << "\n\t queue is_host=" << queue.is_host();
-            std::cerr << "\n\t queue device is_host=" << queue.get_device().is_host();
-#endif
             std::cerr << "\n\t queue device is_cpu=" << queue.get_device().is_cpu();
             std::cerr << "\n\t queue device is_gpu=" << queue.get_device().is_gpu();
             std::cerr << "\n\t queue device is_accelerator=" << queue.get_device().is_accelerator();

--- a/dpnp/backend/src/queue_sycl.cpp
+++ b/dpnp/backend/src/queue_sycl.cpp
@@ -1,5 +1,5 @@
 //*****************************************************************************
-// Copyright (c) 2016-2020, Intel Corporation
+// Copyright (c) 2016-2023, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -215,11 +215,6 @@ bool backend_sycl::backend_sycl_is_cpu()
     if (qptr.get_device().is_cpu()) {
         return true;
     }
-#if (__SYCL_COMPILER_VERSION < __SYCL_COMPILER_2023_SWITCHOVER)
-    else if (qptr.is_host() || qptr.get_device().is_host()) {
-        return true;
-    }
-#endif
 
     return false;
 }

--- a/dpnp/backend/src/queue_sycl.hpp
+++ b/dpnp/backend/src/queue_sycl.hpp
@@ -1,5 +1,5 @@
 //*****************************************************************************
-// Copyright (c) 2016-2020, Intel Corporation
+// Copyright (c) 2016-2023, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -113,7 +113,7 @@ public:
     static void backend_sycl_queue_init(QueueOptions selector = QueueOptions::CPU_SELECTOR);
 
     /**
-     * Return True if current @ref queue is related to cpu or host device
+     * Return True if current @ref queue is related to cpu device
      */
     static bool backend_sycl_is_cpu();
 

--- a/dpnp/dpnp_algo/dpnp_algo.pyx
+++ b/dpnp/dpnp_algo/dpnp_algo.pyx
@@ -1,7 +1,7 @@
 # cython: language_level=3
 # -*- coding: utf-8 -*-
 # *****************************************************************************
-# Copyright (c) 2016-2022, Intel Corporation
+# Copyright (c) 2016-2023, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -221,7 +221,7 @@ cpdef dpnp_queue_initialize():
 
 
 cpdef dpnp_queue_is_cpu():
-    """Return 1 if current queue is CPU or HOST. Return 0 otherwise.
+    """Return 1 if current queue is CPU. Return 0 otherwise.
 
     """
     return dpnp_queue_is_cpu_c()


### PR DESCRIPTION
The PR implements a similar fix for debug building with introducing link option `-fsycl-link-huge-device-code`, as described in PR [#1028](https://github.com/IntelPython/dpctl/pull/1028) for `dpctl`.

Additionally `TMP` environment variable were set to a source directory in case of debug build in `0.build.sh` script to redirect a path where the compiler creates temporary files, since default `/tmp` location is limited and the size is not enough to keep all the generated files there.

Removed use of `__SYCL_COMPILER_2023_SWITCHOVER` and `__INTEL_MKL_2023_SWITCHOVER` preprocessor constants and introduced `__SYCL_COMPILER_VERSION_REQUIRED` and `__INTEL_MKL_2023_VERSION_REQUIRED` instead to ensure that the compiler or MKL meets the minimum required version where required.

Also few minor compilation warnings were fixed.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
