### PR TITLE
Intel LLVM is to use conda's gcc toolchain, sysroot and target libraries

### DIFF
--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -29,6 +29,11 @@ fi
 export CFLAGS="-Wl,-rpath,\$ORIGIN/../dpctl,-rpath,\$ORIGIN $CFLAGS"
 export LDFLAGS="-Wl,-rpath,\$ORIGIN/../dpctl,-rpath,\$ORIGIN $LDFLAGS"
 
+# Intel LLVM must cooperate with compiler and sysroot from conda
+echo "--gcc-toolchain=${BUILD_PREFIX} --sysroot=${BUILD_PREFIX}/${HOST}/sysroot -target ${HOST}" > icpx_for_conda.cfg
+export ICPXCFG="$(pwd)/icpx_for_conda.cfg"
+export ICXCFG="$(pwd)/icpx_for_conda.cfg"
+
 $PYTHON setup.py build_clib
 $PYTHON setup.py build_ext install
 


### PR DESCRIPTION
Use compiler CFG files for Intel LLVM to use conda's `sysroot` and `toolchain`.
The fix is based on a solution implemented in `dpctl`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
