### PR TITLE
Fix hanging with pybind11 extension around MKL calls

### DIFF
--- a/dpnp/__init__.py
+++ b/dpnp/__init__.py
@@ -41,6 +41,8 @@ if system() == 'Windows':
         os.add_dll_directory(dpctlpath)
     os.environ["PATH"] = os.pathsep.join([os.getenv("PATH", ""), mypath, dpctlpath])
 
+# workaround against hanging in OneMKL calls
+os.environ.setdefault('SYCL_QUEUE_THREAD_POOL_SIZE', '6')
 
 from dpnp.dpnp_array import dpnp_array as ndarray
 from dpnp.dpnp_flatiter import flatiter as flatiter


### PR DESCRIPTION
The PR implements a workaround when pybind11 extension hangs inside OneMKL.
The change is needed until the issue is resolve in DPC++ compiler.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
