### PR TITLE
Fix compilation error with sycl::abs()

### DIFF
--- a/dpnp/backend/kernels/dpnp_krnl_mathematical.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_mathematical.cpp
@@ -170,10 +170,14 @@ DPCTLSyclEventRef dpnp_elemwise_absolute_c(DPCTLSyclQueueRef q_ref,
 
                 sycl::vec<_DataType_input, vec_sz> data_vec = sg.load<vec_sz>(input_ptrT(&array1[start]));
 
+#if (__SYCL_COMPILER_VERSION < __SYCL_COMPILER_VECTOR_ABS_CHANGED)
                 // sycl::abs() returns unsigned integers only, so explicit casting to signed ones is required
                 using result_absT = typename cl::sycl::detail::make_unsigned<_DataType_output>::type;
                 sycl::vec<_DataType_output, vec_sz> res_vec =
                     dpnp_vec_cast<_DataType_output, result_absT, vec_sz>(sycl::abs(data_vec));
+#else
+                sycl::vec<_DataType_output, vec_sz> res_vec = sycl::abs(data_vec);
+#endif
 
                 sg.store<vec_sz>(result_ptrT(&result[start]), res_vec);
             }

--- a/dpnp/backend/src/dpnp_utils.hpp
+++ b/dpnp/backend/src/dpnp_utils.hpp
@@ -41,6 +41,14 @@
         (__LIBSYCL_MAJOR_VERSION == major and __LIBSYCL_MINOR_VERSION == minor and __LIBSYCL_PATCH_VERSION >= patch)
 
 /**
+ * Version of SYCL DPC++ 2023 compiler where a return type of sycl::abs() is changed
+ * from unsinged integer to signed one of input vector.
+ */
+#ifndef __SYCL_COMPILER_VECTOR_ABS_CHANGED
+#define __SYCL_COMPILER_VECTOR_ABS_CHANGED 20230503L
+#endif
+
+/**
  * Version of SYCL DPC++ 2023 compiler at which transition to SYCL 2020 occurs.
  * Intel(R) oneAPI DPC++ 2022.2.1 compiler has version 20221020L on Linux and
  * 20221101L on Windows.


### PR DESCRIPTION
DPC++ 2023.1 declared a return type of `sycl::abs()` as unsigned one, even when an input type is signed.
With DPC++ 2023.2 the behavior is changed and result type has the same sign as input one now.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
