### PR TITLE
dpnp.power() doesn't work properly with a scalar

### DIFF
--- a/dpnp/backend/include/dpnp_gen_2arg_3type_tbl.hpp
+++ b/dpnp/backend/include/dpnp_gen_2arg_3type_tbl.hpp
@@ -176,11 +176,11 @@ MACRO_2ARG_3TYPES_OP(dpnp_multiply_c,
                      MACRO_UNPACK_TYPES(float, double, std::complex<float>, std::complex<double>))
 
 MACRO_2ARG_3TYPES_OP(dpnp_power_c,
-                     sycl::pow((double)input1_elem, (double)input2_elem),
-                     nullptr,
-                     std::false_type,
+                     static_cast<_DataType_output>(std::pow(input1_elem, input2_elem)),
+                     sycl::pow(x1, x2),
+                     MACRO_UNPACK_TYPES(float, double),
                      oneapi::mkl::vm::pow,
-                     MACRO_UNPACK_TYPES(float, double))
+                     MACRO_UNPACK_TYPES(float, double, std::complex<float>, std::complex<double>))
 
 MACRO_2ARG_3TYPES_OP(dpnp_subtract_c,
                      input1_elem - input2_elem,

--- a/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
@@ -1247,18 +1247,6 @@ static void func_map_elemwise_2arg_3type_core(func_map_t& fmap)
                                  func_type_map_t::find_type<FT1>,
                                  func_type_map_t::find_type<FTs>>}),
      ...);
-    ((fmap[DPNPFuncName::DPNP_FN_MULTIPLY_EXT][FT1][FTs] =
-          {populate_func_types<FT1, FTs>(),
-           (void*)dpnp_multiply_c_ext<func_type_map_t::find_type<populate_func_types<FT1, FTs>()>,
-                                      func_type_map_t::find_type<FT1>,
-                                      func_type_map_t::find_type<FTs>>}),
-     ...);
-    ((fmap[DPNPFuncName::DPNP_FN_SUBTRACT_EXT][FT1][FTs] =
-          {populate_func_types<FT1, FTs>(),
-           (void*)dpnp_subtract_c_ext<func_type_map_t::find_type<populate_func_types<FT1, FTs>()>,
-                                      func_type_map_t::find_type<FT1>,
-                                      func_type_map_t::find_type<FTs>>}),
-     ...);
     ((fmap[DPNPFuncName::DPNP_FN_DIVIDE_EXT][FT1][FTs] =
           {get_divide_res_type<FT1, FTs>(),
            (void*)dpnp_divide_c_ext<func_type_map_t::find_type<get_divide_res_type<FT1, FTs>()>,
@@ -1268,6 +1256,24 @@ static void func_map_elemwise_2arg_3type_core(func_map_t& fmap)
            (void*)dpnp_divide_c_ext<func_type_map_t::find_type<get_divide_res_type<FT1, FTs, std::false_type>()>,
                                     func_type_map_t::find_type<FT1>,
                                     func_type_map_t::find_type<FTs>>}),
+     ...);
+    ((fmap[DPNPFuncName::DPNP_FN_MULTIPLY_EXT][FT1][FTs] =
+          {populate_func_types<FT1, FTs>(),
+           (void*)dpnp_multiply_c_ext<func_type_map_t::find_type<populate_func_types<FT1, FTs>()>,
+                                      func_type_map_t::find_type<FT1>,
+                                      func_type_map_t::find_type<FTs>>}),
+     ...);
+    ((fmap[DPNPFuncName::DPNP_FN_POWER_EXT][FT1][FTs] =
+          {populate_func_types<FT1, FTs>(),
+           (void*)dpnp_power_c_ext<func_type_map_t::find_type<populate_func_types<FT1, FTs>()>,
+                                   func_type_map_t::find_type<FT1>,
+                                   func_type_map_t::find_type<FTs>>}),
+     ...);
+    ((fmap[DPNPFuncName::DPNP_FN_SUBTRACT_EXT][FT1][FTs] =
+          {populate_func_types<FT1, FTs>(),
+           (void*)dpnp_subtract_c_ext<func_type_map_t::find_type<populate_func_types<FT1, FTs>()>,
+                                      func_type_map_t::find_type<FT1>,
+                                      func_type_map_t::find_type<FTs>>}),
      ...);
 }
 
@@ -1854,39 +1860,6 @@ static void func_map_init_elemwise_2arg_3type(func_map_t& fmap)
                                                            (void*)dpnp_power_c_default<double, double, float>};
     fmap[DPNPFuncName::DPNP_FN_POWER][eft_DBL][eft_DBL] = {eft_DBL,
                                                            (void*)dpnp_power_c_default<double, double, double>};
-
-    fmap[DPNPFuncName::DPNP_FN_POWER_EXT][eft_INT][eft_INT] = {eft_INT,
-                                                               (void*)dpnp_power_c_ext<int32_t, int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_POWER_EXT][eft_INT][eft_LNG] = {eft_LNG,
-                                                               (void*)dpnp_power_c_ext<int64_t, int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_POWER_EXT][eft_INT][eft_FLT] = {eft_DBL,
-                                                               (void*)dpnp_power_c_ext<double, int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_POWER_EXT][eft_INT][eft_DBL] = {eft_DBL,
-                                                               (void*)dpnp_power_c_ext<double, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_POWER_EXT][eft_LNG][eft_INT] = {eft_LNG,
-                                                               (void*)dpnp_power_c_ext<int64_t, int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_POWER_EXT][eft_LNG][eft_LNG] = {eft_LNG,
-                                                               (void*)dpnp_power_c_ext<int64_t, int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_POWER_EXT][eft_LNG][eft_FLT] = {eft_DBL,
-                                                               (void*)dpnp_power_c_ext<double, int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_POWER_EXT][eft_LNG][eft_DBL] = {eft_DBL,
-                                                               (void*)dpnp_power_c_ext<double, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_POWER_EXT][eft_FLT][eft_INT] = {eft_DBL,
-                                                               (void*)dpnp_power_c_ext<double, float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_POWER_EXT][eft_FLT][eft_LNG] = {eft_DBL,
-                                                               (void*)dpnp_power_c_ext<double, float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_POWER_EXT][eft_FLT][eft_FLT] = {eft_FLT,
-                                                               (void*)dpnp_power_c_ext<float, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_POWER_EXT][eft_FLT][eft_DBL] = {eft_DBL,
-                                                               (void*)dpnp_power_c_ext<double, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_POWER_EXT][eft_DBL][eft_INT] = {eft_DBL,
-                                                               (void*)dpnp_power_c_ext<double, double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_POWER_EXT][eft_DBL][eft_LNG] = {eft_DBL,
-                                                               (void*)dpnp_power_c_ext<double, double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_POWER_EXT][eft_DBL][eft_FLT] = {eft_DBL,
-                                                               (void*)dpnp_power_c_ext<double, double, float>};
-    fmap[DPNPFuncName::DPNP_FN_POWER_EXT][eft_DBL][eft_DBL] = {eft_DBL,
-                                                               (void*)dpnp_power_c_ext<double, double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_SUBTRACT][eft_INT][eft_INT] = {
         eft_INT, (void*)dpnp_subtract_c_default<int32_t, int32_t, int32_t>};

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -211,7 +211,11 @@ class dpnp_array:
 
  # '__invert__',
  # '__ior__',
- # '__ipow__',
+
+    def __ipow__(self, other):
+        dpnp.power(self, other, out=self)
+        return self
+
  # '__irshift__',
  # '__isub__',
  # '__iter__',
@@ -279,7 +283,10 @@ class dpnp_array:
         return dpnp.multiply(other, self)
 
  # '__ror__',
- # '__rpow__',
+ 
+    def __rpow__(self, other):
+        return dpnp.power(other, self)
+
  # '__rrshift__',
  # '__rshift__',
 

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -761,7 +761,6 @@ tests/third_party/cupy/math_tests/test_arithmetic.py::TestArithmeticModf::test_m
 tests/third_party/cupy/math_tests/test_arithmetic.py::TestArithmeticRaisesWithNumpyInput_param_10_{name='remainder', nargs=2}::test_raises_with_numpy_input
 tests/third_party/cupy/math_tests/test_arithmetic.py::TestArithmeticRaisesWithNumpyInput_param_11_{name='mod', nargs=2}::test_raises_with_numpy_input
 tests/third_party/cupy/math_tests/test_arithmetic.py::TestArithmeticRaisesWithNumpyInput_param_1_{name='angle', nargs=1}::test_raises_with_numpy_input
-tests/third_party/cupy/math_tests/test_arithmetic.py::TestArithmeticRaisesWithNumpyInput_param_5_{name='power', nargs=2}::test_raises_with_numpy_input
 tests/third_party/cupy/math_tests/test_arithmetic.py::TestArithmeticRaisesWithNumpyInput_param_8_{name='floor_divide', nargs=2}::test_raises_with_numpy_input
 
 tests/third_party/cupy/math_tests/test_explog.py::TestExplog::test_logaddexp

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -976,7 +976,6 @@ tests/third_party/cupy/math_tests/test_arithmetic.py::TestArithmeticBinary2_para
 tests/third_party/cupy/math_tests/test_arithmetic.py::TestArithmeticRaisesWithNumpyInput_param_10_{name='remainder', nargs=2}::test_raises_with_numpy_input
 tests/third_party/cupy/math_tests/test_arithmetic.py::TestArithmeticRaisesWithNumpyInput_param_11_{name='mod', nargs=2}::test_raises_with_numpy_input
 tests/third_party/cupy/math_tests/test_arithmetic.py::TestArithmeticRaisesWithNumpyInput_param_1_{name='angle', nargs=1}::test_raises_with_numpy_input
-tests/third_party/cupy/math_tests/test_arithmetic.py::TestArithmeticRaisesWithNumpyInput_param_5_{name='power', nargs=2}::test_raises_with_numpy_input
 tests/third_party/cupy/math_tests/test_arithmetic.py::TestArithmeticRaisesWithNumpyInput_param_8_{name='floor_divide', nargs=2}::test_raises_with_numpy_input
 
 tests/third_party/cupy/math_tests/test_explog.py::TestExplog::test_logaddexp

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -8,6 +8,7 @@ from numpy.testing import (
     assert_allclose,
     assert_array_almost_equal,
     assert_array_equal,
+    assert_equal,
     assert_raises
 )
 
@@ -66,7 +67,7 @@ def test_diff(array):
 @pytest.mark.parametrize("dtype1", get_all_dtypes())
 @pytest.mark.parametrize("dtype2", get_all_dtypes())
 @pytest.mark.parametrize("func",
-                         ['add', 'multiply', 'subtract', 'divide'])
+                         ['add', 'divide', 'multiply', 'power', 'subtract'])
 @pytest.mark.parametrize("data",
                          [[[1, 2], [3, 4]]],
                          ids=['[[1, 2], [3, 4]]'])
@@ -84,7 +85,7 @@ def test_op_multiple_dtypes(dtype1, func, dtype2, data):
     else:
         result = getattr(dpnp, func)(dpnp_a, dpnp_b)
         expected = getattr(numpy, func)(np_a, np_b)
-        assert_array_equal(result, expected)
+        assert_allclose(result, expected)
 
 
 @pytest.mark.parametrize("rhs", [[[1, 2, 3], [4, 5, 6]], [2.0, 1.5, 1.0], 3, 0.3])
@@ -116,7 +117,7 @@ class TestMathematical:
         else:
             result = getattr(dpnp, name)(a_dpnp, b_dpnp)
             expected = getattr(numpy, name)(a_np, b_np)
-            assert_allclose(result, expected, atol=1e-4)
+            assert_allclose(result, expected, rtol=1e-6)
 
     @pytest.mark.parametrize("dtype", get_all_dtypes())
     def test_add(self, dtype, lhs, rhs):
@@ -170,8 +171,7 @@ class TestMathematical:
     def test_remainder(self, dtype, lhs, rhs):
         self._test_mathematical('remainder', dtype, lhs, rhs)
 
-    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
-    @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True))
+    @pytest.mark.parametrize("dtype", get_all_dtypes())
     def test_power(self, dtype, lhs, rhs):
         self._test_mathematical('power', dtype, lhs, rhs)
 
@@ -186,7 +186,7 @@ class TestMathematical:
                          ids=['bool', 'int', 'float'])
 @pytest.mark.parametrize("data_type", get_all_dtypes())
 @pytest.mark.parametrize("func",
-                         ['add', 'multiply', 'subtract', 'divide'])
+                         ['add', 'divide', 'multiply', 'power', 'subtract'])
 @pytest.mark.parametrize("val",
                          [0, 1, 5],
                          ids=['0', '1', '5'])
@@ -205,6 +205,9 @@ def test_op_with_scalar(array, val, func, data_type, val_type):
     np_a = numpy.array(array, dtype=data_type)
     dpnp_a = dpnp.array(array, dtype=data_type)
     val_ = val_type(val)
+
+    if func == 'power' and val_ == 0 and numpy.issubdtype(data_type, numpy.complexfloating):
+        pytest.skip("(0j ** 0) is different: (NaN + NaNj) in dpnp and (1 + 0j) in numpy")
 
     if func == 'subtract' and val_type == bool and data_type == dpnp.bool:
         with pytest.raises(TypeError):
@@ -275,6 +278,23 @@ def test_divide_scalar(shape, dtype):
     assert_allclose(result, expected)
 
 
+@pytest.mark.parametrize("shape",
+                         [(), (3, 2)],
+                         ids=['()', '(3, 2)'])
+@pytest.mark.parametrize("dtype", get_all_dtypes())
+def test_power_scalar(shape, dtype):
+    np_a = numpy.ones(shape, dtype=dtype)
+    dpnp_a = dpnp.ones(shape, dtype=dtype)
+
+    result = 4.2 ** dpnp_a ** -1.3
+    expected = 4.2 ** np_a ** -1.3
+    assert_allclose(result, expected, rtol=1e-6)
+
+    result **= dpnp_a
+    expected **= np_a
+    assert_allclose(result, expected, rtol=1e-6)
+
+
 @pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("array", [[1, 2, 3, 4, 5],
                                    [1, 2, numpy.nan, 4, 5],
@@ -314,12 +334,11 @@ def test_negative(data, dtype):
     assert_array_equal(result, expected)
 
 
-@pytest.mark.usefixtures("allow_fall_back_on_numpy")
-@pytest.mark.parametrize("val_type", get_all_dtypes(no_bool=True, no_complex=True, no_none=True))
-@pytest.mark.parametrize("data_type", get_all_dtypes(no_bool=True, no_complex=True))
+@pytest.mark.parametrize("val_type", get_all_dtypes(no_none=True))
+@pytest.mark.parametrize("data_type", get_all_dtypes())
 @pytest.mark.parametrize("val",
-                         [0, 1, 5],
-                         ids=['0', '1', '5'])
+                         [1.5, 1, 5],
+                         ids=['1.5', '1', '5'])
 @pytest.mark.parametrize("array",
                          [[[0, 0], [0, 0]],
                           [[1, 2], [1, 2]],
@@ -335,9 +354,10 @@ def test_power(array, val, data_type, val_type):
     np_a = numpy.array(array, dtype=data_type)
     dpnp_a = dpnp.array(array, dtype=data_type)
     val_ = val_type(val)
+
     result = dpnp.power(dpnp_a, val_)
     expected = numpy.power(np_a, val_)
-    assert_array_equal(expected, result)
+    assert_allclose(expected, result, rtol=1e-6)
 
 
 class TestEdiff1d:
@@ -622,13 +642,10 @@ class TestPower:
 
         assert_array_equal(expected, result)
 
-    @pytest.mark.parametrize("dtype",
-                             [numpy.float32, numpy.int64, numpy.int32],
-                             ids=['numpy.float32', 'numpy.int64', 'numpy.int32'])
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True, no_none=True))
     def test_invalid_dtype(self, dtype):
-
-        dp_array1 = dpnp.arange(10, dtype=dpnp.float64)
-        dp_array2 = dpnp.arange(5, 15, dtype=dpnp.float64)
+        dp_array1 = dpnp.arange(10, dtype=dpnp.complex64)
+        dp_array2 = dpnp.arange(5, 15, dtype=dpnp.complex64)
         dp_out = dpnp.empty(10, dtype=dtype)
 
         with pytest.raises(ValueError):
@@ -638,10 +655,54 @@ class TestPower:
                              [(0,), (15, ), (2, 2)],
                              ids=['(0,)', '(15, )', '(2,2)'])
     def test_invalid_shape(self, shape):
-
         dp_array1 = dpnp.arange(10, dtype=dpnp.float64)
         dp_array2 = dpnp.arange(5, 15, dtype=dpnp.float64)
         dp_out = dpnp.empty(shape, dtype=dpnp.float64)
 
         with pytest.raises(ValueError):
             dpnp.power(dp_array1, dp_array2, out=dp_out)
+
+    @pytest.mark.parametrize("out",
+                             [4, (), [], (3, 7), [2, 4]],
+                             ids=['4', '()', '[]', '(3, 7)', '[2, 4]'])
+    def test_invalid_out(self, out):
+        a = dpnp.arange(10)
+
+        assert_raises(TypeError, dpnp.power, a, 2,  out)
+        assert_raises(TypeError, numpy.power, a.asnumpy(), 2,  out)
+
+    @pytest.mark.usefixtures("suppress_invalid_numpy_warnings")
+    def test_complex_values(self):
+        np_arr = numpy.array([0j, 1+1j, 0+2j, 1+2j, numpy.inf, numpy.nan])
+        dp_arr = dpnp.array(np_arr)
+        func = lambda x: x ** 2
+
+        assert_allclose(func(np_arr), func(dp_arr).asnumpy())
+
+    @pytest.mark.parametrize("val", [0, 1], ids=['0', '1'])
+    @pytest.mark.parametrize("dtype", [dpnp.int32, dpnp.int64])
+    def test_integer_power_of_0_or_1(self, val, dtype):
+        np_arr = numpy.arange(10, dtype=dtype)
+        dp_arr = dpnp.array(np_arr)
+        func = lambda x: 1 ** x
+
+        assert_equal(func(np_arr), func(dp_arr))
+
+    @pytest.mark.parametrize("dtype", [dpnp.int32, dpnp.int64])
+    def test_integer_to_negative_power(self, dtype):
+        ones = dpnp.ones(10, dtype=dtype)
+        a = dpnp.arange(2, 10, dtype=dtype)
+        b = dpnp.full(10, -2, dtype=dtype)
+
+        assert_array_equal(ones ** (-2), ones)
+        assert_equal(a ** (-3), 0) # positive integer to negative integer power
+        assert_equal(b ** (-4), 0) # negative integer to negative integer power
+
+    def test_float_to_inf(self):
+        a = numpy.array([1, 1, 2, 2, -2, -2, numpy.inf, -numpy.inf], dtype=numpy.float32)
+        b = numpy.array([numpy.inf, -numpy.inf, numpy.inf, -numpy.inf,
+                         numpy.inf, -numpy.inf, numpy.inf, -numpy.inf], dtype=numpy.float32)
+        numpy_res = a ** b
+        dpnp_res = dpnp.array(a) ** dpnp.array(b)
+
+        assert_allclose(numpy_res, dpnp_res.asnumpy())

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -63,6 +63,21 @@ def test_coerced_usm_types_divide(usm_type_x, usm_type_y):
     assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
 
 
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+def test_coerced_usm_types_power(usm_type_x, usm_type_y):
+    x = dp.arange(70, usm_type = usm_type_x).reshape((7, 5, 2))
+    y = dp.arange(70, usm_type = usm_type_y).reshape((7, 5, 2))
+
+    z = 2 ** x ** y ** 1.5
+    z **= x
+    z **= 1.7
+
+    assert x.usm_type == usm_type_x
+    assert y.usm_type == usm_type_y
+    assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
+
+
 @pytest.mark.parametrize(
     "func, args",
     [

--- a/tests/third_party/cupy/math_tests/test_arithmetic.py
+++ b/tests/third_party/cupy/math_tests/test_arithmetic.py
@@ -153,7 +153,7 @@ class ArithmeticBinaryBase:
             is_int_float = lambda _x, _y: numpy.issubdtype(_x, numpy.integer) and numpy.issubdtype(_y, numpy.floating)
             is_same_type = lambda _x, _y, _type: numpy.issubdtype(_x, _type) and numpy.issubdtype(_y, _type)
 
-            if self.name in ('add', 'multiply', 'subtract'):
+            if self.name in ('add', 'multiply', 'power', 'subtract'):
                 if is_array_arg1 and is_array_arg2:
                     # If both inputs are arrays where one is of floating type and another - integer,
                     # NumPy will return an output array of always "float64" type,


### PR DESCRIPTION
Since the change implemented in #1201 and until now, implicit `operation **` of array with a scalar or explicit one through `dpnp.power` leads to raising of the not-implemented exception in dpnp. This is because dpnp was falling back on NumPy implementation in that use case, but has to call an internal kernel function from the backend.

The PR proposes to copy a scalar data from host memory into USM allocated memory, which means to create zero-dimension dpnp array from the scalar. This way the power of array with a scalar or the power of scalar with an array will be handled in the same way as power with two arrays, which already works fine in dpnp.

Note that if some input argument is a scalar and another one is an array, memory for the scalar will be allocated on the same SYCL device and with the same USM type as the array has. It's required to proceed with further computing and to be compliant with compute follows data paradigm (all input data has to reside on the same device).

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
