### PR TITLE
duplicate: Add workaround for klocwork scan

### DIFF
--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Workaround to Klocwork overwriting LD_LIBRARY_PATH that was modified
+# by DPC++ compiler conda packages. Will need to be added to DPC++ compiler
+# activation scripts.
+export LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$PREFIX/compiler/lib/intel64_lin:$PREFIX/compiler/lib:$PREFIX/lib"
+
 # Intel LLVM must cooperate with compiler and sysroot from conda
 echo "--gcc-toolchain=${BUILD_PREFIX} --sysroot=${BUILD_PREFIX}/${HOST}/sysroot -target ${HOST}" > icpx_for_conda.cfg
 export ICPXCFG="$(pwd)/icpx_for_conda.cfg"


### PR DESCRIPTION
This PR adds `LD_LIBRARY_PATH` to build.sh as workaround for klocwork

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
