### PR TITLE
Remove debug empty print from test_eigenvalue.py

### DIFF
--- a/tests/third_party/cupy/linalg_tests/test_eigenvalue.py
+++ b/tests/third_party/cupy/linalg_tests/test_eigenvalue.py
@@ -85,7 +85,6 @@ class TestEigenvalue(unittest.TestCase):
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4, contiguous_check=False)
     def test_eigh_complex_batched(self, xp, dtype):
-        print()
         a = xp.array([[[1, 2j, 3], [4j, 5, 6j], [7, 8j, 9]],
                       [[0, 2j, 3], [4j, 4, 6j], [7, 8j, 8]]], dtype)
         w, v = xp.linalg.eigh(a, UPLO=self.UPLO)


### PR DESCRIPTION
The PR removes unnecessary new line print in `test_eigh_complex_batched` test from test_eigenvalue.py.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
