### PR TITLE
Reuse dpctl.tensor.place for dpnp.place

### DIFF
--- a/dpnp/backend/include/dpnp_iface_fptr.hpp
+++ b/dpnp/backend/include/dpnp_iface_fptr.hpp
@@ -240,7 +240,6 @@ enum class DPNPFuncName : size_t
     DPNP_FN_PARTITION,                    /**< Used in numpy.partition() impl */
     DPNP_FN_PARTITION_EXT,                /**< Used in numpy.partition() impl, requires extra parameters */
     DPNP_FN_PLACE,                        /**< Used in numpy.place() impl  */
-    DPNP_FN_PLACE_EXT,                    /**< Used in numpy.place() impl, requires extra parameters */
     DPNP_FN_POWER,                        /**< Used in numpy.power() impl  */
     DPNP_FN_POWER_EXT,                    /**< Used in numpy.power() impl, requires extra parameters */
     DPNP_FN_PROD,                         /**< Used in numpy.prod() impl  */

--- a/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
@@ -546,19 +546,11 @@ void dpnp_place_c(void* arr_in, long* mask_in, void* vals_in, const size_t arr_s
                                                           vals_size,
                                                           dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
 void (*dpnp_place_default_c)(void*, long*, void*, const size_t, const size_t) = dpnp_place_c<_DataType>;
-
-template <typename _DataType>
-DPCTLSyclEventRef (*dpnp_place_ext_c)(DPCTLSyclQueueRef,
-                                      void*,
-                                      long*,
-                                      void*,
-                                      const size_t,
-                                      const size_t,
-                                      const DPCTLEventVectorRef) = dpnp_place_c<_DataType>;
 
 template <typename _DataType, typename _IndecesType, typename _ValueType>
 DPCTLSyclEventRef dpnp_put_c(DPCTLSyclQueueRef q_ref,
@@ -1016,11 +1008,6 @@ void func_map_init_indexing_func(func_map_t& fmap)
     fmap[DPNPFuncName::DPNP_FN_PLACE][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_place_default_c<int64_t>};
     fmap[DPNPFuncName::DPNP_FN_PLACE][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_place_default_c<float>};
     fmap[DPNPFuncName::DPNP_FN_PLACE][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_place_default_c<double>};
-
-    fmap[DPNPFuncName::DPNP_FN_PLACE_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_place_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_PLACE_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_place_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_PLACE_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_place_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_PLACE_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_place_ext_c<double>};
 
     fmap[DPNPFuncName::DPNP_FN_PUT][eft_INT][eft_INT] = {eft_INT,
                                                          (void*)dpnp_put_default_c<int32_t, int64_t, int32_t>};

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -217,7 +217,6 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_PARTITION
         DPNP_FN_PARTITION_EXT
         DPNP_FN_PLACE
-        DPNP_FN_PLACE_EXT
         DPNP_FN_POWER
         DPNP_FN_POWER_EXT
         DPNP_FN_PROD

--- a/dpnp/dpnp_algo/dpnp_algo_indexing.pyx
+++ b/dpnp/dpnp_algo/dpnp_algo_indexing.pyx
@@ -40,7 +40,6 @@ __all__ += [
     "dpnp_diagonal",
     "dpnp_fill_diagonal",
     "dpnp_indices",
-    "dpnp_place",
     "dpnp_put",
     "dpnp_put_along_axis",
     "dpnp_putmask",
@@ -305,41 +304,6 @@ cpdef object dpnp_indices(dimensions):
 
     dpnp_result = dpnp.array(result)
     return dpnp_result
-
-
-cpdef dpnp_place(dpnp_descriptor arr, object mask, dpnp_descriptor vals):
-    result_sycl_device, result_usm_type, result_sycl_queue = utils.get_common_usm_allocation(arr, vals)
-
-    cdef utils.dpnp_descriptor mask_ = utils_py.create_output_descriptor_py((mask.size,),
-                                                                            dpnp.int64,
-                                                                            None,
-                                                                            device=result_sycl_device,
-                                                                            usm_type=result_usm_type,
-                                                                            sycl_queue=result_sycl_queue)
-    for i in range(mask.size):
-        if mask.item(i):
-            mask_.get_pyobj()[i] = 1
-        else:
-            mask_.get_pyobj()[i] = 0
-    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(arr.dtype)
-
-    cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_PLACE_EXT, param1_type, param1_type)
-
-    cdef c_dpctl.SyclQueue q = <c_dpctl.SyclQueue> result_sycl_queue
-    cdef c_dpctl.DPCTLSyclQueueRef q_ref = q.get_queue_ref()
-
-    cdef custom_indexing_3in_func_ptr_t func = <custom_indexing_3in_func_ptr_t > kernel_data.ptr
-
-    cdef c_dpctl.DPCTLSyclEventRef event_ref = func(q_ref,
-                                                    arr.get_data(),
-                                                    mask_.get_data(),
-                                                    vals.get_data(),
-                                                    arr.size,
-                                                    vals.size,
-                                                    NULL)  # dep_events_ref
-
-    with nogil: c_dpctl.DPCTLEvent_WaitAndThrow(event_ref)
-    c_dpctl.DPCTLEvent_Delete(event_ref)
 
 
 cpdef dpnp_put(dpnp_descriptor x1, object ind, v):

--- a/dpnp/dpnp_iface_indexing.py
+++ b/dpnp/dpnp_iface_indexing.py
@@ -296,7 +296,7 @@ def nonzero(x, /):
     -------
     y : tuple[dpnp.ndarray]
         Indices of elements that are non-zero.
-    
+
     Limitations
     -----------
     Parameters `x` is supported as either :class:`dpnp.ndarray`
@@ -342,24 +342,27 @@ def nonzero(x, /):
     return call_origin(numpy.nonzero, x)
 
 
-def place(x1, mask, vals):
+def place(x, mask, vals, /):
     """
     Change elements of an array based on conditional and input values.
     For full documentation refer to :obj:`numpy.place`.
 
     Limitations
     -----------
-    Input arrays ``arr`` and ``mask``  are supported as :obj:`dpnp.ndarray`.
-    Parameter ``vals`` is supported as 1-D sequence.
+    Parameters `arr`, `mask` and `vals` are supported either
+    :class:`dpnp.ndarray` or :class:`dpctl.tensor.usm_ndarray`.
+    Otherwise the function will be executed sequentially on CPU.
+    Parameter `vals` is supported as 1-D sequence.
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
-    mask_desc = dpnp.get_dpnp_descriptor(mask, copy_when_nondefault_queue=False)
-    vals_desc = dpnp.get_dpnp_descriptor(vals, copy_when_nondefault_queue=False)
-    if x1_desc and mask_desc and vals_desc:
-        return dpnp_place(x1_desc, mask, vals_desc)
+    check_dtype = lambda x: isinstance(x, (dpnp_array, dpt.usm_ndarray))
+    if check_dtype(x) and check_dtype(mask) and check_dtype(vals):
+        dpt_array = x.get_array() if isinstance(x, dpnp_array) else x
+        dpt_mask = mask.get_array() if isinstance(mask, dpnp_array) else mask
+        dpt_vals = vals.get_array() if isinstance(vals, dpnp_array) else vals
+        return dpt.place(dpt_array, dpt_mask, dpt_vals)
 
-    return call_origin(numpy.place, x1, mask, vals, dpnp_inplace=True)
+    return call_origin(numpy.place, x, mask, vals, dpnp_inplace=True)
 
 
 def put(x1, ind, v, mode='raise'):

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -514,12 +514,6 @@ tests/third_party/cupy/indexing_tests/test_insert.py::TestFillDiagonal_param_5_{
 tests/third_party/cupy/indexing_tests/test_insert.py::TestFillDiagonal_param_6_{shape=(3, 3), val=(2, 2), wrap=True}::test_columnar_slice
 tests/third_party/cupy/indexing_tests/test_insert.py::TestFillDiagonal_param_7_{shape=(3, 3), val=(2, 2), wrap=False}::test_columnar_slice
 tests/third_party/cupy/indexing_tests/test_insert.py::TestFillDiagonal_param_9_{shape=(2, 2, 2), val=1, wrap=False}::test_1darray
-tests/third_party/cupy/indexing_tests/test_insert.py::TestPlaceRaises_param_0_{shape=(7,)}::test_place_empty_value_error
-tests/third_party/cupy/indexing_tests/test_insert.py::TestPlaceRaises_param_0_{shape=(7,)}::test_place_shape_unmatch_error
-tests/third_party/cupy/indexing_tests/test_insert.py::TestPlaceRaises_param_1_{shape=(2, 3)}::test_place_empty_value_error
-tests/third_party/cupy/indexing_tests/test_insert.py::TestPlaceRaises_param_1_{shape=(2, 3)}::test_place_shape_unmatch_error
-tests/third_party/cupy/indexing_tests/test_insert.py::TestPlaceRaises_param_2_{shape=(4, 3, 2)}::test_place_empty_value_error
-tests/third_party/cupy/indexing_tests/test_insert.py::TestPlaceRaises_param_2_{shape=(4, 3, 2)}::test_place_shape_unmatch_error
 tests/third_party/cupy/indexing_tests/test_insert.py::TestPutmaskDifferentDtypes::test_putmask_differnt_dtypes_raises
 tests/third_party/cupy/indexing_tests/test_insert.py::TestPutmask::test_putmask_non_equal_shape_raises
 tests/third_party/cupy/indexing_tests/test_iterate.py::TestFlatiter::test_next

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -53,15 +53,6 @@ tests/test_sycl_queue.py::test_1in_1out[opencl:gpu:0-trapz-data19]
 tests/test_sycl_queue.py::test_1in_1out[opencl:cpu:0-trapz-data19]
 
 tests/third_party/cupy/indexing_tests/test_indexing.py::TestIndexing::test_take_no_axis
-tests/third_party/cupy/indexing_tests/test_insert.py::TestPlace_param_3_{n_vals=1, shape=(7,)}::test_place
-tests/third_party/cupy/indexing_tests/test_insert.py::TestPlace_param_4_{n_vals=1, shape=(2, 3)}::test_place
-tests/third_party/cupy/indexing_tests/test_insert.py::TestPlace_param_5_{n_vals=1, shape=(4, 3, 2)}::test_place
-tests/third_party/cupy/indexing_tests/test_insert.py::TestPlace_param_6_{n_vals=3, shape=(7,)}::test_place
-tests/third_party/cupy/indexing_tests/test_insert.py::TestPlace_param_7_{n_vals=3, shape=(2, 3)}::test_place
-tests/third_party/cupy/indexing_tests/test_insert.py::TestPlace_param_8_{n_vals=3, shape=(4, 3, 2)}::test_place
-tests/third_party/cupy/indexing_tests/test_insert.py::TestPlace_param_9_{n_vals=15, shape=(7,)}::test_place
-tests/third_party/cupy/indexing_tests/test_insert.py::TestPlace_param_10_{n_vals=15, shape=(2, 3)}::test_place
-tests/third_party/cupy/indexing_tests/test_insert.py::TestPlace_param_11_{n_vals=15, shape=(4, 3, 2)}::test_place
 tests/third_party/cupy/indexing_tests/test_insert.py::TestDiagIndices_param_0_{n=2, ndim=2}::test_diag_indices
 tests/third_party/cupy/indexing_tests/test_insert.py::TestDiagIndices_param_1_{n=2, ndim=3}::test_diag_indices
 tests/third_party/cupy/indexing_tests/test_insert.py::TestDiagIndices_param_2_{n=2, ndim=1}::test_diag_indices
@@ -708,12 +699,6 @@ tests/third_party/cupy/indexing_tests/test_insert.py::TestFillDiagonal_param_5_{
 tests/third_party/cupy/indexing_tests/test_insert.py::TestFillDiagonal_param_6_{shape=(3, 3), val=(2, 2), wrap=True}::test_columnar_slice
 tests/third_party/cupy/indexing_tests/test_insert.py::TestFillDiagonal_param_7_{shape=(3, 3), val=(2, 2), wrap=False}::test_columnar_slice
 tests/third_party/cupy/indexing_tests/test_insert.py::TestFillDiagonal_param_9_{shape=(2, 2, 2), val=1, wrap=False}::test_1darray
-tests/third_party/cupy/indexing_tests/test_insert.py::TestPlaceRaises_param_0_{shape=(7,)}::test_place_empty_value_error
-tests/third_party/cupy/indexing_tests/test_insert.py::TestPlaceRaises_param_0_{shape=(7,)}::test_place_shape_unmatch_error
-tests/third_party/cupy/indexing_tests/test_insert.py::TestPlaceRaises_param_1_{shape=(2, 3)}::test_place_empty_value_error
-tests/third_party/cupy/indexing_tests/test_insert.py::TestPlaceRaises_param_1_{shape=(2, 3)}::test_place_shape_unmatch_error
-tests/third_party/cupy/indexing_tests/test_insert.py::TestPlaceRaises_param_2_{shape=(4, 3, 2)}::test_place_empty_value_error
-tests/third_party/cupy/indexing_tests/test_insert.py::TestPlaceRaises_param_2_{shape=(4, 3, 2)}::test_place_shape_unmatch_error
 tests/third_party/cupy/indexing_tests/test_insert.py::TestPutmaskDifferentDtypes::test_putmask_differnt_dtypes_raises
 tests/third_party/cupy/indexing_tests/test_insert.py::TestPutmask::test_putmask_non_equal_shape_raises
 tests/third_party/cupy/indexing_tests/test_iterate.py::TestFlatiter::test_next

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -138,8 +138,9 @@ def test_place1(arr, mask, vals):
     ia = dpnp.array(a)
     m = numpy.array(mask)
     im = dpnp.array(m)
+    iv = dpnp.array(vals)
     numpy.place(a, m, vals)
-    dpnp.place(ia, im, vals)
+    dpnp.place(ia, im, iv)
     assert_array_equal(a, ia)
 
 
@@ -162,8 +163,9 @@ def test_place2(arr, mask, vals):
     ia = dpnp.array(a)
     m = numpy.array(mask)
     im = dpnp.array(m)
+    iv = dpnp.array(vals)
     numpy.place(a, m, vals)
-    dpnp.place(ia, im, vals)
+    dpnp.place(ia, im, iv)
     assert_array_equal(a, ia)
 
 
@@ -187,8 +189,9 @@ def test_place3(arr, mask, vals):
     ia = dpnp.array(a)
     m = numpy.array(mask)
     im = dpnp.array(m)
+    iv = dpnp.array(vals)
     numpy.place(a, m, vals)
-    dpnp.place(ia, im, vals)
+    dpnp.place(ia, im, iv)
     assert_array_equal(a, ia)
 
 

--- a/tests/third_party/cupy/indexing_tests/test_insert.py
+++ b/tests/third_party/cupy/indexing_tests/test_insert.py
@@ -39,6 +39,7 @@ class TestPlaceRaises(unittest.TestCase):
     # https://github.com/numpy/numpy/pull/5821
     @testing.with_requires('numpy>=1.10')
     @testing.for_all_dtypes()
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_place_empty_value_error(self, dtype):
         for xp in (numpy, cupy):
             a = testing.shaped_arange(self.shape, xp, dtype)

--- a/tests/third_party/cupy/testing/helper.py
+++ b/tests/third_party/cupy/testing/helper.py
@@ -15,6 +15,7 @@ import dpnp as cupyx
 # from dpnp.core import internal
 from tests.third_party.cupy.testing import array
 from tests.third_party.cupy.testing import parameterized
+from dpctl import select_default_device
 # import dpnp
 # import dpnp.scipy.sparse
 
@@ -654,9 +655,15 @@ def for_dtypes(dtypes, name='dtype'):
         return test_func
     return decorator
 
+def _get_supported_float_dtypes():
+    if select_default_device().has_aspect_fp64:
+        return (numpy.float64, numpy.float32)
+    else:
+        return (numpy.float32,)
+
 
 _complex_dtypes = ()
-_regular_float_dtypes = (numpy.float64, numpy.float32)
+_regular_float_dtypes = _get_supported_float_dtypes()
 _float_dtypes = _regular_float_dtypes
 _signed_dtypes = ()
 _unsigned_dtypes = tuple(numpy.dtype(i).type for i in 'BHILQ')
@@ -667,7 +674,7 @@ _dtypes = _float_dtypes + _int_bool_dtypes
 
 
 def _make_all_dtypes(no_float16, no_bool, no_complex):
-    return (numpy.float64, numpy.float32, numpy.int64, numpy.int32)
+    return (numpy.int64, numpy.int32) + _get_supported_float_dtypes()
 #     if no_float16:
 #         dtypes = _regular_float_dtypes
 #     else:


### PR DESCRIPTION
This PR modifies `dpnp.place()` implementation to use `dpctl.tensor.place()` instead of dpnp implementation.


- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
