### PR TITLE
Change the name of branches for generate_coverage.yaml

### DIFF
--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -2,7 +2,7 @@ name: Generate coverage data for dpnp
 on:
   pull_request:
   push:
-    branches: [use-skbuild-and-cmake]
+    branches: [master]
 
 jobs:
   generate-coverage:


### PR DESCRIPTION
This PR fixes the workflow of generating coverage to run on the `master` branch when using the `push` events in `generate_coverage.yaml`

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
