### PR TITLE
Add missing dtype aliases

### DIFF
--- a/dpnp/dpnp_algo/dpnp_algo.pyx
+++ b/dpnp/dpnp_algo/dpnp_algo.pyx
@@ -233,11 +233,11 @@ cpdef dpnp_queue_is_cpu():
 Internal functions
 """
 cdef DPNPFuncType dpnp_dtype_to_DPNPFuncType(dtype):
-    dt_c = numpy.dtype(dtype).char
-    kind = numpy.dtype(dtype).kind
+    dt_c = dpnp.dtype(dtype).char
+    kind = dpnp.dtype(dtype).kind
     if isinstance(kind, int):
         kind = chr(kind)
-    itemsize = numpy.dtype(dtype).itemsize
+    itemsize = dpnp.dtype(dtype).itemsize
 
     if dt_c == 'd':
         return DPNP_FT_DOUBLE
@@ -266,19 +266,19 @@ cdef dpnp_DPNPFuncType_to_dtype(size_t type):
     TODO needs to use DPNPFuncType here
     """
     if type == <size_t > DPNP_FT_DOUBLE:
-        return numpy.float64
+        return dpnp.float64
     elif type == <size_t > DPNP_FT_FLOAT:
-        return numpy.float32
+        return dpnp.float32
     elif type == <size_t > DPNP_FT_LONG:
-        return numpy.int64
+        return dpnp.int64
     elif type == <size_t > DPNP_FT_INT:
-        return numpy.int32
+        return dpnp.int32
     elif type == <size_t > DPNP_FT_CMPLX64:
-        return numpy.complex64
+        return dpnp.complex64
     elif type == <size_t > DPNP_FT_CMPLX128:
-        return numpy.complex128
+        return dpnp.complex128
     elif type == <size_t > DPNP_FT_BOOL:
-        return numpy.bool_
+        return dpnp.bool
     else:
         utils.checker_throw_type_error("dpnp_DPNPFuncType_to_dtype", type)
 

--- a/dpnp/dpnp_algo/dpnp_algo_statistics.pyx
+++ b/dpnp/dpnp_algo/dpnp_algo_statistics.pyx
@@ -1,7 +1,7 @@
 # cython: language_level=3
 # -*- coding: utf-8 -*-
 # *****************************************************************************
-# Copyright (c) 2016-2020, Intel Corporation
+# Copyright (c) 2016-2023, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -129,7 +129,7 @@ cpdef dpnp_average(utils.dpnp_descriptor x1):
     array_sum = dpnp_sum(x1).get_pyobj()
 
     """ Numpy interface inconsistency """
-    return_type = numpy.float32 if (x1.dtype == numpy.float32) else numpy.float64
+    return_type = dpnp.float32 if (x1.dtype == dpnp.float32) else dpnp.float64
 
     return (return_type(array_sum / x1.size))
 

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -527,7 +527,7 @@ class dpnp_array:
 
         """
 
-        if not numpy.issubsctype(self.dtype, numpy.complex_):
+        if not dpnp.issubsctype(self.dtype, dpnp.complex_):
             return self
         else:
             return dpnp.conjugate(self)
@@ -540,7 +540,7 @@ class dpnp_array:
 
         """
 
-        if not numpy.issubsctype(self.dtype, numpy.complex_):
+        if not dpnp.issubsctype(self.dtype, dpnp.complex_):
             return self
         else:
             return dpnp.conjugate(self)

--- a/dpnp/dpnp_iface_linearalgebra.py
+++ b/dpnp/dpnp_iface_linearalgebra.py
@@ -2,7 +2,7 @@
 # distutils: language = c++
 # -*- coding: utf-8 -*-
 # *****************************************************************************
-# Copyright (c) 2016-2020, Intel Corporation
+# Copyright (c) 2016-2023, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -269,7 +269,7 @@ def matmul(x1, x2, out=None, **kwargs):
                 array2_size = x2_desc.size
                 cost_size = 4096  # 2D array shape(64, 64)
 
-                if ((x1_desc.dtype == numpy.float64) or (x1_desc.dtype == numpy.float32)):
+                if ((x1_desc.dtype == dpnp.float64) or (x1_desc.dtype == dpnp.float32)):
                     """
                     Floating point types are handled via original math library better than SYCL math library
                     """

--- a/dpnp/dpnp_iface_logic.py
+++ b/dpnp/dpnp_iface_logic.py
@@ -497,9 +497,8 @@ def isfinite(x1, out=None, **kwargs):
 
     Examples
     --------
-    >>> import numpy
     >>> import dpnp as np
-    >>> x = np.array([-numpy.inf, 0., numpy.inf])
+    >>> x = np.array([-np.inf, 0., np.inf])
     >>> out = np.isfinite(x)
     >>> [i for i in out]
     [False, True, False]
@@ -542,9 +541,8 @@ def isinf(x1, out=None, **kwargs):
 
     Examples
     --------
-    >>> import numpy
     >>> import dpnp as np
-    >>> x = np.array([-numpy.inf, 0., numpy.inf])
+    >>> x = np.array([-np.inf, 0., np.inf])
     >>> out = np.isinf(x)
     >>> [i for i in out]
     [True, False, True]
@@ -588,9 +586,8 @@ def isnan(x1, out=None, **kwargs):
 
     Examples
     --------
-    >>> import numpy
     >>> import dpnp as np
-    >>> x = np.array([numpy.inf, 0., np.nan])
+    >>> x = np.array([np.inf, 0., np.nan])
     >>> out = np.isnan(x)
     >>> [i for i in out]
     [False, False, True]

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -2,7 +2,7 @@
 # distutils: language = c++
 # -*- coding: utf-8 -*-
 # *****************************************************************************
-# Copyright (c) 2016-2022, Intel Corporation
+# Copyright (c) 2016-2023, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -73,7 +73,7 @@ __all__ = [
 ]
 
 
-def asfarray(x1, dtype=numpy.float64):
+def asfarray(x1, dtype=dpnp.float64):
     """
     Return an array converted to a float type.
 
@@ -88,8 +88,8 @@ def asfarray(x1, dtype=numpy.float64):
     x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if x1_desc:
         # behavior of original function: int types replaced with float64
-        if numpy.issubdtype(dtype, numpy.integer):
-            dtype = numpy.float64
+        if dpnp.issubdtype(dtype, dpnp.integer):
+            dtype = dpnp.float64
 
         # if type is the same then same object should be returned
         if x1_desc.dtype == dtype:

--- a/dpnp/dpnp_iface_trigonometric.py
+++ b/dpnp/dpnp_iface_trigonometric.py
@@ -2,7 +2,7 @@
 # distutils: language = c++
 # -*- coding: utf-8 -*-
 # *****************************************************************************
-# Copyright (c) 2016-2020, Intel Corporation
+# Copyright (c) 2016-2023, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -136,9 +136,8 @@ def arccosh(x1):
 
     Examples
     --------
-    >>> import numpy
     >>> import dpnp as np
-    >>> x = np.array([numpy.e, 10.0])
+    >>> x = np.array([np.e, 10.0])
     >>> out = np.arccosh(x)
     >>> [i for i in out]
     [1.65745445, 2.99322285]
@@ -205,9 +204,8 @@ def arcsinh(x1):
 
     Examples
     --------
-    >>> import numpy
     >>> import dpnp as np
-    >>> x = np.array([numpy.e, 10.0])
+    >>> x = np.array([np.e, 10.0])
     >>> out = np.arcsinh(x)
     >>> [i for i in out]
     [1.72538256, 2.99822295]
@@ -384,9 +382,8 @@ def cos(x1, out=None, **kwargs):
 
     Examples
     --------
-    >>> import numpy
     >>> import dpnp as np
-    >>> x = np.array([0, numpy.pi/2, numpy.pi])
+    >>> x = np.array([0, np.pi/2, np.pi])
     >>> out = np.cos(x)
     >>> [i for i in out]
     [1.0, 6.123233995736766e-17, -1.0]
@@ -464,9 +461,8 @@ def degrees(x1):
 
     Examples
     --------
-    >>> import numpy
     >>> import dpnp as np
-    >>> rad = np.arange(6.) * numpy.pi/6
+    >>> rad = np.arange(6.) * np.pi/6
     >>> out = np.degrees(rad)
     >>> [i for i in out]
     [0.0, 30.0, 60.0, 90.0, 120.0, 150.0]
@@ -652,9 +648,8 @@ def log(x1, out=None, **kwargs):
 
     Examples
     --------
-    >>> import numpy
     >>> import dpnp as np
-    >>> x = np.array([1.0, numpy.e, numpy.e**2, 0.0])
+    >>> x = np.array([1.0, np.e, np.e**2, 0.0])
     >>> out = np.log(x)
     >>> [i for i in out]
     [0.0, 1.0, 2.0, -inf]
@@ -867,9 +862,8 @@ def sin(x1, out=None, **kwargs):
 
     Examples
     --------
-    >>> import numpy
     >>> import dpnp as np
-    >>> x = np.array([0, numpy.pi/2, numpy.pi])
+    >>> x = np.array([0, np.pi/2, np.pi])
     >>> out = np.sin(x)
     >>> [i for i in out]
     [0.0, 1.0, 1.2246467991473532e-16]
@@ -897,9 +891,8 @@ def sinh(x1):
 
     Examples
     --------
-    >>> import numpy
     >>> import dpnp as np
-    >>> x = np.array([0, numpy.pi/2, numpy.pi])
+    >>> x = np.array([0, np.pi/2, np.pi])
     >>> out = np.sinh(x)
     >>> [i for i in out]
     [0.0, 2.3012989, 11.548739]
@@ -991,9 +984,8 @@ def tan(x1, out=None, **kwargs):
 
     Examples
     --------
-    >>> import numpy
     >>> import dpnp as np
-    >>> x = np.array([-numpy.pi, numpy.pi/2, numpy.pi])
+    >>> x = np.array([-np.pi, np.pi/2, np.pi])
     >>> out = np.tan(x)
     >>> [i for i in out]
     [1.22460635e-16, 1.63317787e+16, -1.22460635e-16]
@@ -1021,9 +1013,8 @@ def tanh(x1):
 
     Examples
     --------
-    >>> import numpy
     >>> import dpnp as np
-    >>> x = np.array([-numpy.pi, numpy.pi/2, numpy.pi])
+    >>> x = np.array([-np.pi, np.pi/2, np.pi])
     >>> out = np.tanh(x)
     >>> [i for i in out]
     [-0.996272, 0.917152, 0.996272]
@@ -1055,11 +1046,10 @@ def unwrap(x1):
 
     Examples
     --------
-    >>> import numpy
     >>> import dpnp as np
-    >>> phase = np.linspace(0, numpy.pi, num=5)
+    >>> phase = np.linspace(0, np.pi, num=5)
     >>> for i in range(3, 5):
-    >>>     phase[i] += numpy.pi
+    >>>     phase[i] += np.pi
     >>> out = np.unwrap(phase)
     >>> [i for i in out]
     [0.0, 0.78539816, 1.57079633, 5.49778714, 6.28318531]

--- a/dpnp/dpnp_iface_types.py
+++ b/dpnp/dpnp_iface_types.py
@@ -49,6 +49,7 @@ __all__ = [
     "csingle",
     "double",
     "dtype",
+    "e",
     "float",
     "float_",
     "float16",
@@ -56,6 +57,7 @@ __all__ = [
     "float64",
     "floating",
     "inexact",
+    "inf",
     "int",
     "int_",
     "int32",
@@ -69,6 +71,7 @@ __all__ = [
     "nan",
     "newaxis",
     "number",
+    "pi",
     "signedinteger",
     "single",
     "singlecomplex",
@@ -137,8 +140,11 @@ def issubsctype(arg1, arg2):
     return numpy.issubsctype(arg1, arg2)
 
 
+e = numpy.e
+inf = numpy.inf
 nan = numpy.nan
 newaxis = None
+pi = numpy.pi
 
 
 def is_type_supported(obj_type):

--- a/dpnp/dpnp_iface_types.py
+++ b/dpnp/dpnp_iface_types.py
@@ -70,7 +70,6 @@ __all__ = [
     "nan",
     "newaxis",
     "number",
-    "object_",
     "signedinteger",
     "single",
     "singlecomplex",
@@ -103,7 +102,6 @@ integer = numpy.integer
 intc = numpy.intc
 longcomplex = numpy.longcomplex
 number = numpy.number
-object_ = numpy.object_
 signedinteger = numpy.signedinteger
 single = numpy.single
 singlecomplex = numpy.singlecomplex

--- a/dpnp/dpnp_iface_types.py
+++ b/dpnp/dpnp_iface_types.py
@@ -50,6 +50,7 @@ __all__ = [
     "double",
     "dtype",
     "e",
+    "euler_gamma",
     "float",
     "float_",
     "float16",
@@ -57,7 +58,10 @@ __all__ = [
     "float64",
     "floating",
     "inexact",
+    "Inf",
     "inf",
+    "Infinity",
+    "infty",
     "int",
     "int_",
     "int32",
@@ -68,16 +72,25 @@ __all__ = [
     "issubdtype",
     "issubsctype",
     "is_type_supported",
+    "NAN",
+    "NaN",
     "nan",
     "newaxis",
+    "NINF",
+    "NZERO",
     "number",
     "pi",
+    "PINF",
+    "PZERO",
     "signedinteger",
     "single",
-    "singlecomplex",
-    "void"
+    "singlecomplex"
 ]
 
+
+# =============================================================================
+# Data types (borrowed from NumPy)
+# =============================================================================
 bool = numpy.bool_
 bool_ = numpy.bool_
 cdouble = numpy.cdouble
@@ -106,6 +119,26 @@ number = numpy.number
 signedinteger = numpy.signedinteger
 single = numpy.single
 singlecomplex = numpy.singlecomplex
+
+
+# =============================================================================
+# Constants (borrowed from NumPy)
+# =============================================================================
+e = numpy.e
+euler_gamma = numpy.euler_gamma
+Inf = numpy.Inf
+inf = numpy.inf
+Infinity = numpy.Infinity
+infty = numpy.infty
+NAN = numpy.NAN
+NaN = numpy.NaN
+nan = numpy.nan
+newaxis = None
+NINF = numpy.NINF
+NZERO = numpy.NZERO
+pi = numpy.pi
+PINF = numpy.PINF
+PZERO = numpy.PZERO
 
 
 def isscalar(obj):
@@ -138,13 +171,6 @@ def issubsctype(arg1, arg2):
     """
 
     return numpy.issubsctype(arg1, arg2)
-
-
-e = numpy.e
-inf = numpy.inf
-nan = numpy.nan
-newaxis = None
-pi = numpy.pi
 
 
 def is_type_supported(obj_type):

--- a/dpnp/dpnp_iface_types.py
+++ b/dpnp/dpnp_iface_types.py
@@ -40,39 +40,73 @@ import numpy
 __all__ = [
     "bool",
     "bool_",
+    "cdouble",
+    "complex_",
     "complex128",
     "complex64",
+    "complexfloating",
+    "cfloat",
+    "csingle",
+    "double",
     "dtype",
     "float",
+    "float_",
     "float16",
     "float32",
     "float64",
+    "floating",
+    "inexact",
     "int",
+    "int_",
     "int32",
     "int64",
     "integer",
+    "intc",
     "isscalar",
+    "issubdtype",
+    "issubsctype",
     "is_type_supported",
     "longcomplex",
     "nan",
     "newaxis",
+    "number",
+    "object_",
+    "signedinteger",
+    "single",
+    "singlecomplex",
     "void"
 ]
 
 bool = numpy.bool_
 bool_ = numpy.bool_
+cdouble = numpy.cdouble
+complex_ = numpy.complex_
 complex128 = numpy.complex128
 complex64 = numpy.complex64
+complexfloating = numpy.complexfloating
+cfloat = numpy.cfloat
+csingle = numpy.csingle
+double = numpy.double
 dtype = numpy.dtype
+float = numpy.float_
+float_ = numpy.float_
 float16 = numpy.float16
 float32 = numpy.float32
 float64 = numpy.float64
-float = numpy.float_
+floating = numpy.floating
+inexact = numpy.inexact
+int = numpy.int_
+int_ = numpy.int_
 int32 = numpy.int32
 int64 = numpy.int64
 integer = numpy.integer
-int = numpy.int_
+intc = numpy.intc
 longcomplex = numpy.longcomplex
+number = numpy.number
+object_ = numpy.object_
+signedinteger = numpy.signedinteger
+single = numpy.single
+singlecomplex = numpy.singlecomplex
 
 
 def isscalar(obj):
@@ -83,6 +117,28 @@ def isscalar(obj):
 
     """
     return numpy.isscalar(obj)
+
+
+def issubdtype(arg1, arg2):
+    """
+    Returns True if first argument is a typecode lower/equal in type hierarchy.
+
+    For full documentation refer to :obj:`numpy.issubdtype`.
+
+    """
+
+    return numpy.issubdtype(arg1, arg2)
+
+
+def issubsctype(arg1, arg2):
+    """
+    Determine if the first argument is a subclass of the second argument.
+
+    For full documentation refer to :obj:`numpy.issubsctype`.
+
+    """
+
+    return numpy.issubsctype(arg1, arg2)
 
 
 nan = numpy.nan

--- a/dpnp/dpnp_iface_types.py
+++ b/dpnp/dpnp_iface_types.py
@@ -66,7 +66,6 @@ __all__ = [
     "issubdtype",
     "issubsctype",
     "is_type_supported",
-    "longcomplex",
     "nan",
     "newaxis",
     "number",
@@ -100,7 +99,6 @@ int32 = numpy.int32
 int64 = numpy.int64
 integer = numpy.integer
 intc = numpy.intc
-longcomplex = numpy.longcomplex
 number = numpy.number
 signedinteger = numpy.signedinteger
 single = numpy.single
@@ -141,7 +139,6 @@ def issubsctype(arg1, arg2):
 
 nan = numpy.nan
 newaxis = None
-void = numpy.void
 
 
 def is_type_supported(obj_type):

--- a/dpnp/dpnp_utils/dpnp_algo_utils.pyx
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pyx
@@ -418,7 +418,7 @@ cdef tuple get_shape_dtype(object input_obj):
 
             # shape and dtype does not match with siblings.
             if ((return_shape != elem_shape) or (return_dtype != elem_dtype)):
-                return (elem_shape, dpnp.dtype(dpnp.object_))
+                return (elem_shape, dpnp.dtype(numpy.object_))
 
         list_shape.push_back(len(input_obj))
         list_shape.insert(list_shape.end(), return_shape.begin(), return_shape.end())

--- a/dpnp/dpnp_utils/dpnp_algo_utils.pyx
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pyx
@@ -268,18 +268,18 @@ def map_dtype_to_device(dtype, device):
     Map an input ``dtype`` with type ``device`` may use
     """
 
-    dtype = numpy.dtype(dtype)
+    dtype = dpnp.dtype(dtype)
     if not hasattr(dtype, 'char'):
         raise TypeError(f"Invalid type of input dtype={dtype}")
     elif not isinstance(device, dpctl.SyclDevice):
         raise TypeError(f"Invalid type of input device={device}")
 
     dtc = dtype.char
-    if dtc == "?" or numpy.issubdtype(dtype, numpy.integer):
+    if dtc == "?" or dpnp.issubdtype(dtype, dpnp.integer):
         # bool or integer type
         return dtype
 
-    if numpy.issubdtype(dtype, numpy.floating):
+    if dpnp.issubdtype(dtype, dpnp.floating):
         if dtc == "f":
             # float32 type
             return dtype
@@ -294,7 +294,7 @@ def map_dtype_to_device(dtype, device):
         # float32 is default floating type
         return dpnp.dtype("f4")
 
-    if numpy.issubdtype(dtype, numpy.complexfloating):
+    if dpnp.issubdtype(dtype, dpnp.complexfloating):
         if dtc == "F":
             # complex64 type
             return dtype
@@ -418,14 +418,14 @@ cdef tuple get_shape_dtype(object input_obj):
 
             # shape and dtype does not match with siblings.
             if ((return_shape != elem_shape) or (return_dtype != elem_dtype)):
-                return (elem_shape, numpy.dtype(numpy.object_))
+                return (elem_shape, dpnp.dtype(dpnp.object_))
 
         list_shape.push_back(len(input_obj))
         list_shape.insert(list_shape.end(), return_shape.begin(), return_shape.end())
         return (list_shape, return_dtype)
 
     # assume scalar or object
-    return (return_shape, numpy.dtype(type(input_obj)))
+    return (return_shape, dpnp.dtype(type(input_obj)))
 
 
 cpdef find_common_type(object x1_obj, object x2_obj):

--- a/dpnp/linalg/dpnp_algo_linalg.pyx
+++ b/dpnp/linalg/dpnp_algo_linalg.pyx
@@ -119,10 +119,10 @@ cpdef object dpnp_cond(object input, object p):
         sqnorm = dpnp.dot(input, input)
         res = dpnp.sqrt(sqnorm)
         ret = dpnp.array([res])
-    elif p == numpy.inf:
+    elif p == dpnp.inf:
         dpnp_sum_val = dpnp.sum(dpnp.abs(input), axis=1)
         ret = dpnp.max(dpnp_sum_val)
-    elif p == -numpy.inf:
+    elif p == -dpnp.inf:
         dpnp_sum_val = dpnp.sum(dpnp.abs(input), axis=1)
         ret = dpnp.min(dpnp_sum_val)
     elif p == 1:
@@ -368,9 +368,9 @@ cpdef object dpnp_norm(object input, ord=None, axis=None):
 
     len_axis = 1 if axis is None else len(axis_)
     if len_axis == 1:
-        if ord == numpy.inf:
+        if ord == dpnp.inf:
             return dpnp.array([dpnp.abs(input).max(axis=axis)])
-        elif ord == -numpy.inf:
+        elif ord == -dpnp.inf:
             return dpnp.array([dpnp.abs(input).min(axis=axis)])
         elif ord == 0:
             return input.dtype.type(dpnp.count_nonzero(input, axis=axis))
@@ -414,7 +414,7 @@ cpdef object dpnp_norm(object input, ord=None, axis=None):
                 col_axis -= 1
             dpnp_sum_val = dpnp.sum(dpnp.abs(input), axis=row_axis)
             ret = dpnp_sum_val.min(axis=col_axis)
-        elif ord == numpy.inf:
+        elif ord == dpnp.inf:
             if row_axis > col_axis:
                 row_axis -= 1
             dpnp_sum_val = dpnp.sum(dpnp.abs(input), axis=col_axis)
@@ -424,7 +424,7 @@ cpdef object dpnp_norm(object input, ord=None, axis=None):
                 col_axis -= 1
             dpnp_sum_val = dpnp.sum(dpnp.abs(input), axis=row_axis)
             ret = dpnp_sum_val.min(axis=col_axis)
-        elif ord == -numpy.inf:
+        elif ord == -dpnp.inf:
             if row_axis > col_axis:
                 row_axis -= 1
             dpnp_sum_val = dpnp.sum(dpnp.abs(input), axis=col_axis)

--- a/dpnp/linalg/dpnp_algo_linalg.pyx
+++ b/dpnp/linalg/dpnp_algo_linalg.pyx
@@ -1,7 +1,7 @@
 # cython: language_level=3
 # -*- coding: utf-8 -*-
 # *****************************************************************************
-# Copyright (c) 2016-2022, Intel Corporation
+# Copyright (c) 2016-2023, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -342,13 +342,13 @@ cpdef object dpnp_norm(object input, ord=None, axis=None):
     cdef long size_input = input.size
     cdef shape_type_c shape_input = input.shape
 
-    if input.dtype == numpy.float32:
-        res_type = numpy.float32
+    if input.dtype == dpnp.float32:
+        res_type = dpnp.float32
     else:
-        res_type = numpy.float64
+        res_type = dpnp.float64
 
     if size_input == 0:
-        return dpnp.array([numpy.nan], dtype=res_type)
+        return dpnp.array([dpnp.nan], dtype=res_type)
 
     if isinstance(axis, int):
         axis_ = tuple([axis])

--- a/dpnp/linalg/dpnp_iface_linalg.py
+++ b/dpnp/linalg/dpnp_iface_linalg.py
@@ -2,7 +2,7 @@
 # distutils: language = c++
 # -*- coding: utf-8 -*-
 # *****************************************************************************
-# Copyright (c) 2016-2020, Intel Corporation
+# Copyright (c) 2016-2023, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -111,7 +111,7 @@ def cond(input, p=None):
     Limitations
     -----------
     Input array is supported as :obj:`dpnp.ndarray`.
-    Parameter p=[None, 1, -1, 2, -2, numpy.inf, -numpy.inf, 'fro'] is supported.
+    Parameter p=[None, 1, -1, 2, -2, dpnp.inf, -dpnp.inf, 'fro'] is supported.
 
     See Also
     --------
@@ -119,7 +119,7 @@ def cond(input, p=None):
     """
 
     if (not use_origin_backend(input)):
-        if p in [None, 1, -1, 2, -2, numpy.inf, -numpy.inf, 'fro']:
+        if p in [None, 1, -1, 2, -2, dpnp.inf, -dpnp.inf, 'fro']:
             result_obj = dpnp_cond(input, p)
             result = dpnp.convert_single_elem_array_to_scalar(result_obj)
 

--- a/dpnp/random/dpnp_algo_random.pyx
+++ b/dpnp/random/dpnp_algo_random.pyx
@@ -1,7 +1,7 @@
 # cython: language_level=3
 # -*- coding: utf-8 -*-
 # *****************************************************************************
-# Copyright (c) 2016-2022, Intel Corporation
+# Copyright (c) 2016-2023, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -353,9 +353,9 @@ cdef class MT19937:
 
     cdef bint is_integer(self, value):
         if isinstance(value, numbers.Number):
-            return isinstance(value, int) or isinstance(value, numpy.integer)
+            return isinstance(value, int) or isinstance(value, dpnp.integer)
         # cover an element of dpnp array:
-        return numpy.ndim(value) == 0 and hasattr(value, "dtype") and numpy.issubdtype(value, numpy.integer)
+        return numpy.ndim(value) == 0 and hasattr(value, "dtype") and dpnp.issubdtype(value, dpnp.integer)
 
 
     cdef bint is_uint_range(self, value):
@@ -455,7 +455,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_beta(double a, double b, size):
     """
 
     # convert string type names (array.dtype) to C enum DPNPFuncType
-    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(numpy.float64)
+    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(dpnp.float64)
 
     # get the FPTR data structure
     cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_RNG_BETA_EXT, param1_type, param1_type)
@@ -488,7 +488,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_binomial(int ntrial, double p, size):
 
     """
 
-    dtype = numpy.int32
+    dtype = dpnp.int32
     cdef DPNPFuncType param1_type
     cdef DPNPFuncData kernel_data
     cdef fptr_dpnp_rng_binomial_c_1out_t func
@@ -527,7 +527,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_chisquare(int df, size):
     """
 
     # convert string type names (array.dtype) to C enum DPNPFuncType
-    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(numpy.float64)
+    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(dpnp.float64)
 
     # get the FPTR data structure
     cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_RNG_CHISQUARE_EXT, param1_type, param1_type)
@@ -560,7 +560,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_exponential(double beta, size):
 
     """
 
-    dtype = numpy.float64
+    dtype = dpnp.float64
     # convert string type names (array.dtype) to C enum DPNPFuncType
     cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(dtype)
 
@@ -593,7 +593,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_f(double df_num, double df_den, size):
     univariate F distribution.
     """
 
-    dtype = numpy.float64
+    dtype = dpnp.float64
     # convert string type names (array.dtype) to C enum DPNPFuncType
     cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(dtype)
 
@@ -627,7 +627,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_gamma(double shape, double scale, size):
 
     """
 
-    dtype = numpy.float64
+    dtype = dpnp.float64
     cdef DPNPFuncType param1_type
     cdef DPNPFuncData kernel_data
     cdef fptr_dpnp_rng_gamma_c_1out_t func
@@ -664,7 +664,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_geometric(float p, size):
 
     """
 
-    dtype = numpy.int32
+    dtype = dpnp.int32
     cdef DPNPFuncType param1_type
     cdef DPNPFuncData kernel_data
     cdef fptr_dpnp_rng_geometric_c_1out_t func
@@ -702,7 +702,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_gumbel(double loc, double scale, size):
 
     """
 
-    dtype = numpy.float64
+    dtype = dpnp.float64
     cdef DPNPFuncType param1_type
     cdef DPNPFuncData kernel_data
     cdef fptr_dpnp_rng_gumbel_c_1out_t func
@@ -737,7 +737,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_hypergeometric(int l, int s, int m, size):
 
     """
 
-    dtype = numpy.int32
+    dtype = dpnp.int32
     cdef DPNPFuncType param1_type
     cdef DPNPFuncData kernel_data
     cdef fptr_dpnp_rng_hypergeometric_c_1out_t func
@@ -775,7 +775,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_laplace(double loc, double scale, size):
 
     """
 
-    dtype = numpy.float64
+    dtype = dpnp.float64
     cdef DPNPFuncType param1_type
     cdef DPNPFuncData kernel_data
     cdef fptr_dpnp_rng_laplace_c_1out_t func
@@ -814,7 +814,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_logistic(double loc, double scale, size):
     """
 
     # convert string type names (array.dtype) to C enum DPNPFuncType
-    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(numpy.float64)
+    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(dpnp.float64)
 
     # get the FPTR data structure
     cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_RNG_LOGISTIC_EXT, param1_type, param1_type)
@@ -846,7 +846,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_lognormal(double mean, double stddev, size)
 
     """
 
-    dtype = numpy.float64
+    dtype = dpnp.float64
     cdef DPNPFuncType param1_type
     cdef DPNPFuncData kernel_data
     cdef fptr_dpnp_rng_lognormal_c_1out_t func
@@ -886,7 +886,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_multinomial(int ntrial, utils.dpnp_descript
 
     """
 
-    dtype = numpy.int32
+    dtype = dpnp.int32
     cdef DPNPFuncType param1_type
     cdef DPNPFuncData kernel_data
     cdef fptr_dpnp_rng_multinomial_c_1out_t func
@@ -934,7 +934,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_multivariate_normal(utils.dpnp_descriptor m
 
     """
 
-    dtype = numpy.float64
+    dtype = dpnp.float64
     cdef int dimen
     cdef size_t mean_size
     cdef size_t cov_size
@@ -981,7 +981,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_negative_binomial(double a, double p, size)
 
     """
 
-    dtype = numpy.int32
+    dtype = dpnp.int32
     cdef utils.dpnp_descriptor result
     cdef DPNPFuncType param1_type
     cdef DPNPFuncData kernel_data
@@ -1031,7 +1031,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_noncentral_chisquare(double df, double nonc
     """
 
     # convert string type names (array.dtype) to C enum DPNPFuncType
-    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(numpy.float64)
+    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(dpnp.float64)
 
     # get the FPTR data structure
     cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_RNG_NONCENTRAL_CHISQUARE_EXT, param1_type, param1_type)
@@ -1063,7 +1063,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_pareto(double alpha, size):
 
     """
 
-    dtype = numpy.float64
+    dtype = dpnp.float64
     # convert string type names (array.dtype) to C enum DPNPFuncType
     cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(dtype)
 
@@ -1098,7 +1098,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_poisson(double lam, size):
 
     """
 
-    dtype = numpy.int32
+    dtype = dpnp.int32
     cdef shape_type_c result_shape
     cdef utils.dpnp_descriptor result
     cdef DPNPFuncType param1_type
@@ -1143,7 +1143,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_power(double alpha, size):
     univariate power distribution of `alpha`.
     """
 
-    dtype = numpy.float64
+    dtype = dpnp.float64
     # convert string type names (array.dtype) to C enum DPNPFuncType
     cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(dtype)
 
@@ -1177,7 +1177,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_rayleigh(double scale, size):
 
     """
 
-    dtype = numpy.float64
+    dtype = dpnp.float64
     cdef shape_type_c result_shape
     cdef utils.dpnp_descriptor result
     cdef DPNPFuncType param1_type
@@ -1252,7 +1252,7 @@ cpdef dpnp_rng_srand(seed):
     """
 
     # convert string type names (array.dtype) to C enum DPNPFuncType
-    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(numpy.float64)
+    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(dpnp.float64)
 
     # get the FPTR data structure
     cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_RNG_SRAND, param1_type, param1_type)
@@ -1271,7 +1271,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_standard_cauchy(size):
     """
 
     # convert string type names (array.dtype) to C enum DPNPFuncType
-    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(numpy.float64)
+    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(dpnp.float64)
 
     # get the FPTR data structure
     cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_RNG_STANDARD_CAUCHY_EXT, param1_type, param1_type)
@@ -1306,7 +1306,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_standard_exponential(size):
     cdef fptr_dpnp_rng_standard_exponential_c_1out_t func
 
     # convert string type names (array.dtype) to C enum DPNPFuncType
-    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(numpy.float64)
+    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(dpnp.float64)
 
     # get the FPTR data structure
     cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_RNG_STANDARD_EXPONENTIAL_EXT, param1_type, param1_type)
@@ -1338,7 +1338,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_standard_gamma(double shape, size):
 
     """
 
-    dtype = numpy.float64
+    dtype = dpnp.float64
     cdef shape_type_c result_shape
     cdef utils.dpnp_descriptor result
     cdef DPNPFuncType param1_type
@@ -1385,7 +1385,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_standard_t(double df, size):
     """
 
     # convert string type names (array.dtype) to C enum DPNPFuncType
-    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(numpy.float64)
+    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(dpnp.float64)
 
     # get the FPTR data structure
     cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_RNG_STANDARD_T_EXT, param1_type, param1_type)
@@ -1417,7 +1417,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_triangular(double left, double mode, double
 
     """
 
-    dtype = numpy.float64
+    dtype = dpnp.float64
     # convert string type names (array.dtype) to C enum DPNPFuncType
     cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(dtype)
 
@@ -1452,7 +1452,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_vonmises(double mu, double kappa, size):
     """
 
     # convert string type names (array.dtype) to C enum DPNPFuncType
-    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(numpy.float64)
+    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(dpnp.float64)
 
     # get the FPTR data structure
     cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_RNG_VONMISES_EXT, param1_type, param1_type)
@@ -1484,7 +1484,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_wald(double mean, double scale, size):
 
     """
 
-    dtype = numpy.float64
+    dtype = dpnp.float64
     # convert string type names (array.dtype) to C enum DPNPFuncType
     cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(dtype)
 
@@ -1518,13 +1518,13 @@ cpdef utils.dpnp_descriptor dpnp_rng_weibull(double a, size):
 
     """
 
-    dtype = numpy.float64
+    dtype = dpnp.float64
     cdef DPNPFuncType param1_type
     cdef DPNPFuncData kernel_data
     cdef fptr_dpnp_rng_weibull_c_1out_t func
 
     # convert string type names (array.dtype) to C enum DPNPFuncType
-    param1_type = dpnp_dtype_to_DPNPFuncType(numpy.float64)
+    param1_type = dpnp_dtype_to_DPNPFuncType(dpnp.float64)
 
     # get the FPTR data structure
     kernel_data = get_dpnp_function_ptr(DPNP_FN_RNG_WEIBULL_EXT, param1_type, param1_type)
@@ -1557,7 +1557,7 @@ cpdef utils.dpnp_descriptor dpnp_rng_zipf(double a, size):
     """
 
     # convert string type names (array.dtype) to C enum DPNPFuncType
-    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(numpy.float64)
+    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(dpnp.float64)
 
     # get the FPTR data structure
     cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_RNG_ZIPF_EXT, param1_type, param1_type)

--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -670,7 +670,7 @@ def multinomial(n, pvals, size=None):
         d = len(pvals)
         if n < 0:
             pass
-        elif n > numpy.iinfo(numpy.int32).max:
+        elif n > numpy.iinfo(dpnp.int32).max:
             pass
         elif pvals_sum > 1.0:
             pass
@@ -714,11 +714,11 @@ def multivariate_normal(mean, cov, size=None, check_valid='warn', tol=1e-8):
     """
 
     if not use_origin_backend(mean):
-        mean_ = dpnp.get_dpnp_descriptor(dpnp.array(mean, dtype=numpy.float64))
-        cov_ = dpnp.get_dpnp_descriptor(dpnp.array(cov, dtype=numpy.float64))
+        mean_ = dpnp.get_dpnp_descriptor(dpnp.array(mean, dtype=dpnp.float64))
+        cov_ = dpnp.get_dpnp_descriptor(dpnp.array(cov, dtype=dpnp.float64))
         if size is None:
             shape = []
-        elif isinstance(size, (int, numpy.integer)):
+        elif isinstance(size, (int, dpnp.integer)):
             shape = [size]
         else:
             shape = size

--- a/tests/test_arraycreation.py
+++ b/tests/test_arraycreation.py
@@ -30,7 +30,7 @@ import operator
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_float16=False))
 def test_arange(start, stop, step, dtype):
     rtol_mult = 2
-    if numpy.issubdtype(dtype, numpy.float16):
+    if dpnp.issubdtype(dtype, dpnp.float16):
         # numpy casts to float32 type when computes float16 data
         rtol_mult = 4
 
@@ -51,7 +51,7 @@ def test_arange(start, stop, step, dtype):
     else:
         _dtype = dtype
 
-    if numpy.issubdtype(_dtype, numpy.floating) or numpy.issubdtype(_dtype, numpy.complexfloating):
+    if dpnp.issubdtype(_dtype, dpnp.floating) or dpnp.issubdtype(_dtype, dpnp.complexfloating):
         assert_allclose(exp_array, res_array, rtol=rtol_mult*numpy.finfo(_dtype).eps)
     else:
         assert_array_equal(exp_array, res_array)

--- a/tests/test_dparray.py
+++ b/tests/test_dparray.py
@@ -139,11 +139,11 @@ def test_print_dpnp_special_character():
     expected = "[ 1.  0. nan  3.]"
     assert(result==expected)
 # inf
-    result = repr(dpnp.array([1., 0., numpy.inf, 3.]))
+    result = repr(dpnp.array([1., 0., dpnp.inf, 3.]))
     expected = "array([ 1.,  0., inf,  3.])"
     assert(result==expected)
 
-    result = str(dpnp.array([1., 0., numpy.inf, 3.]))
+    result = str(dpnp.array([1., 0., dpnp.inf, 3.]))
     expected = "[ 1.  0. inf  3.]"
     assert(result==expected)
 

--- a/tests/test_random_state.py
+++ b/tests/test_random_state.py
@@ -174,9 +174,9 @@ class TestNormal:
 
     @pytest.mark.parametrize("dtype",
                              [dpnp.float16, float, dpnp.integer, dpnp.int64, dpnp.int32, dpnp.int, int,
-                              dpnp.longcomplex, dpnp.complex128, dpnp.complex64, dpnp.bool, dpnp.bool_],
+                              numpy.longcomplex, dpnp.complex128, dpnp.complex64, dpnp.bool, dpnp.bool_],
                              ids=['dpnp.float16', 'float', 'dpnp.integer', 'dpnp.int64', 'dpnp.int32', 'dpnp.int', 'int',
-                                  'dpnp.longcomplex', 'dpnp.complex128', 'dpnp.complex64', 'dpnp.bool', 'dpnp.bool_'])
+                                  'numpy.longcomplex', 'dpnp.complex128', 'dpnp.complex64', 'dpnp.bool', 'dpnp.bool_'])
     def test_invalid_dtype(self, dtype):
         # dtype must be float32 or float64
         assert_raises(TypeError, RandomState().normal, dtype=dtype)
@@ -834,9 +834,9 @@ class TestUniform:
 
     @pytest.mark.parametrize("dtype",
                              [dpnp.float16, float, dpnp.integer, dpnp.int64, dpnp.int, int,
-                              dpnp.longcomplex, dpnp.complex128, dpnp.complex64, dpnp.bool, dpnp.bool_],
+                              numpy.longcomplex, dpnp.complex128, dpnp.complex64, dpnp.bool, dpnp.bool_],
                              ids=['dpnp.float16', 'float', 'dpnp.integer', 'dpnp.int64', 'dpnp.int', 'int',
-                                  'dpnp.longcomplex', 'dpnp.complex128', 'dpnp.complex64', 'dpnp.bool', 'dpnp.bool_'])
+                                  'numpy.longcomplex', 'dpnp.complex128', 'dpnp.complex64', 'dpnp.bool', 'dpnp.bool_'])
     def test_invalid_dtype(self, dtype):
         if dtype in (dpnp.int, dpnp.integer) and dtype == dpnp.dtype('int32'):
             pytest.skip("dtype is alias on dpnp.int32 on the target OS, so no error here")


### PR DESCRIPTION
The list of missing aliases on numpy types are ported to dpnp:
- cdouble
- complex_
- complexfloating
- cfloat
- csingle
- double
- float_
- floating
- inexact
- int_
- intc
- number
- object_
- signedinteger
- single
- singlecomplex

The flowing type-related functions are added to dpnp:
 - issubdtype
 - issubsctype

The following constants are borrowed from numpy:
 - e
 - euler_gamma
 - Inf
 - inf
 - Infinity
 - infty
 - NAN
 - NaN
 - NINF
 - NZERO
 - pi
 - PINF
 - PZERO

This PR is intended to resolve issue #1307.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
