### PR TITLE
Update tests with proper call of dpctl.SyclQueue()

### DIFF
--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -426,7 +426,7 @@ def test_random_state(func, args, kwargs, device, usm_type):
     assert device == res_array.sycl_device
     assert usm_type == res_array.usm_type
 
-    sycl_queue = dpctl.SyclQueue(device=device, property="in_order")
+    sycl_queue = dpctl.SyclQueue(device, property="in_order")
 
     # test with in-order SYCL queue per a device and passed as argument
     rs = dpnp.random.RandomState((147, 56, 896), sycl_queue=sycl_queue)


### PR DESCRIPTION
The PR fixes incorrect call of dpctl.SyclQueue() function with device keyword from `dpnp` test.

The issue breaks `dpnp` tests since PR [#1052](https://github.com/IntelPython/dpctl/pull/1052), where `dpctl` introduced a validation check which will raise an exception if any keyword passed in `SyclQueue` constructor.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
