### PR TITLE
Not use DPC++ 2023.2.0 for conda build

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
       - wheel
     build:
       - {{ compiler('cxx') }}
-      - {{ compiler('dpcpp') }}  >=2023.0  # [not osx]
+      - {{ compiler('dpcpp') }}  =2023.1.0  # [not osx]
     run:
       - python
       - dpctl >=0.14

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     build:
       - {{ compiler('cxx') }}
       - {{ compiler('dpcpp') }}  =2023.1.0  # [not osx]
+      - sysroot_linux-64 >=2.17  # [linux]
     run:
       - python
       - dpctl >=0.14


### PR DESCRIPTION
Temporarily do not use DPC++ 2023.2.0 for conda build until an issue with it is solved.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
