### PR TITLE
Add operation __index__ and __complex__

### DIFF
--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -140,7 +140,10 @@ class dpnp_array:
         return self._array_obj.__bool__()
 
  # '__class__',
- # '__complex__',
+ 
+    def __complex__(self):
+        return self._array_obj.__complex__()
+
  # '__contains__',
  # '__copy__',
  # '__deepcopy__',
@@ -187,7 +190,10 @@ class dpnp_array:
  # '__imatmul__',
  # '__imod__',
  # '__imul__',
- # '__index__',
+ 
+    def __index__(self):
+        return self._array_obj.__index__()
+
  # '__init__',
  # '__init_subclass__',
 

--- a/tests/test_dparray.py
+++ b/tests/test_dparray.py
@@ -1,15 +1,17 @@
-import dpnp
-import numpy
 import pytest
+from .helper import get_all_dtypes
+
+import dpnp
 import dpctl.tensor as dpt
 
+import numpy
+from numpy.testing import (
+    assert_array_equal
+)
 
-@pytest.mark.parametrize("res_dtype",
-                         [numpy.float64, numpy.float32, numpy.int64, numpy.int32, numpy.bool_, numpy.complex_],
-                         ids=['float64', 'float32', 'int64', 'int32', 'bool', 'complex'])
-@pytest.mark.parametrize("arr_dtype",
-                         [numpy.float64, numpy.float32, numpy.int64, numpy.int32, numpy.bool_, numpy.complex_],
-                         ids=['float64', 'float32', 'int64', 'int32', 'bool', 'complex'])
+
+@pytest.mark.parametrize("res_dtype", get_all_dtypes())
+@pytest.mark.parametrize("arr_dtype", get_all_dtypes())
 @pytest.mark.parametrize("arr",
                          [[-2, -1, 0, 1, 2], [[-2, -1], [1, 2]], []],
                          ids=['[-2, -1, 0, 1, 2]', '[[-2, -1], [1, 2]]', '[]'])
@@ -18,12 +20,10 @@ def test_astype(arr, arr_dtype, res_dtype):
     dpnp_array = dpnp.array(numpy_array)
     expected = numpy_array.astype(res_dtype)
     result = dpnp_array.astype(res_dtype)
-    numpy.testing.assert_array_equal(expected, result)
+    assert_array_equal(expected, result)
 
 
-@pytest.mark.parametrize("arr_dtype",
-                         [numpy.float64, numpy.float32, numpy.int64, numpy.int32, numpy.bool_, numpy.complex_],
-                         ids=['float64', 'float32', 'int64', 'int32', 'bool', 'complex'])
+@pytest.mark.parametrize("arr_dtype", get_all_dtypes())
 @pytest.mark.parametrize("arr",
                          [[-2, -1, 0, 1, 2], [[-2, -1], [1, 2]], []],
                          ids=['[-2, -1, 0, 1, 2]', '[[-2, -1], [1, 2]]', '[]'])
@@ -32,7 +32,7 @@ def test_flatten(arr, arr_dtype):
     dpnp_array = dpnp.array(arr, dtype=arr_dtype)
     expected = numpy_array.flatten()
     result = dpnp_array.flatten()
-    numpy.testing.assert_array_equal(expected, result)
+    assert_array_equal(expected, result)
 
 
 @pytest.mark.parametrize("shape",
@@ -68,3 +68,29 @@ def test_flags_strides(dtype, order, strides):
     assert usm_array.flags == dpnp_array.flags
     assert numpy_array.flags.c_contiguous == dpnp_array.flags.c_contiguous
     assert numpy_array.flags.f_contiguous == dpnp_array.flags.f_contiguous
+
+
+@pytest.mark.parametrize("func", [bool, float, int, complex])
+@pytest.mark.parametrize("shape", [tuple(), (1,), (1, 1), (1, 1, 1)])
+@pytest.mark.parametrize("dtype", get_all_dtypes(no_float16=False, no_complex=True))
+def test_scalar_type_casting(func, shape, dtype):
+    numpy_array = numpy.full(shape, 5, dtype=dtype)
+    dpnp_array = dpnp.full(shape, 5, dtype=dtype)
+    assert func(numpy_array) == func(dpnp_array)
+
+
+@pytest.mark.parametrize("method", ["__bool__", "__float__", "__int__", "__complex__"])
+@pytest.mark.parametrize("shape", [tuple(), (1,), (1, 1), (1, 1, 1)])
+@pytest.mark.parametrize("dtype", get_all_dtypes(no_float16=False, no_complex=True, no_none=True))
+def test_scalar_type_casting_by_method(method, shape, dtype):
+    numpy_array = numpy.full(shape, 4.7, dtype=dtype)
+    dpnp_array = dpnp.full(shape, 4.7, dtype=dtype)
+    assert getattr(numpy_array, method)() == getattr(dpnp_array, method)()
+
+
+@pytest.mark.parametrize("shape", [(1,), (1, 1), (1, 1, 1)])
+@pytest.mark.parametrize("index_dtype", [dpnp.int32, dpnp.int64])
+def test_array_as_index(shape, index_dtype):
+    ind_arr = dpnp.ones(shape, dtype=index_dtype)
+    a = numpy.arange(ind_arr.size + 1)
+    assert a[tuple(ind_arr)] == a[1]


### PR DESCRIPTION
This PR implements missing `dpnp.__index()__` and `dpnp.__complex__()` functions to support `__index__` and `__complex__` operation with dpnp array appropriately.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
