### PR TITLE
Reuse dpctl.tensor comparison functions for dpnp

### DIFF
--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -152,8 +152,6 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_FMOD_EXT
         DPNP_FN_FULL
         DPNP_FN_FULL_LIKE
-        DPNP_FN_GREATER_EXT
-        DPNP_FN_GREATER_EQUAL_EXT
         DPNP_FN_HYPOT
         DPNP_FN_HYPOT_EXT
         DPNP_FN_IDENTITY
@@ -168,8 +166,6 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_KRON_EXT
         DPNP_FN_LEFT_SHIFT
         DPNP_FN_LEFT_SHIFT_EXT
-        DPNP_FN_LESS_EXT
-        DPNP_FN_LESS_EQUAL_EXT
         DPNP_FN_LOG
         DPNP_FN_LOG_EXT
         DPNP_FN_LOG10
@@ -203,7 +199,6 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_NEGATIVE
         DPNP_FN_NEGATIVE_EXT
         DPNP_FN_NONZERO
-        DPNP_FN_NOT_EQUAL_EXT
         DPNP_FN_ONES
         DPNP_FN_ONES_LIKE
         DPNP_FN_PARTITION
@@ -484,18 +479,12 @@ cpdef dpnp_descriptor dpnp_right_shift(dpnp_descriptor x1_obj,
 """
 Logic functions
 """
-cpdef dpnp_descriptor dpnp_equal(dpnp_descriptor array1, dpnp_descriptor input2)
-cpdef dpnp_descriptor dpnp_greater(dpnp_descriptor input1, dpnp_descriptor input2)
-cpdef dpnp_descriptor dpnp_greater_equal(dpnp_descriptor input1, dpnp_descriptor input2)
 cpdef dpnp_descriptor dpnp_isclose(dpnp_descriptor input1, dpnp_descriptor input2,
                                    double rtol=*, double atol=*, cpp_bool equal_nan=*)
-cpdef dpnp_descriptor dpnp_less(dpnp_descriptor input1, dpnp_descriptor input2)
-cpdef dpnp_descriptor dpnp_less_equal(dpnp_descriptor input1, dpnp_descriptor input2)
 cpdef dpnp_descriptor dpnp_logical_and(dpnp_descriptor input1, dpnp_descriptor input2)
 cpdef dpnp_descriptor dpnp_logical_not(dpnp_descriptor input1)
 cpdef dpnp_descriptor dpnp_logical_or(dpnp_descriptor input1, dpnp_descriptor input2)
 cpdef dpnp_descriptor dpnp_logical_xor(dpnp_descriptor input1, dpnp_descriptor input2)
-cpdef dpnp_descriptor dpnp_not_equal(dpnp_descriptor input1, dpnp_descriptor input2)
 
 
 """

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -123,7 +123,6 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_EIG_EXT
         DPNP_FN_EIGVALS
         DPNP_FN_EIGVALS_EXT
-        DPNP_FN_EQUAL_EXT
         DPNP_FN_ERF
         DPNP_FN_ERF_EXT
         DPNP_FN_EYE

--- a/dpnp/dpnp_algo/dpnp_algo_logic.pxi
+++ b/dpnp/dpnp_algo/dpnp_algo_logic.pxi
@@ -39,20 +39,14 @@ __all__ += [
     "dpnp_all",
     "dpnp_allclose",
     "dpnp_any",
-    "dpnp_equal",
-    "dpnp_greater",
-    "dpnp_greater_equal",
     "dpnp_isclose",
     "dpnp_isfinite",
     "dpnp_isinf",
     "dpnp_isnan",
-    "dpnp_less",
-    "dpnp_less_equal",
     "dpnp_logical_and",
     "dpnp_logical_not",
     "dpnp_logical_or",
     "dpnp_logical_xor",
-    "dpnp_not_equal"
 ]
 
 
@@ -167,30 +161,6 @@ cpdef utils.dpnp_descriptor dpnp_any(utils.dpnp_descriptor array1):
     return result
 
 
-cpdef utils.dpnp_descriptor dpnp_equal(utils.dpnp_descriptor x1_obj,
-                                       utils.dpnp_descriptor x2_obj,
-                                       object dtype=None,
-                                       utils.dpnp_descriptor out=None,
-                                       object where=True):
-    return call_fptr_2in_1out_strides(DPNP_FN_EQUAL_EXT, x1_obj, x2_obj, dtype, out, where, func_name="equal")
-
-
-cpdef utils.dpnp_descriptor dpnp_greater(utils.dpnp_descriptor x1_obj,
-                                         utils.dpnp_descriptor x2_obj,
-                                         object dtype=None,
-                                         utils.dpnp_descriptor out=None,
-                                         object where=True):
-    return call_fptr_2in_1out_strides(DPNP_FN_GREATER_EXT, x1_obj, x2_obj, dtype, out, where, func_name="greater")
-
-
-cpdef utils.dpnp_descriptor dpnp_greater_equal(utils.dpnp_descriptor x1_obj,
-                                               utils.dpnp_descriptor x2_obj,
-                                               object dtype=None,
-                                               utils.dpnp_descriptor out=None,
-                                               object where=True):
-    return call_fptr_2in_1out_strides(DPNP_FN_GREATER_EQUAL_EXT, x1_obj, x2_obj, dtype, out, where, func_name="greater_equal")
-
-
 cpdef utils.dpnp_descriptor dpnp_isclose(utils.dpnp_descriptor input1,
                                          utils.dpnp_descriptor input2,
                                          double rtol=1e-05,
@@ -255,22 +225,6 @@ cpdef utils.dpnp_descriptor dpnp_isnan(utils.dpnp_descriptor input1):
     return result
 
 
-cpdef utils.dpnp_descriptor dpnp_less(utils.dpnp_descriptor x1_obj,
-                                      utils.dpnp_descriptor x2_obj,
-                                      object dtype=None,
-                                      utils.dpnp_descriptor out=None,
-                                      object where=True):
-    return call_fptr_2in_1out_strides(DPNP_FN_LESS_EXT, x1_obj, x2_obj, dtype, out, where, func_name="less")
-
-
-cpdef utils.dpnp_descriptor dpnp_less_equal(utils.dpnp_descriptor x1_obj,
-                                            utils.dpnp_descriptor x2_obj,
-                                            object dtype=None,
-                                            utils.dpnp_descriptor out=None,
-                                            object where=True):
-    return call_fptr_2in_1out_strides(DPNP_FN_LESS_EQUAL_EXT, x1_obj, x2_obj, dtype, out, where, func_name="less_equal")
-
-
 cpdef utils.dpnp_descriptor dpnp_logical_and(utils.dpnp_descriptor x1_obj,
                                              utils.dpnp_descriptor x2_obj,
                                              object dtype=None,
@@ -300,11 +254,3 @@ cpdef utils.dpnp_descriptor dpnp_logical_xor(utils.dpnp_descriptor x1_obj,
                                              utils.dpnp_descriptor out=None,
                                              object where=True):
     return call_fptr_2in_1out_strides(DPNP_FN_LOGICAL_XOR_EXT, x1_obj, x2_obj, dtype, out, where, func_name="logical_xor")
-
-
-cpdef utils.dpnp_descriptor dpnp_not_equal(utils.dpnp_descriptor x1_obj,
-                                           utils.dpnp_descriptor x2_obj,
-                                           object dtype=None,
-                                           utils.dpnp_descriptor out=None,
-                                           object where=True):
-    return call_fptr_2in_1out_strides(DPNP_FN_NOT_EQUAL_EXT, x1_obj, x2_obj, dtype, out, where, func_name="not_equal")

--- a/dpnp/dpnp_algo/dpnp_elementwise_common.py
+++ b/dpnp/dpnp_algo/dpnp_elementwise_common.py
@@ -45,7 +45,13 @@ __all__ = [
     "dpnp_add",
     "dpnp_divide",
     "dpnp_multiply",
-    "dpnp_subtract"
+    "dpnp_subtract",
+    "dpnp_less",
+    "dpnp_less_equal",
+    "dpnp_greater",
+    "dpnp_greater_equal",
+    "dpnp_equal",
+    "dpnp_not_equal",
 ]
 
 
@@ -239,5 +245,245 @@ def dpnp_subtract(x1, x2, out=None, order='K'):
 
     func = BinaryElementwiseFunc("subtract", ti._subtract_result_type, ti._subtract,
                                  _subtract_docstring_, ti._subtract_inplace)
+    res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
+    return dpnp_array._create_from_usm_ndarray(res_usm)
+
+
+_less_docstring_ = """
+less(x1, x2, out=None, order='K')
+
+Calculates the less-than results for each element `x1_i` of
+the input array `x1` the respective element `x2_i` of the input array `x2`.
+
+Args:
+    x1 (dpnp.ndarray):
+        First input array, expected to have numeric data type.
+    x2 (dpnp.ndarray):
+        Second input array, also expected to have numeric data type.
+    out ({None, dpnp.ndarray}, optional):
+        Output array to populate.
+        Array have the correct shape and the expected data type.
+    order ("C","F","A","K", None, optional):
+        Memory layout of the newly output array, if parameter `out` is `None`.
+        Default: "K".
+Returns:
+    dpnp.ndarray:
+        an array containing the result of element-wise less-than comparison.
+        The data type of the returned array is determined by the Type Promotion Rules.
+"""
+
+def dpnp_less(x1, x2, out=None, order='K'):
+    """
+    Invokes less() from dpctl.tensor implementation for less() function.
+
+    """
+
+    # dpctl.tensor only works with usm_ndarray or scalar
+    x1_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x1)
+    x2_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x2)
+    out_usm = None if out is None else dpnp.get_usm_ndarray(out)
+
+    func = BinaryElementwiseFunc("less", ti._less_result_type, ti._less,
+                                 _less_docstring_)
+    res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
+    return dpnp_array._create_from_usm_ndarray(res_usm)
+
+
+_less_equal_docstring_ = """
+lessy_equal(x1, x2, out=None, order='K')
+
+Calculates the less-than or equal-to results for each element `x1_i` of
+the input array `x1` the respective element `x2_i` of the input array `x2`.
+
+Args:
+    x1 (dpnp.ndarray):
+        First input array, expected to have numeric data type.
+    x2 (dpnp.ndarray):
+        Second input array, also expected to have numeric data type.
+    out ({None, dpnp.ndarray}, optional):
+        Output array to populate.
+        Array have the correct shape and the expected data type.
+    order ("C","F","A","K", None, optional):
+        Memory layout of the newly output array, if parameter `out` is `None`.
+        Default: "K".
+Returns:
+    dpnp.ndarray:
+        An array containing the result of element-wise less-than or equal-to comparison.
+        The data type of the returned array is determined by the Type Promotion Rules.
+"""
+
+def dpnp_less_equal(x1, x2, out=None, order='K'):
+    """
+    Invokes less_equal() from dpctl.tensor implementation for less_equal() function.
+
+    """
+
+    # dpctl.tensor only works with usm_ndarray or scalar
+    x1_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x1)
+    x2_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x2)
+    out_usm = None if out is None else dpnp.get_usm_ndarray(out)
+
+    func = BinaryElementwiseFunc("less_equal", ti._less_equal_result_type, ti._less_equal,
+                                 _less_equal_docstring_)
+    res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
+    return dpnp_array._create_from_usm_ndarray(res_usm)
+
+
+_greater_docstring_ = """
+greater(x1, x2, out=None, order='K')
+
+Calculates the greater-than results for each element `x1_i` of
+the input array `x1` the respective element `x2_i` of the input array `x2`.
+
+Args:
+    x1 (dpnp.ndarray):
+        First input array, expected to have numeric data type.
+    x2 (dpnp.ndarray):
+        Second input array, also expected to have numeric data type.
+    out ({None, dpnp.ndarray}, optional):
+        Output array to populate.
+        Array have the correct shape and the expected data type.
+    order ("C","F","A","K", None, optional):
+        Memory layout of the newly output array, if parameter `out` is `None`.
+        Default: "K".
+Returns:
+    dpnp.ndarray:
+        an array containing the result of element-wise greater-than comparison.
+        The data type of the returned array is determined by the Type Promotion Rules.
+"""
+
+def dpnp_greater(x1, x2, out=None, order='K'):
+    """
+    Invokes greater() from dpctl.tensor implementation for greater() function.
+
+    """
+
+    # dpctl.tensor only works with usm_ndarray or scalar
+    x1_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x1)
+    x2_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x2)
+    out_usm = None if out is None else dpnp.get_usm_ndarray(out)
+
+    func = BinaryElementwiseFunc("greater", ti._greater_result_type, ti._greater,
+                                 _greater_docstring_)
+    res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
+    return dpnp_array._create_from_usm_ndarray(res_usm)
+
+
+_greater_docstring_ = """
+greater(x1, x2, out=None, order='K')
+
+Calculates the greater-than or equal-to results for each element `x1_i` of
+the input array `x1` the respective element `x2_i` of the input array `x2`.
+
+Args:
+    x1 (dpnp.ndarray):
+        First input array, expected to have numeric data type.
+    x2 (dpnp.ndarray):
+        Second input array, also expected to have numeric data type.
+    out ({None, dpnp.ndarray}, optional):
+        Output array to populate.
+        Array have the correct shape and the expected data type.
+    order ("C","F","A","K", None, optional):
+        Memory layout of the newly output array, if parameter `out` is `None`.
+        Default: "K".
+Returns:
+    dpnp.ndarray:
+        an array containing the result of element-wise greater-than or equal-to comparison.
+        The data type of the returned array is determined by the Type Promotion Rules.
+"""
+
+def dpnp_greater_equal(x1, x2, out=None, order='K'):
+    """
+    Invokes greater_equal() from dpctl.tensor implementation for greater_equal() function.
+
+    """
+
+    # dpctl.tensor only works with usm_ndarray or scalar
+    x1_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x1)
+    x2_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x2)
+    out_usm = None if out is None else dpnp.get_usm_ndarray(out)
+
+    func = BinaryElementwiseFunc("greater_equal", ti._greater_equal_result_type,
+                                  ti._greater_equal, _greater_docstring_)
+    res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
+    return dpnp_array._create_from_usm_ndarray(res_usm)
+
+
+_equal_docstring_ = """
+equal(x1, x2, out=None, order='K')
+
+Calculates equality results for each element `x1_i` of
+the input array `x1` the respective element `x2_i` of the input array `x2`.
+
+Args:
+    x1 (dpnp.ndarray):
+        First input array, expected to have numeric data type.
+    x2 (dpnp.ndarray):
+        Second input array, also expected to have numeric data type.
+    out ({None, dpnp.ndarray}, optional):
+        Output array to populate.
+        Array have the correct shape and the expected data type.
+    order ("C","F","A","K", None, optional):
+        Memory layout of the newly output array, if parameter `out` is `None`.
+        Default: "K".
+Returns:
+    dpnp.ndarray:
+        an array containing the result of element-wise equality comparison.
+        The data type of the returned array is determined by the Type Promotion Rules.
+"""
+
+def dpnp_equal(x1, x2, out=None, order='K'):
+    """
+    Invokes equal() from dpctl.tensor implementation for equal() function.
+
+    """
+
+    # dpctl.tensor only works with usm_ndarray or scalar
+    x1_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x1)
+    x2_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x2)
+    out_usm = None if out is None else dpnp.get_usm_ndarray(out)
+
+    func = BinaryElementwiseFunc("equal", ti._equal_result_type, ti._equal,
+                                 _equal_docstring_)
+    res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
+    return dpnp_array._create_from_usm_ndarray(res_usm)
+
+
+_not_equal_docstring_ = """
+not_equal(x1, x2, out=None, order='K')
+
+Calculates inequality results for each element `x1_i` of
+the input array `x1` the respective element `x2_i` of the input array `x2`.
+
+Args:
+    x1 (dpnp.ndarray):
+        First input array, expected to have numeric data type.
+    x2 (dpnp.ndarray):
+        Second input array, also expected to have numeric data type.
+    out ({None, dpnp.ndarray}, optional):
+        Output array to populate.
+        Array have the correct shape and the expected data type.
+    order ("C","F","A","K", None, optional):
+        Memory layout of the newly output array, if parameter `out` is `None`.
+        Default: "K".
+Returns:
+    dpnp.ndarray:
+        an array containing the result of element-wise inequality comparison.
+        The data type of the returned array is determined by the Type Promotion Rules.
+"""
+
+def dpnp_not_equal(x1, x2, out=None, order='K'):
+    """
+    Invokes not_equal() from dpctl.tensor implementation for not_equal() function.
+
+    """
+
+    # dpctl.tensor only works with usm_ndarray or scalar
+    x1_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x1)
+    x2_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x2)
+    out_usm = None if out is None else dpnp.get_usm_ndarray(out)
+
+    func = BinaryElementwiseFunc("not_equal", ti._not_equal_result_type, ti._not_equal,
+                                 _not_equal_docstring_)
     res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)

--- a/dpnp/dpnp_algo/dpnp_elementwise_common.py
+++ b/dpnp/dpnp_algo/dpnp_elementwise_common.py
@@ -44,14 +44,14 @@ import numpy
 __all__ = [
     "dpnp_add",
     "dpnp_divide",
-    "dpnp_multiply",
-    "dpnp_subtract",
-    "dpnp_less",
-    "dpnp_less_equal",
+    "dpnp_equal",
     "dpnp_greater",
     "dpnp_greater_equal",
-    "dpnp_equal",
+    "dpnp_less",
+    "dpnp_less_equal",
+    "dpnp_multiply",
     "dpnp_not_equal",
+    "dpnp_subtract",
 ]
 
 

--- a/dpnp/dpnp_algo/dpnp_elementwise_common.py
+++ b/dpnp/dpnp_algo/dpnp_elementwise_common.py
@@ -290,7 +290,7 @@ def dpnp_less(x1, x2, out=None, order='K'):
 
 
 _less_equal_docstring_ = """
-lessy_equal(x1, x2, out=None, order='K')
+less_equal(x1, x2, out=None, order='K')
 
 Calculates the less-than or equal-to results for each element `x1_i` of
 the input array `x1` the respective element `x2_i` of the input array `x2`.

--- a/dpnp/dpnp_algo/dpnp_elementwise_common.py
+++ b/dpnp/dpnp_algo/dpnp_elementwise_common.py
@@ -404,7 +404,7 @@ def dpnp_greater_equal(x1, x2, out=None, order='K'):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     func = BinaryElementwiseFunc("greater_equal", ti._greater_equal_result_type,
-                                  ti._greater_equal, _greater_docstring_)
+                                  ti._greater_equal, _greater_equal_docstring_)
     res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 

--- a/dpnp/dpnp_algo/dpnp_elementwise_common.py
+++ b/dpnp/dpnp_algo/dpnp_elementwise_common.py
@@ -369,8 +369,8 @@ def dpnp_greater(x1, x2, out=None, order='K'):
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
-_greater_docstring_ = """
-greater(x1, x2, out=None, order='K')
+_greater_equal_docstring_ = """
+greater_equal(x1, x2, out=None, order='K')
 
 Calculates the greater-than or equal-to results for each element `x1_i` of
 the input array `x1` the respective element `x2_i` of the input array `x2`.

--- a/dpnp/dpnp_iface_logic.py
+++ b/dpnp/dpnp_iface_logic.py
@@ -42,9 +42,16 @@ it contains:
 
 import numpy
 import dpnp
-
-import dpnp.config as config
 from dpnp.dpnp_algo import *
+from .dpnp_algo.dpnp_elementwise_common import (
+    dpnp_equal,
+    dpnp_greater,
+    dpnp_greater_equal,
+    dpnp_less,
+    dpnp_less_equal,
+    dpnp_not_equal
+)
+from .dpnp_iface_mathematical import _check_nd_call
 from dpnp.dpnp_utils import *
 
 
@@ -238,9 +245,11 @@ def equal(x1,
           /,
           out=None,
           *,
+          order='K',
           where=True,
           dtype=None,
-          subok=True):
+          subok=True,
+          **kwargs):
     """
     Return the truth value of (x1 == x2) element-wise.
 
@@ -257,8 +266,7 @@ def equal(x1,
     or :class:`dpctl.tensor.usm_ndarray`, but both `x1` and `x2` can not be scalars at the same time.
     Parameters `out`, `where`, `dtype` and `subok` are supported with their default values.
     Otherwise the function will be executed sequentially on CPU.
-    Input array data types are limited by supported DPNP :ref:`Data types`,
-    excluding `dpnp.complex64` and `dpnp.complex128`.
+    Input array data types are limited by supported DPNP :ref:`Data types`.
 
     See Also
     --------
@@ -273,35 +281,12 @@ def equal(x1,
     >>> import dpnp as np
     >>> x1 = np.array([0, 1, 3])
     >>> x2 = np.arange(3)
-    >>> out = np.equal(x1, x2)
-    >>> [i for i in out]
-    [True, True, False]
+    >>> np.equal(x1, x2)
+    array([ True,  True, False])
 
     """
-    
-    if out is not None:
-        pass
-    elif where is not True:
-        pass
-    elif dtype is not None:
-        pass
-    elif subok is not True:
-        pass
-    elif dpnp.isscalar(x1) and dpnp.isscalar(x2):
-        # at least either x1 or x2 has to be an array
-        pass
-    else:
-        # get USM type and queue to copy scalar from the host memory into a USM allocation
-        usm_type, queue = get_usm_allocations([x1, x2]) if dpnp.isscalar(x1) or dpnp.isscalar(x2) else (None, None)
 
-        x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_strides=False, copy_when_nondefault_queue=False,
-                                           alloc_usm_type=usm_type, alloc_queue=queue)
-        x2_desc = dpnp.get_dpnp_descriptor(x2, copy_when_strides=False, copy_when_nondefault_queue=False,
-                                           alloc_usm_type=usm_type, alloc_queue=queue)
-        if x1_desc and x2_desc:
-            return dpnp_equal(x1_desc, x2_desc).get_pyobj()
-
-    return call_origin(numpy.equal, x1, x2, out=out, where=where, dtype=dtype, subok=subok)
+    return _check_nd_call(numpy.equal, dpnp_equal, x1, x2, out=out, where=where, order=order, dtype=dtype, subok=subok, **kwargs)
 
 
 def greater(x1,
@@ -309,9 +294,11 @@ def greater(x1,
             /,
             out=None,
             *,
+            order='K',
             where=True,
             dtype=None,
-            subok=True):
+            subok=True,
+            **kwargs):
     """
     Return the truth value of (x1 > x2) element-wise.
 
@@ -328,8 +315,7 @@ def greater(x1,
     or :class:`dpctl.tensor.usm_ndarray`, but both `x1` and `x2` can not be scalars at the same time.
     Parameters `out`, `where`, `dtype` and `subok` are supported with their default values.
     Otherwise the function will be executed sequentially on CPU.
-    Input array data types are limited by supported DPNP :ref:`Data types`,
-    excluding `dpnp.complex64` and `dpnp.complex128`.
+    Input array data types are limited by supported DPNP :ref:`Data types`.
 
     See Also
     --------
@@ -344,45 +330,24 @@ def greater(x1,
     >>> import dpnp as np
     >>> x1 = np.array([4, 2])
     >>> x2 = np.array([2, 2])
-    >>> out = np.greater(x1, x2)
-    >>> [i for i in out]
-    [True, False]
+    >>> np.greater(x1, x2)
+    array([ True, False])
 
     """
 
-    if out is not None:
-        pass
-    elif where is not True:
-        pass
-    elif dtype is not None:
-        pass
-    elif subok is not True:
-        pass
-    elif dpnp.isscalar(x1) and dpnp.isscalar(x2):
-        # at least either x1 or x2 has to be an array
-        pass
-    else:
-        # get USM type and queue to copy scalar from the host memory into a USM allocation
-        usm_type, queue = get_usm_allocations([x1, x2]) if dpnp.isscalar(x1) or dpnp.isscalar(x2) else (None, None)
-
-        x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_strides=False, copy_when_nondefault_queue=False,
-                                           alloc_usm_type=usm_type, alloc_queue=queue)
-        x2_desc = dpnp.get_dpnp_descriptor(x2, copy_when_strides=False, copy_when_nondefault_queue=False,
-                                           alloc_usm_type=usm_type, alloc_queue=queue)
-        if x1_desc and x2_desc:
-            return dpnp_greater(x1_desc, x2_desc).get_pyobj()
-
-    return call_origin(numpy.greater, x1, x2, out=out, where=where, dtype=dtype, subok=subok)
+    return _check_nd_call(numpy.greater, dpnp_greater, x1, x2, out=out, where=where, order=order, dtype=dtype, subok=subok, **kwargs)
 
 
 def greater_equal(x1,
-                  x2,
-                  /,
-                  out=None,
-                  *,
-                  where=True,
-                  dtype=None,
-                  subok=True):
+               x2,
+               /,
+               out=None,
+               *,
+               order='K',
+               where=True,
+               dtype=None,
+               subok=True,
+               **kwargs):
     """
     Return the truth value of (x1 >= x2) element-wise.
 
@@ -415,35 +380,12 @@ def greater_equal(x1,
     >>> import dpnp as np
     >>> x1 = np.array([4, 2, 1])
     >>> x2 = np.array([2, 2, 2])
-    >>> out = np.greater_equal(x1, x2)
-    >>> [i for i in out]
-    [True, True, False]
+    >>> np.greater_equal(x1, x2)
+    array([ True,  True, False])
 
     """
 
-    if out is not None:
-        pass
-    elif where is not True:
-        pass
-    elif dtype is not None:
-        pass
-    elif subok is not True:
-        pass
-    elif dpnp.isscalar(x1) and dpnp.isscalar(x2):
-        # at least either x1 or x2 has to be an array
-        pass
-    else:
-        # get USM type and queue to copy scalar from the host memory into a USM allocation
-        usm_type, queue = get_usm_allocations([x1, x2]) if dpnp.isscalar(x1) or dpnp.isscalar(x2) else (None, None)
-
-        x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_strides=False, copy_when_nondefault_queue=False,
-                                           alloc_usm_type=usm_type, alloc_queue=queue)
-        x2_desc = dpnp.get_dpnp_descriptor(x2, copy_when_strides=False, copy_when_nondefault_queue=False,
-                                           alloc_usm_type=usm_type, alloc_queue=queue)
-        if x1_desc and x2_desc:
-            return dpnp_greater_equal(x1_desc, x2_desc).get_pyobj()
-
-    return call_origin(numpy.greater_equal, x1, x2, out=out, where=where, dtype=dtype, subok=subok)
+    return _check_nd_call(numpy.greater_equal, dpnp_greater_equal, x1, x2, out=out, where=where, order=order, dtype=dtype, subok=subok, **kwargs)
 
 
 def isclose(x1, x2, rtol=1e-05, atol=1e-08, equal_nan=False):
@@ -626,9 +568,11 @@ def less(x1,
          /,
          out=None,
          *,
+         order='K',
          where=True,
          dtype=None,
-         subok=True):
+         subok=True,
+         **kwargs):
     """
     Return the truth value of (x1 < x2) element-wise.
 
@@ -645,8 +589,7 @@ def less(x1,
     or :class:`dpctl.tensor.usm_ndarray`, but both `x1` and `x2` can not be scalars at the same time.
     Parameters `out`, `where`, `dtype` and `subok` are supported with their default values.
     Otherwise the function will be executed sequentially on CPU.
-    Input array data types are limited by supported DPNP :ref:`Data types`,
-    excluding `dpnp.complex64` and `dpnp.complex128`.
+    Input array data types are limited by supported DPNP :ref:`Data types`.
 
     See Also
     --------
@@ -661,35 +604,12 @@ def less(x1,
     >>> import dpnp as np
     >>> x1 = np.array([1, 2])
     >>> x2 = np.array([2, 2])
-    >>> out = np.less(x1, x2)
-    >>> [i for i in out]
-    [True, False]
+    >>> np.less(x1, x2)
+    array([ True, False])
 
     """
 
-    if out is not None:
-        pass
-    elif where is not True:
-        pass
-    elif dtype is not None:
-        pass
-    elif subok is not True:
-        pass
-    elif dpnp.isscalar(x1) and dpnp.isscalar(x2):
-        # at least either x1 or x2 has to be an array
-        pass
-    else:
-        # get USM type and queue to copy scalar from the host memory into a USM allocation
-        usm_type, queue = get_usm_allocations([x1, x2]) if dpnp.isscalar(x1) or dpnp.isscalar(x2) else (None, None)
-
-        x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_strides=False, copy_when_nondefault_queue=False,
-                                           alloc_usm_type=usm_type, alloc_queue=queue)
-        x2_desc = dpnp.get_dpnp_descriptor(x2, copy_when_strides=False, copy_when_nondefault_queue=False,
-                                           alloc_usm_type=usm_type, alloc_queue=queue)
-        if x1_desc and x2_desc:
-            return dpnp_less(x1_desc, x2_desc).get_pyobj()
-
-    return call_origin(numpy.less, x1, x2, out=out, where=where, dtype=dtype, subok=subok)
+    return _check_nd_call(numpy.less, dpnp_less, x1, x2, out=out, where=where, order=order, dtype=dtype, subok=subok, **kwargs)
 
 
 def less_equal(x1,
@@ -697,9 +617,11 @@ def less_equal(x1,
                /,
                out=None,
                *,
+               order='K',
                where=True,
                dtype=None,
-               subok=True):
+               subok=True,
+               **kwargs):
     """
     Return the truth value of (x1 <= x2) element-wise.
 
@@ -716,8 +638,7 @@ def less_equal(x1,
     or :class:`dpctl.tensor.usm_ndarray`, but both `x1` and `x2` can not be scalars at the same time.
     Parameters `out`, `where`, `dtype` and `subok` are supported with their default values.
     Otherwise the function will be executed sequentially on CPU.
-    Input array data types are limited by supported DPNP :ref:`Data types`,
-    excluding `dpnp.complex64` and `dpnp.complex128`.
+    Input array data types are limited by supported DPNP :ref:`Data types`.
 
     See Also
     --------
@@ -733,34 +654,11 @@ def less_equal(x1,
     >>> x1 = np.array([4, 2, 1])
     >>> x2 = np.array([2, 2, 2])
     >>> out = np.less_equal(x1, x2)
-    >>> [i for i in out]
-    [False, True, True]
+    array([False,  True,  True])
 
     """
 
-    if out is not None:
-        pass
-    elif where is not True:
-        pass
-    elif dtype is not None:
-        pass
-    elif subok is not True:
-        pass
-    elif dpnp.isscalar(x1) and dpnp.isscalar(x2):
-        # at least either x1 or x2 has to be an array
-        pass
-    else:
-        # get USM type and queue to copy scalar from the host memory into a USM allocation
-        usm_type, queue = get_usm_allocations([x1, x2]) if dpnp.isscalar(x1) or dpnp.isscalar(x2) else (None, None)
-
-        x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_strides=False, copy_when_nondefault_queue=False,
-                                           alloc_usm_type=usm_type, alloc_queue=queue)
-        x2_desc = dpnp.get_dpnp_descriptor(x2, copy_when_strides=False, copy_when_nondefault_queue=False,
-                                           alloc_usm_type=usm_type, alloc_queue=queue)
-        if x1_desc and x2_desc:
-            return dpnp_less_equal(x1_desc, x2_desc).get_pyobj()
-
-    return call_origin(numpy.less_equal, x1, x2, out=out, where=where, dtype=dtype, subok=subok)
+    return _check_nd_call(numpy.less_equal, dpnp_less_equal, x1, x2, out=out, where=where, order=order, dtype=dtype, subok=subok, **kwargs)
 
 
 def logical_and(x1,
@@ -1036,9 +934,11 @@ def not_equal(x1,
               /,
               out=None,
               *,
+              order='K',
               where=True,
               dtype=None,
-              subok=True):
+              subok=True,
+              **kwargs):
     """
     Return the truth value of (x1 != x2) element-wise.
 
@@ -1055,8 +955,7 @@ def not_equal(x1,
     or :class:`dpctl.tensor.usm_ndarray`, but both `x1` and `x2` can not be scalars at the same time.
     Parameters `out`, `where`, `dtype` and `subok` are supported with their default values.
     Otherwise the function will be executed sequentially on CPU.
-    Input array data types are limited by supported DPNP :ref:`Data types`,
-    excluding `dpnp.complex64` and `dpnp.complex128`.
+    Input array data types are limited by supported DPNP :ref:`Data types`.
 
     See Also
     --------
@@ -1071,32 +970,9 @@ def not_equal(x1,
     >>> import dpnp as np
     >>> x1 = np.array([1., 2.])
     >>> x2 = np.arange(1., 3.)
-    >>> out = np.not_equal(x1, x2)
-    >>> [i for i in out]
-    [False, False]
+    >>> np.not_equal(x1, x2)
+    array([False, False])
 
     """
 
-    if out is not None:
-        pass
-    elif where is not True:
-        pass
-    elif dtype is not None:
-        pass
-    elif subok is not True:
-        pass
-    elif dpnp.isscalar(x1) and dpnp.isscalar(x2):
-        # at least either x1 or x2 has to be an array
-        pass
-    else:
-        # get USM type and queue to copy scalar from the host memory into a USM allocation
-        usm_type, queue = get_usm_allocations([x1, x2]) if dpnp.isscalar(x1) or dpnp.isscalar(x2) else (None, None)
-
-        x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_strides=False, copy_when_nondefault_queue=False,
-                                           alloc_usm_type=usm_type, alloc_queue=queue)
-        x2_desc = dpnp.get_dpnp_descriptor(x2, copy_when_strides=False, copy_when_nondefault_queue=False,
-                                           alloc_usm_type=usm_type, alloc_queue=queue)
-        if x1_desc and x2_desc:
-            return dpnp_not_equal(x1_desc, x2_desc).get_pyobj()
-
-    return call_origin(numpy.not_equal, x1, x2, out=out, where=where, dtype=dtype, subok=subok)
+    return _check_nd_call(numpy.not_equal, dpnp_not_equal, x1, x2, out=out, where=where, order=order, dtype=dtype, subok=subok, **kwargs)


### PR DESCRIPTION
This PR adds the ability to rely on `dpctl.tensor` implementation for `equal`,  `not_equal`, `less`, `less_equal`, `greater`, `greater_equal` functions.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
