### PR TITLE
Change dpnp.asfarray to run on Iris Xe

### DIFF
--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -2,7 +2,7 @@
 # distutils: language = c++
 # -*- coding: utf-8 -*-
 # *****************************************************************************
-# Copyright (c) 2016-2022, Intel Corporation
+# Copyright (c) 2016-2023, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -73,7 +73,7 @@ __all__ = [
 ]
 
 
-def asfarray(x1, dtype=numpy.float64):
+def asfarray(x1, dtype=None):
     """
     Return an array converted to a float type.
 
@@ -87,9 +87,10 @@ def asfarray(x1, dtype=numpy.float64):
 
     x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if x1_desc:
-        # behavior of original function: int types replaced with float64
-        if numpy.issubdtype(dtype, numpy.integer):
-            dtype = numpy.float64
+        # int types replaced with a floating type by default in DPNP
+        # depending on device capabilities.
+        if dtype is None or numpy.issubdtype(dtype, numpy.integer):
+            dtype = dpnp.default_float_type()
 
         # if type is the same then same object should be returned
         if x1_desc.dtype == dtype:

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -48,7 +48,6 @@ from dpnp.dpnp_iface_arraycreation import array
 
 import dpnp
 import numpy
-import numpy.core.numeric as _nx
 
 
 __all__ = [
@@ -90,7 +89,7 @@ def asfarray(x1, dtype=None):
 
     x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if x1_desc:
-        if dtype is None or not numpy.issubdtype(dtype, _nx.inexact):
+        if dtype is None or not numpy.issubdtype(dtype, numpy.inexact):
             dtype = dpnp.default_float_type(sycl_queue=x1.sycl_queue)
 
         # if type is the same then same object should be returned

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -48,6 +48,7 @@ from dpnp.dpnp_iface_arraycreation import array
 
 import dpnp
 import numpy
+import numpy.core.numeric as _nx
 
 
 __all__ = [
@@ -82,15 +83,15 @@ def asfarray(x1, dtype=None):
     Notes
     -----
     This function works exactly the same as :obj:`dpnp.array`.
+    If dtype is `None`, `bool` or one of the `int` dtypes, it is replaced with
+    the default floating type in DPNP depending on device capabilities.
 
     """
 
     x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if x1_desc:
-        # int types replaced with a floating type by default in DPNP
-        # depending on device capabilities.
-        if dtype is None or numpy.issubdtype(dtype, numpy.integer):
-            dtype = dpnp.default_float_type()
+        if dtype is None or not numpy.issubdtype(dtype, _nx.inexact):
+            dtype = dpnp.default_float_type(sycl_queue=x1.sycl_queue)
 
         # if type is the same then same object should be returned
         if x1_desc.dtype == dtype:

--- a/tests/test_arraymanipulation.py
+++ b/tests/test_arraymanipulation.py
@@ -6,7 +6,7 @@ import numpy
 
 
 @pytest.mark.usefixtures("allow_fall_back_on_numpy")
-@pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
+@pytest.mark.parametrize("dtype", get_all_dtypes())
 @pytest.mark.parametrize(
     "data", [[1, 2, 3], [1.0, 2.0, 3.0]], ids=["[1, 2, 3]", "[1., 2., 3.]"]
 )
@@ -17,13 +17,12 @@ def test_asfarray(dtype, data):
     numpy.testing.assert_array_equal(result, expected)
 
 
-@pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
-@pytest.mark.parametrize(
-    "data", [[1, 2, 3], [1.0, 2.0, 3.0]], ids=["[1, 2, 3]", "[1., 2., 3.]"]
-)
-def test_asfarray2(dtype, data):
-    expected = numpy.asfarray(numpy.array(data), dtype)
-    result = dpnp.asfarray(dpnp.array(data), dtype)
+@pytest.mark.parametrize("dtype", get_all_dtypes())
+@pytest.mark.parametrize("data", [[1.0, 2.0, 3.0]], ids=["[1., 2., 3.]"])
+@pytest.mark.parametrize("data_dtype", get_all_dtypes(no_none=True))
+def test_asfarray2(dtype, data, data_dtype):
+    expected = numpy.asfarray(numpy.array(data, dtype=data_dtype), dtype)
+    result = dpnp.asfarray(dpnp.array(data, dtype=data_dtype), dtype)
 
     numpy.testing.assert_array_equal(result, expected)
 

--- a/tests/test_arraymanipulation.py
+++ b/tests/test_arraymanipulation.py
@@ -1,16 +1,15 @@
 import pytest
+from .helper import get_all_dtypes
 
 import dpnp
 import numpy
 
 
 @pytest.mark.usefixtures("allow_fall_back_on_numpy")
-@pytest.mark.parametrize("dtype",
-                         [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
-                         ids=["float64", "float32", "int64", "int32"])
-@pytest.mark.parametrize("data",
-                         [[1, 2, 3], [1., 2., 3.]],
-                         ids=["[1, 2, 3]", "[1., 2., 3.]"])
+@pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
+@pytest.mark.parametrize(
+    "data", [[1, 2, 3], [1.0, 2.0, 3.0]], ids=["[1, 2, 3]", "[1., 2., 3.]"]
+)
 def test_asfarray(dtype, data):
     expected = numpy.asfarray(data, dtype)
     result = dpnp.asfarray(data, dtype)
@@ -18,12 +17,10 @@ def test_asfarray(dtype, data):
     numpy.testing.assert_array_equal(result, expected)
 
 
-@pytest.mark.parametrize("dtype",
-                         [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
-                         ids=["float64", "float32", "int64", "int32"])
-@pytest.mark.parametrize("data",
-                         [[1, 2, 3], [1., 2., 3.]],
-                         ids=["[1, 2, 3]", "[1., 2., 3.]"])
+@pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
+@pytest.mark.parametrize(
+    "data", [[1, 2, 3], [1.0, 2.0, 3.0]], ids=["[1, 2, 3]", "[1., 2., 3.]"]
+)
 def test_asfarray2(dtype, data):
     expected = numpy.asfarray(numpy.array(data), dtype)
     result = dpnp.asfarray(dpnp.array(data), dtype)
@@ -59,7 +56,9 @@ class TestConcatenate:
         numpy.testing.assert_array_equal(dpnp.concatenate((r4, r3)), r4 + r3)
         # Mixed sequence types
         numpy.testing.assert_array_equal(dpnp.concatenate((tuple(r4), r3)), r4 + r3)
-        numpy.testing.assert_array_equal(dpnp.concatenate((dpnp.array(r4), r3)), r4 + r3)
+        numpy.testing.assert_array_equal(
+            dpnp.concatenate((dpnp.array(r4), r3)), r4 + r3
+        )
         # Explicit axis specification
         numpy.testing.assert_array_equal(dpnp.concatenate((r4, r3), 0), r4 + r3)
         # Including negative


### PR DESCRIPTION
This PR adds new logic for dpnp.asfarray function to return floating type depending on the device capabilities if the input array has an integer or boolean type.
These changes are necessary to support work on Iris Xe.
Subtask for #1294 


- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
