### PR TITLE
Rework transpose methods to use dpctl.tensor functions

### DIFF
--- a/dpnp/backend/include/dpnp_iface_fptr.hpp
+++ b/dpnp/backend/include/dpnp_iface_fptr.hpp
@@ -360,7 +360,6 @@ enum class DPNPFuncName : size_t
     DPNP_FN_TANH,                         /**< Used in numpy.tanh() impl  */
     DPNP_FN_TANH_EXT,                     /**< Used in numpy.tanh() impl, requires extra parameters */
     DPNP_FN_TRANSPOSE,                    /**< Used in numpy.transpose() impl  */
-    DPNP_FN_TRANSPOSE_EXT,                /**< Used in numpy.transpose() impl, requires extra parameters */
     DPNP_FN_TRACE,                        /**< Used in numpy.trace() impl  */
     DPNP_FN_TRACE_EXT,                    /**< Used in numpy.trace() impl, requires extra parameters */
     DPNP_FN_TRAPZ,                        /**< Used in numpy.trapz() impl  */

--- a/dpnp/backend/kernels/dpnp_krnl_manipulation.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_manipulation.cpp
@@ -1,5 +1,5 @@
 //*****************************************************************************
-// Copyright (c) 2016-2020, Intel Corporation
+// Copyright (c) 2016-2023, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -211,6 +211,7 @@ void dpnp_elemwise_transpose_c(void* array1_in,
                                                                        size,
                                                                        dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
+    DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
@@ -221,17 +222,6 @@ void (*dpnp_elemwise_transpose_default_c)(void*,
                                           size_t,
                                           void*,
                                           size_t) = dpnp_elemwise_transpose_c<_DataType>;
-
-template <typename _DataType>
-DPCTLSyclEventRef (*dpnp_elemwise_transpose_ext_c)(DPCTLSyclQueueRef,
-                                                   void*,
-                                                   const shape_elem_type*,
-                                                   const shape_elem_type*,
-                                                   const shape_elem_type*,
-                                                   size_t,
-                                                   void*,
-                                                   size_t,
-                                                   const DPCTLEventVectorRef) = dpnp_elemwise_transpose_c<_DataType>;
 
 void func_map_init_manipulation(func_map_t& fmap)
 {
@@ -253,15 +243,5 @@ void func_map_init_manipulation(func_map_t& fmap)
                                                                (void*)dpnp_elemwise_transpose_default_c<float>};
     fmap[DPNPFuncName::DPNP_FN_TRANSPOSE][eft_DBL][eft_DBL] = {eft_DBL,
                                                                (void*)dpnp_elemwise_transpose_default_c<double>};
-
-    fmap[DPNPFuncName::DPNP_FN_TRANSPOSE_EXT][eft_INT][eft_INT] = {eft_INT,
-                                                                   (void*)dpnp_elemwise_transpose_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRANSPOSE_EXT][eft_LNG][eft_LNG] = {eft_LNG,
-                                                                   (void*)dpnp_elemwise_transpose_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRANSPOSE_EXT][eft_FLT][eft_FLT] = {eft_FLT,
-                                                                   (void*)dpnp_elemwise_transpose_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_TRANSPOSE_EXT][eft_DBL][eft_DBL] = {eft_DBL,
-                                                                   (void*)dpnp_elemwise_transpose_ext_c<double>};
-
     return;
 }

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -339,7 +339,6 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_TRACE
         DPNP_FN_TRACE_EXT
         DPNP_FN_TRANSPOSE
-        DPNP_FN_TRANSPOSE_EXT
         DPNP_FN_TRAPZ
         DPNP_FN_TRAPZ_EXT
         DPNP_FN_TRI
@@ -555,7 +554,6 @@ cpdef dpnp_descriptor dpnp_subtract(dpnp_descriptor x1_obj, dpnp_descriptor x2_o
 Array manipulation routines
 """
 cpdef dpnp_descriptor dpnp_repeat(dpnp_descriptor array1, repeats, axes=*)
-cpdef dpnp_descriptor dpnp_transpose(dpnp_descriptor array1, axes=*)
 
 
 """

--- a/dpnp/dpnp_algo/dpnp_algo_manipulation.pxi
+++ b/dpnp/dpnp_algo/dpnp_algo_manipulation.pxi
@@ -42,21 +42,11 @@ __all__ += [
     "dpnp_expand_dims",
     "dpnp_repeat",
     "dpnp_reshape",
-    "dpnp_transpose",
     "dpnp_squeeze",
 ]
 
 
 # C function pointer to the C library template functions
-ctypedef c_dpctl.DPCTLSyclEventRef(*fptr_custom_elemwise_transpose_1in_1out_t)(c_dpctl.DPCTLSyclQueueRef,
-                                                                               void * ,
-                                                                               shape_elem_type * ,
-                                                                               shape_elem_type * ,
-                                                                               shape_elem_type * ,
-                                                                               size_t,
-                                                                               void * ,
-                                                                               size_t,
-                                                                               const c_dpctl.DPCTLEventVectorRef)
 ctypedef c_dpctl.DPCTLSyclEventRef(*fptr_dpnp_repeat_t)(c_dpctl.DPCTLSyclQueueRef,
                                                         const void *, void * , const size_t , const size_t,
                                                         const c_dpctl.DPCTLEventVectorRef)
@@ -230,70 +220,6 @@ cpdef utils.dpnp_descriptor dpnp_reshape(utils.dpnp_descriptor array1, newshape,
                                                usm_type=array1_obj.usm_type,
                                                sycl_queue=array1_obj.sycl_queue),
                                     copy_when_nondefault_queue=False)
-
-
-cpdef utils.dpnp_descriptor dpnp_transpose(utils.dpnp_descriptor array1, axes=None):
-    cdef shape_type_c input_shape = array1.shape
-    cdef size_t input_shape_size = array1.ndim
-    cdef shape_type_c result_shape = shape_type_c(input_shape_size, 1)
-
-    cdef shape_type_c permute_axes
-    if axes is None:
-        """
-        template to do transpose a tensor
-        input_shape=[2, 3, 4]
-        permute_axes=[2, 1, 0]
-        after application `permute_axes` to `input_shape` result:
-        result_shape=[4, 3, 2]
-
-        'do nothing' axes variable is `permute_axes=[0, 1, 2]`
-
-        test: pytest tests/third_party/cupy/manipulation_tests/test_transpose.py::TestTranspose::test_external_transpose_all
-        """
-        permute_axes = list(reversed([i for i in range(input_shape_size)]))
-    else:
-        permute_axes = utils.normalize_axis(axes, input_shape_size)
-
-    for i in range(input_shape_size):
-        """ construct output shape """
-        result_shape[i] = input_shape[permute_axes[i]]
-
-    # convert string type names (array.dtype) to C enum DPNPFuncType
-    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(array1.dtype)
-
-    # get the FPTR data structure
-    cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_TRANSPOSE_EXT, param1_type, param1_type)
-
-    array1_obj = array1.get_array()
-
-    # ceate result array with type given by FPTR data
-    cdef utils.dpnp_descriptor result = utils.create_output_descriptor(result_shape,
-                                                                       kernel_data.return_type,
-                                                                       None,
-                                                                       device=array1_obj.sycl_device,
-                                                                       usm_type=array1_obj.usm_type,
-                                                                       sycl_queue=array1_obj.sycl_queue)
-    result_sycl_queue = result.get_array().sycl_queue
-
-    cdef c_dpctl.SyclQueue q = <c_dpctl.SyclQueue> result_sycl_queue
-    cdef c_dpctl.DPCTLSyclQueueRef q_ref = q.get_queue_ref()
-
-    cdef fptr_custom_elemwise_transpose_1in_1out_t func = <fptr_custom_elemwise_transpose_1in_1out_t > kernel_data.ptr
-    # call FPTR function
-    cdef c_dpctl.DPCTLSyclEventRef event_ref = func(q_ref,
-                                                    array1.get_data(),
-                                                    input_shape.data(),
-                                                    result_shape.data(),
-                                                    permute_axes.data(),
-                                                    input_shape_size,
-                                                    result.get_data(),
-                                                    array1.size,
-                                                    NULL)  # dep_events_ref
-
-    with nogil: c_dpctl.DPCTLEvent_WaitAndThrow(event_ref)
-    c_dpctl.DPCTLEvent_Delete(event_ref)
-
-    return result
 
 
 cpdef utils.dpnp_descriptor dpnp_squeeze(utils.dpnp_descriptor in_array, axis):

--- a/dpnp/dpnp_iface_statistics.py
+++ b/dpnp/dpnp_iface_statistics.py
@@ -290,8 +290,7 @@ def cov(x1, y=None, rowvar=True, bias=False, ddof=None, fweights=None, aweights=
         pass
     else:
         if not rowvar and x1.shape[0] != 1:
-            x1 = x1.get_array() if isinstance(x1, dpnp_array) else x1
-            x1 = dpnp_array._create_from_usm_ndarray(x1.mT)
+            x1 = x1.T
 
         if not x1.dtype in (dpnp.float32, dpnp.float64):
             x1 = dpnp.astype(x1, dpnp.default_float_type(sycl_queue=x1.sycl_queue))

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -234,8 +234,6 @@ tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAn
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_astype_strides_swapped
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_astype_type_c_contiguous_no_copy
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_astype_type_f_contiguous_no_copy
-tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_transposed_fill
-tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_transposed_flatten
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_flatten
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_flatten_copied
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_isinstance_numpy_copy
@@ -837,7 +835,6 @@ tests/third_party/cupy/math_tests/test_rounding.py::TestRounding::test_rint_nega
 tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_all
 tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_all2
 tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_all_keepdims
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_all_transposed
 tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_all_transposed2
 tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_axes
 tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_axes2
@@ -886,7 +883,6 @@ tests/third_party/cupy/math_tests/test_sumprod.py::TestNansumNanprodLong_param_1
 tests/third_party/cupy/math_tests/test_sumprod.py::TestNansumNanprodLong_param_9_{axis=0, func='nanprod', keepdims=True, shape=(2, 3, 4), transpose_axes=False}::test_nansum_all
 tests/third_party/cupy/math_tests/test_sumprod.py::TestNansumNanprodLong_param_9_{axis=0, func='nanprod', keepdims=True, shape=(2, 3, 4), transpose_axes=False}::test_nansum_axis_transposed
 tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_all2
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_all_transposed2
 tests/third_party/cupy/math_tests/test_trigonometric.py::TestUnwrap::test_unwrap_1dim
 tests/third_party/cupy/math_tests/test_trigonometric.py::TestUnwrap::test_unwrap_1dim_with_discont
 tests/third_party/cupy/math_tests/test_trigonometric.py::TestUnwrap::test_unwrap_2dim_with_axis

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -142,7 +142,6 @@ tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsPois
 
 tests/test_random.py::TestPermutationsTestShuffle::test_shuffle1[lambda x: dpnp.asarray([[i, i] for i in x])]
 
-tests/test_arraymanipulation.py::TestConcatenate::test_concatenate
 tests/test_histograms.py::TestHistogram::test_density
 
 tests/test_random.py::TestPermutationsTestShuffle::test_shuffle1[lambda x: dpnp.astype(dpnp.asarray(x), dpnp.int8)]
@@ -376,8 +375,6 @@ tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAn
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_astype_strides_swapped
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_astype_type_c_contiguous_no_copy
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_astype_type_f_contiguous_no_copy
-tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_transposed_fill
-tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_transposed_flatten
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_flatten_copied
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_flatten
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayCopyAndView::test_isinstance_numpy_copy
@@ -783,15 +780,11 @@ tests/third_party/cupy/linalg_tests/test_einsum.py::TestEinSumLarge_param_9_{opt
 tests/third_party/cupy/linalg_tests/test_einsum.py::TestEinSumUnaryOperationWithScalar::test_scalar_float
 tests/third_party/cupy/linalg_tests/test_einsum.py::TestEinSumUnaryOperationWithScalar::test_scalar_int
 tests/third_party/cupy/linalg_tests/test_einsum.py::TestListArgEinSumError::test_invalid_sub1
-tests/third_party/cupy/linalg_tests/test_product.py::TestProduct::test_transposed_dot
 tests/third_party/cupy/linalg_tests/test_product.py::TestMatrixPower::test_matrix_power_invlarge
 tests/third_party/cupy/linalg_tests/test_product.py::TestMatrixPower::test_matrix_power_large
 tests/third_party/cupy/linalg_tests/test_product.py::TestMatrixPower::test_matrix_power_of_two
 tests/third_party/cupy/linalg_tests/test_product.py::TestProduct::test_dot_vec2
 tests/third_party/cupy/linalg_tests/test_product.py::TestProduct::test_multidim_vdot
-tests/third_party/cupy/linalg_tests/test_product.py::TestProduct::test_transposed_dot
-tests/third_party/cupy/linalg_tests/test_product.py::TestProduct::test_transposed_dot_with_out
-tests/third_party/cupy/linalg_tests/test_product.py::TestProduct::test_transposed_higher_order_inner
 tests/third_party/cupy/linalg_tests/test_product.py::TestProduct::test_transposed_tensordot
 tests/third_party/cupy/linalg_tests/test_product.py::TestProduct::test_transposed_tensordot_with_int_axes
 tests/third_party/cupy/linalg_tests/test_product.py::TestProduct::test_transposed_tensordot_with_list_axes
@@ -1005,7 +998,7 @@ tests/third_party/cupy/math_tests/test_rounding.py::TestRounding::test_rint
 tests/third_party/cupy/math_tests/test_rounding.py::TestRounding::test_rint_negative
 tests/third_party/cupy/math_tests/test_rounding.py::TestRounding::test_round_
 tests/third_party/cupy/math_tests/test_rounding.py::TestRounding::test_trunc
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_all_transposed
+
 tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_all_transposed2
 tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_axes
 tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_axes2

--- a/tests/third_party/cupy/linalg_tests/test_eigenvalue.py
+++ b/tests/third_party/cupy/linalg_tests/test_eigenvalue.py
@@ -8,8 +8,7 @@ from tests.third_party.cupy import testing
 
 
 def _get_hermitian(xp, a, UPLO):
-    # TODO: fix this, currently dpnp.transpose() doesn't support complex types
-    # and no dpnp_array.swapaxes()
+    # TODO: remove wrapping, but now there is no dpnp_array.swapaxes()
     a = _wrap_as_numpy_array(xp, a)
     _xp = numpy
 


### PR DESCRIPTION
The PR propose to rework implementation of `dpnp.transpose`, `dpnp.ndarray.transpose()` and `dpnp.ndarray.T` to fully rely on methods from `dpctl.tensor` module, i.e. with help of `usm_ndarray.T` and `usm_ndarray.permute_dims`.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
