### PR TITLE
Remove temporary solution accepting CFD with equal SYCL context instead of queue

### DIFF
--- a/dpnp/dpnp_utils/dpnp_algo_utils.pyx
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pyx
@@ -651,9 +651,6 @@ cdef tuple get_common_usm_allocation(dpnp_descriptor x1, dpnp_descriptor x2):
             "".format(array1_obj.usm_type, array2_obj.usm_type))
 
     common_sycl_queue = dpu.get_execution_queue((array1_obj.sycl_queue, array2_obj.sycl_queue))
-    # TODO: refactor, remove when CFD is implemented in all array constructors
-    if common_sycl_queue is None and array1_obj.sycl_context == array2_obj.sycl_context:
-        common_sycl_queue = array1_obj.sycl_queue
     if common_sycl_queue is None:
         raise ValueError(
             "could not recognize common SYCL queue for inputs in SYCL queues {} and {}"

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -6,7 +6,8 @@ import dpctl
 import numpy
 
 from numpy.testing import (
-    assert_array_equal
+    assert_array_equal,
+    assert_raises
 )
 
 
@@ -351,6 +352,19 @@ def test_broadcasting(func, data1, data2, device):
     result_queue = result.get_array().sycl_queue
 
     assert_sycl_queue_equal(result_queue, expected_queue)
+
+
+@pytest.mark.parametrize("func", ["add", "copysign", "divide", "floor_divide", "fmod",
+                                  "maximum", "minimum", "multiply", "outer", "power",
+                                  "remainder", "subtract"])
+@pytest.mark.parametrize("device",
+                         valid_devices,
+                         ids=[device.filter_string for device in valid_devices])
+def test_2in_1out_diff_queue_but_equal_context(func, device):
+    x1 = dpnp.arange(10)
+    x2 = dpnp.arange(10, sycl_queue=dpctl.SyclQueue(device))[::-1]
+    with assert_raises(ValueError):
+        getattr(dpnp, func)(x1, x2)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
In terms of compute follows data paradigm it is prohibited to manipulate data if they were allocated on the same device and if they have the same SYCL context, but different SYCL queues.
The PR removes a temporary solution existing in the code which assumed the same SYCL context but different queues as valid and as following the paradigm. But that isn't needed anymore and potentially might be dangerous.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
