### PR TITLE
fix_cov_for_no_fp64

### DIFF
--- a/dpnp/backend/kernels/dpnp_krnl_statistics.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_statistics.cpp
@@ -192,7 +192,7 @@ DPCTLSyclEventRef dpnp_cov_c(DPCTLSyclQueueRef q_ref,
                                 nrows,                            // std::int64_t n,
                                 ncols,                            // std::int64_t k,
                                 alpha,                            // T alpha,
-                                temp,                             //const T* a,
+                                temp,                             // const T* a,
                                 ncols,                            // std::int64_t lda,
                                 beta,                             // T beta,
                                 result,                           // T* c,
@@ -1384,7 +1384,7 @@ void func_map_init_statistics(func_map_t& fmap)
 
     fmap[DPNPFuncName::DPNP_FN_COV_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_cov_ext_c<double>};
     fmap[DPNPFuncName::DPNP_FN_COV_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_cov_ext_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_COV_EXT][eft_FLT][eft_FLT] = {eft_DBL, (void*)dpnp_cov_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_COV_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_cov_ext_c<float>};
     fmap[DPNPFuncName::DPNP_FN_COV_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_cov_ext_c<double>};
 
     fmap[DPNPFuncName::DPNP_FN_MAX][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_max_default_c<int32_t>};

--- a/dpnp/dpnp_algo/dpnp_algo_statistics.pxi
+++ b/dpnp/dpnp_algo/dpnp_algo_statistics.pxi
@@ -179,7 +179,6 @@ cpdef utils.dpnp_descriptor dpnp_correlate(utils.dpnp_descriptor x1, utils.dpnp_
     return result
 
 
-# supports "double" input only
 cpdef utils.dpnp_descriptor dpnp_cov(utils.dpnp_descriptor array1):
     cdef shape_type_c input_shape = array1.shape
 

--- a/dpnp/dpnp_iface_statistics.py
+++ b/dpnp/dpnp_iface_statistics.py
@@ -41,7 +41,7 @@ it contains:
 
 
 import numpy
-
+import dpctl.tensor as dpt
 from dpnp.dpnp_algo import *
 from dpnp.dpnp_utils import *
 from dpnp.dpnp_array import dpnp_array
@@ -247,7 +247,7 @@ def cov(x1, y=None, rowvar=True, bias=False, ddof=None, fweights=None, aweights=
     Limitations
     -----------
     Input array ``m`` is supported as :obj:`dpnp.ndarray`.
-    Dimension of input array ``m`` is limited by ``m.ndim > 2``.
+    Dimension of input array ``m`` is limited by ``m.ndim <= 2``.
     Size and shape of input arrays are supported to be equal.
     Prameters ``y`` is supported only with default value ``None``.
     Prameters ``bias`` is supported only with default value ``False``.
@@ -257,7 +257,7 @@ def cov(x1, y=None, rowvar=True, bias=False, ddof=None, fweights=None, aweights=
     Otherwise the function will be executed sequentially on CPU.
     Input array data types are limited by supported DPNP :ref:`Data types`.
 
-    .. seealso:: :obj:`dpnp.corrcoef` normalized covariance matrix.
+    .. see also:: :obj:`dpnp.corrcoef` normalized covariance matrix.
 
     Examples
     --------
@@ -274,31 +274,30 @@ def cov(x1, y=None, rowvar=True, bias=False, ddof=None, fweights=None, aweights=
     [1.0, -1.0, -1.0, 1.0]
 
     """
+    if not isinstance(x1, (dpnp_array, dpt.usm_ndarray)):
+        pass
+    elif x1.ndim > 2:
+        pass
+    elif y is not None:
+        pass
+    elif bias:
+        pass
+    elif ddof is not None:
+        pass
+    elif fweights is not None:
+        pass
+    elif aweights is not None:
+        pass
+    else:
+        if not rowvar and x1.shape[0] != 1:
+            x1 = x1.get_array() if isinstance(x1, dpnp_array) else x1
+            x1 = dpnp_array._create_from_usm_ndarray(x1.mT)
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
-    if x1_desc:
-        if x1_desc.ndim > 2:
-            pass
-        elif y is not None:
-            pass
-        elif bias:
-            pass
-        elif ddof is not None:
-            pass
-        elif fweights is not None:
-            pass
-        elif aweights is not None:
-            pass
-        else:
-            if not rowvar and x1.shape[0] != 1:
-                x1 = x1.get_array() if isinstance(x1, dpnp_array) else x1
-                x1 = dpnp_array._create_from_usm_ndarray(x1.mT)
-                x1 = dpnp.astype(x1, dpnp.float64) if x1_desc.dtype != dpnp.float64 else x1
-                x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
-            elif x1_desc.dtype != dpnp.float64:
-                x1 = dpnp.astype(x1, dpnp.float64)
-                x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
+        if not x1.dtype in (dpnp.float32, dpnp.float64):
+            x1 = dpnp.astype(x1, dpnp.default_float_type(sycl_queue=x1.sycl_queue))
 
+        x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
+        if x1_desc:
             return dpnp_cov(x1_desc).get_pyobj()
 
     return call_origin(numpy.cov, x1, y, rowvar, bias, ddof, fweights, aweights)

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -116,14 +116,14 @@ class TestBincount:
         numpy.testing.assert_array_equal(expected, result)
 
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_none=True, no_complex=True))
-def test_cov_rowvar1(dtype):
+def test_cov_rowvar(dtype):
     a = dpnp.array([[0, 2], [1, 1], [2, 0]], dtype=dtype)
     b = numpy.array([[0, 2], [1, 1], [2, 0]], dtype=dtype)
     numpy.testing.assert_array_equal(dpnp.cov(a.T), dpnp.cov(a,rowvar=False))
     numpy.testing.assert_array_equal(numpy.cov(b,rowvar=False), dpnp.cov(a,rowvar=False))
 
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_none=True, no_complex=True))
-def test_cov_rowvar2(dtype):
+def test_cov_1D_rowvar(dtype):
     a = dpnp.array([[0, 1, 2]], dtype=dtype)
     b = numpy.array([[0, 1, 2]], dtype=dtype)
     numpy.testing.assert_array_equal(numpy.cov(b,rowvar=False), dpnp.cov(a,rowvar=False))

--- a/tests/third_party/cupy/statistics_tests/test_correlation.py
+++ b/tests/third_party/cupy/statistics_tests/test_correlation.py
@@ -48,7 +48,7 @@ class TestCov(unittest.TestCase):
         return a, y
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(type_check=False)
     def check(self, a_shape, y_shape=None, rowvar=True, bias=False,
               ddof=None, xp=None, dtype=None):
         a, y = self.generate_input(a_shape, y_shape, xp, dtype)


### PR DESCRIPTION
closes issue #1379 
In this PR, `dpnp.cov` is modified to work on GPUs that only support `float32`.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [X] If this PR is a work in progress, are you filing the PR as a draft?
