### PR TITLE
Simplify asserts in dlpack tests

### DIFF
--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -848,8 +848,7 @@ def test_from_dlpack(arr_dtype, shape, device):
     Y = dpnp.from_dlpack(X)
     assert_array_equal(X, Y)
     assert X.__dlpack_device__() == Y.__dlpack_device__()
-    assert X.sycl_device == Y.sycl_device
-    assert X.sycl_context == Y.sycl_context
+    assert_sycl_queue_equal(X.sycl_queue, Y.sycl_queue)
     assert X.usm_type == Y.usm_type
     if Y.ndim:
         V = Y[::-1]
@@ -868,6 +867,5 @@ def test_from_dlpack_with_dpt(arr_dtype, device):
     assert_array_equal(X, Y)
     assert isinstance(Y, dpnp.dpnp_array.dpnp_array)
     assert X.__dlpack_device__() == Y.__dlpack_device__()
-    assert X.sycl_device == Y.sycl_device
-    assert X.sycl_context == Y.sycl_context
     assert X.usm_type == Y.usm_type
+    assert_sycl_queue_equal(X.sycl_queue, Y.sycl_queue)


### PR DESCRIPTION
Since [#1016](https://github.com/IntelPython/dpctl/pull/1076) dpctl will use a dedicated queue cache with (context, device) pair.
The cache will be available in `dpctl.tensor.from_dlpack`, so it will return the same queue for a given device.

Thus the PR is to update corresponding tests in dpnp and simplify the verifications asserts by a common function.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
