### PR TITLE
Reuse dpctl.tensor.sum for dpnp.sum

### DIFF
--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -993,7 +993,7 @@ class dpnp_array:
 
         return self._array_obj.strides
 
-    def sum(self, axis=None, dtype=None, out=None, keepdims=False, initial=0, where=True):
+    def sum(self, /, axis=None, dtype=None, keepdims=False, *, out=None, initial=False, where=True):
         """
         Returns the sum along a given axis.
 
@@ -1003,7 +1003,7 @@ class dpnp_array:
 
         """
 
-        return dpnp.sum(self, axis, dtype, out, keepdims, initial, where)
+        return dpnp.sum(self, axis=axis, dtype=dtype, out=out, keepdims=keepdims, initial=initial, where=where)
 
  # 'swapaxes',
 

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -993,7 +993,7 @@ class dpnp_array:
 
         return self._array_obj.strides
 
-    def sum(self, /, axis=None, dtype=None, keepdims=False, *, out=None, initial=False, where=True):
+    def sum(self, /, *, axis=None, dtype=None, keepdims=False, out=None, initial=0, where=True):
         """
         Returns the sum along a given axis.
 

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -44,6 +44,7 @@ from dpnp.dpnp_algo import *
 from dpnp.dpnp_utils import *
 
 import dpnp
+from dpnp.dpnp_array import dpnp_array
 
 import numpy
 import dpctl.tensor as dpt
@@ -172,7 +173,7 @@ def absolute(x,
     -------
     y : dpnp.ndarray
         An array containing the absolute value of each element in `x`.
-    
+
     Limitations
     -----------
     Parameters `x` is only supported as either :class:`dpnp.ndarray` or :class:`dpctl.tensor.usm_ndarray`.
@@ -598,7 +599,7 @@ def divide(x1,
     -------
     y : dpnp.ndarray
         The quotient ``x1/x2``, element-wise.
-    
+
     Limitations
     -----------
     Parameters `x1` and `x2` are supported as either scalar, :class:`dpnp.ndarray`
@@ -1360,7 +1361,7 @@ def power(x1,
     -------
     y : dpnp.ndarray
         The bases in `x1` raised to the exponents in `x2`.
-    
+
     Limitations
     -----------
     Parameters `x1` and `x2` are supported as either scalar, :class:`dpnp.ndarray`
@@ -1556,7 +1557,7 @@ def subtract(x1,
     -------
     y : dpnp.ndarray
         The difference of `x1` and `x2`, element-wise.
-    
+
     Limitations
     -----------
     Parameters `x1` and `x2` are supported as either scalar, :class:`dpnp.ndarray`
@@ -1603,16 +1604,27 @@ def subtract(x1,
     return call_origin(numpy.subtract, x1, x2, out=out, where=where, dtype=dtype, subok=subok, **kwargs)
 
 
-def sum(x1, axis=None, dtype=None, out=None, keepdims=False, initial=None, where=True):
+def sum(x, /, axis=None, dtype=None, keepdims=False, *, out=None, initial=False, where=True):
     """
     Sum of array elements over a given axis.
 
     For full documentation refer to :obj:`numpy.sum`.
 
+    Returns
+    -------
+        y : dpnp.ndarray
+            an array containing the sums. If the sum was computed over the
+            entire array, a zero-dimensional array is returned. The returned
+            array has the data type as described in the `dtype` parameter
+            description above.
+
     Limitations
     -----------
-        Parameter `where`` is unsupported.
-        Input array data types are limited by DPNP :ref:`Data types`.
+        Parameters `x` is supported as either :class:`dpnp.ndarray`
+        or :class:`dpctl.tensor.usm_ndarray`.
+        Parameters `out`, `initial` and `where` are supported with their default values.
+        Otherwise the function will be executed sequentially on CPU.
+        Input array data types are limited by supported DPNP :ref:`Data types`.
 
     Examples
     --------
@@ -1624,24 +1636,19 @@ def sum(x1, axis=None, dtype=None, out=None, keepdims=False, initial=None, where
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
-    if x1_desc:
-        if where is not True:
-            pass
-        else:
-            if dpnp.isscalar(out):
-                raise TypeError("output must be an array")
-            out_desc = dpnp.get_dpnp_descriptor(out, copy_when_nondefault_queue=False) if out is not None else None
-            result_obj = dpnp_sum(x1_desc, axis, dtype, out_desc, keepdims, initial, where).get_pyobj()
-            result = dpnp.convert_single_elem_array_to_scalar(result_obj, keepdims)
 
-            if x1_desc.size == 0 and axis is None:
-                result = dpnp.zeros_like(result)
-                if out is not None:
-                    out[...] = result
-            return result
+    if out is not None:
+        pass
+    elif initial is not False:
+        pass
+    elif where is not True:
+        pass
+    else:
+        if isinstance(x, dpnp_array) or isinstance(x, dpt.usm_ndarray):
+            dpt_array = x.get_array() if isinstance(x, dpnp_array) else x
+            return dpnp_array._create_from_usm_ndarray(dpt.sum(dpt_array, axis=axis, dtype=dtype, keepdims=keepdims))
 
-    return call_origin(numpy.sum, x1, axis=axis, dtype=dtype, out=out, keepdims=keepdims, initial=initial, where=where)
+    return call_origin(numpy.sum, x, axis=axis, dtype=dtype, out=out, keepdims=keepdims, initial=initial, where=where)
 
 
 def trapz(y1, x1=None, dx=1.0, axis=-1):

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -1606,7 +1606,7 @@ def subtract(x1,
     return call_origin(numpy.subtract, x1, x2, out=out, where=where, dtype=dtype, subok=subok, **kwargs)
 
 
-def sum(x, /, axis=None, dtype=None, keepdims=False, *, out=None, initial=False, where=True):
+def sum(x, /, *, axis=None, dtype=None, keepdims=False, out=None, initial=0, where=True):
     """
     Sum of array elements over a given axis.
 
@@ -1614,11 +1614,11 @@ def sum(x, /, axis=None, dtype=None, keepdims=False, *, out=None, initial=False,
 
     Returns
     -------
-        y : dpnp.ndarray
-            an array containing the sums. If the sum was computed over the
-            entire array, a zero-dimensional array is returned. The returned
-            array has the data type as described in the `dtype` parameter
-            description above.
+    y : dpnp.ndarray
+        an array containing the sums. If the sum was computed over the
+        entire array, a zero-dimensional array is returned. The returned
+        array has the data type as described in the `dtype` parameter
+        of the Python Array API standard for the `sum` function.
 
     Limitations
     -----------
@@ -1632,23 +1632,24 @@ def sum(x, /, axis=None, dtype=None, keepdims=False, *, out=None, initial=False,
     --------
     >>> import dpnp as np
     >>> np.sum(np.array([1, 2, 3, 4, 5]))
-    15
-    >>> result = np.sum([[0, 1], [0, 5]], axis=0)
-    [0, 6]
+    array(15)
+    >>> np.sum(np.array(5))
+    array(5)
+    >>> result = np.sum(np.array([[0, 1], [0, 5]]), axis=0)
+    array([0, 6])
 
     """
 
 
     if out is not None:
         pass
-    elif initial is not False:
+    elif initial != 0:
         pass
     elif where is not True:
         pass
     else:
-        if isinstance(x, dpnp_array) or isinstance(x, dpt.usm_ndarray):
-            dpt_array = x.get_array() if isinstance(x, dpnp_array) else x
-            return dpnp_array._create_from_usm_ndarray(dpt.sum(dpt_array, axis=axis, dtype=dtype, keepdims=keepdims))
+        y = dpt.sum(dpnp.get_usm_ndarray(x), axis=axis, dtype=dtype, keepdims=keepdims)
+        return dpnp_array._create_from_usm_ndarray(y)
 
     return call_origin(numpy.sum, x, axis=axis, dtype=dtype, out=out, keepdims=keepdims, initial=initial, where=where)
 

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -831,23 +831,6 @@ tests/third_party/cupy/math_tests/test_rounding.py::TestRounding::test_rint
 tests/third_party/cupy/math_tests/test_rounding.py::TestRounding::test_rint_negative
 tests/third_party/cupy/math_tests/test_rounding.py::TestRounding::test_round_
 tests/third_party/cupy/math_tests/test_rounding.py::TestRounding::test_trunc
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_all
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_all2
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_all_keepdims
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_all_transposed
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_all_transposed2
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_axes
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_axes2
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_axes3
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_axes4
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_axis
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_axis2
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_axis_huge
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_axis_transposed
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_axis_transposed2
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_dtype
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_keepdims_and_dtype
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_keepdims_multiple_axes
 tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_out
 tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_out_wrong_shape
 tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_ndarray_cumprod_2dim_with_axis
@@ -882,8 +865,6 @@ tests/third_party/cupy/math_tests/test_sumprod.py::TestNansumNanprodLong_param_1
 tests/third_party/cupy/math_tests/test_sumprod.py::TestNansumNanprodLong_param_15_{axis=0, func='nanprod', keepdims=False, shape=(20, 30, 40), transpose_axes=False}::test_nansum_axis_transposed
 tests/third_party/cupy/math_tests/test_sumprod.py::TestNansumNanprodLong_param_9_{axis=0, func='nanprod', keepdims=True, shape=(2, 3, 4), transpose_axes=False}::test_nansum_all
 tests/third_party/cupy/math_tests/test_sumprod.py::TestNansumNanprodLong_param_9_{axis=0, func='nanprod', keepdims=True, shape=(2, 3, 4), transpose_axes=False}::test_nansum_axis_transposed
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_all2
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_all_transposed2
 tests/third_party/cupy/math_tests/test_trigonometric.py::TestUnwrap::test_unwrap_1dim
 tests/third_party/cupy/math_tests/test_trigonometric.py::TestUnwrap::test_unwrap_1dim_with_discont
 tests/third_party/cupy/math_tests/test_trigonometric.py::TestUnwrap::test_unwrap_2dim_with_axis

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -84,15 +84,8 @@ tests/third_party/cupy/math_tests/test_arithmetic.py::TestArithmeticBinary2_para
 tests/third_party/cupy/math_tests/test_arithmetic.py::TestArithmeticBinary2_param_535_{arg1=array([[1, 2, 3],       [4, 5, 6]], dtype=int64), arg2=array([[0, 1, 2],       [3, 4, 5]]), dtype=float64, name='floor_divide', use_dtype=False}::test_binary
 tests/third_party/cupy/math_tests/test_arithmetic.py::TestArithmeticBinary2_param_543_{arg1=array([[1, 2, 3],       [4, 5, 6]], dtype=int64), arg2=array([[0, 1, 2],       [3, 4, 5]], dtype=int64), dtype=float64, name='floor_divide', use_dtype=False}::test_binary
 
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_external_prod_all
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_external_prod_axis
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_external_sum_all
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_external_sum_axis
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_prod_all
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_prod_axis
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_all
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_all2
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_all_keepdims
+tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_out
+tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_out_wrong_shape
 tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_cumprod_1dim
 tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_cumprod_2dim_without_axis
 tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum_param_0_{axis=0}::test_cumsum
@@ -974,22 +967,6 @@ tests/third_party/cupy/math_tests/test_rounding.py::TestRounding::test_rint
 tests/third_party/cupy/math_tests/test_rounding.py::TestRounding::test_rint_negative
 tests/third_party/cupy/math_tests/test_rounding.py::TestRounding::test_round_
 tests/third_party/cupy/math_tests/test_rounding.py::TestRounding::test_trunc
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_all_transposed
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_all_transposed2
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_axes
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_axes2
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_axes3
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_axes4
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_axis
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_axis2
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_axis_huge
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_axis_transposed
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_axis_transposed2
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_dtype
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_keepdims_and_dtype
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_keepdims_multiple_axes
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_out
-tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_out_wrong_shape
 tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_ndarray_cumprod_2dim_with_axis
 tests/third_party/cupy/math_tests/test_sumprod.py::TestDiff::test_diff_1dim
 tests/third_party/cupy/math_tests/test_sumprod.py::TestDiff::test_diff_1dim_with_n
@@ -1374,7 +1351,7 @@ tests/third_party/cupy/statistics_tests/test_histogram.py::TestHistogram::test_h
 tests/third_party/cupy/statistics_tests/test_histogram.py::TestHistogram::test_histogram_array_bins
 tests/third_party/cupy/statistics_tests/test_histogram.py::TestHistogram::test_histogram_bins_not_ordered
 tests/third_party/cupy/statistics_tests/test_histogram.py::TestHistogram::test_histogram_complex_weights
-tests/third_party/cupy/statistics_tests/test_histogram.py::TestHistogram::test_histogram_complex_weights_uneven_bins 
+tests/third_party/cupy/statistics_tests/test_histogram.py::TestHistogram::test_histogram_complex_weights_uneven_bins
 tests/third_party/cupy/statistics_tests/test_histogram.py::TestHistogram::test_histogram_density
 tests/third_party/cupy/statistics_tests/test_histogram.py::TestHistogram::test_histogram_empty
 tests/third_party/cupy/statistics_tests/test_histogram.py::TestHistogram::test_histogram_float_weights

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -387,7 +387,7 @@ class TestEdiff1d:
         expected = numpy.ediff1d(np_a)
         assert_array_equal(expected, result)
 
-    
+
     @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_ediff1d_args(self):
         np_a = numpy.array([1, 2, 4, 7, 0])
@@ -934,6 +934,7 @@ def test_sum_empty(dtype, axis):
     assert_array_equal(numpy_res, dpnp_res.asnumpy())
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True, no_bool=True))
 def test_sum_empty_out(dtype):
     a = dpnp.empty((1, 2, 0, 4), dtype=dtype)

--- a/tests/test_sum.py
+++ b/tests/test_sum.py
@@ -1,15 +1,24 @@
+import pytest
+
 import dpnp
+from tests.helper import get_float_dtypes, has_support_aspect64
 
 import numpy
 
-
-def test_sum_float64():
-    a = numpy.array([[[-2., 3.], [9.1, 0.2]], [[-2., 5.0], [-2, -1.2]], [[1.0, -2.], [5.0, -1.1]]])
+# Note: numpy.sum() always upcast integers to (u)int64 and float32 to
+# float64 for dtype=None. `np.sum` does that too for integers, but not for
+# float32, so we need to special-case it for these tests
+@pytest.mark.parametrize("dtype", get_float_dtypes())
+def test_sum_float(dtype):
+    a = numpy.array([[[-2., 3.], [9.1, 0.2]], [[-2., 5.0], [-2, -1.2]], [[1.0, -2.], [5.0, -1.1]]], dtype=dtype)
     ia = dpnp.array(a)
 
     for axis in range(len(a)):
         result = dpnp.sum(ia, axis=axis)
-        expected = numpy.sum(a, axis=axis)
+        if dtype == dpnp.float32 and has_support_aspect64():
+            expected = numpy.sum(a, axis=axis, dtype=numpy.float64)
+        else:
+            expected = numpy.sum(a, axis=axis)
         numpy.testing.assert_array_equal(expected, result)
 
 
@@ -23,9 +32,12 @@ def test_sum_int():
 
 
 def test_sum_axis():
-    a = numpy.array([[[-2., 3.], [9.1, 0.2]], [[-2., 5.0], [-2, -1.2]], [[1.0, -2.], [5.0, -1.1]]])
+    a = numpy.array([[[-2., 3.], [9.1, 0.2]], [[-2., 5.0], [-2, -1.2]], [[1.0, -2.], [5.0, -1.1]]], dtype='f4')
     ia = dpnp.array(a)
 
     result = dpnp.sum(ia, axis=1)
-    expected = numpy.sum(a, axis=1)
+    if has_support_aspect64():
+        expected = numpy.sum(a, axis=1, dtype=numpy.float64)
+    else:
+        expected = numpy.sum(a, axis=1)
     numpy.testing.assert_array_equal(expected, result)

--- a/tests/third_party/cupy/math_tests/test_sumprod.py
+++ b/tests/third_party/cupy/math_tests/test_sumprod.py
@@ -4,6 +4,7 @@ import numpy
 import pytest
 
 import dpnp as cupy
+from tests.helper import has_support_aspect64
 from tests.third_party.cupy import testing
 
 
@@ -16,47 +17,79 @@ class TestSumprod(unittest.TestCase):
         # cupy.get_default_pinned_memory_pool().free_all_blocks()
         pass
 
+    # Note: numpy.sum() always upcast integers to (u)int64 and float32 to
+    # float64 for dtype=None. `np.sum` does that too for integers, but not for
+    # float32, so we need to special-case it for these tests
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_sum_all(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
-        return a.sum()
+        if xp is numpy and dtype == numpy.float32 and has_support_aspect64():
+            dtype=numpy.float64
+            return a.sum(dtype=dtype)
+        else:
+            return a.sum()
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_sum_all_keepdims(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
-        return a.sum(keepdims=True)
+        if xp is numpy and dtype == numpy.float32 and has_support_aspect64():
+            dtype=numpy.float64
+            return a.sum(dtype=dtype, keepdims=True)
+        else:
+            return a.sum(keepdims=True)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_external_sum_all(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
-        return xp.sum(a)
+        if xp is numpy and dtype == numpy.float32 and has_support_aspect64():
+            dtype=numpy.float64
+            return xp.sum(a, dtype=dtype)
+        else:
+            return xp.sum(a)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_sum_all2(self, xp, dtype):
         a = testing.shaped_arange((20, 30, 40), xp, dtype)
-        return a.sum()
+        if xp is numpy and dtype == numpy.float32 and has_support_aspect64():
+            dtype=numpy.float64
+            return a.sum(dtype=dtype)
+        else:
+            return a.sum()
+
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_sum_all_transposed(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype).transpose(2, 0, 1)
-        return a.sum()
+        if xp is numpy and dtype == numpy.float32 and has_support_aspect64():
+            dtype=numpy.float64
+            return a.sum(dtype=dtype)
+        else:
+            return a.sum()
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_sum_all_transposed2(self, xp, dtype):
         a = testing.shaped_arange((20, 30, 40), xp, dtype).transpose(2, 0, 1)
-        return a.sum()
+        if xp is numpy and dtype == numpy.float32 and has_support_aspect64():
+            dtype=numpy.float64
+            return a.sum(dtype=dtype)
+        else:
+            return a.sum()
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_sum_axis(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
-        return a.sum(axis=1)
+        if xp is numpy and dtype == numpy.float32 and has_support_aspect64():
+            dtype=numpy.float64
+            return a.sum(dtype=dtype, axis=1)
+        else:
+            return a.sum(axis=1)
 
     @testing.slow
     @testing.numpy_cupy_allclose()
@@ -68,7 +101,11 @@ class TestSumprod(unittest.TestCase):
     @testing.numpy_cupy_allclose()
     def test_external_sum_axis(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
-        return xp.sum(a, axis=1)
+        if xp is numpy and dtype == numpy.float32 and has_support_aspect64():
+            dtype=numpy.float64
+            return xp.sum(a, axis=1, dtype=dtype)
+        else:
+            return xp.sum(a, axis=1)
 
     # float16 is omitted, since NumPy's sum on float16 arrays has more error
     # than CuPy's.
@@ -76,43 +113,71 @@ class TestSumprod(unittest.TestCase):
     @testing.numpy_cupy_allclose()
     def test_sum_axis2(self, xp, dtype):
         a = testing.shaped_arange((20, 30, 40), xp, dtype)
-        return a.sum(axis=1)
+        if xp is numpy and dtype == numpy.float32 and has_support_aspect64():
+            dtype=numpy.float64
+            return a.sum(axis=1, dtype=dtype)
+        else:
+            return a.sum(axis=1)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_sum_axis_transposed(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype).transpose(2, 0, 1)
-        return a.sum(axis=1)
+        if xp is numpy and dtype == numpy.float32 and has_support_aspect64():
+            dtype=numpy.float64
+            return a.sum(axis=1, dtype=dtype)
+        else:
+            return a.sum(axis=1)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_sum_axis_transposed2(self, xp, dtype):
         a = testing.shaped_arange((20, 30, 40), xp, dtype).transpose(2, 0, 1)
-        return a.sum(axis=1)
+        if xp is numpy and dtype == numpy.float32 and has_support_aspect64():
+            dtype=numpy.float64
+            return a.sum(axis=1, dtype=dtype)
+        else:
+            return a.sum(axis=1)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_sum_axes(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4, 5), xp, dtype)
-        return a.sum(axis=(1, 3))
+        if xp is numpy and dtype == numpy.float32 and has_support_aspect64():
+            dtype=numpy.float64
+            return a.sum(axis=(1, 3), dtype=dtype)
+        else:
+            return a.sum(axis=(1, 3))
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4)
     def test_sum_axes2(self, xp, dtype):
         a = testing.shaped_arange((20, 30, 40, 50), xp, dtype)
-        return a.sum(axis=(1, 3))
+        if xp is numpy and dtype == numpy.float32 and has_support_aspect64():
+            dtype=numpy.float64
+            return a.sum(axis=(1, 3), dtype=dtype)
+        else:
+            return a.sum(axis=(1, 3))
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-6)
     def test_sum_axes3(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4, 5), xp, dtype)
-        return a.sum(axis=(0, 2, 3))
+        if xp is numpy and dtype == numpy.float32 and has_support_aspect64():
+            dtype=numpy.float64
+            return a.sum(axis=(0, 2, 3), dtype=dtype)
+        else:
+            return a.sum(axis=(0, 2, 3))
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-6)
     def test_sum_axes4(self, xp, dtype):
         a = testing.shaped_arange((20, 30, 40, 50), xp, dtype)
-        return a.sum(axis=(0, 2, 3))
+        if xp is numpy and dtype == numpy.float32 and has_support_aspect64():
+            dtype=numpy.float64
+            return a.sum(axis=(0, 2, 3), dtype=dtype)
+        else:
+            return a.sum(axis=(0, 2, 3))
 
     @testing.for_all_dtypes_combination(names=['src_dtype', 'dst_dtype'])
     @testing.numpy_cupy_allclose()
@@ -130,7 +195,11 @@ class TestSumprod(unittest.TestCase):
     @testing.numpy_cupy_allclose()
     def test_sum_keepdims_multiple_axes(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
-        return a.sum(axis=(1, 2), keepdims=True)
+        if xp is numpy and dtype == numpy.float32 and has_support_aspect64():
+            dtype=numpy.float64
+            return a.sum(axis=(1, 2), keepdims=True, dtype=dtype)
+        else:
+            return a.sum(axis=(1, 2), keepdims=True)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()

--- a/tests/third_party/cupy/math_tests/test_sumprod.py
+++ b/tests/third_party/cupy/math_tests/test_sumprod.py
@@ -51,7 +51,7 @@ class TestSumprod(unittest.TestCase):
             return xp.sum(a)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(rtol=1e-06)
     def test_sum_all2(self, xp, dtype):
         a = testing.shaped_arange((20, 30, 40), xp, dtype)
         if xp is numpy and dtype == numpy.float32 and has_support_aspect64():
@@ -72,7 +72,7 @@ class TestSumprod(unittest.TestCase):
             return a.sum()
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(rtol=1e-06)
     def test_sum_all_transposed2(self, xp, dtype):
         a = testing.shaped_arange((20, 30, 40), xp, dtype).transpose(2, 0, 1)
         if xp is numpy and dtype == numpy.float32 and has_support_aspect64():
@@ -94,7 +94,7 @@ class TestSumprod(unittest.TestCase):
     @testing.slow
     @testing.numpy_cupy_allclose()
     def test_sum_axis_huge(self, xp):
-        a = testing.shaped_random((204, 102, 102), xp, 'd')
+        a = testing.shaped_random((204, 102, 102), xp, 'i4')
         return a.sum(axis=2)
 
     @testing.for_all_dtypes()

--- a/tests/third_party/cupy/testing/helper.py
+++ b/tests/third_party/cupy/testing/helper.py
@@ -278,7 +278,7 @@ def _make_decorator(check_func, name, type_check, accept_error, sp_name=None,
     return decorator
 
 
-def numpy_cupy_allclose(rtol=1e-6, atol=0, err_msg='', verbose=True,
+def numpy_cupy_allclose(rtol=1e-7, atol=0, err_msg='', verbose=True,
                         name='xp', type_check=True, accept_error=False,
                         sp_name=None, scipy_name=None, contiguous_check=True):
     """Decorator that checks NumPy results and CuPy ones are close.
@@ -1165,11 +1165,6 @@ def shaped_random(shape, xp=dpnp, dtype=numpy.float64, scale=10, seed=0):
     """
     numpy.random.seed(seed)
     dtype = numpy.dtype(dtype)
-    if not has_support_aspect64():
-        if dtype.type is numpy.float64:
-            dtype = numpy.dtype('float32')
-        elif dtype.type is numpy.complex128:
-            dtype = numpy.dtype('complex64')
 
     if dtype == '?':
         return xp.asarray(numpy.random.randint(2, size=shape), dtype=dtype)

--- a/tests/third_party/cupy/testing/helper.py
+++ b/tests/third_party/cupy/testing/helper.py
@@ -13,6 +13,7 @@ import dpnp
 import dpnp as cupy
 import dpnp as cupyx
 # from dpnp.core import internal
+from tests.helper import has_support_aspect64
 from tests.third_party.cupy.testing import array
 from tests.third_party.cupy.testing import parameterized
 from dpctl import select_default_device
@@ -277,7 +278,7 @@ def _make_decorator(check_func, name, type_check, accept_error, sp_name=None,
     return decorator
 
 
-def numpy_cupy_allclose(rtol=1e-7, atol=0, err_msg='', verbose=True,
+def numpy_cupy_allclose(rtol=1e-6, atol=0, err_msg='', verbose=True,
                         name='xp', type_check=True, accept_error=False,
                         sp_name=None, scipy_name=None, contiguous_check=True):
     """Decorator that checks NumPy results and CuPy ones are close.
@@ -1164,6 +1165,12 @@ def shaped_random(shape, xp=dpnp, dtype=numpy.float64, scale=10, seed=0):
     """
     numpy.random.seed(seed)
     dtype = numpy.dtype(dtype)
+    if not has_support_aspect64():
+        if dtype.type is numpy.float64:
+            dtype = numpy.dtype('float32')
+        elif dtype.type is numpy.complex128:
+            dtype = numpy.dtype('complex64')
+
     if dtype == '?':
         return xp.asarray(numpy.random.randint(2, size=shape), dtype=dtype)
     elif dtype.kind == 'c':

--- a/tests/third_party/cupy/testing/helper.py
+++ b/tests/third_party/cupy/testing/helper.py
@@ -13,7 +13,6 @@ import dpnp
 import dpnp as cupy
 import dpnp as cupyx
 # from dpnp.core import internal
-from tests.helper import has_support_aspect64
 from tests.third_party.cupy.testing import array
 from tests.third_party.cupy.testing import parameterized
 from dpctl import select_default_device


### PR DESCRIPTION
This PR modifies `dpnp.sun()` implementation to use `dpctl.tensor.sum()` and removes skipped tests in `skipped_tests.tbl` and `skipped_tests_gpu.tbl`

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
