### PR TITLE
Extend support of out parameter for dpnp.sqrt()

### DIFF
--- a/dpnp/dpnp_iface_trigonometric.py
+++ b/dpnp/dpnp_iface_trigonometric.py
@@ -107,9 +107,7 @@ def _check_nd_call(origin_func, dpnp_func, x1, out=None, where=True, dtype=None,
                 out_desc = dpnp.get_dpnp_descriptor(out, copy_when_nondefault_queue=False) or None
             else:
                 out_desc = None
-            print("DPNP")
             return dpnp_func(x1_desc, out=out_desc).get_pyobj()
-    print("NUMPY")
     return call_origin(origin_func, x1, dtype=dtype, out=out, where=where, subok=subok, **kwargs)
 
 def arccos(x1):

--- a/dpnp/dpnp_iface_trigonometric.py
+++ b/dpnp/dpnp_iface_trigonometric.py
@@ -82,6 +82,36 @@ __all__ = [
 ]
 
 
+def _check_nd_call(origin_func, dpnp_func, x1, out=None, where=True, dtype=None, subok=True, **kwargs):
+    """Choose function to call based on input and call chosen fucntion."""
+
+    if kwargs:
+        pass
+    elif where is not True:
+        pass
+    elif dtype is not None:
+        pass
+    elif subok is not True:
+        pass
+    elif dpnp.isscalar(x1):
+        pass
+    else:
+        x1_desc = dpnp.get_dpnp_descriptor(
+            x1, copy_when_strides=False, copy_when_nondefault_queue=False
+        )
+
+        if x1_desc:
+            if out is not None:
+                if not isinstance(out, (dpnp.ndarray, dpt.usm_ndarray)):
+                    raise TypeError("return array must be of supported array type")
+                out_desc = dpnp.get_dpnp_descriptor(out, copy_when_nondefault_queue=False) or None
+            else:
+                out_desc = None
+            print("DPNP")
+            return dpnp_func(x1_desc, out=out_desc).get_pyobj()
+    print("NUMPY")
+    return call_origin(origin_func, x1, dtype=dtype, out=out, where=where, subok=subok, **kwargs)
+
 def arccos(x1):
     """
     Trigonometric inverse cosine, element-wise.
@@ -907,7 +937,7 @@ def sinh(x1):
     return call_origin(numpy.sinh, x1, **kwargs)
 
 
-def sqrt(x1, /, out = None, **kwargs):
+def sqrt(x1, /, out = None, where=True, dtype=None, subok=True, **kwargs):
     """
     Return the positive square-root of an array, element-wise.
 
@@ -918,6 +948,8 @@ def sqrt(x1, /, out = None, **kwargs):
     Input array is supported as either :class:`dpnp.ndarray` or :class:`dpctl.tensor.usm_ndarray`.
     Parameter `out` is supported as class:`dpnp.ndarray`, class:`dpctl.tensor.usm_ndarray` or
     with default value ``None``.
+    Parameters `where`, `dtype` and `subok` are supported with their default values.
+    Keyword arguments ``kwargs`` are currently unsupported.
     Otherwise the function will be executed sequentially on CPU.
     Keyword arguments ``kwargs`` are currently unsupported.
     Input array data types are limited by supported DPNP :ref:`Data types`.
@@ -932,23 +964,7 @@ def sqrt(x1, /, out = None, **kwargs):
 
     """
 
-    x1_desc = (
-        dpnp.get_dpnp_descriptor(
-            x1, copy_when_strides=False, copy_when_nondefault_queue=False
-        )
-        if not kwargs
-        else None
-    )
-    if x1_desc:
-        if out is not None:
-            if not isinstance(out, (dpnp.ndarray, dpt.usm_ndarray)):
-                raise TypeError("return array must be of supported array type")
-            out_desc = dpnp.get_dpnp_descriptor(out, copy_when_nondefault_queue=False) or None
-        else:
-            out_desc = None
-        return dpnp_sqrt(x1_desc, out=out_desc).get_pyobj()
-
-    return call_origin(numpy.sqrt, x1, out=out, **kwargs)
+    return _check_nd_call(numpy.sqrt, dpnp_sqrt, x1, out=out, where=where, dtype=dtype, subok=subok, **kwargs)
 
 
 def square(x1):

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -2,6 +2,7 @@ import pytest
 from .helper import (
     get_all_dtypes,
     get_float_complex_dtypes,
+    get_float_dtypes,
     is_cpu_device,
     is_win_platform
 )
@@ -387,7 +388,7 @@ class TestEdiff1d:
         expected = numpy.ediff1d(np_a)
         assert_array_equal(expected, result)
 
-    
+
     @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_ediff1d_args(self):
         np_a = numpy.array([1, 2, 4, 7, 0])
@@ -532,16 +533,19 @@ class TestCeil:
 
         assert_array_equal(expected, result)
 
-    @pytest.mark.parametrize("dtype",
-                             [numpy.float32, numpy.int64, numpy.int32],
-                             ids=['numpy.float32', 'numpy.int64', 'numpy.int32'])
-    def test_invalid_dtype(self, dtype):
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True, no_none=True))
+    @pytest.mark.parametrize("dtype_out", get_float_dtypes())
+    def test_out_dtype(self, dtype, dtype_out):
 
-        dp_array = dpnp.arange(10, dtype=dpnp.float64)
-        dp_out = dpnp.empty(10, dtype=dtype)
+        np_array = numpy.arange(10, dtype=dtype)
+        np_out = numpy.empty(10, dtype=dtype_out)
+        expected = numpy.ceil(np_array, np_out)
 
-        with pytest.raises(ValueError):
-            dpnp.ceil(dp_array, out=dp_out)
+        dp_array = dpnp.arange(10, dtype=dtype)
+        dp_out = dpnp.empty(10, dtype=dtype_out)
+        result = dpnp.ceil(dp_array, dp_out)
+
+        assert_allclose(expected, result)
 
     @pytest.mark.parametrize("shape",
                              [(0,), (15, ), (2, 2)],
@@ -572,16 +576,19 @@ class TestFloor:
 
         assert_array_equal(expected, result)
 
-    @pytest.mark.parametrize("dtype",
-                             [numpy.float32, numpy.int64, numpy.int32],
-                             ids=['numpy.float32', 'numpy.int64', 'numpy.int32'])
-    def test_invalid_dtype(self, dtype):
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True, no_none=True))
+    @pytest.mark.parametrize("dtype_out", get_float_dtypes())
+    def test_out_dtype(self, dtype, dtype_out):
 
-        dp_array = dpnp.arange(10, dtype=dpnp.float64)
-        dp_out = dpnp.empty(10, dtype=dtype)
+        np_array = numpy.arange(10, dtype=dtype)
+        np_out = numpy.empty(10, dtype=dtype_out)
+        expected = numpy.floor(np_array, np_out)
 
-        with pytest.raises(ValueError):
-            dpnp.floor(dp_array, out=dp_out)
+        dp_array = dpnp.arange(10, dtype=dtype)
+        dp_out = dpnp.empty(10, dtype=dtype_out)
+        result = dpnp.floor(dp_array, dp_out)
+
+        assert_allclose(expected, result)
 
     @pytest.mark.parametrize("shape",
                              [(0,), (15, ), (2, 2)],
@@ -612,16 +619,19 @@ class TestTrunc:
 
         assert_array_equal(expected, result)
 
-    @pytest.mark.parametrize("dtype",
-                             [numpy.float32, numpy.int64, numpy.int32],
-                             ids=['numpy.float32', 'numpy.int64', 'numpy.int32'])
-    def test_invalid_dtype(self, dtype):
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True, no_none=True))
+    @pytest.mark.parametrize("dtype_out", get_float_dtypes())
+    def test_out_dtype(self, dtype, dtype_out):
 
-        dp_array = dpnp.arange(10, dtype=dpnp.float64)
-        dp_out = dpnp.empty(10, dtype=dtype)
+        np_array = numpy.arange(10, dtype=dtype)
+        np_out = numpy.empty(10, dtype=dtype_out)
+        expected = numpy.trunc(np_array, np_out)
 
-        with pytest.raises(ValueError):
-            dpnp.trunc(dp_array, out=dp_out)
+        dp_array = dpnp.arange(10, dtype=dtype)
+        dp_out = dpnp.empty(10, dtype=dtype_out)
+        result = dpnp.trunc(dp_array, dp_out)
+
+        assert_allclose(expected, result)
 
     @pytest.mark.parametrize("shape",
                              [(0,), (15, ), (2, 2)],

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -545,7 +545,7 @@ class TestCeil:
         dp_out = dpnp.empty(10, dtype=dtype_out)
         result = dpnp.ceil(dp_array, dp_out)
 
-        assert_allclose(expected, result)
+        assert_allclose(expected, result, rtol=1e-06)
 
     @pytest.mark.parametrize("shape",
                              [(0,), (15, ), (2, 2)],
@@ -588,7 +588,7 @@ class TestFloor:
         dp_out = dpnp.empty(10, dtype=dtype_out)
         result = dpnp.floor(dp_array, dp_out)
 
-        assert_allclose(expected, result)
+        assert_allclose(expected, result, rtol=1e-06)
 
     @pytest.mark.parametrize("shape",
                              [(0,), (15, ), (2, 2)],
@@ -631,7 +631,7 @@ class TestTrunc:
         dp_out = dpnp.empty(10, dtype=dtype_out)
         result = dpnp.trunc(dp_array, dp_out)
 
-        assert_allclose(expected, result)
+        assert_allclose(expected, result, rtol=1e-06)
 
     @pytest.mark.parametrize("shape",
                              [(0,), (15, ), (2, 2)],

--- a/tests/test_umath.py
+++ b/tests/test_umath.py
@@ -100,16 +100,19 @@ class TestSin:
 
         assert_array_equal(expected, result)
 
-    @pytest.mark.parametrize("dtype",
-                             [numpy.float32, numpy.int64, numpy.int32],
-                             ids=['numpy.float32', 'numpy.int64', 'numpy.int32'])
-    def test_invalid_dtype(self, dtype):
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True, no_none=True))
+    @pytest.mark.parametrize("dtype_out", get_float_dtypes())
+    def test_out_dtype(self, dtype, dtype_out):
 
-        dp_array = dpnp.arange(10, dtype=dpnp.float64)
-        dp_out = dpnp.empty(10, dtype=dtype)
+        np_array = numpy.arange(10, dtype=dtype)
+        np_out = numpy.empty(10, dtype=dtype_out)
+        expected = numpy.sin(np_array, np_out)
 
-        with pytest.raises(ValueError):
-            dpnp.sin(dp_array, out=dp_out)
+        dp_array = dpnp.arange(10, dtype=dtype)
+        dp_out = dpnp.empty(10, dtype=dtype_out)
+        result = dpnp.sin(dp_array, dp_out)
+
+        assert_allclose(expected, result)
 
     @pytest.mark.parametrize("shape",
                              [(0,), (15, ), (2, 2)],
@@ -140,16 +143,19 @@ class TestCos:
 
         assert_array_equal(expected, result)
 
-    @pytest.mark.parametrize("dtype",
-                             [numpy.float32, numpy.int64, numpy.int32],
-                             ids=['numpy.float32', 'numpy.int64', 'numpy.int32'])
-    def test_invalid_dtype(self, dtype):
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True, no_none=True))
+    @pytest.mark.parametrize("dtype_out", get_float_dtypes())
+    def test_out_dtype(self, dtype, dtype_out):
 
-        dp_array = dpnp.arange(10, dtype=dpnp.float64)
-        dp_out = dpnp.empty(10, dtype=dtype)
+        np_array = numpy.arange(10, dtype=dtype)
+        np_out = numpy.empty(10, dtype=dtype_out)
+        expected = numpy.cos(np_array, np_out)
 
-        with pytest.raises(ValueError):
-            dpnp.cos(dp_array, out=dp_out)
+        dp_array = dpnp.arange(10, dtype=dtype)
+        dp_out = dpnp.empty(10, dtype=dtype_out)
+        result = dpnp.cos(dp_array, dp_out)
+
+        assert_allclose(expected, result)
 
     @pytest.mark.parametrize("shape",
                              [(0,), (15, ), (2, 2)],
@@ -163,7 +169,7 @@ class TestCos:
             dpnp.cos(dp_array, out=dp_out)
 
 
-class TestsLog:
+class TestLog:
 
     def test_log(self):
         array_data = numpy.arange(10)
@@ -180,16 +186,19 @@ class TestsLog:
 
         assert_array_equal(expected, result)
 
-    @pytest.mark.parametrize("dtype",
-                             [numpy.float32, numpy.int64, numpy.int32],
-                             ids=['numpy.float32', 'numpy.int64', 'numpy.int32'])
-    def test_invalid_dtype(self, dtype):
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True, no_none=True))
+    @pytest.mark.parametrize("dtype_out", get_float_dtypes())
+    def test_out_dtype(self, dtype, dtype_out):
 
-        dp_array = dpnp.arange(10, dtype=dpnp.float64)
-        dp_out = dpnp.empty(10, dtype=dtype)
+        np_array = numpy.arange(10, dtype=dtype)
+        np_out = numpy.empty(10, dtype=dtype_out)
+        expected = numpy.log(np_array, np_out)
 
-        with pytest.raises(ValueError):
-            dpnp.log(dp_array, out=dp_out)
+        dp_array = dpnp.arange(10, dtype=dtype)
+        dp_out = dpnp.empty(10, dtype=dtype_out)
+        result = dpnp.log(dp_array, dp_out)
+
+        assert_allclose(expected, result)
 
     @pytest.mark.parametrize("shape",
                              [(0,), (15, ), (2, 2)],
@@ -220,16 +229,19 @@ class TestExp:
 
         assert_array_equal(expected, result)
 
-    @pytest.mark.parametrize("dtype",
-                             [numpy.float32, numpy.int64, numpy.int32],
-                             ids=['numpy.float32', 'numpy.int64', 'numpy.int32'])
-    def test_invalid_dtype(self, dtype):
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True, no_none=True))
+    @pytest.mark.parametrize("dtype_out", get_float_dtypes())
+    def test_out_dtype(self, dtype, dtype_out):
 
-        dp_array = dpnp.arange(10, dtype=dpnp.float64)
-        dp_out = dpnp.empty(10, dtype=dtype)
+        np_array = numpy.arange(10, dtype=dtype)
+        np_out = numpy.empty(10, dtype=dtype_out)
+        expected = numpy.exp(np_array, np_out)
 
-        with pytest.raises(ValueError):
-            dpnp.exp(dp_array, out=dp_out)
+        dp_array = dpnp.arange(10, dtype=dtype)
+        dp_out = dpnp.empty(10, dtype=dtype_out)
+        result = dpnp.exp(dp_array, dp_out)
+
+        assert_allclose(expected, result)
 
     @pytest.mark.parametrize("shape",
                              [(0,), (15, ), (2, 2)],
@@ -260,16 +272,19 @@ class TestArcsin:
 
         assert_array_equal(expected, result)
 
-    @pytest.mark.parametrize("dtype",
-                             [numpy.float32, numpy.int64, numpy.int32],
-                             ids=['numpy.float32', 'numpy.int64', 'numpy.int32'])
-    def test_invalid_dtype(self, dtype):
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True, no_none=True))
+    @pytest.mark.parametrize("dtype_out", get_float_dtypes())
+    def test_out_dtype(self, dtype, dtype_out):
 
-        dp_array = dpnp.arange(10, dtype=dpnp.float64)
-        dp_out = dpnp.empty(10, dtype=dtype)
+        np_array = numpy.arange(10, dtype=dtype)
+        np_out = numpy.empty(10, dtype=dtype_out)
+        expected = numpy.arcsin(np_array, np_out)
 
-        with pytest.raises(ValueError):
-            dpnp.arcsin(dp_array, out=dp_out)
+        dp_array = dpnp.arange(10, dtype=dtype)
+        dp_out = dpnp.empty(10, dtype=dtype_out)
+        result = dpnp.arcsin(dp_array, dp_out)
+
+        assert_allclose(expected, result)
 
     @pytest.mark.parametrize("shape",
                              [(0,), (15, ), (2, 2)],
@@ -300,16 +315,19 @@ class TestArctan:
 
         assert_array_equal(expected, result)
 
-    @pytest.mark.parametrize("dtype",
-                             [numpy.float32, numpy.int64, numpy.int32],
-                             ids=['numpy.float32', 'numpy.int64', 'numpy.int32'])
-    def test_invalid_dtype(self, dtype):
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True, no_none=True))
+    @pytest.mark.parametrize("dtype_out", get_float_dtypes())
+    def test_out_dtype(self, dtype, dtype_out):
 
-        dp_array = dpnp.arange(10, dtype=dpnp.float64)
-        dp_out = dpnp.empty(10, dtype=dtype)
+        np_array = numpy.arange(10, dtype=dtype)
+        np_out = numpy.empty(10, dtype=dtype_out)
+        expected = numpy.arctan(np_array, np_out)
 
-        with pytest.raises(ValueError):
-            dpnp.arctan(dp_array, out=dp_out)
+        dp_array = dpnp.arange(10, dtype=dtype)
+        dp_out = dpnp.empty(10, dtype=dtype_out)
+        result = dpnp.arctan(dp_array, dp_out)
+
+        assert_allclose(expected, result)
 
     @pytest.mark.parametrize("shape",
                              [(0,), (15, ), (2, 2)],
@@ -340,16 +358,19 @@ class TestTan:
 
         assert_array_equal(expected, result)
 
-    @pytest.mark.parametrize("dtype",
-                             [numpy.float32, numpy.int64, numpy.int32],
-                             ids=['numpy.float32', 'numpy.int64', 'numpy.int32'])
-    def test_invalid_dtype(self, dtype):
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True, no_none=True))
+    @pytest.mark.parametrize("dtype_out", get_float_dtypes())
+    def test_out_dtype(self, dtype, dtype_out):
 
-        dp_array = dpnp.arange(10, dtype=dpnp.float64)
-        dp_out = dpnp.empty(10, dtype=dtype)
+        np_array = numpy.arange(10, dtype=dtype)
+        np_out = numpy.empty(10, dtype=dtype_out)
+        expected = numpy.tan(np_array, np_out)
 
-        with pytest.raises(ValueError):
-            dpnp.tan(dp_array, out=dp_out)
+        dp_array = dpnp.arange(10, dtype=dtype)
+        dp_out = dpnp.empty(10, dtype=dtype_out)
+        result = dpnp.tan(dp_array, dp_out)
+
+        assert_allclose(expected, result, rtol=1e-06)
 
     @pytest.mark.parametrize("shape",
                              [(0,), (15, ), (2, 2)],

--- a/tests/test_umath.py
+++ b/tests/test_umath.py
@@ -423,16 +423,29 @@ class TestSqrt:
         numpy.testing.assert_allclose(expected, result)
         numpy.testing.assert_allclose(out, dp_out)
 
-    @pytest.mark.parametrize("dtype",
-                             [numpy.int64, numpy.int32],
-                             ids=['numpy.int64', 'numpy.int32'])
-    def test_invalid_dtype(self, dtype):
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True, no_none=True))
+    def test_out_dtype(self, dtype):
 
-        dp_array = dpnp.arange(10, dtype=dpnp.float32)
-        dp_out = dpnp.empty(10, dtype=dtype)
+        np_array = numpy.arange(10, dtype=dtype)
+        np_out = numpy.empty(10, dtype=numpy.float32)
+        expected = numpy.sqrt(np_array, np_out)
 
-        with pytest.raises(ValueError):
-            dpnp.sqrt(dp_array, out=dp_out)
+        dp_array = dpnp.arange(10, dtype=dtype)
+        dp_out = dpnp.empty(10, dtype=dpnp.float32)
+        result = dpnp.sqrt(dp_array, dp_out)
+
+        assert_allclose(expected, result)
+
+    @pytest.mark.parametrize("dtype", get_float_dtypes())
+    def test_out_equal_array(self, dtype):
+
+        np_array = numpy.arange(10, dtype=dtype)
+        expected = numpy.sqrt(np_array, np_array)
+
+        dp_array = dpnp.arange(10, dtype=dtype)
+        result = dpnp.sqrt(dp_array, dp_array)
+
+        assert_allclose(expected, result)
 
     @pytest.mark.parametrize("shape",
                              [(0,), (15, ), (2, 2)],

--- a/tests/test_umath.py
+++ b/tests/test_umath.py
@@ -112,7 +112,7 @@ class TestSin:
         dp_out = dpnp.empty(10, dtype=dtype_out)
         result = dpnp.sin(dp_array, dp_out)
 
-        assert_allclose(expected, result)
+        assert_allclose(expected, result, rtol=1e-06)
 
     @pytest.mark.parametrize("shape",
                              [(0,), (15, ), (2, 2)],
@@ -155,7 +155,7 @@ class TestCos:
         dp_out = dpnp.empty(10, dtype=dtype_out)
         result = dpnp.cos(dp_array, dp_out)
 
-        assert_allclose(expected, result)
+        assert_allclose(expected, result, rtol=1e-06)
 
     @pytest.mark.parametrize("shape",
                              [(0,), (15, ), (2, 2)],
@@ -198,7 +198,7 @@ class TestLog:
         dp_out = dpnp.empty(10, dtype=dtype_out)
         result = dpnp.log(dp_array, dp_out)
 
-        assert_allclose(expected, result)
+        assert_allclose(expected, result, rtol=1e-06)
 
     @pytest.mark.parametrize("shape",
                              [(0,), (15, ), (2, 2)],
@@ -241,7 +241,7 @@ class TestExp:
         dp_out = dpnp.empty(10, dtype=dtype_out)
         result = dpnp.exp(dp_array, dp_out)
 
-        assert_allclose(expected, result)
+        assert_allclose(expected, result, rtol=1e-06)
 
     @pytest.mark.parametrize("shape",
                              [(0,), (15, ), (2, 2)],
@@ -284,7 +284,7 @@ class TestArcsin:
         dp_out = dpnp.empty(10, dtype=dtype_out)
         result = dpnp.arcsin(dp_array, dp_out)
 
-        assert_allclose(expected, result)
+        assert_allclose(expected, result, rtol=1e-06)
 
     @pytest.mark.parametrize("shape",
                              [(0,), (15, ), (2, 2)],
@@ -327,7 +327,7 @@ class TestArctan:
         dp_out = dpnp.empty(10, dtype=dtype_out)
         result = dpnp.arctan(dp_array, dp_out)
 
-        assert_allclose(expected, result)
+        assert_allclose(expected, result, rtol=1e-06)
 
     @pytest.mark.parametrize("shape",
                              [(0,), (15, ), (2, 2)],
@@ -412,7 +412,7 @@ class TestArctan2:
         dp_out = dpnp.empty(size, dtype=dpnp.complex64)
         result = dpnp.arctan2(dp_array, dp_array, out=dp_out)
 
-        assert_allclose(expected, result)
+        assert_allclose(expected, result, rtol=1e-06)
 
     @pytest.mark.parametrize("shape",
                              [(0,), (15, ), (2, 2)],
@@ -456,7 +456,7 @@ class TestSqrt:
         dp_out = dpnp.empty(10, dtype=dtype_out)
         result = dpnp.sqrt(dp_array, dp_out)
 
-        assert_allclose(expected, result)
+        assert_allclose(expected, result, rtol=1e-06)
 
     @pytest.mark.parametrize("dtype", get_float_dtypes())
     def test_out_equal_array(self, dtype):

--- a/tests/test_umath.py
+++ b/tests/test_umath.py
@@ -445,14 +445,15 @@ class TestSqrt:
         numpy.testing.assert_allclose(out, dp_out)
 
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True, no_none=True))
-    def test_out_dtype(self, dtype):
+    @pytest.mark.parametrize("dtype_out", get_float_dtypes())
+    def test_out_dtype(self, dtype, dtype_out):
 
         np_array = numpy.arange(10, dtype=dtype)
-        np_out = numpy.empty(10, dtype=numpy.float32)
+        np_out = numpy.empty(10, dtype=dtype_out)
         expected = numpy.sqrt(np_array, np_out)
 
         dp_array = dpnp.arange(10, dtype=dtype)
-        dp_out = dpnp.empty(10, dtype=dpnp.float32)
+        dp_out = dpnp.empty(10, dtype=dtype_out)
         result = dpnp.sqrt(dp_array, dp_out)
 
         assert_allclose(expected, result)


### PR DESCRIPTION
This PR extends the handling of  `out` in-place parameter for `1in_1out` dpnp functions , in particular for  `dpnp.sqrt` function as #1341 

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
