### PR TITLE
Unwrap dpnp array while calling dpctl indexer operators

### DIFF
--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -174,6 +174,9 @@ class dpnp_array:
  # '__getattribute__',
 
     def __getitem__(self, key):
+        if isinstance(key, dpnp_array):
+            key = key.get_array()
+
         item = self._array_obj.__getitem__(key)
         if not isinstance(item, dpt.usm_ndarray):
             raise RuntimeError(
@@ -290,6 +293,11 @@ class dpnp_array:
  # '__setattr__',
 
     def __setitem__(self, key, val):
+        if isinstance(key, dpnp_array):
+            key = key.get_array()
+        if isinstance(val, dpnp_array):
+            val = val.get_array()
+
         self._array_obj.__setitem__(key, val)
 
  # '__setstate__',


### PR DESCRIPTION
Needs to pass exactly `usm_ndarray` when calling dpctl indexer operators rather than to pass `dpnp_array`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
