### PR TITLE
Use MCG59 engine on GPU device

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -196,8 +196,6 @@ jobs:
         run: |
           python -m pytest -q -ra --disable-warnings -vv ${{ env.TEST_SCOPE }}
         working-directory: ${{ env.tests-path }}
-        env:
-          SYCL_QUEUE_THREAD_POOL_SIZE: 6
 
   test_windows:
     name: Test ['windows-latest', python='${{ matrix.python }}']
@@ -335,8 +333,6 @@ jobs:
         run: |
           python -m pytest -q -ra --disable-warnings -vv ${{ env.TEST_SCOPE }}
         working-directory: ${{ env.tests-path }}
-        env:
-          SYCL_QUEUE_THREAD_POOL_SIZE: 6
 
   upload:
     name: Upload ['${{ matrix.os }}', python='${{ matrix.python }}']

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -66,7 +66,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_PARALLEL: true
-          SYCL_QUEUE_THREAD_POOL_SIZE: 6
 
   coveralls:
     name: Indicate completion to coveralls.io

--- a/dpnp/__init__.py
+++ b/dpnp/__init__.py
@@ -27,6 +27,9 @@
 import os
 mypath = os.path.dirname(os.path.realpath(__file__))
 
+# workaround against hanging in OneMKL calls and in DPCTL
+os.environ.setdefault('SYCL_QUEUE_THREAD_POOL_SIZE', '6')
+
 import dpctl
 dpctlpath = os.path.dirname(dpctl.__file__)
 
@@ -40,9 +43,6 @@ if system() == 'Windows':
         os.add_dll_directory(mypath)
         os.add_dll_directory(dpctlpath)
     os.environ["PATH"] = os.pathsep.join([os.getenv("PATH", ""), mypath, dpctlpath])
-
-# workaround against hanging in OneMKL calls
-os.environ.setdefault('SYCL_QUEUE_THREAD_POOL_SIZE', '6')
 
 from dpnp.dpnp_array import dpnp_array as ndarray
 from dpnp.dpnp_flatiter import flatiter as flatiter

--- a/dpnp/backend/kernels/dpnp_krnl_random.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_random.cpp
@@ -77,22 +77,76 @@ void dpnp_rng_srand_c(size_t seed)
 }
 
 template <typename _DistrType, typename _EngineType, typename _DataType>
-static inline DPCTLSyclEventRef dpnp_rng_generate(const _DistrType& distr,
-                                                  _EngineType& engine,
-                                                  const int64_t size,
-                                                  _DataType* result) {
+static inline DPCTLSyclEventRef
+    dpnp_rng_generate(const _DistrType& distr, _EngineType& engine, const int64_t size, _DataType* result)
+{
     DPCTLSyclEventRef event_ref = nullptr;
     sycl::event event;
 
     // perform rng generation
-    try {
+    try
+    {
         event = mkl_rng::generate<_DistrType, _EngineType>(distr, engine, size, result);
         event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
-    } catch (const std::exception &e) {
+    }
+    catch (const std::exception& e)
+    {
         // TODO: add error reporting
         return event_ref;
     }
     return DPCTLEvent_Copy(event_ref);
+}
+
+template <typename _EngineType, typename _DataType>
+static inline DPCTLSyclEventRef dpnp_rng_generate_uniform(
+    _EngineType& engine, sycl::queue* q, const _DataType a, const _DataType b, const int64_t size, _DataType* result)
+{
+    DPCTLSyclEventRef event_ref = nullptr;
+
+    if constexpr (std::is_same<_DataType, int32_t>::value)
+    {
+        if (q->get_device().has(sycl::aspect::fp64))
+        {
+            /**
+             * A note from oneMKL for oneapi::mkl::rng::uniform (Discrete):
+             * The oneapi::mkl::rng::uniform_method::standard uses the s BRNG type on GPU devices.
+             * This might cause the produced numbers to have incorrect statistics (due to rounding error)
+             * when abs(b-a) > 2^23 || abs(b) > 2^23 || abs(a) > 2^23. To get proper statistics for this case,
+             * use the oneapi::mkl::rng::uniform_method::accurate method instead.
+             */
+            using method_type = mkl_rng::uniform_method::accurate;
+            mkl_rng::uniform<_DataType, method_type> distribution(a, b);
+
+            // perform generation
+            try
+            {
+                sycl::event event = mkl_rng::generate(distribution, engine, size, result);
+
+                event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
+                return DPCTLEvent_Copy(event_ref);
+            }
+            catch (const oneapi::mkl::unsupported_device&)
+            {
+                // fall through to try with uniform_method::standard
+            }
+            catch (const oneapi::mkl::unimplemented&)
+            {
+                // fall through to try with uniform_method::standard
+            }
+            catch (const std::exception& e)
+            {
+                // TODO: add error reporting
+                return event_ref;
+            }
+        }
+    }
+
+    // uniform_method::standard is a method used by default
+    using method_type = mkl_rng::uniform_method::standard;
+    mkl_rng::uniform<_DataType, method_type> distribution(a, b);
+
+    // perform generation
+    return dpnp_rng_generate(distribution, engine, size, result);
 }
 
 template <typename _DataType>
@@ -1392,17 +1446,17 @@ DPCTLSyclEventRef dpnp_rng_normal_c(DPCTLSyclQueueRef q_ref,
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
-    (void)q_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
+    sycl::queue* q = reinterpret_cast<sycl::queue*>(q_ref);
 
     if (!size)
     {
         return event_ref;
     }
+    assert(q != nullptr);
 
-    mt19937_struct* random_state = static_cast<mt19937_struct *>(random_state_in);
-    _DataType* result = static_cast<_DataType *>(result_out);
+    _DataType* result = static_cast<_DataType*>(result_out);
 
     // set mean of distribution
     const _DataType mean = static_cast<_DataType>(mean_in);
@@ -1410,31 +1464,57 @@ DPCTLSyclEventRef dpnp_rng_normal_c(DPCTLSyclQueueRef q_ref,
     const _DataType stddev = static_cast<_DataType>(stddev_in);
 
     mkl_rng::gaussian<_DataType> distribution(mean, stddev);
-    mkl_rng::mt19937 *engine = static_cast<mkl_rng::mt19937 *>(random_state->engine);
 
-    // perform generation
-    return dpnp_rng_generate<mkl_rng::gaussian<_DataType>, mkl_rng::mt19937, _DataType>(
-        distribution, *engine, size, result);
+    if (q->get_device().is_cpu())
+    {
+        mt19937_struct* random_state = static_cast<mt19937_struct*>(random_state_in);
+        mkl_rng::mt19937* engine = static_cast<mkl_rng::mt19937*>(random_state->engine);
+
+        // perform generation with MT19937 engine
+        event_ref = dpnp_rng_generate(distribution, *engine, size, result);
+    }
+    else
+    {
+        mcg59_struct* random_state = static_cast<mcg59_struct*>(random_state_in);
+        mkl_rng::mcg59* engine = static_cast<mkl_rng::mcg59*>(random_state->engine);
+
+        // perform generation with MCG59 engine
+        event_ref = dpnp_rng_generate(distribution, *engine, size, result);
+    }
+    return event_ref;
 }
 
 template <typename _DataType>
 void dpnp_rng_normal_c(void* result, const _DataType mean, const _DataType stddev, const size_t size)
 {
-    DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
+    sycl::queue* q = &DPNP_QUEUE;
+    DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(q);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    mt19937_struct* mt19937 = new mt19937_struct();
-    mt19937->engine = &DPNP_RNG_ENGINE;
+    DPCTLSyclEventRef event_ref = nullptr;
 
-    DPCTLSyclEventRef event_ref = dpnp_rng_normal_c<_DataType>(q_ref,
-                                                               result,
-                                                               mean,
-                                                               stddev,
-                                                               static_cast<int64_t>(size),
-                                                               mt19937,
-                                                               dep_event_vec_ref);
-    DPCTLEvent_WaitAndThrow(event_ref);
-    DPCTLEvent_Delete(event_ref);
-    delete mt19937;
+    if (q->get_device().is_cpu())
+    {
+        mt19937_struct* mt19937 = new mt19937_struct();
+        mt19937->engine = &DPNP_RNG_ENGINE;
+
+        event_ref = dpnp_rng_normal_c<_DataType>(
+            q_ref, result, mean, stddev, static_cast<int64_t>(size), mt19937, dep_event_vec_ref);
+        DPCTLEvent_WaitAndThrow(event_ref);
+        DPCTLEvent_Delete(event_ref);
+        delete mt19937;
+    }
+    else
+    {
+        // MCG59 engine is assumed to provide a better performance on GPU than MT19937
+        mcg59_struct* mcg59 = new mcg59_struct();
+        mcg59->engine = &DPNP_RNG_MCG59_ENGINE;
+
+        event_ref = dpnp_rng_normal_c<_DataType>(
+            q_ref, result, mean, stddev, static_cast<int64_t>(size), mcg59, dep_event_vec_ref);
+        DPCTLEvent_WaitAndThrow(event_ref);
+        DPCTLEvent_Delete(event_ref);
+        delete mcg59;
+    }
 }
 
 template <typename _DataType>
@@ -2149,74 +2229,75 @@ DPCTLSyclEventRef dpnp_rng_uniform_c(DPCTLSyclQueueRef q_ref,
         return event_ref;
     }
 
-    sycl::queue *q = reinterpret_cast<sycl::queue *>(q_ref);
+    sycl::queue* q = reinterpret_cast<sycl::queue*>(q_ref);
 
-    mt19937_struct* random_state = static_cast<mt19937_struct *>(random_state_in);
-    _DataType* result = static_cast<_DataType *>(result_out);
+    _DataType* result = static_cast<_DataType*>(result_out);
 
     // set left bound of distribution
     const _DataType a = static_cast<_DataType>(low);
     // set right bound of distribution
     const _DataType b = static_cast<_DataType>(high);
 
-    mkl_rng::mt19937 *engine = static_cast<mkl_rng::mt19937 *>(random_state->engine);
+    if (q->get_device().is_cpu())
+    {
+        mt19937_struct* random_state = static_cast<mt19937_struct*>(random_state_in);
+        mkl_rng::mt19937* engine = static_cast<mkl_rng::mt19937*>(random_state->engine);
 
-    if constexpr (std::is_same<_DataType, int32_t>::value) {
-        if (q->get_device().has(sycl::aspect::fp64)) {
-            /**
-             * A note from oneMKL for oneapi::mkl::rng::uniform (Discrete):
-             * The oneapi::mkl::rng::uniform_method::standard uses the s BRNG type on GPU devices.
-             * This might cause the produced numbers to have incorrect statistics (due to rounding error)
-             * when abs(b-a) > 2^23 || abs(b) > 2^23 || abs(a) > 2^23. To get proper statistics for this case,
-             * use the oneapi::mkl::rng::uniform_method::accurate method instead.
-             */
-            using method_type = mkl_rng::uniform_method::accurate;
-            mkl_rng::uniform<_DataType, method_type> distribution(a, b);
-
-            // perform generation
-            try {
-                auto event = mkl_rng::generate<mkl_rng::uniform<_DataType, method_type>, mkl_rng::mt19937>(
-                    distribution, *engine, size, result);
-                event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
-                return DPCTLEvent_Copy(event_ref);
-            } catch (const oneapi::mkl::unsupported_device&) {
-                // fall through to try with uniform_method::standard
-            } catch (const oneapi::mkl::unimplemented&) {
-                // fall through to try with uniform_method::standard
-            } catch (const std::exception &e) {
-                // TODO: add error reporting
-                return event_ref;
-            }
-        }
+        // perform generation with MT19937 engine
+        event_ref = dpnp_rng_generate_uniform(*engine, q, a, b, size, result);
     }
+    else
+    {
+        mcg59_struct* random_state = static_cast<mcg59_struct*>(random_state_in);
+        mkl_rng::mcg59* engine = static_cast<mkl_rng::mcg59*>(random_state->engine);
 
-    // uniform_method::standard is a method used by default
-    using method_type = mkl_rng::uniform_method::standard;
-    mkl_rng::uniform<_DataType, method_type> distribution(a, b);
-
-    // perform generation
-    return dpnp_rng_generate<mkl_rng::uniform<_DataType, method_type>, mkl_rng::mt19937, _DataType>(
-        distribution, *engine, size, result);
+        // perform generation with MCG59 engine
+        event_ref = dpnp_rng_generate_uniform(*engine, q, a, b, size, result);
+    }
+    return event_ref;
 }
 
 template <typename _DataType>
 void dpnp_rng_uniform_c(void* result, const long low, const long high, const size_t size)
 {
-    DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
+    sycl::queue* q = &DPNP_QUEUE;
+    DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(q);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    mt19937_struct* mt19937 = new mt19937_struct();
-    mt19937->engine = &DPNP_RNG_ENGINE;
+    DPCTLSyclEventRef event_ref = nullptr;
 
-    DPCTLSyclEventRef event_ref = dpnp_rng_uniform_c<_DataType>(q_ref,
-                                                                result,
-                                                                static_cast<double>(low),
-                                                                static_cast<double>(high),
-                                                                static_cast<int64_t>(size),
-                                                                mt19937,
-                                                                dep_event_vec_ref);
-    DPCTLEvent_WaitAndThrow(event_ref);
-    DPCTLEvent_Delete(event_ref);
-    delete mt19937;
+    if (q->get_device().is_cpu())
+    {
+        mt19937_struct* mt19937 = new mt19937_struct();
+        mt19937->engine = &DPNP_RNG_ENGINE;
+
+        event_ref = dpnp_rng_uniform_c<_DataType>(q_ref,
+                                                  result,
+                                                  static_cast<double>(low),
+                                                  static_cast<double>(high),
+                                                  static_cast<int64_t>(size),
+                                                  mt19937,
+                                                  dep_event_vec_ref);
+        DPCTLEvent_WaitAndThrow(event_ref);
+        DPCTLEvent_Delete(event_ref);
+        delete mt19937;
+    }
+    else
+    {
+        // MCG59 engine is assumed to provide a better performance on GPU than MT19937
+        mcg59_struct* mcg59 = new mcg59_struct();
+        mcg59->engine = &DPNP_RNG_MCG59_ENGINE;
+
+        event_ref = dpnp_rng_uniform_c<_DataType>(q_ref,
+                                                  result,
+                                                  static_cast<double>(low),
+                                                  static_cast<double>(high),
+                                                  static_cast<int64_t>(size),
+                                                  mcg59,
+                                                  dep_event_vec_ref);
+        DPCTLEvent_WaitAndThrow(event_ref);
+        DPCTLEvent_Delete(event_ref);
+        delete mcg59;
+    }
 }
 
 template <typename _DataType>

--- a/dpnp/backend/src/dpnp_random_state.cpp
+++ b/dpnp/backend/src/dpnp_random_state.cpp
@@ -1,5 +1,5 @@
 //*****************************************************************************
-// Copyright (c) 2022, Intel Corporation
+// Copyright (c) 2022-2023, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -50,5 +50,18 @@ void MT19937_InitVectorSeed(mt19937_struct *mt19937, DPCTLSyclQueueRef q_ref, ui
 void MT19937_Delete(mt19937_struct *mt19937) {
     mkl_rng::mt19937 *engine = static_cast<mkl_rng::mt19937 *>(mt19937->engine);
     mt19937->engine = nullptr;
+    delete engine;
+}
+
+void MCG59_InitScalarSeed(mcg59_struct* mcg59, DPCTLSyclQueueRef q_ref, uint64_t seed)
+{
+    sycl::queue* q = reinterpret_cast<sycl::queue*>(q_ref);
+    mcg59->engine = new mkl_rng::mcg59(*q, seed);
+}
+
+void MCG59_Delete(mcg59_struct* mcg59)
+{
+    mkl_rng::mcg59* engine = static_cast<mkl_rng::mcg59*>(mcg59->engine);
+    mcg59->engine = nullptr;
     delete engine;
 }

--- a/dpnp/backend/src/dpnp_random_state.hpp
+++ b/dpnp/backend/src/dpnp_random_state.hpp
@@ -1,5 +1,5 @@
 //*****************************************************************************
-// Copyright (c) 2022, Intel Corporation
+// Copyright (c) 2022-2023, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -47,10 +47,20 @@
 
 #include <dpctl_sycl_interface.h>
 
-// Structure storing MKL engine for MT199374x32x10 algorithm
-struct mt19937_struct
+// Structure storing a base MKL engine
+struct engine_struct
 {
     void* engine;
+};
+
+// Structure storing MKL engine for MT199374x32x10 generator
+struct mt19937_struct : engine_struct
+{
+};
+
+// Structure storing MKL engine for MCG59 generator
+struct mcg59_struct : engine_struct
+{
 };
 
 /**
@@ -87,5 +97,27 @@ INP_DLLEXPORT void MT19937_InitVectorSeed(mt19937_struct *mt19937, DPCTLSyclQueu
  * @param [in]  mt19937       A structure with the MKL engine.
  */
 INP_DLLEXPORT void MT19937_Delete(mt19937_struct *mt19937);
+
+/**
+ * @ingroup BACKEND_API
+ * @brief Create a MKL engine from scalar seed.
+ *
+ * Invoke a common seed initialization of the engine for MCG59 algorithm.
+ *
+ * @param [in]  mcg59         A structure with MKL engine which will be filled with generated value by MKL.
+ * @param [in]  q_ref         A refference on SYCL queue which will be used to obtain random numbers.
+ * @param [in]  seed          An initial condition of the generator state.
+ */
+INP_DLLEXPORT void MCG59_InitScalarSeed(mcg59_struct* mcg59, DPCTLSyclQueueRef q_ref, uint64_t seed);
+
+/**
+ * @ingroup BACKEND_API
+ * @brief Release a MKL engine.
+ *
+ * Release all resource required for storing of the MKL engine.
+ *
+ * @param [in]  mcg59         A structure with the MKL engine.
+ */
+INP_DLLEXPORT void MCG59_Delete(mcg59_struct* mcg59);
 
 #endif // BACKEND_RANDOM_STATE_H

--- a/dpnp/backend/src/queue_sycl.cpp
+++ b/dpnp/backend/src/queue_sycl.cpp
@@ -35,6 +35,7 @@
 sycl::queue* backend_sycl::queue = nullptr;
 #endif
 mkl_rng::mt19937* backend_sycl::rng_engine = nullptr;
+mkl_rng::mcg59* backend_sycl::rng_mcg59_engine = nullptr;
 
 static void dpnpc_show_mathlib_version()
 {
@@ -226,6 +227,7 @@ void backend_sycl::backend_sycl_rng_engine_init(size_t seed)
         backend_sycl::destroy_rng_engine();
     }
     rng_engine = new mkl_rng::mt19937(DPNP_QUEUE, seed);
+    rng_mcg59_engine = new mkl_rng::mcg59(DPNP_QUEUE, seed);
 }
 
 void dpnp_queue_initialize_c(QueueOptions selector)

--- a/dpnp/backend/src/queue_sycl.hpp
+++ b/dpnp/backend/src/queue_sycl.hpp
@@ -56,8 +56,9 @@
 
 namespace mkl_rng = oneapi::mkl::rng;
 
-#define DPNP_QUEUE      backend_sycl::get_queue()
-#define DPNP_RNG_ENGINE backend_sycl::get_rng_engine()
+#define DPNP_QUEUE            backend_sycl::get_queue()
+#define DPNP_RNG_ENGINE       backend_sycl::get_rng_engine()
+#define DPNP_RNG_MCG59_ENGINE backend_sycl::get_rng_mcg59_engine()
 
 /**
  * This is container for the SYCL queue, random number generation engine and related functions like queue and engine
@@ -70,7 +71,10 @@ class backend_sycl
 #if defined(DPNP_LOCAL_QUEUE)
     static sycl::queue* queue; /**< contains SYCL queue pointer initialized in @ref backend_sycl_queue_init */
 #endif
-    static mkl_rng::mt19937* rng_engine; /**< RNG engine ptr. initialized in @ref backend_sycl_rng_engine_init */
+    static mkl_rng::mt19937*
+        rng_engine;       /**< RNG MT19937 engine ptr. initialized in @ref backend_sycl_rng_engine_init */
+    static mkl_rng::mcg59*
+        rng_mcg59_engine; /**< RNG MCG59 engine ptr. initialized in @ref backend_sycl_rng_engine_init */
 
     static void destroy()
     {
@@ -84,7 +88,10 @@ class backend_sycl
     static void destroy_rng_engine()
     {
         delete rng_engine;
+        delete rng_mcg59_engine;
+
         rng_engine = nullptr;
+        rng_mcg59_engine = nullptr;
     }
 
 public:
@@ -118,7 +125,7 @@ public:
     static bool backend_sycl_is_cpu();
 
     /**
-     * Initialize @ref rng_engine
+     * Initialize @ref rng_engine and @ref rng_mcg59_engine
      */
     static void backend_sycl_rng_engine_init(size_t seed = 1);
 
@@ -158,6 +165,18 @@ public:
             backend_sycl_rng_engine_init();
         }
         return *rng_engine;
+    }
+
+    /**
+     * Return the @ref rng_mcg59_engine to the user
+     */
+    static mkl_rng::mcg59& get_rng_mcg59_engine()
+    {
+        if (!rng_engine)
+        {
+            backend_sycl_rng_engine_init();
+        }
+        return *rng_mcg59_engine;
     }
 };
 

--- a/dpnp/dpnp_algo/dpnp_algo.pyx
+++ b/dpnp/dpnp_algo/dpnp_algo.pyx
@@ -497,14 +497,8 @@ cdef utils.dpnp_descriptor call_fptr_2in_1out_strides(DPNPFuncName fptr_name,
     result_sycl_device, result_usm_type, result_sycl_queue = utils.get_common_usm_allocation(x1_obj, x2_obj)
 
     # get FPTR function and return type
-    cdef fptr_2in_1out_strides_t func = NULL
-    cdef DPNPFuncType return_type = DPNP_FT_NONE
-    if result_sycl_device.has_aspect_fp64:
-        return_type = kernel_data.return_type
-        func = < fptr_2in_1out_strides_t > kernel_data.ptr
-    else:
-        return_type = kernel_data.return_type_no_fp64
-        func = < fptr_2in_1out_strides_t > kernel_data.ptr_no_fp64
+    cdef fptr_2in_1out_strides_t func = < fptr_2in_1out_strides_t > kernel_data.ptr
+    cdef DPNPFuncType return_type = kernel_data.return_type
 
     # check 'out' parameter data
     if out is not None:

--- a/dpnp/random/dpnp_algo_random.pyx
+++ b/dpnp/random/dpnp_algo_random.pyx
@@ -42,7 +42,7 @@ import dpnp.config as config
 from dpnp.dpnp_array import dpnp_array
 
 from libc.stdlib cimport free, malloc
-from libc.stdint cimport uint32_t, int64_t
+from libc.stdint cimport uint32_t, uint64_t, int64_t
 
 from dpnp.dpnp_algo cimport *
 cimport dpctl as c_dpctl
@@ -53,6 +53,7 @@ cimport numpy
 
 
 __all__ = [
+    "MCG59",
     "MT19937",
     "dpnp_rng_beta",
     "dpnp_rng_binomial",
@@ -271,28 +272,28 @@ ctypedef c_dpctl.DPCTLSyclEventRef(*fptr_dpnp_rng_zipf_c_1out_t)(c_dpctl.DPCTLSy
 
 
 cdef extern from "dpnp_random_state.hpp":
+    cdef struct engine_struct:
+        pass
+
     cdef struct mt19937_struct:
         pass
     void MT19937_InitScalarSeed(mt19937_struct *, c_dpctl.DPCTLSyclQueueRef, uint32_t)
     void MT19937_InitVectorSeed(mt19937_struct *, c_dpctl.DPCTLSyclQueueRef, uint32_t *, unsigned int)
     void MT19937_Delete(mt19937_struct *)
 
+    cdef struct mcg59_struct:
+        pass
+    void MCG59_InitScalarSeed(mcg59_struct *, c_dpctl.DPCTLSyclQueueRef, uint64_t)
+    void MCG59_Delete(mcg59_struct *)
 
-cdef class MT19937:
-    """
-    Class storing MKL engine for MT199374x32x10 algorithm.
-    """
 
-    cdef mt19937_struct mt19937
+cdef class _Engine:
+    cdef engine_struct* engine_base
     cdef c_dpctl.DPCTLSyclQueueRef q_ref
     cdef c_dpctl.SyclQueue q
 
     def __cinit__(self, seed, sycl_queue):
-        cdef bint is_vector_seed = False
-        cdef uint32_t scalar_seed = 0
-        cdef unsigned int vector_seed_len = 0
-        cdef unsigned int *vector_seed = NULL
-
+        self.engine_base = NULL
         self.q_ref = NULL
         if sycl_queue is None:
             raise ValueError("SyclQueue isn't defined")
@@ -302,6 +303,113 @@ cdef class MT19937:
         self.q_ref = c_dpctl.DPCTLQueue_Copy((self.q).get_queue_ref())
         if self.q_ref is NULL:
             raise ValueError("SyclQueue copy failed")
+
+    def __dealloc__(self):
+        self.engine_base = NULL
+        c_dpctl.DPCTLQueue_Delete(self.q_ref)
+
+    cdef bint is_integer(self, value):
+        if isinstance(value, numbers.Number):
+            return isinstance(value, int) or isinstance(value, dpnp.integer)
+        # cover an element of dpnp array:
+        return numpy.ndim(value) == 0 and hasattr(value, "dtype") and dpnp.issubdtype(value, dpnp.integer)
+
+    cdef void set_engine(self, engine_struct* engine):
+        self.engine_base = engine
+
+    cdef engine_struct* get_engine(self):
+        return self.engine_base
+
+    cdef c_dpctl.SyclQueue get_queue(self):
+        return self.q
+
+    cdef c_dpctl.DPCTLSyclQueueRef get_queue_ref(self):
+        return self.q_ref
+
+    cpdef utils.dpnp_descriptor normal(self, loc, scale, size, dtype, usm_type):
+        cdef shape_type_c result_shape
+        cdef utils.dpnp_descriptor result
+        cdef DPNPFuncType param1_type
+        cdef DPNPFuncData kernel_data
+        cdef fptr_dpnp_rng_normal_c_1out_t func
+        cdef c_dpctl.DPCTLSyclEventRef event_ref
+
+        result_shape = utils._object_to_tuple(size)
+        if scale == 0.0:
+            return utils.dpnp_descriptor(dpnp.full(result_shape, loc, dtype=dtype))
+
+        # convert string type names (array.dtype) to C enum DPNPFuncType
+        param1_type = dpnp_dtype_to_DPNPFuncType(dtype)
+
+        # get the FPTR data structure
+        kernel_data = get_dpnp_function_ptr(DPNP_FN_RNG_NORMAL_EXT, param1_type, param1_type)
+
+        # ceate result array with type given by FPTR data
+        result = utils.create_output_descriptor(result_shape,
+                                                kernel_data.return_type,
+                                                None,
+                                                device=None,
+                                                usm_type=usm_type,
+                                                sycl_queue=self.get_queue())
+
+        func = <fptr_dpnp_rng_normal_c_1out_t > kernel_data.ptr
+        # call FPTR function
+        event_ref = func(self.get_queue_ref(), result.get_data(), loc, scale, result.size, self.get_engine(), NULL)
+
+        if event_ref != NULL:
+            with nogil: c_dpctl.DPCTLEvent_WaitAndThrow(event_ref)
+            c_dpctl.DPCTLEvent_Delete(event_ref)
+        return result
+
+    cpdef utils.dpnp_descriptor uniform(self, low, high, size, dtype, usm_type):
+        cdef shape_type_c result_shape
+        cdef utils.dpnp_descriptor result
+        cdef DPNPFuncType param1_type
+        cdef DPNPFuncData kernel_data
+        cdef fptr_dpnp_rng_uniform_c_1out_t func
+        cdef c_dpctl.DPCTLSyclEventRef event_ref
+
+        result_shape = utils._object_to_tuple(size)
+        if low == high:
+            return utils.dpnp_descriptor(dpnp.full(result_shape, low, dtype=dtype))
+
+        # convert string type names (array.dtype) to C enum DPNPFuncType
+        param1_type = dpnp_dtype_to_DPNPFuncType(dtype)
+
+        # get the FPTR data structure
+        kernel_data = get_dpnp_function_ptr(DPNP_FN_RNG_UNIFORM_EXT, param1_type, param1_type)
+
+        # ceate result array with type given by FPTR data
+        result = utils.create_output_descriptor(result_shape,
+                                                kernel_data.return_type,
+                                                None,
+                                                device=None,
+                                                usm_type=usm_type,
+                                                sycl_queue=self.get_queue())
+
+        func = <fptr_dpnp_rng_uniform_c_1out_t > kernel_data.ptr
+        # call FPTR function
+        event_ref = func(self.get_queue_ref(), result.get_data(), low, high, result.size, self.get_engine(), NULL)
+
+        if event_ref != NULL:
+            with nogil: c_dpctl.DPCTLEvent_WaitAndThrow(event_ref)
+            c_dpctl.DPCTLEvent_Delete(event_ref)
+        return result
+
+
+cdef class MT19937(_Engine):
+    """
+    Class storing MKL engine for MT199374x32x10 (The Mersenne Twister pseudorandom number generator).
+
+    """
+
+    cdef mt19937_struct mt19937
+
+    def __cinit__(self, seed, sycl_queue):
+        cdef bint is_vector_seed = False
+        cdef uint32_t scalar_seed = 0
+        cdef unsigned int vector_seed_len = 0
+        cdef unsigned int *vector_seed = NULL
 
         # get a scalar seed value or a vector of seeds
         if self.is_integer(seed):
@@ -345,106 +453,44 @@ cdef class MT19937:
             free(vector_seed)
         else:
             MT19937_InitScalarSeed(&self.mt19937, self.q_ref, scalar_seed)
-
+        self.set_engine(<engine_struct*> &self.mt19937)
 
     def __dealloc__(self):
         MT19937_Delete(&self.mt19937)
-        c_dpctl.DPCTLQueue_Delete(self.q_ref)
-
-
-    cdef bint is_integer(self, value):
-        if isinstance(value, numbers.Number):
-            return isinstance(value, int) or isinstance(value, dpnp.integer)
-        # cover an element of dpnp array:
-        return numpy.ndim(value) == 0 and hasattr(value, "dtype") and dpnp.issubdtype(value, dpnp.integer)
-
 
     cdef bint is_uint_range(self, value):
         return value >= 0 and value <= numpy.iinfo(numpy.uint32).max
 
 
-    cdef mt19937_struct * get_mt19937(self):
-        return &self.mt19937
+cdef class MCG59(_Engine):
+    """
+    Class storing MKL engine for MCG59
+    (the 59-bit multiplicative congruential pseudorandom number generator).
 
+    """
 
-    cdef c_dpctl.SyclQueue get_queue(self):
-        return self.q
+    cdef mcg59_struct mcg59
 
+    def __cinit__(self, seed, sycl_queue):
+        cdef uint64_t scalar_seed = 1
 
-    cdef c_dpctl.DPCTLSyclQueueRef get_queue_ref(self):
-        return self.q_ref
+        # get a scalar seed value or a vector of seeds
+        if self.is_integer(seed):
+            if self.is_uint64_range(seed):
+                scalar_seed = <uint64_t> seed
+            else:
+                raise ValueError("Seed must be between 0 and 2**64 - 1")
+        else:
+            raise TypeError("Seed must be an integer")
 
+        MCG59_InitScalarSeed(&self.mcg59, self.q_ref, scalar_seed)
+        self.set_engine(<engine_struct*> &self.mcg59)
 
-    cpdef utils.dpnp_descriptor normal(self, loc, scale, size, dtype, usm_type):
-        cdef shape_type_c result_shape
-        cdef utils.dpnp_descriptor result
-        cdef DPNPFuncType param1_type
-        cdef DPNPFuncData kernel_data
-        cdef fptr_dpnp_rng_normal_c_1out_t func
-        cdef c_dpctl.DPCTLSyclEventRef event_ref
+    def __dealloc__(self):
+        MCG59_Delete(&self.mcg59)
 
-        result_shape = utils._object_to_tuple(size)
-        if scale == 0.0:
-            return utils.dpnp_descriptor(dpnp.full(result_shape, loc, dtype=dtype))
-
-        # convert string type names (array.dtype) to C enum DPNPFuncType
-        param1_type = dpnp_dtype_to_DPNPFuncType(dtype)
-
-        # get the FPTR data structure
-        kernel_data = get_dpnp_function_ptr(DPNP_FN_RNG_NORMAL_EXT, param1_type, param1_type)
-
-        # ceate result array with type given by FPTR data
-        result = utils.create_output_descriptor(result_shape,
-                                                kernel_data.return_type,
-                                                None,
-                                                device=None,
-                                                usm_type=usm_type,
-                                                sycl_queue=self.get_queue())
-
-        func = <fptr_dpnp_rng_normal_c_1out_t > kernel_data.ptr
-        # call FPTR function
-        event_ref = func(self.get_queue_ref(), result.get_data(), loc, scale, result.size, self.get_mt19937(), NULL)
-
-        if event_ref != NULL:
-            with nogil: c_dpctl.DPCTLEvent_WaitAndThrow(event_ref)
-            c_dpctl.DPCTLEvent_Delete(event_ref)
-        return result
-
-
-    cpdef utils.dpnp_descriptor uniform(self, low, high, size, dtype, usm_type):
-        cdef shape_type_c result_shape
-        cdef utils.dpnp_descriptor result
-        cdef DPNPFuncType param1_type
-        cdef DPNPFuncData kernel_data
-        cdef fptr_dpnp_rng_uniform_c_1out_t func
-        cdef c_dpctl.DPCTLSyclEventRef event_ref
-
-        result_shape = utils._object_to_tuple(size)
-        if low == high:
-            return utils.dpnp_descriptor(dpnp.full(result_shape, low, dtype=dtype))
-
-        # convert string type names (array.dtype) to C enum DPNPFuncType
-        param1_type = dpnp_dtype_to_DPNPFuncType(dtype)
-
-        # get the FPTR data structure
-        kernel_data = get_dpnp_function_ptr(DPNP_FN_RNG_UNIFORM_EXT, param1_type, param1_type)
-
-        # ceate result array with type given by FPTR data
-        result = utils.create_output_descriptor(result_shape,
-                                                kernel_data.return_type,
-                                                None,
-                                                device=None,
-                                                usm_type=usm_type,
-                                                sycl_queue=self.get_queue())
-
-        func = <fptr_dpnp_rng_uniform_c_1out_t > kernel_data.ptr
-        # call FPTR function
-        event_ref = func(self.get_queue_ref(), result.get_data(), low, high, result.size, self.get_mt19937(), NULL)
-
-        if event_ref != NULL:
-            with nogil: c_dpctl.DPCTLEvent_WaitAndThrow(event_ref)
-            c_dpctl.DPCTLEvent_Delete(event_ref)
-        return result
+    cdef bint is_uint64_range(self, value):
+        return value >= 0 and value <= numpy.iinfo(numpy.uint64).max
 
 
 cpdef utils.dpnp_descriptor dpnp_rng_beta(double a, double b, size):

--- a/dpnp/random/dpnp_random_state.py
+++ b/dpnp/random/dpnp_random_state.py
@@ -84,12 +84,15 @@ class RandomState:
 
         is_cpu = self._sycl_device.is_cpu
         if seed is None:
+            low = 0
+            high = numpy.iinfo(numpy.int32).max + 1
+
             if is_cpu:
                 # ask NumPy to generate an array of three random integers as default seed value
-                self._seed = numpy.random.randint(low=0, high=numpy.iinfo(numpy.int32).max + 1, size=3)
+                self._seed = numpy.random.randint(low=low, high=high, size=3)
             else:
-                # ask NumPy to generate a random 64-bit integer as default seed value
-                self._seed = numpy.random.randint(low=0, high=numpy.iinfo(numpy.int64).max + 1, size=1)[0]
+                # ask NumPy to generate a random 32-bit integer as default seed value
+                self._seed = numpy.random.randint(low=low, high=high, size=1)[0]
         else:
             self._seed = seed
 

--- a/tests/test_random_state.py
+++ b/tests/test_random_state.py
@@ -1,4 +1,7 @@
 import pytest
+from .helper import (
+    is_cpu_device
+)
 from unittest import mock
 
 import dpnp
@@ -57,10 +60,19 @@ class TestNormal:
 
         # default dtype depends on fp64 support by the device
         dtype = get_default_floating() if dtype is None else dtype
-        expected = numpy.array([[0.428205496031286, -0.55383273779227 ],
-                                [2.027017795643378,  4.318888073163015],
-                                [2.69080893259102,  -1.047967253719708]], dtype=dtype)
-
+        if sycl_queue.sycl_device.is_cpu:
+            expected = numpy.array([[0.428205496031286, -0.55383273779227 ],
+                                    [2.027017795643378,  4.318888073163015],
+                                    [2.69080893259102,  -1.047967253719708]], dtype=dtype)
+        else:
+            if dtype == dpnp.float64:
+                expected = numpy.array([[-15.73532523, -11.84163022],
+                                        [  0.548032,     1.41296207],
+                                        [-2.63250381,    2.77542322]], dtype=dtype)
+            else:
+                expected = numpy.array([[-15.735329, -11.841626],
+                                        [  0.548032,   1.4129621],
+                                        [-2.6325033,   2.7754242]], dtype=dtype)
         # TODO: discuss with opneMKL: there is a difference between CPU and GPU
         # generated samples since 9 digit while precision=15 for float64
         # precision = numpy.finfo(dtype=dtype).precision
@@ -200,11 +212,16 @@ class TestRand:
         dtype = get_default_floating()
 
         data = RandomState(seed, sycl_queue=sycl_queue).rand(3, 2, usm_type=usm_type)
-        expected = numpy.array([[0.7592552667483687, 0.5937560645397753],
-                                [0.257010098779574 , 0.749422621447593 ],
-                                [0.6316644293256104, 0.7411410815548152]], dtype=dtype)
+        if sycl_queue.sycl_device.is_cpu:
+            expected = numpy.array([[0.7592552667483687, 0.5937560645397753],
+                                    [0.257010098779574 , 0.749422621447593 ],
+                                    [0.6316644293256104, 0.7411410815548152]], dtype=dtype)
+        else:
+            expected = numpy.array([[4.864511571334162e-14, 7.333946068708259e-01],
+                                    [8.679067575689537e-01, 5.627257087965376e-01],
+                                    [4.413379518222594e-01, 4.334482843514076e-01]], dtype=dtype)
 
-        precision = numpy.finfo(dtype=numpy.float64).precision
+        precision = numpy.finfo(dtype=dtype).precision
         assert_array_almost_equal(data.asnumpy(), expected, decimal=precision)
         assert_cfd(data, sycl_queue, usm_type)
 
@@ -276,9 +293,14 @@ class TestRandInt:
                                                                 size=(3, 2),
                                                                 dtype=dtype,
                                                                 usm_type=usm_type)
-        expected = numpy.array([[4, 1],
-                                [5, 3],
-                                [5, 7]], dtype=numpy.int32)
+        if sycl_queue.sycl_device.is_cpu:
+            expected = numpy.array([[4, 1],
+                                    [5, 3],
+                                    [5, 7]], dtype=numpy.int32)
+        else:
+            expected = numpy.array([[1, 2],
+                                    [1, 5],
+                                    [3, 7]], dtype=numpy.int32)
         assert_array_equal(data.asnumpy(), expected)
         assert_cfd(data, sycl_queue, usm_type)
 
@@ -310,16 +332,23 @@ class TestRandInt:
 
 
     def test_float_bounds(self):
-        actual = RandomState(365852).randint(low=0.6, high=6.789102534, size=(7,)).asnumpy()
-        expected = numpy.array([4, 4, 3, 3, 1, 0, 3], dtype=numpy.int32)
-        assert_array_equal(actual, expected)
+        actual = RandomState(365852).randint(low=0.6, high=6.789102534, size=(7,))
+        if actual.sycl_device.is_cpu:
+            expected = numpy.array([4, 4, 3, 3, 1, 0, 3], dtype=numpy.int32)
+        else:
+            expected = numpy.array([0, 1, 4, 0, 3, 3, 3], dtype=numpy.int32)
+        assert_array_equal(actual.asnumpy(), expected)
 
 
     def test_negative_bounds(self):
-        actual = RandomState(5143).randint(low=-15.74, high=-3, size=(2, 7)).asnumpy()
-        expected = numpy.array([[-9, -12, -4,  -12, -5, -13, -9],
-                                [-4, -6,  -13, -9,  -9,  -6, -15]], dtype=numpy.int32)
-        assert_array_equal(actual, expected)
+        actual = RandomState(5143).randint(low=-15.74, high=-3, size=(2, 7))
+        if actual.sycl_device.is_cpu:
+            expected = numpy.array([[-9, -12, -4,  -12, -5, -13, -9],
+                                    [-4, -6,  -13, -9,  -9,  -6, -15]], dtype=numpy.int32)
+        else:
+            expected = numpy.array([[-15,  -7, -12,  -5, -10, -11, -11],
+                                    [-14,  -7,  -7, -10, -14,  -9,  -6]], dtype=numpy.int32)
+        assert_array_equal(actual.asnumpy(), expected)
 
 
     def test_negative_interval(self):
@@ -459,14 +488,19 @@ class TestRandN:
         dtype = get_default_floating()
 
         data = RandomState(seed, sycl_queue=sycl_queue).randn(3, 2, usm_type=usm_type)
-        expected = numpy.array([[-0.862485623762009,  1.169492612490272],
-                                [-0.405876118480338,  0.939006537666719],
-                                [-0.615075625641019,  0.555260469834381]], dtype=dtype)
+        if sycl_queue.sycl_device.is_cpu:
+            expected = numpy.array([[-0.862485623762009,  1.169492612490272],
+                                    [-0.405876118480338,  0.939006537666719],
+                                    [-0.615075625641019,  0.555260469834381]], dtype=dtype)
+        else:
+            expected = numpy.array([[-4.019566117504177,  7.016412093100934],
+                                    [-1.044015254820266, -0.839721616192757],
+                                    [ 0.545079768980527,  0.380676324099473]], dtype=dtype)
 
         # TODO: discuss with opneMKL: there is a difference between CPU and GPU
         # generated samples since 9 digit while precision=15 for float64
         # precision = numpy.finfo(dtype=numpy.float64).precision
-        precision = numpy.finfo(dtype=numpy.float32).precision
+        precision = numpy.finfo(dtype=dtype).precision
         assert_array_almost_equal(data.asnumpy(), expected, decimal=precision)
 
         # call with the same seed has to draw the same values
@@ -543,6 +577,9 @@ class TestSeed:
                                   'dpnp.arange(2)',
                                   '[0]', '[4294967295]', '[2, 7, 15]', '(1,)', '(85, 6, 17)'])
     def test_array_range(self, seed):
+        if not is_cpu_device():
+            pytest.skip("seed as a scalar is only supported on GPU")
+
         size = 15
         a1 = RandomState(seed).uniform(size=size).asnumpy()
         a2 = RandomState(seed).uniform(size=size).asnumpy()
@@ -580,9 +617,16 @@ class TestSeed:
                                   'numpy.iinfo(numpy.uint32).max + 1',
                                   '(1, 7, numpy.iinfo(numpy.uint32).max + 1)'])
     def test_invalid_value(self, seed):
-        # seed must be an unsigned 32-bit integer
-        assert_raises(ValueError, RandomState, seed)
-
+        if is_cpu_device():
+            # seed must be an unsigned 32-bit integer
+            assert_raises(ValueError, RandomState, seed)
+        else:
+            if dpnp.isscalar(seed):
+                # seed must be an unsigned 64-bit integer
+                assert_raises(ValueError, RandomState, seed)
+            else:
+                # seed must be a scalar
+                assert_raises(TypeError, RandomState, seed)
 
     @pytest.mark.parametrize("seed",
                              [[], (),
@@ -596,8 +640,16 @@ class TestSeed:
                                   'numpy.array([], dtype=numpy.int64)',
                                   'dpnp.array([], dtype=numpy.int64)'])
     def test_invalid_shape(self, seed):
-        # seed must be an unsigned or 1-D array
-        assert_raises(ValueError, RandomState, seed)
+        if is_cpu_device():
+            # seed must be an unsigned or 1-D array
+            assert_raises(ValueError, RandomState, seed)
+        else:
+            if dpnp.isscalar(seed):
+                # seed must be an unsigned 64-bit scalar
+                assert_raises(ValueError, RandomState, seed)
+            else:
+                # seed must be a scalar
+                assert_raises(TypeError, RandomState, seed)
 
 
 class TestStandardNormal:
@@ -610,15 +662,21 @@ class TestStandardNormal:
         dtype = get_default_floating()
 
         data = RandomState(seed, sycl_queue=sycl_queue).standard_normal(size=(4, 2), usm_type=usm_type)
-        expected = numpy.array([[0.112455902594571, -0.249919829443642],
-                                [0.702423540827815,  1.548132130318456],
-                                [0.947364919775284, -0.432257289195464],
-                                [0.736848611436872,  1.557284323302839]], dtype=dtype)
+        if sycl_queue.sycl_device.is_cpu:
+            expected = numpy.array([[0.112455902594571, -0.249919829443642],
+                                    [0.702423540827815,  1.548132130318456],
+                                    [0.947364919775284, -0.432257289195464],
+                                    [0.736848611436872,  1.557284323302839]], dtype=dtype)
+        else:
+            expected = numpy.array([[-5.851946579836138, -4.415158753007455],
+                                    [ 0.156672323326223,  0.475834711471613],
+                                    [-1.016957125278234,  0.978587902851975],
+                                    [-0.295425067084912,  1.438622345507964]], dtype=dtype)
 
         # TODO: discuss with opneMKL: there is a difference between CPU and GPU
         # generated samples since 9 digit while precision=15 for float64
         # precision = numpy.finfo(dtype=numpy.float64).precision
-        precision = numpy.finfo(dtype=numpy.float32).precision
+        precision = numpy.finfo(dtype=dtype).precision
         assert_array_almost_equal(data.asnumpy(), expected, decimal=precision)
 
         # call with the same seed has to draw the same values
@@ -670,11 +728,18 @@ class TestRandSample:
         dtype = get_default_floating()
 
         data = RandomState(seed, sycl_queue=sycl_queue).random_sample(size=(4, 2), usm_type=usm_type)
-        expected = numpy.array([[0.1887628440745175, 0.2763057765550911],
-                                [0.3973943444434553, 0.2975987731479108],
-                                [0.4144027342554182, 0.2636592474300414],
-                                [0.6129623607266694, 0.2596735346596688]], dtype=dtype)
-        
+        if sycl_queue.sycl_device.is_cpu:
+            expected = numpy.array([[0.1887628440745175, 0.2763057765550911],
+                                    [0.3973943444434553, 0.2975987731479108],
+                                    [0.4144027342554182, 0.2636592474300414],
+                                    [0.6129623607266694, 0.2596735346596688]], dtype=dtype)
+        else:
+            expected = numpy.array([[0.219563950354e-13, 0.6500454867400344],
+                                    [0.8847833902913576, 0.9030532521302965],
+                                    [0.2943803743033427, 0.2688879158061396],
+                                    [0.2730219631925900, 0.8695396883048091]], dtype=dtype)
+
+
         precision = numpy.finfo(dtype=dtype).precision
         assert_array_almost_equal(data.asnumpy(), expected, decimal=precision)
 
@@ -746,16 +811,28 @@ class TestUniform:
 
         # default dtype depends on fp64 support by the device
         dtype = get_default_floating() if dtype is None else dtype
-        if dtype != dpnp.int32:
-            expected = numpy.array([[4.023770128630567, 8.87456423597643 ],
-                                    [2.888630247435067, 4.823004481580574],
-                                    [2.030351535445079, 4.533497077834326]])
-            assert_array_almost_equal(actual, expected, decimal=numpy.finfo(dtype=dtype).precision)
+        if sycl_queue.sycl_device.is_cpu:
+            if dtype != dpnp.int32:
+                expected = numpy.array([[4.023770128630567, 8.87456423597643 ],
+                                        [2.888630247435067, 4.823004481580574],
+                                        [2.030351535445079, 4.533497077834326]])
+                assert_array_almost_equal(actual, expected, decimal=numpy.finfo(dtype=dtype).precision)
+            else:
+                expected = numpy.array([[3, 8],
+                                        [2, 4],
+                                        [1, 4]])
+                assert_array_equal(actual, expected)
         else:
-            expected = numpy.array([[3, 8],
-                                   [2, 4],
-                                   [1, 4]])
-            assert_array_equal(actual, expected)
+            if dtype != dpnp.int32:
+                expected = numpy.array([[1.230000000452886, 4.889115418092382],
+                                        [6.084098950993071, 1.682066500463302],
+                                        [3.316473517549554, 8.428297791221597]])
+                assert_array_almost_equal(actual, expected, decimal=numpy.finfo(dtype=dtype).precision)
+            else:
+                expected = numpy.array([[1, 4],
+                                        [5, 1],
+                                        [3, 7]])
+                assert_array_equal(actual, expected)
 
         # check if compute follows data isn't broken
         assert_cfd(dpnp_data, sycl_queue, usm_type)

--- a/tests/test_random_state.py
+++ b/tests/test_random_state.py
@@ -500,7 +500,7 @@ class TestRandN:
         # TODO: discuss with opneMKL: there is a difference between CPU and GPU
         # generated samples since 9 digit while precision=15 for float64
         # precision = numpy.finfo(dtype=numpy.float64).precision
-        precision = numpy.finfo(dtype=dtype).precision
+        precision = numpy.finfo(dtype=numpy.float32).precision
         assert_array_almost_equal(data.asnumpy(), expected, decimal=precision)
 
         # call with the same seed has to draw the same values
@@ -676,7 +676,7 @@ class TestStandardNormal:
         # TODO: discuss with opneMKL: there is a difference between CPU and GPU
         # generated samples since 9 digit while precision=15 for float64
         # precision = numpy.finfo(dtype=numpy.float64).precision
-        precision = numpy.finfo(dtype=dtype).precision
+        precision = numpy.finfo(dtype=numpy.float32).precision
         assert_array_almost_equal(data.asnumpy(), expected, decimal=precision)
 
         # call with the same seed has to draw the same values

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -529,7 +529,8 @@ def test_random_state(func, args, kwargs, device, usm_type):
     sycl_queue = dpctl.SyclQueue(device, property="in_order")
 
     # test with in-order SYCL queue per a device and passed as argument
-    rs = dpnp.random.RandomState((147, 56, 896), sycl_queue=sycl_queue)
+    seed = (147, 56, 896) if device.is_cpu else 987654
+    rs = dpnp.random.RandomState(seed, sycl_queue=sycl_queue)
     res_array = getattr(rs, func)(*args, **kwargs)
     assert usm_type == res_array.usm_type
     assert_sycl_queue_equal(res_array.sycl_queue, sycl_queue)


### PR DESCRIPTION
OneMKL provides `mcg59` engine for random generator which assumes to demonstrate a better performance on GPU device.
The PR is about to implement support of `mcg59` engine for GPU device and to left `mt19937` engine for PCU one.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
