### PR TITLE
Use internal dpnp kernel instead of MKL if no FP64 support

### DIFF
--- a/dpnp/backend/include/dpnp_gen_1arg_1type_tbl.hpp
+++ b/dpnp/backend/include/dpnp_gen_1arg_1type_tbl.hpp
@@ -91,14 +91,14 @@
 MACRO_1ARG_1TYPE_OP(dpnp_conjugate_c, std::conj(input_elem), q.submit(kernel_func))
 MACRO_1ARG_1TYPE_OP(dpnp_copy_c, input_elem, q.submit(kernel_func))
 MACRO_1ARG_1TYPE_OP(dpnp_erf_c,
-                    sycl::erf((double)input_elem),
-                    oneapi::mkl::vm::erf(q, input1_size, input1_data, result)) // no sycl::erf for int and long
+                    dispatch_erf_op(input_elem),
+                    oneapi::mkl::vm::erf(q, input1_size, input1_data, result))
 MACRO_1ARG_1TYPE_OP(dpnp_negative_c, -input_elem, q.submit(kernel_func))
 MACRO_1ARG_1TYPE_OP(dpnp_recip_c,
                     _DataType(1) / input_elem,
                     q.submit(kernel_func)) // error: no member named 'recip' in namespace 'sycl'
 MACRO_1ARG_1TYPE_OP(dpnp_sign_c,
-                    sycl::sign((double)input_elem),
+                    dispatch_sign_op(input_elem),
                     q.submit(kernel_func)) // no sycl::sign for int and long
 MACRO_1ARG_1TYPE_OP(dpnp_square_c,
                     input_elem* input_elem,

--- a/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
@@ -560,11 +560,11 @@ static void func_map_init_elemwise_1arg_2type(func_map_t& fmap)
 }
 
 template <typename T>
-constexpr auto dispatch_erf_op(T elem)
+constexpr T dispatch_erf_op(T elem)
 {
     if constexpr (is_any_v<T, std::int32_t, std::int64_t>)
     {
-        // TODO: need to convert to double when possible?
+        // TODO: need to convert to double when possible
         return sycl::erf((float)elem);
     }
     else
@@ -574,7 +574,7 @@ constexpr auto dispatch_erf_op(T elem)
 }
 
 template <typename T>
-constexpr auto dispatch_sign_op(T elem)
+constexpr T dispatch_sign_op(T elem)
 {
     if constexpr (is_any_v<T, std::int32_t, std::int64_t>)
     {
@@ -625,7 +625,6 @@ constexpr auto dispatch_sign_op(T elem)
         }                                                                                                              \
                                                                                                                        \
         sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));                                                      \
-        const bool has_fp64_aspect = q.get_device().has(sycl::aspect::fp64);                                           \
                                                                                                                        \
         _DataType* input1_data = static_cast<_DataType*>(const_cast<void*>(input1_in));                                \
         _DataType* result = static_cast<_DataType*>(result_out);                                                       \
@@ -706,7 +705,7 @@ constexpr auto dispatch_sign_op(T elem)
                                                                                                                        \
             if constexpr (is_any_v<_DataType, float, double>)                                                          \
             {                                                                                                          \
-                if (has_fp64_aspect)                                                                                   \
+                if (q.get_device().has(sycl::aspect::fp64))                                                            \
                 {                                                                                                      \
                     event = __operation2__;                                                                            \
                                                                                                                        \

--- a/dpnp/backend/src/dpnp_fptr.hpp
+++ b/dpnp/backend/src/dpnp_fptr.hpp
@@ -164,7 +164,7 @@ template <typename T, typename... Ts>
 struct are_same : std::conjunction<std::is_same<T, Ts>...> {};
 
 /**
- * A template constant to check if type T matces any type from Ts.
+ * A template constant to check if type T matches any type from Ts.
  */
 template <typename T, typename... Ts>
 constexpr auto is_any_v = is_any<T, Ts...>::value;

--- a/tests/test_strides.py
+++ b/tests/test_strides.py
@@ -68,19 +68,16 @@ def test_strides_1arg(func_name, dtype, shape):
                          [(10,)],
                          ids=["(10,)"])
 def test_strides_erf(dtype, shape):
-    a = numpy.arange(numpy.prod(shape), dtype=dtype).reshape(shape)
+    a = dpnp.reshape(dpnp.linspace(-1, 1, num=numpy.prod(shape), dtype=dtype), shape)
     b = a[::2]
 
-    dpa = dpnp.reshape(dpnp.arange(numpy.prod(shape), dtype=dtype), shape)
-    dpb = dpa[::2]
+    result = dpnp.erf(b)
 
-    result = dpnp.erf(dpb)
-
-    expected = numpy.empty_like(b)
+    expected = numpy.empty_like(b.asnumpy())
     for idx, val in enumerate(b):
         expected[idx] = math.erf(val)
 
-    assert_allclose(result, expected)
+    assert_allclose(result, expected, rtol=1e-06)
 
 
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True))


### PR DESCRIPTION
OneMKL VM functions copy data to the host when a device doesn't provide support of fp64, which might impact the performance.
The PR propose to use internal DPNP kernel instead of VM function from OneMKL in that case.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
