### PR TITLE
Allow asarray to work on sequences of dpnp_array

### DIFF
--- a/dpnp/dpnp_container.py
+++ b/dpnp/dpnp_container.py
@@ -91,7 +91,6 @@ def asarray(x1,
     else:
         x1_obj = x1
 
-    sycl_queue_normalized = dpnp.get_normalized_queue_device(x1_obj, device=device, sycl_queue=sycl_queue)
     if order is None:
         order = 'C'
 
@@ -100,8 +99,9 @@ def asarray(x1,
                             dtype=dtype,
                             copy=copy,
                             order=order,
+                            device=device,
                             usm_type=usm_type,
-                            sycl_queue=sycl_queue_normalized)
+                            sycl_queue=sycl_queue)
     return dpnp_array(array_obj.shape, buffer=array_obj, order=order)
 
 

--- a/dpnp/dpnp_container.py
+++ b/dpnp/dpnp_container.py
@@ -86,22 +86,34 @@ def asarray(x1,
             usm_type=None,
             sycl_queue=None):
     """Converts `x1` to `dpnp_array`."""
-    if isinstance(x1, dpnp_array):
-        x1_obj = x1.get_array()
-    else:
-        x1_obj = x1
+    dpu.validate_usm_type(usm_type, allow_none=True)
 
     if order is None:
         order = 'C'
 
     """Converts incoming 'x1' object to 'dpnp_array'."""
-    array_obj = dpt.asarray(x1_obj,
-                            dtype=dtype,
-                            copy=copy,
-                            order=order,
-                            device=device,
-                            usm_type=usm_type,
-                            sycl_queue=sycl_queue)
+    if isinstance(x1, (list, tuple, range)):
+        array_obj = dpt.asarray(x1,
+                                dtype=dtype,
+                                copy=copy,
+                                order=order,
+                                device=device,
+                                usm_type=usm_type,
+                                sycl_queue=sycl_queue)
+    else:
+        if isinstance(x1, dpnp_array):
+            x1_obj = x1.get_array()
+        else:
+            x1_obj = x1
+
+        sycl_queue_normalized = dpnp.get_normalized_queue_device(x1_obj, device=device, sycl_queue=sycl_queue)
+
+        array_obj = dpt.asarray(x1_obj,
+                                dtype=dtype,
+                                copy=copy,
+                                order=order,
+                                usm_type=usm_type,
+                                sycl_queue=sycl_queue_normalized)
     return dpnp_array(array_obj.shape, buffer=array_obj, order=order)
 
 

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -955,5 +955,5 @@ def test_broadcast_to(device):
                          ids=[device.filter_string for device in valid_devices])
 def test_asarray(device_x, device_y):
     x = dpnp.array([1, 2, 3], device=device_x)
-    y = dpnp.asarray([x], device=device_y)
+    y = dpnp.asarray([x, x, x], device=device_y)
     assert_sycl_queue_equal(y.sycl_queue, x.to_device(device_y).sycl_queue)

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -945,3 +945,15 @@ def test_broadcast_to(device):
     x = dpnp.arange(5, device=device)
     y = dpnp.broadcast_to(x, (3, 5))
     assert_sycl_queue_equal(x.sycl_queue, y.sycl_queue)
+
+
+@pytest.mark.parametrize("device_x",
+                         valid_devices,
+                         ids=[device.filter_string for device in valid_devices])
+@pytest.mark.parametrize("device_y",
+                         valid_devices,
+                         ids=[device.filter_string for device in valid_devices])
+def test_asarray(device_x, device_y):
+    x = dpnp.array([1, 2, 3], device=device_x)
+    y = dpnp.asarray([x], device=device_y)
+    assert_sycl_queue_equal(y.sycl_queue, x.to_device(device_y).sycl_queue)


### PR DESCRIPTION
close #1345 

Allow asarray to work on sequences of dpnp_array with support compute-follows-data.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
