### PR TITLE
Set dependencies for dpnp_algo Cython extension to account for files involved via use of include 

### DIFF
--- a/dpnp/backend/CMakeLists.txt
+++ b/dpnp/backend/CMakeLists.txt
@@ -91,7 +91,6 @@ endif()
 # SYCL related compile options
 string(CONCAT COMMON_COMPILE_FLAGS
   "-fsycl "
-  "-fsycl-device-code-split=per_kernel "
   "-fno-approx-func "
   "-fno-finite-math-only "
 )
@@ -173,6 +172,7 @@ if(NOT WIN32)
     "-fno-delete-null-pointer-checks "
     "-fstack-protector-strong "
     "-fno-strict-overflow "
+    "-fwrapv "
     )
   string(APPEND COMMON_LINK_FLAGS
     "LINKER:-z,noexecstack,-z,relro,-z,now "

--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,7 @@ if IS_WIN:
     '''
     This variable controls setuptools execution on windows
     to avoid automatically search and confirm workability of the compiler
-    If not set, error "Microsoft Visual C++ 14.0 or greater is required." appiars
+    If not set, error "Microsoft Visual C++ 14.0 or greater is required." appears
     '''
     os.environ["DISTUTILS_USE_SDK"] = "1"
 
@@ -145,6 +145,21 @@ kwargs_common = {
 dpnp_algo = Extension(
     name="dpnp.dpnp_algo.dpnp_algo",
     sources=[os.path.join("dpnp", "dpnp_algo", "dpnp_algo.pyx")],
+    depends=[
+        os.path.join("dpnp", "dpnp_algo", "dpnp_algo_linearalgebra.pyx"),
+        os.path.join("dpnp", "dpnp_algo", "dpnp_algo_manipulation.pyx"),
+        os.path.join("dpnp", "dpnp_algo", "dpnp_algo_counting.pyx"),
+        os.path.join("dpnp", "dpnp_algo", "dpnp_algo_statistics.pyx"),
+        os.path.join("dpnp", "dpnp_algo", "dpnp_algo_trigonometric.pyx"),
+        os.path.join("dpnp", "dpnp_algo", "dpnp_algo_sorting.pyx"),
+        os.path.join("dpnp", "dpnp_algo", "dpnp_algo_arraycreation.pyx"),
+        os.path.join("dpnp", "dpnp_algo", "dpnp_algo_mathematical.pyx"),
+        os.path.join("dpnp", "dpnp_algo", "dpnp_algo_searching.pyx"),
+        os.path.join("dpnp", "dpnp_algo", "dpnp_algo_indexing.pyx"),
+        os.path.join("dpnp", "dpnp_algo", "dpnp_algo_logic.pyx"),
+        os.path.join("dpnp", "dpnp_algo", "dpnp_algo_bitwise.pyx"),
+        os.path.join("dpnp", "dpnp_algo", "dpnp_algo_special.pyx"),
+    ],
     **kwargs_common)
 
 dpnp_dparray = Extension(


### PR DESCRIPTION
Since `dpnp_algo.pyx` includes a bunch of other `.pyx` files, build generator needs to be aware of such dependency to correctly perform incremental builds.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
