### PR TITLE
Tests are crashing if no default device

### DIFF
--- a/dpnp/backend/src/queue_sycl.hpp
+++ b/dpnp/backend/src/queue_sycl.hpp
@@ -137,6 +137,13 @@ public:
 #else
         // temporal solution. Started from Sept-2020
         DPCTLSyclQueueRef DPCtrl_queue = DPCTLQueueMgr_GetCurrentQueue();
+        if (DPCtrl_queue == nullptr)
+        {
+            std::string reason = (DPCTLQueueMgr_GetQueueStackSize() == static_cast<size_t>(-1))
+                                     ? ": the queue stack is empty, probably no device is available."
+                                     : ".";
+            throw std::runtime_error("Failed to create a copy of SYCL queue with default device" + reason);
+        }
         return *(reinterpret_cast<sycl::queue*>(DPCtrl_queue));
 #endif
     }

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -391,7 +391,7 @@ cdef extern from "constants.hpp":
 
 cdef extern from "dpnp_iface.hpp":
     void dpnp_queue_initialize_c(QueueOptions selector)
-    size_t dpnp_queue_is_cpu_c()
+    size_t dpnp_queue_is_cpu_c() except +
 
     char * dpnp_memory_alloc_c(size_t size_in_bytes) except +
     void dpnp_memory_free_c(void * ptr)


### PR DESCRIPTION
This PR adds a protection check to resolve a crash while running `dpnp` test scope when no device is available.
Since function `DPCTLQueueMgr_GetCurrentQueue()` will return a null pointer in that case.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
