### PR TITLE
Obtain a proper result type on device without fp64

### DIFF
--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -371,8 +371,6 @@ cdef extern from "dpnp_iface_fptr.hpp":
     struct DPNPFuncData:
         DPNPFuncType return_type
         void * ptr
-        DPNPFuncType return_type_no_fp64
-        void *ptr_no_fp64
 
     DPNPFuncData get_dpnp_function_ptr(DPNPFuncName name, DPNPFuncType first_type, DPNPFuncType second_type) except +
 

--- a/dpnp/dpnp_algo/dpnp_algo.pyx
+++ b/dpnp/dpnp_algo/dpnp_algo.pyx
@@ -497,14 +497,8 @@ cdef utils.dpnp_descriptor call_fptr_2in_1out_strides(DPNPFuncName fptr_name,
     result_sycl_device, result_usm_type, result_sycl_queue = utils.get_common_usm_allocation(x1_obj, x2_obj)
 
     # get FPTR function and return type
-    cdef fptr_2in_1out_strides_t func = NULL
-    cdef DPNPFuncType return_type = DPNP_FT_NONE
-    if result_sycl_device.has_aspect_fp64:
-        return_type = kernel_data.return_type
-        func = < fptr_2in_1out_strides_t > kernel_data.ptr
-    else:
-        return_type = kernel_data.return_type_no_fp64
-        func = < fptr_2in_1out_strides_t > kernel_data.ptr_no_fp64
+    cdef fptr_2in_1out_strides_t func = < fptr_2in_1out_strides_t > kernel_data.ptr
+    cdef DPNPFuncType return_type = kernel_data.return_type
 
     # check 'out' parameter data
     if out is not None:


### PR DESCRIPTION
The PR fixes an issue how result type is calculated internally in cython layout on a device without fp64 support.
The issue comes from #1418.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
