### PR TITLE
Add dlpack support

### DIFF
--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -319,6 +319,16 @@ class dpnp_array:
 
  # '__xor__',
 
+    @staticmethod
+    def _create_from_usm_ndarray(usm_ary : dpt.usm_ndarray):
+        if not isinstance(usm_ary, dpt.usm_ndarray):
+            raise TypeError(
+                f"Expected dpctl.tensor.usm_ndarray, got {type(usm_ary)}"
+                )
+        res = dpnp_array.__new__(dpnp_array)
+        res._array_obj = usm_ary
+        return res
+
     def all(self, axis=None, out=None, keepdims=False):
         """
         Returns True if all elements evaluate to True.

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -140,7 +140,7 @@ class dpnp_array:
         return self._array_obj.__bool__()
 
  # '__class__',
- 
+
     def __complex__(self):
         return self._array_obj.__complex__()
 
@@ -152,6 +152,12 @@ class dpnp_array:
  # '__dir__',
  # '__divmod__',
  # '__doc__',
+
+    def __dlpack__(self, stream=None):
+        return self._array_obj.__dlpack__(stream=stream)
+
+    def __dlpack_device__(self):
+        return self._array_obj.__dlpack_device__()
 
     def __eq__(self, other):
         return dpnp.equal(self, other)
@@ -190,7 +196,7 @@ class dpnp_array:
  # '__imatmul__',
  # '__imod__',
  # '__imul__',
- 
+
     def __index__(self):
         return self._array_obj.__index__()
 

--- a/dpnp/dpnp_iface.py
+++ b/dpnp/dpnp_iface.py
@@ -223,7 +223,7 @@ def default_float_type(device=None, sycl_queue=None):
     return map_dtype_to_device(float64, _sycl_queue.sycl_device)
 
 
-def from_dlpack(obj):
+def from_dlpack(obj, /):
     """
     Create a dpnp array from a Python object implementing the ``__dlpack__``
     protocol.
@@ -232,19 +232,20 @@ def from_dlpack(obj):
 
     Parameters
     ----------
-    obj : A Python object representing an array that implements the ``__dlpack__``
+    obj : object
+        A Python object representing an array that implements the ``__dlpack__``
         and ``__dlpack_device__`` methods.
 
     Returns
     -------
-    array : dpnp_array
+    out : dpnp_array
+        Returns a new dpnp array containing the data from another array
+        (obj) with the ``__dlpack__`` method on the same device as object.
 
     """
 
     usm_ary = dpt.from_dlpack(obj)
-    dpnp_ary = dpnp_array.__new__(dpnp_array)
-    dpnp_ary._array_obj = usm_ary
-    return dpnp_ary
+    return dpnp_array._create_from_usm_ndarray(usm_ary)
 
 
 def get_dpnp_descriptor(ext_obj,

--- a/dpnp/dpnp_iface.py
+++ b/dpnp/dpnp_iface.py
@@ -64,6 +64,7 @@ __all__ = [
     "default_float_type",
     "dpnp_queue_initialize",
     "dpnp_queue_is_cpu",
+    "from_dlpack",
     "get_dpnp_descriptor",
     "get_include",
     "get_normalized_queue_device"
@@ -220,6 +221,30 @@ def default_float_type(device=None, sycl_queue=None):
 
     _sycl_queue = get_normalized_queue_device(device=device, sycl_queue=sycl_queue)
     return map_dtype_to_device(float64, _sycl_queue.sycl_device)
+
+
+def from_dlpack(obj):
+    """
+    Create a dpnp array from a Python object implementing the ``__dlpack__``
+    protocol.
+
+    See https://dmlc.github.io/dlpack/latest/ for more details.
+
+    Parameters
+    ----------
+    obj : A Python object representing an array that implements the ``__dlpack__``
+        and ``__dlpack_device__`` methods.
+
+    Returns
+    -------
+    array : dpnp_array
+
+    """
+
+    usm_ary = dpt.from_dlpack(obj)
+    dpnp_ary = dpnp_array.__new__(dpnp_array)
+    dpnp_ary._array_obj = usm_ary
+    return dpnp_ary
 
 
 def get_dpnp_descriptor(ext_obj,

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -32,7 +32,7 @@ def get_all_dtypes(no_bool=False,
         dtypes.append(dpnp.complex64)
         if dev.has_aspect_fp64:
             dtypes.append(dpnp.complex128)
-    
+
     # add None value to validate a default dtype
     if not no_none:
         dtypes.append(None)

--- a/tests/test_dparray.py
+++ b/tests/test_dparray.py
@@ -24,39 +24,6 @@ def test_astype(arr, arr_dtype, res_dtype):
 
 
 @pytest.mark.parametrize("arr_dtype", get_all_dtypes())
-@pytest.mark.parametrize("shape", [tuple(), (2,), (3, 0, 1), (2, 2, 2)])
-def test_from_dlpack(arr_dtype,shape):
-    X = dpnp.empty(shape=shape,dtype=arr_dtype)
-    Y = dpnp.from_dlpack(X)
-    assert_array_equal(X, Y)
-    assert X.__dlpack_device__() == Y.__dlpack_device__()
-    assert X.shape == Y.shape
-    assert X.dtype == Y.dtype or (
-        str(X.dtype) == "bool" and str(Y.dtype) == "uint8"
-    )
-    assert X.sycl_device == Y.sycl_device
-    assert X.usm_type == Y.usm_type
-    if Y.ndim:
-        V = Y[::-1]
-        W = dpnp.from_dlpack(V)
-        assert V.strides == W.strides
-
-@pytest.mark.parametrize("arr_dtype", get_all_dtypes())
-def test_from_dlpack_with_dpt(arr_dtype):
-    X = dpt.empty((64,),dtype=arr_dtype)
-    Y = dpnp.from_dlpack(X)
-    assert_array_equal(X, Y)
-    assert isinstance(Y, dpnp.dpnp_array.dpnp_array)
-    assert X.__dlpack_device__() == Y.__dlpack_device__()
-    assert X.shape == Y.shape
-    assert X.dtype == Y.dtype or (
-        str(X.dtype) == "bool" and str(Y.dtype) == "uint8"
-    )
-    assert X.sycl_device == Y.sycl_device
-    assert X.usm_type == Y.usm_type
-
-
-@pytest.mark.parametrize("arr_dtype", get_all_dtypes())
 @pytest.mark.parametrize("arr",
                          [[-2, -1, 0, 1, 2], [[-2, -1], [1, 2]], []],
                          ids=['[-2, -1, 0, 1, 2]', '[[-2, -1], [1, 2]]', '[]'])

--- a/tests/test_dparray.py
+++ b/tests/test_dparray.py
@@ -41,6 +41,20 @@ def test_from_dlpack(arr_dtype,shape):
         W = dpnp.from_dlpack(V)
         assert V.strides == W.strides
 
+@pytest.mark.parametrize("arr_dtype", get_all_dtypes())
+def test_from_dlpack_with_dpt(arr_dtype):
+    X = dpt.empty((64,),dtype=arr_dtype)
+    Y = dpnp.from_dlpack(X)
+    assert_array_equal(X, Y)
+    assert isinstance(Y, dpnp.dpnp_array.dpnp_array)
+    assert X.__dlpack_device__() == Y.__dlpack_device__()
+    assert X.shape == Y.shape
+    assert X.dtype == Y.dtype or (
+        str(X.dtype) == "bool" and str(Y.dtype) == "uint8"
+    )
+    assert X.sycl_device == Y.sycl_device
+    assert X.usm_type == Y.usm_type
+
 
 @pytest.mark.parametrize("arr_dtype", get_all_dtypes())
 @pytest.mark.parametrize("arr",

--- a/tests/test_dparray.py
+++ b/tests/test_dparray.py
@@ -24,6 +24,25 @@ def test_astype(arr, arr_dtype, res_dtype):
 
 
 @pytest.mark.parametrize("arr_dtype", get_all_dtypes())
+@pytest.mark.parametrize("shape", [tuple(), (2,), (3, 0, 1), (2, 2, 2)])
+def test_from_dlpack(arr_dtype,shape):
+    X = dpnp.empty(shape=shape,dtype=arr_dtype)
+    Y = dpnp.from_dlpack(X)
+    assert_array_equal(X, Y)
+    assert X.__dlpack_device__() == Y.__dlpack_device__()
+    assert X.shape == Y.shape
+    assert X.dtype == Y.dtype or (
+        str(X.dtype) == "bool" and str(Y.dtype) == "uint8"
+    )
+    assert X.sycl_device == Y.sycl_device
+    assert X.usm_type == Y.usm_type
+    if Y.ndim:
+        V = Y[::-1]
+        W = dpnp.from_dlpack(V)
+        assert V.strides == W.strides
+
+
+@pytest.mark.parametrize("arr_dtype", get_all_dtypes())
 @pytest.mark.parametrize("arr",
                          [[-2, -1, 0, 1, 2], [[-2, -1], [1, 2]], []],
                          ids=['[-2, -1, 0, 1, 2]', '[[-2, -1], [1, 2]]', '[]'])

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -1,8 +1,13 @@
 import pytest
+from .helper import get_all_dtypes
 
 import dpnp
 import dpctl
 import numpy
+
+from numpy.testing import (
+    assert_array_equal
+)
 
 
 list_of_backend_str = [
@@ -155,7 +160,7 @@ def test_array_creation_like(func, kwargs, device_x, device_y):
 
     dpnp_kwargs = dict(kwargs)
     dpnp_kwargs['device'] = device_y
-    
+
     y = getattr(dpnp, func)(x, **dpnp_kwargs)
     numpy.testing.assert_array_equal(y_orig, y)
     assert_sycl_queue_equal(y.sycl_queue, x.to_device(device_y).sycl_queue)
@@ -637,7 +642,7 @@ def test_eig(device):
     dpnp_val_queue = dpnp_val.get_array().sycl_queue
     dpnp_vec_queue = dpnp_vec.get_array().sycl_queue
 
-    # compare queue and device    
+    # compare queue and device
     assert_sycl_queue_equal(dpnp_val_queue, expected_queue)
     assert_sycl_queue_equal(dpnp_vec_queue, expected_queue)
 
@@ -806,3 +811,39 @@ def test_array_copy(device, func, device_param, queue_param):
     result = dpnp.array(dpnp_data, **kwargs)
 
     assert_sycl_queue_equal(result.sycl_queue, dpnp_data.sycl_queue)
+
+
+@pytest.mark.parametrize("device",
+                         valid_devices,
+                         ids=[device.filter_string for device in valid_devices])
+#TODO need to delete no_bool=True when use dlpack > 0.7 version
+@pytest.mark.parametrize("arr_dtype", get_all_dtypes(no_float16=True, no_bool=True))
+@pytest.mark.parametrize("shape", [tuple(), (2,), (3, 0, 1), (2, 2, 2)])
+def test_from_dlpack(arr_dtype, shape, device):
+    X = dpnp.empty(shape=shape, dtype=arr_dtype, device=device)
+    Y = dpnp.from_dlpack(X)
+    assert_array_equal(X, Y)
+    assert X.__dlpack_device__() == Y.__dlpack_device__()
+    assert X.sycl_device == Y.sycl_device
+    assert X.sycl_context == Y.sycl_context
+    assert X.usm_type == Y.usm_type
+    if Y.ndim:
+        V = Y[::-1]
+        W = dpnp.from_dlpack(V)
+        assert V.strides == W.strides
+
+
+@pytest.mark.parametrize("device",
+                         valid_devices,
+                         ids=[device.filter_string for device in valid_devices])
+#TODO need to delete no_bool=True when use dlpack > 0.7 version
+@pytest.mark.parametrize("arr_dtype", get_all_dtypes(no_float16=True, no_bool=True))
+def test_from_dlpack_with_dpt(arr_dtype, device):
+    X = dpctl.tensor.empty((64,), dtype=arr_dtype, device=device)
+    Y = dpnp.from_dlpack(X)
+    assert_array_equal(X, Y)
+    assert isinstance(Y, dpnp.dpnp_array.dpnp_array)
+    assert X.__dlpack_device__() == Y.__dlpack_device__()
+    assert X.sycl_device == Y.sycl_device
+    assert X.sycl_context == Y.sycl_context
+    assert X.usm_type == Y.usm_type


### PR DESCRIPTION
This PR closes #1291 

The PR adds **__dlpack__** and **__dlpack_device__** protocols to dpnp_array and implements **dpnp.from_dlpack** function including tests and docstrings.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
