### PR TITLE
Add clang format to pre-commit config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,71 +1,40 @@
 BasedOnStyle: LLVM
-IndentWidth: 4
-UseTab: Never
-Language: Cpp
-Standard: Cpp11
 
 AccessModifierOffset: -4
 
-AlignConsecutiveDeclarations: false
-AlignConsecutiveAssignments: false
 AlignConsecutiveMacros: true
-AlignTrailingComments: true
+AlignConsecutiveAssignments: true
 AlignEscapedNewlines: Right
 
-AllowShortBlocksOnASingleLine: false
-AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: false
-AllowShortIfStatementsOnASingleLine: false
-AllowShortLoopsOnASingleLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Empty
 
-AlwaysBreakBeforeMultilineStrings: true
-AlwaysBreakTemplateDeclarations: true
+AlwaysBreakTemplateDeclarations: Yes
 
-BinPackArguments: false
 BinPackParameters: false
 
-BreakBeforeBraces: Allman
-BreakConstructorInitializersBeforeComma: true
-
 BraceWrapping:
+  AfterCaseLabel:  true
   AfterClass:      true
-  AfterControlStatement: true
+  AfterControlStatement: MultiLine
   AfterEnum:       true
   AfterFunction:   true
   AfterNamespace:  true
-  AfterObjCDeclaration: true
+  AfterObjCDeclaration: false
   AfterStruct:     true
   AfterUnion:      true
-  BeforeCatch:     true
+  AfterExternBlock: true
+  BeforeCatch:     false
   BeforeElse:      true
   IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
 BreakBeforeBraces: Custom
 
-ColumnLimit: 120
-CommentPragmas: '.*'
+ColumnLimit:     80
 
-IndentCaseLabels: false
+IndentWidth: 4
 IndentWrappedFunctionNames: true
 
-KeepEmptyLinesAtTheStartOfBlocks: false
-NamespaceIndentation: All
-
-PointerAlignment: Left
-SpaceAfterCStyleCast: false
-SpaceBeforeAssignmentOperators: true
-SpaceBeforeParens: ControlStatements
-SpaceInEmptyParentheses: false
-SpacesInAngles: false
-SpacesInCStyleCastParentheses: false
-SpacesInParentheses: false
-SpacesInSquareBrackets: false
-
-SortIncludes: false
-ReflowComments: true
-
-IncludeCategories:
-  - Regex:           '^".*'
-    Priority:        3
-  - Regex:           '^<.*'
-    Priority:        2
-SortIncludes: true
+Standard: c++17

--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,6 @@ BasedOnStyle: LLVM
 AccessModifierOffset: -4
 
 AlignConsecutiveMacros: true
-AlignConsecutiveAssignments: true
 AlignConsecutiveBitFields: true
 AlignEscapedNewlines: Right
 

--- a/.clang-format
+++ b/.clang-format
@@ -4,6 +4,7 @@ AccessModifierOffset: -4
 
 AlignConsecutiveMacros: true
 AlignConsecutiveAssignments: true
+AlignConsecutiveBitFields: true
 AlignEscapedNewlines: Right
 
 AllowAllParametersOfDeclarationOnNextLine: false
@@ -26,6 +27,8 @@ BraceWrapping:
   AfterExternBlock: true
   BeforeCatch:     false
   BeforeElse:      true
+  BeforeLambdaBody: false
+  BeforeWhile:     false
   IndentBraces:    false
   SplitEmptyFunction: true
   SplitEmptyRecord: true

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Add pre-commit hooks
+b0cd5f85c9b0c2705359fee3a3f4f3feda53bfa0
+
+# Add black to pre-commit config
+88981b5ae1c99f9b64758db44dfb39f2c20b10db

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,8 +9,15 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.5.2
-    - uses: actions/setup-python@v4.6.1
-      with:
-        python-version: '3.10'
-    - uses: pre-commit/action@v3.0.0
+      - name: Set up clang-format
+        run: |
+          sudo apt-get install -y clang-format-12
+          sudo unlink /usr/bin/clang-format
+          sudo ln -s /usr/bin/clang-format-12 /usr/bin/clang-format
+          clang-format --version
+
+      - uses: actions/checkout@v3.5.2
+      - uses: actions/setup-python@v4.6.1
+        with:
+          python-version: '3.10'
+      - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,8 @@ repos:
     hooks:
     -   id: black
         args: ["--check", "--diff", "--color"]
+-   repo: https://github.com/pocc/pre-commit-hooks
+    rev: v1.3.5
+    hooks:
+    -   id: clang-format
+        args: ["-i"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,4 +32,4 @@ repos:
     rev: v1.3.5
     hooks:
     -   id: clang-format
-        args: ["-i"]
+        args: ["-i", "--version=12"]

--- a/dpnp/backend/examples/example10.cpp
+++ b/dpnp/backend/examples/example10.cpp
@@ -27,7 +27,9 @@
  * Example 10.
  *
  * Possible compile line:
- * clang++ -fsycl dpnp/backend/examples/example10.cpp -Idpnp -Idpnp/backend/include -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o example10 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_core
+ * clang++ -fsycl dpnp/backend/examples/example10.cpp -Idpnp
+ * -Idpnp/backend/include -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o
+ * example10 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_core
  */
 
 #include <iostream>
@@ -38,21 +40,23 @@
 
 #include <dpnp_iface.hpp>
 
-void test_dpnp_random_normal(
-    const size_t size, const size_t iters, const size_t seed, const double loc, const double scale)
+void test_dpnp_random_normal(const size_t size,
+                             const size_t iters,
+                             const size_t seed,
+                             const double loc,
+                             const double scale)
 {
     clock_t start, end;
-    double dev_time_used = 0.0;
+    double dev_time_used     = 0.0;
     double sum_dev_time_used = 0.0;
 
     dpnp_queue_initialize_c(QueueOptions::GPU_SELECTOR);
 
-    double* result = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    double *result = (double *)dpnp_memory_alloc_c(size * sizeof(double));
 
     dpnp_rng_srand_c(seed); // TODO: will move
 
-    for (size_t i = 0; i < iters; ++i)
-    {
+    for (size_t i = 0; i < iters; ++i) {
         start = clock();
         dpnp_rng_normal_c<double>(result, loc, scale, size);
         end = clock();
@@ -70,29 +74,32 @@ void test_dpnp_random_normal(
 }
 
 // TODO: name check
-void test_mkl_random_normal(
-    const size_t size, const size_t iters, const size_t seed, const double loc, const double scale)
+void test_mkl_random_normal(const size_t size,
+                            const size_t iters,
+                            const size_t seed,
+                            const double loc,
+                            const double scale)
 {
     clock_t start, end;
-    double dev_time_used = 0.0;
+    double dev_time_used     = 0.0;
     double sum_dev_time_used = 0.0;
 
     sycl::queue queue{sycl::gpu_selector()};
 
-    double* result = reinterpret_cast<double*>(malloc_shared(size * sizeof(double), queue));
-    if (result == nullptr)
-    {
+    double *result =
+        reinterpret_cast<double *>(malloc_shared(size * sizeof(double), queue));
+    if (result == nullptr) {
         throw std::runtime_error("Error: out of memory.");
     }
 
     oneapi::mkl::rng::mt19937 rng_engine(queue, seed);
     oneapi::mkl::rng::gaussian<double> distribution(loc, scale);
 
-    for (size_t i = 0; i < iters; ++i)
-    {
+    for (size_t i = 0; i < iters; ++i) {
         start = clock();
 
-        auto event_out = oneapi::mkl::rng::generate(distribution, rng_engine, size, result);
+        auto event_out =
+            oneapi::mkl::rng::generate(distribution, rng_engine, size, result);
         event_out.wait();
 
         end = clock();
@@ -110,16 +117,17 @@ void test_mkl_random_normal(
     return;
 }
 
-int main(int, char**)
+int main(int, char **)
 {
-    const size_t size = 100000000;
+    const size_t size  = 100000000;
     const size_t iters = 30;
 
-    const size_t seed = 10;
-    const double loc = 0.0;
+    const size_t seed  = 10;
+    const double loc   = 0.0;
     const double scale = 1.0;
 
-    std::cout << "Normal distr. params:\nloc is " << loc << ", scale is " << scale << std::endl;
+    std::cout << "Normal distr. params:\nloc is " << loc << ", scale is "
+              << scale << std::endl;
 
     test_dpnp_random_normal(size, iters, seed, loc, scale);
     test_mkl_random_normal(size, iters, seed, loc, scale);

--- a/dpnp/backend/examples/example10.cpp
+++ b/dpnp/backend/examples/example10.cpp
@@ -47,7 +47,7 @@ void test_dpnp_random_normal(const size_t size,
                              const double scale)
 {
     clock_t start, end;
-    double dev_time_used     = 0.0;
+    double dev_time_used = 0.0;
     double sum_dev_time_used = 0.0;
 
     dpnp_queue_initialize_c(QueueOptions::GPU_SELECTOR);
@@ -81,7 +81,7 @@ void test_mkl_random_normal(const size_t size,
                             const double scale)
 {
     clock_t start, end;
-    double dev_time_used     = 0.0;
+    double dev_time_used = 0.0;
     double sum_dev_time_used = 0.0;
 
     sycl::queue queue{sycl::gpu_selector()};
@@ -119,11 +119,11 @@ void test_mkl_random_normal(const size_t size,
 
 int main(int, char **)
 {
-    const size_t size  = 100000000;
+    const size_t size = 100000000;
     const size_t iters = 30;
 
-    const size_t seed  = 10;
-    const double loc   = 0.0;
+    const size_t seed = 10;
+    const double loc = 0.0;
     const double scale = 1.0;
 
     std::cout << "Normal distr. params:\nloc is " << loc << ", scale is "

--- a/dpnp/backend/examples/example11.cpp
+++ b/dpnp/backend/examples/example11.cpp
@@ -55,12 +55,12 @@ int main(int, char **)
     // 1) array size = 100, ndim = 1, high_dim_size = 10 (aka ndarray with shape
     // (100,) ) 2) array size = 100, ndim = 2, high_dim_size = 20 (e.g. ndarray
     // with shape (20, 5) and len(array) = 20 )
-    const size_t ndim_cases                = 2;
-    const size_t itemsize                  = sizeof(double);
-    const size_t ndim[ndim_cases]          = {1, 2};
+    const size_t ndim_cases = 2;
+    const size_t itemsize = sizeof(double);
+    const size_t ndim[ndim_cases] = {1, 2};
     const size_t high_dim_size[ndim_cases] = {100, 20};
-    const size_t size                      = 100;
-    const size_t seed                      = 1234;
+    const size_t size = 100;
+    const size_t seed = 1234;
 
     // DPNPC dpnp_rng_shuffle_c
     // DPNPC interface

--- a/dpnp/backend/examples/example11.cpp
+++ b/dpnp/backend/examples/example11.cpp
@@ -26,11 +26,12 @@
 /**
  * Example 11.
  *
- * This example shows simple usage of the DPNP C++ Backend library RNG shuffle function
- * for one and ndim arrays.
+ * This example shows simple usage of the DPNP C++ Backend library RNG shuffle
+ * function for one and ndim arrays.
  *
  * Possible compile line:
- * g++ -g dpnp/backend/examples/example11.cpp -Idpnp -Idpnp/backend/include -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o example11
+ * g++ -g dpnp/backend/examples/example11.cpp -Idpnp -Idpnp/backend/include
+ * -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o example11
  *
  */
 
@@ -39,33 +40,33 @@
 #include <dpnp_iface.hpp>
 
 template <typename T>
-void print_dpnp_array(T* arr, size_t size)
+void print_dpnp_array(T *arr, size_t size)
 {
     std::cout << std::endl;
-    for (size_t i = 0; i < size; ++i)
-    {
+    for (size_t i = 0; i < size; ++i) {
         std::cout << arr[i] << ", ";
     }
     std::cout << std::endl;
 }
 
-int main(int, char**)
+int main(int, char **)
 {
     // Two cases:
-    // 1) array size = 100, ndim = 1, high_dim_size = 10 (aka ndarray with shape (100,) )
-    // 2) array size = 100, ndim = 2, high_dim_size = 20 (e.g. ndarray with shape (20, 5) and len(array) = 20 )
-    const size_t ndim_cases = 2;
-    const size_t itemsize = sizeof(double);
-    const size_t ndim[ndim_cases] = {1, 2};
+    // 1) array size = 100, ndim = 1, high_dim_size = 10 (aka ndarray with shape
+    // (100,) ) 2) array size = 100, ndim = 2, high_dim_size = 20 (e.g. ndarray
+    // with shape (20, 5) and len(array) = 20 )
+    const size_t ndim_cases                = 2;
+    const size_t itemsize                  = sizeof(double);
+    const size_t ndim[ndim_cases]          = {1, 2};
     const size_t high_dim_size[ndim_cases] = {100, 20};
-    const size_t size = 100;
-    const size_t seed = 1234;
+    const size_t size                      = 100;
+    const size_t seed                      = 1234;
 
     // DPNPC dpnp_rng_shuffle_c
     // DPNPC interface
-    double* array_1 = reinterpret_cast<double*>(dpnp_memory_alloc_c(size * sizeof(double)));
-    for (size_t i = 0; i < ndim_cases; i++)
-    {
+    double *array_1 =
+        reinterpret_cast<double *>(dpnp_memory_alloc_c(size * sizeof(double)));
+    for (size_t i = 0; i < ndim_cases; i++) {
         std::cout << "\nREPRODUCE: DPNPC dpnp_rng_shuffle_c:";
         std::cout << "\nDIMS: " << ndim[i] << std::endl;
         // init array 0, 1, 2, 3, 4, 5, 6, ....
@@ -74,7 +75,8 @@ int main(int, char**)
         std::cout << "\nINPUT array:";
         print_dpnp_array(array_1, size);
         dpnp_rng_srand_c(seed);
-        dpnp_rng_shuffle_c<double>(array_1, itemsize, ndim[i], high_dim_size[i], size);
+        dpnp_rng_shuffle_c<double>(array_1, itemsize, ndim[i], high_dim_size[i],
+                                   size);
         // print shuffle result
         std::cout << "\nSHUFFLE INPUT array:";
         print_dpnp_array(array_1, size);

--- a/dpnp/backend/examples/example3.cpp
+++ b/dpnp/backend/examples/example3.cpp
@@ -31,7 +31,8 @@
  *
  * Possible compile line:
  * . /opt/intel/oneapi/setvars.sh
- * g++ -g dpnp/backend/examples/example3.cpp -Idpnp -Idpnp/backend/include -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o example3
+ * g++ -g dpnp/backend/examples/example3.cpp -Idpnp -Idpnp/backend/include
+ * -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o example3
  *
  */
 
@@ -39,34 +40,35 @@
 
 #include "dpnp_iface.hpp"
 
-int main(int, char**)
+int main(int, char **)
 {
     const size_t size = 256;
 
     dpnp_queue_initialize_c();
     std::cout << "SYCL queue is CPU: " << dpnp_queue_is_cpu_c() << std::endl;
 
-    int* array1 = (int*)dpnp_memory_alloc_c(size * sizeof(int));
-    double* result = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    int *array1    = (int *)dpnp_memory_alloc_c(size * sizeof(int));
+    double *result = (double *)dpnp_memory_alloc_c(size * sizeof(double));
 
-    for (size_t i = 0; i < 10; ++i)
-    {
+    for (size_t i = 0; i < 10; ++i) {
         array1[i] = i;
         result[i] = 0;
         std::cout << ", " << array1[i];
     }
     std::cout << std::endl;
 
-    const long ndim = 1;
-    shape_elem_type* shape = reinterpret_cast<shape_elem_type*>(dpnp_memory_alloc_c(ndim * sizeof(shape_elem_type)));
-    shape[0] = size;
-    shape_elem_type* strides = reinterpret_cast<shape_elem_type*>(dpnp_memory_alloc_c(ndim * sizeof(shape_elem_type)));
+    const long ndim        = 1;
+    shape_elem_type *shape = reinterpret_cast<shape_elem_type *>(
+        dpnp_memory_alloc_c(ndim * sizeof(shape_elem_type)));
+    shape[0]                 = size;
+    shape_elem_type *strides = reinterpret_cast<shape_elem_type *>(
+        dpnp_memory_alloc_c(ndim * sizeof(shape_elem_type)));
     strides[0] = 1;
 
-    dpnp_cos_c<int, double>(result, size, ndim, shape, strides, array1, size, ndim, shape, strides, NULL);
+    dpnp_cos_c<int, double>(result, size, ndim, shape, strides, array1, size,
+                            ndim, shape, strides, NULL);
 
-    for (size_t i = 0; i < 10; ++i)
-    {
+    for (size_t i = 0; i < 10; ++i) {
         std::cout << ", " << result[i];
     }
     std::cout << std::endl;

--- a/dpnp/backend/examples/example3.cpp
+++ b/dpnp/backend/examples/example3.cpp
@@ -47,7 +47,7 @@ int main(int, char **)
     dpnp_queue_initialize_c();
     std::cout << "SYCL queue is CPU: " << dpnp_queue_is_cpu_c() << std::endl;
 
-    int *array1    = (int *)dpnp_memory_alloc_c(size * sizeof(int));
+    int *array1 = (int *)dpnp_memory_alloc_c(size * sizeof(int));
     double *result = (double *)dpnp_memory_alloc_c(size * sizeof(double));
 
     for (size_t i = 0; i < 10; ++i) {
@@ -57,10 +57,10 @@ int main(int, char **)
     }
     std::cout << std::endl;
 
-    const long ndim        = 1;
+    const long ndim = 1;
     shape_elem_type *shape = reinterpret_cast<shape_elem_type *>(
         dpnp_memory_alloc_c(ndim * sizeof(shape_elem_type)));
-    shape[0]                 = size;
+    shape[0] = size;
     shape_elem_type *strides = reinterpret_cast<shape_elem_type *>(
         dpnp_memory_alloc_c(ndim * sizeof(shape_elem_type)));
     strides[0] = 1;

--- a/dpnp/backend/examples/example5.cpp
+++ b/dpnp/backend/examples/example5.cpp
@@ -57,8 +57,8 @@ int main(int, char **)
     double *result = (double *)dpnp_memory_alloc_c(size * sizeof(double));
 
     size_t seed = 10;
-    long low    = 1;
-    long high   = 120;
+    long low = 1;
+    long high = 120;
 
     std::cout << "Uniform distr. params:\nlow is " << low << ", high is "
               << high << std::endl;

--- a/dpnp/backend/examples/example5.cpp
+++ b/dpnp/backend/examples/example5.cpp
@@ -30,7 +30,8 @@
  *
  * Possible compile line:
  * . /opt/intel/oneapi/setvars.sh
- * g++ -g dpnp/backend/examples/example5.cpp -Idpnp -Idpnp/backend/include -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o example5
+ * g++ -g dpnp/backend/examples/example5.cpp -Idpnp -Idpnp/backend/include
+ * -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o example5
  *
  */
 
@@ -38,33 +39,33 @@
 
 #include <dpnp_iface.hpp>
 
-void print_dpnp_array(double* arr, size_t size)
+void print_dpnp_array(double *arr, size_t size)
 {
     std::cout << std::endl;
-    for (size_t i = 0; i < size; ++i)
-    {
+    for (size_t i = 0; i < size; ++i) {
         std::cout << arr[i] << ", ";
     }
     std::cout << std::endl;
 }
 
-int main(int, char**)
+int main(int, char **)
 {
     const size_t size = 256;
 
     dpnp_queue_initialize_c(QueueOptions::CPU_SELECTOR);
 
-    double* result = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    double *result = (double *)dpnp_memory_alloc_c(size * sizeof(double));
 
     size_t seed = 10;
-    long low = 1;
-    long high = 120;
+    long low    = 1;
+    long high   = 120;
 
-    std::cout << "Uniform distr. params:\nlow is " << low << ", high is " << high << std::endl;
+    std::cout << "Uniform distr. params:\nlow is " << low << ", high is "
+              << high << std::endl;
 
-    std::cout << "Results, when seed is the same (10) for all random number generations:";
-    for (size_t i = 0; i < 4; ++i)
-    {
+    std::cout << "Results, when seed is the same (10) for all random number "
+                 "generations:";
+    for (size_t i = 0; i < 4; ++i) {
         dpnp_rng_srand_c(seed);
         dpnp_rng_uniform_c<double>(result, low, high, size);
         print_dpnp_array(result, 10);
@@ -72,8 +73,7 @@ int main(int, char**)
 
     std::cout << std::endl << "Results, when seed is random:";
     dpnp_rng_srand_c();
-    for (size_t i = 0; i < 4; ++i)
-    {
+    for (size_t i = 0; i < 4; ++i) {
         dpnp_rng_uniform_c<double>(result, low, high, size);
         print_dpnp_array(result, 10);
     }

--- a/dpnp/backend/examples/example7.cpp
+++ b/dpnp/backend/examples/example7.cpp
@@ -43,11 +43,11 @@
 int main(int, char **)
 {
     const size_t size = 2;
-    size_t len        = size * size;
+    size_t len = size * size;
 
     dpnp_queue_initialize_c(QueueOptions::CPU_SELECTOR);
 
-    float *array   = (float *)dpnp_memory_alloc_c(len * sizeof(float));
+    float *array = (float *)dpnp_memory_alloc_c(len * sizeof(float));
     float *result1 = (float *)dpnp_memory_alloc_c(size * sizeof(float));
     float *result2 = (float *)dpnp_memory_alloc_c(len * sizeof(float));
 

--- a/dpnp/backend/examples/example7.cpp
+++ b/dpnp/backend/examples/example7.cpp
@@ -31,7 +31,8 @@
  *
  * Possible compile line:
  * . /opt/intel/oneapi/setvars.sh
- * g++ -g dpnp/backend/examples/example7.cpp -Idpnp -Idpnp/backend/include -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o example7
+ * g++ -g dpnp/backend/examples/example7.cpp -Idpnp -Idpnp/backend/include
+ * -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o example7
  *
  */
 
@@ -39,36 +40,33 @@
 
 #include "dpnp_iface.hpp"
 
-int main(int, char**)
+int main(int, char **)
 {
     const size_t size = 2;
-    size_t len = size * size;
+    size_t len        = size * size;
 
     dpnp_queue_initialize_c(QueueOptions::CPU_SELECTOR);
 
-    float* array = (float*)dpnp_memory_alloc_c(len * sizeof(float));
-    float* result1 = (float*)dpnp_memory_alloc_c(size * sizeof(float));
-    float* result2 = (float*)dpnp_memory_alloc_c(len * sizeof(float));
+    float *array   = (float *)dpnp_memory_alloc_c(len * sizeof(float));
+    float *result1 = (float *)dpnp_memory_alloc_c(size * sizeof(float));
+    float *result2 = (float *)dpnp_memory_alloc_c(len * sizeof(float));
 
     /* init input diagonal array like:
     1, 0, 0,
     0, 2, 0,
     0, 0, 3
     */
-    for (size_t i = 0; i < len; ++i)
-    {
+    for (size_t i = 0; i < len; ++i) {
         array[i] = 0;
     }
-    for (size_t i = 0; i < size; ++i)
-    {
+    for (size_t i = 0; i < size; ++i) {
         array[size * i + i] = i + 1;
     }
 
     dpnp_eig_c<float, float>(array, result1, result2, size);
 
     std::cout << "eigen values" << std::endl;
-    for (size_t i = 0; i < size; ++i)
-    {
+    for (size_t i = 0; i < size; ++i) {
         std::cout << result1[i] << ", ";
     }
     std::cout << std::endl;

--- a/dpnp/backend/examples/example8.cpp
+++ b/dpnp/backend/examples/example8.cpp
@@ -45,7 +45,7 @@ int main(int, char **)
     dpnp_queue_initialize_c(QueueOptions::GPU_SELECTOR);
 
     double *array = (double *)dpnp_memory_alloc_c(size * sizeof(double));
-    long *result  = (long *)dpnp_memory_alloc_c(size * sizeof(long));
+    long *result = (long *)dpnp_memory_alloc_c(size * sizeof(long));
 
     std::cout << "array" << std::endl;
     for (size_t i = 0; i < size; ++i) {

--- a/dpnp/backend/examples/example8.cpp
+++ b/dpnp/backend/examples/example8.cpp
@@ -30,25 +30,25 @@
  *
  * Possible compile line:
  * . /opt/intel/oneapi/setvars.sh
- * g++ -g dpnp/backend/examples/example8.cpp -Idpnp -Idpnp/backend/include -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o example8
+ * g++ -g dpnp/backend/examples/example8.cpp -Idpnp -Idpnp/backend/include
+ * -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o example8
  *
  */
 #include <iostream>
 
 #include "dpnp_iface.hpp"
 
-int main(int, char**)
+int main(int, char **)
 {
     const size_t size = 16;
 
     dpnp_queue_initialize_c(QueueOptions::GPU_SELECTOR);
 
-    double* array = (double*)dpnp_memory_alloc_c(size * sizeof(double));
-    long* result = (long*)dpnp_memory_alloc_c(size * sizeof(long));
+    double *array = (double *)dpnp_memory_alloc_c(size * sizeof(double));
+    long *result  = (long *)dpnp_memory_alloc_c(size * sizeof(long));
 
     std::cout << "array" << std::endl;
-    for (size_t i = 0; i < size; ++i)
-    {
+    for (size_t i = 0; i < size; ++i) {
         array[i] = (double)(size - i) / 2;
         std::cout << array[i] << ", ";
     }
@@ -57,8 +57,7 @@ int main(int, char**)
     dpnp_argsort_c<double, long>(array, result, size);
 
     std::cout << "array with 'sorted' indeces" << std::endl;
-    for (size_t i = 0; i < size; ++i)
-    {
+    for (size_t i = 0; i < size; ++i) {
         std::cout << result[i] << ", ";
     }
     std::cout << std::endl;

--- a/dpnp/backend/examples/example9.cpp
+++ b/dpnp/backend/examples/example9.cpp
@@ -42,8 +42,8 @@
 
 int main(int, char **)
 {
-    const size_t size        = 2097152;
-    long result              = 0;
+    const size_t size = 2097152;
+    long result = 0;
     long result_verification = 0;
 
     dpnp_queue_initialize_c(QueueOptions::CPU_SELECTOR);

--- a/dpnp/backend/examples/example9.cpp
+++ b/dpnp/backend/examples/example9.cpp
@@ -31,7 +31,8 @@
  *
  * Possible compile line:
  * . /opt/intel/oneapi/setvars.sh
- * g++ -g dpnp/backend/examples/example9.cpp -Idpnp -Idpnp/backend/include -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o example9
+ * g++ -g dpnp/backend/examples/example9.cpp -Idpnp -Idpnp/backend/include
+ * -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o example9
  *
  */
 
@@ -39,25 +40,26 @@
 
 #include "dpnp_iface.hpp"
 
-int main(int, char**)
+int main(int, char **)
 {
-    const size_t size = 2097152;
-    long result = 0;
+    const size_t size        = 2097152;
+    long result              = 0;
     long result_verification = 0;
 
     dpnp_queue_initialize_c(QueueOptions::CPU_SELECTOR);
 
-    long* array = reinterpret_cast<long*>(dpnp_memory_alloc_c(size * sizeof(long)));
+    long *array =
+        reinterpret_cast<long *>(dpnp_memory_alloc_c(size * sizeof(long)));
 
-    for (size_t i = 0; i < size; ++i)
-    {
+    for (size_t i = 0; i < size; ++i) {
         array[i] = i;
         result_verification += i;
     }
 
     dpnp_sum_c<long, long>(&result, array, &size, 1, NULL, 0, NULL, NULL);
 
-    std::cout << "SUM() value: " << result << " verification value: " << result_verification << std::endl;
+    std::cout << "SUM() value: " << result
+              << " verification value: " << result_verification << std::endl;
 
     dpnp_memory_free_c(array);
 

--- a/dpnp/backend/examples/example_bs.cpp
+++ b/dpnp/backend/examples/example_bs.cpp
@@ -49,23 +49,23 @@ void black_scholes(double *price,
                    double *put,
                    const size_t size)
 {
-    const size_t ndim        = 1;
+    const size_t ndim = 1;
     const size_t scalar_size = 1;
 
     double *mr = (double *)dpnp_memory_alloc_c(1 * sizeof(double));
-    mr[0]      = -rate;
+    mr[0] = -rate;
 
     double *vol_vol_two = (double *)dpnp_memory_alloc_c(1 * sizeof(double));
-    vol_vol_two[0]      = vol * vol * 2;
+    vol_vol_two[0] = vol * vol * 2;
 
     double *quarter = (double *)dpnp_memory_alloc_c(1 * sizeof(double));
-    quarter[0]      = 0.25;
+    quarter[0] = 0.25;
 
     double *one = (double *)dpnp_memory_alloc_c(1 * sizeof(double));
-    one[0]      = 1.;
+    one[0] = 1.;
 
     double *half = (double *)dpnp_memory_alloc_c(1 * sizeof(double));
-    half[0]      = 0.5;
+    half[0] = 0.5;
 
     double *P = price;
     double *S = strike;
@@ -226,15 +226,15 @@ int main(int, char **)
     const long PL = 10, PH = 50;
     const long SL = 10, SH = 50;
     const long TL = 1, TH = 2;
-    const double RISK_FREE  = 0.1;
+    const double RISK_FREE = 0.1;
     const double VOLATILITY = 0.2;
 
     dpnp_queue_initialize_c(QueueOptions::GPU_SELECTOR);
     std::cout << "SYCL queue is CPU: " << dpnp_queue_is_cpu_c() << std::endl;
 
-    double *price  = (double *)dpnp_memory_alloc_c(SIZE * sizeof(double));
+    double *price = (double *)dpnp_memory_alloc_c(SIZE * sizeof(double));
     double *strike = (double *)dpnp_memory_alloc_c(SIZE * sizeof(double));
-    double *t      = (double *)dpnp_memory_alloc_c(SIZE * sizeof(double));
+    double *t = (double *)dpnp_memory_alloc_c(SIZE * sizeof(double));
 
     dpnp_rng_srand_c(SEED); // np.random.seed(SEED)
     dpnp_rng_uniform_c<double>(price, PL, PH,
@@ -245,13 +245,13 @@ int main(int, char **)
                                SIZE); // np.random.uniform(TL, TH, SIZE)
 
     double *zero = (double *)dpnp_memory_alloc_c(1 * sizeof(double));
-    zero[0]      = 0.;
+    zero[0] = 0.;
 
     double *mone = (double *)dpnp_memory_alloc_c(1 * sizeof(double));
-    mone[0]      = -1.;
+    mone[0] = -1.;
 
     double *call = (double *)dpnp_memory_alloc_c(SIZE * sizeof(double));
-    double *put  = (double *)dpnp_memory_alloc_c(SIZE * sizeof(double));
+    double *put = (double *)dpnp_memory_alloc_c(SIZE * sizeof(double));
 
     dpnp_full_c<double>(zero, call, SIZE); // np.full(SIZE, 0., dtype=DTYPE)
     dpnp_full_c<double>(mone, put, SIZE);  // np.full(SIZE, -1., dtype=DTYPE)

--- a/dpnp/backend/examples/example_bs.cpp
+++ b/dpnp/backend/examples/example_bs.cpp
@@ -31,7 +31,8 @@
  *
  * Possible compile line:
  * . /opt/intel/oneapi/setvars.sh
- * g++ -g dpnp/backend/examples/example_bs.cpp -Idpnp -Idpnp/backend/include -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o example_bs
+ * g++ -g dpnp/backend/examples/example_bs.cpp -Idpnp -Idpnp/backend/include
+ * -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o example_bs
  */
 
 #include <cmath>
@@ -39,157 +40,185 @@
 
 #include "dpnp_iface.hpp"
 
-void black_scholes(double* price,
-                   double* strike,
-                   double* t,
+void black_scholes(double *price,
+                   double *strike,
+                   double *t,
                    const double rate,
                    const double vol,
-                   double* call,
-                   double* put,
+                   double *call,
+                   double *put,
                    const size_t size)
 {
-    const size_t ndim = 1;
+    const size_t ndim        = 1;
     const size_t scalar_size = 1;
 
-    double* mr = (double*)dpnp_memory_alloc_c(1 * sizeof(double));
-    mr[0] = -rate;
+    double *mr = (double *)dpnp_memory_alloc_c(1 * sizeof(double));
+    mr[0]      = -rate;
 
-    double* vol_vol_two = (double*)dpnp_memory_alloc_c(1 * sizeof(double));
-    vol_vol_two[0] = vol * vol * 2;
+    double *vol_vol_two = (double *)dpnp_memory_alloc_c(1 * sizeof(double));
+    vol_vol_two[0]      = vol * vol * 2;
 
-    double* quarter = (double*)dpnp_memory_alloc_c(1 * sizeof(double));
-    quarter[0] = 0.25;
+    double *quarter = (double *)dpnp_memory_alloc_c(1 * sizeof(double));
+    quarter[0]      = 0.25;
 
-    double* one = (double*)dpnp_memory_alloc_c(1 * sizeof(double));
-    one[0] = 1.;
+    double *one = (double *)dpnp_memory_alloc_c(1 * sizeof(double));
+    one[0]      = 1.;
 
-    double* half = (double*)dpnp_memory_alloc_c(1 * sizeof(double));
-    half[0] = 0.5;
+    double *half = (double *)dpnp_memory_alloc_c(1 * sizeof(double));
+    half[0]      = 0.5;
 
-    double* P = price;
-    double* S = strike;
-    double* T = t;
+    double *P = price;
+    double *S = strike;
+    double *T = t;
 
-    double* p_div_s = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    double *p_div_s = (double *)dpnp_memory_alloc_c(size * sizeof(double));
     // p_div_s = P / S
-    dpnp_divide_c<double, double, double>(p_div_s, P, size, &size, ndim, S, size, &size, ndim, NULL);
-    double* a = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    dpnp_divide_c<double, double, double>(p_div_s, P, size, &size, ndim, S,
+                                          size, &size, ndim, NULL);
+    double *a = (double *)dpnp_memory_alloc_c(size * sizeof(double));
     dpnp_log_c<double, double>(p_div_s, a, size); // a = np.log(p_div_s)
     dpnp_memory_free_c(p_div_s);
 
-    double* b = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    double *b = (double *)dpnp_memory_alloc_c(size * sizeof(double));
     // b = T * mr
-    dpnp_multiply_c<double, double, double>(b, T, size, &size, ndim, mr, scalar_size, &scalar_size, ndim, NULL);
-    dpnp_memory_free_c(mr);
-    double* z = (double*)dpnp_memory_alloc_c(size * sizeof(double));
-    // z = T * vol_vol_twos
     dpnp_multiply_c<double, double, double>(
-        z, T, size, &size, ndim, vol_vol_two, scalar_size, &scalar_size, ndim, NULL);
+        b, T, size, &size, ndim, mr, scalar_size, &scalar_size, ndim, NULL);
+    dpnp_memory_free_c(mr);
+    double *z = (double *)dpnp_memory_alloc_c(size * sizeof(double));
+    // z = T * vol_vol_twos
+    dpnp_multiply_c<double, double, double>(z, T, size, &size, ndim,
+                                            vol_vol_two, scalar_size,
+                                            &scalar_size, ndim, NULL);
     dpnp_memory_free_c(vol_vol_two);
 
-    double* c = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    double *c = (double *)dpnp_memory_alloc_c(size * sizeof(double));
     // c = quarters * z
-    dpnp_multiply_c<double, double, double>(c, quarter, scalar_size, &scalar_size, ndim, z, size, &size, ndim, NULL);
+    dpnp_multiply_c<double, double, double>(c, quarter, scalar_size,
+                                            &scalar_size, ndim, z, size, &size,
+                                            ndim, NULL);
     dpnp_memory_free_c(quarter);
 
-    double* sqrt_z = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    double *sqrt_z = (double *)dpnp_memory_alloc_c(size * sizeof(double));
     dpnp_sqrt_c<double, double>(z, sqrt_z, size); // sqrt_z = np.sqrt(z)
     dpnp_memory_free_c(z);
-    double* y = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    double *y = (double *)dpnp_memory_alloc_c(size * sizeof(double));
     // y = ones / np.sqrt(z)
-    dpnp_divide_c<double, double, double>(y, one, scalar_size, &scalar_size, ndim, sqrt_z, size, &size, ndim, NULL);
+    dpnp_divide_c<double, double, double>(y, one, scalar_size, &scalar_size,
+                                          ndim, sqrt_z, size, &size, ndim,
+                                          NULL);
     dpnp_memory_free_c(sqrt_z);
     dpnp_memory_free_c(one);
 
-    double* a_sub_b = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    double *a_sub_b = (double *)dpnp_memory_alloc_c(size * sizeof(double));
     // a_sub_b = a - b
-    dpnp_subtract_c<double, double, double>(a_sub_b, a, size, &size, ndim, b, size, &size, ndim, NULL);
+    dpnp_subtract_c<double, double, double>(a_sub_b, a, size, &size, ndim, b,
+                                            size, &size, ndim, NULL);
     dpnp_memory_free_c(a);
-    double* a_sub_b_add_c = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    double *a_sub_b_add_c =
+        (double *)dpnp_memory_alloc_c(size * sizeof(double));
     // a_sub_b_add_c = a_sub_b + c
-    dpnp_add_c<double, double, double>(a_sub_b_add_c, a_sub_b, size, &size, ndim, c, size, &size, ndim, NULL);
-    double* w1 = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    dpnp_add_c<double, double, double>(a_sub_b_add_c, a_sub_b, size, &size,
+                                       ndim, c, size, &size, ndim, NULL);
+    double *w1 = (double *)dpnp_memory_alloc_c(size * sizeof(double));
     // w1 = a_sub_b_add_c * y
-    dpnp_multiply_c<double, double, double>(w1, a_sub_b_add_c, size, &size, ndim, y, size, &size, ndim, NULL);
+    dpnp_multiply_c<double, double, double>(w1, a_sub_b_add_c, size, &size,
+                                            ndim, y, size, &size, ndim, NULL);
     dpnp_memory_free_c(a_sub_b_add_c);
 
-    double* a_sub_b_sub_c = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    double *a_sub_b_sub_c =
+        (double *)dpnp_memory_alloc_c(size * sizeof(double));
     // a_sub_b_sub_c = a_sub_b - c
-    dpnp_subtract_c<double, double, double>(a_sub_b_sub_c, a_sub_b, size, &size, ndim, c, size, &size, ndim, NULL);
+    dpnp_subtract_c<double, double, double>(a_sub_b_sub_c, a_sub_b, size, &size,
+                                            ndim, c, size, &size, ndim, NULL);
     dpnp_memory_free_c(a_sub_b);
     dpnp_memory_free_c(c);
-    double* w2 = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    double *w2 = (double *)dpnp_memory_alloc_c(size * sizeof(double));
     // w2 = a_sub_b_sub_c * y
-    dpnp_multiply_c<double, double, double>(w2, a_sub_b_sub_c, size, &size, ndim, y, size, &size, ndim, NULL);
+    dpnp_multiply_c<double, double, double>(w2, a_sub_b_sub_c, size, &size,
+                                            ndim, y, size, &size, ndim, NULL);
     dpnp_memory_free_c(a_sub_b_sub_c);
     dpnp_memory_free_c(y);
 
-    double* erf_w1 = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    double *erf_w1 = (double *)dpnp_memory_alloc_c(size * sizeof(double));
     dpnp_erf_c<double>(w1, erf_w1, size); // erf_w1 = np.erf(w1)
     dpnp_memory_free_c(w1);
-    double* halfs_mul_erf_w1 = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    double *halfs_mul_erf_w1 =
+        (double *)dpnp_memory_alloc_c(size * sizeof(double));
     // halfs_mul_erf_w1 = halfs * erf_w1
-    dpnp_multiply_c<double, double, double>(
-        halfs_mul_erf_w1, half, scalar_size, &scalar_size, ndim, erf_w1, size, &size, ndim, NULL);
+    dpnp_multiply_c<double, double, double>(halfs_mul_erf_w1, half, scalar_size,
+                                            &scalar_size, ndim, erf_w1, size,
+                                            &size, ndim, NULL);
     dpnp_memory_free_c(erf_w1);
-    double* d1 = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    double *d1 = (double *)dpnp_memory_alloc_c(size * sizeof(double));
     // d1 = halfs + halfs_mul_erf_w1
-    dpnp_add_c<double, double, double>(
-        d1, half, scalar_size, &scalar_size, ndim, halfs_mul_erf_w1, size, &size, ndim, NULL);
+    dpnp_add_c<double, double, double>(d1, half, scalar_size, &scalar_size,
+                                       ndim, halfs_mul_erf_w1, size, &size,
+                                       ndim, NULL);
     dpnp_memory_free_c(halfs_mul_erf_w1);
 
-    double* erf_w2 = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    double *erf_w2 = (double *)dpnp_memory_alloc_c(size * sizeof(double));
     dpnp_erf_c<double>(w2, erf_w2, size); // erf_w2 = np.erf(w2)
     dpnp_memory_free_c(w2);
-    double* halfs_mul_erf_w2 = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    double *halfs_mul_erf_w2 =
+        (double *)dpnp_memory_alloc_c(size * sizeof(double));
     // halfs_mul_erf_w2 = halfs * erf_w2
-    dpnp_multiply_c<double, double, double>(
-        halfs_mul_erf_w2, half, scalar_size, &scalar_size, ndim, erf_w2, size, &size, ndim, NULL);
+    dpnp_multiply_c<double, double, double>(halfs_mul_erf_w2, half, scalar_size,
+                                            &scalar_size, ndim, erf_w2, size,
+                                            &size, ndim, NULL);
     dpnp_memory_free_c(erf_w2);
-    double* d2 = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    double *d2 = (double *)dpnp_memory_alloc_c(size * sizeof(double));
     // d2 = halfs + halfs_mul_erf_w2
-    dpnp_add_c<double, double, double>(
-        d2, half, scalar_size, &scalar_size, ndim, halfs_mul_erf_w2, size, &size, ndim, NULL);
+    dpnp_add_c<double, double, double>(d2, half, scalar_size, &scalar_size,
+                                       ndim, halfs_mul_erf_w2, size, &size,
+                                       ndim, NULL);
     dpnp_memory_free_c(halfs_mul_erf_w2);
     dpnp_memory_free_c(half);
 
-    double* exp_b = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    double *exp_b = (double *)dpnp_memory_alloc_c(size * sizeof(double));
     dpnp_exp_c<double, double>(b, exp_b, size); // exp_b = np.exp(b)
-    double* Se = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    double *Se = (double *)dpnp_memory_alloc_c(size * sizeof(double));
     // Se = exp_b * S
-    dpnp_multiply_c<double, double, double>(Se, exp_b, size, &size, ndim, S, size, &size, ndim, NULL);
+    dpnp_multiply_c<double, double, double>(Se, exp_b, size, &size, ndim, S,
+                                            size, &size, ndim, NULL);
     dpnp_memory_free_c(exp_b);
     dpnp_memory_free_c(b);
 
-    double* P_mul_d1 = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    double *P_mul_d1 = (double *)dpnp_memory_alloc_c(size * sizeof(double));
     // P_mul_d1 = P * d1
-    dpnp_multiply_c<double, double, double>(P_mul_d1, P, size, &size, ndim, d1, size, &size, ndim, NULL);
+    dpnp_multiply_c<double, double, double>(P_mul_d1, P, size, &size, ndim, d1,
+                                            size, &size, ndim, NULL);
     dpnp_memory_free_c(d1);
-    double* Se_mul_d2 = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    double *Se_mul_d2 = (double *)dpnp_memory_alloc_c(size * sizeof(double));
     // Se_mul_d2 = Se * d2
-    dpnp_multiply_c<double, double, double>(Se_mul_d2, Se, size, &size, ndim, d2, size, &size, ndim, NULL);
+    dpnp_multiply_c<double, double, double>(Se_mul_d2, Se, size, &size, ndim,
+                                            d2, size, &size, ndim, NULL);
     dpnp_memory_free_c(d2);
-    double* r = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    double *r = (double *)dpnp_memory_alloc_c(size * sizeof(double));
     // r = P_mul_d1 - Se_mul_d2
-    dpnp_subtract_c<double, double, double>(r, P_mul_d1, size, &size, ndim, Se_mul_d2, size, &size, ndim, NULL);
+    dpnp_subtract_c<double, double, double>(r, P_mul_d1, size, &size, ndim,
+                                            Se_mul_d2, size, &size, ndim, NULL);
     dpnp_memory_free_c(Se_mul_d2);
     dpnp_memory_free_c(P_mul_d1);
 
     dpnp_copyto_c<double, double>(call, r, size); // call[:] = r
-    double* r_sub_P = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    double *r_sub_P = (double *)dpnp_memory_alloc_c(size * sizeof(double));
     // r_sub_P = r - P
-    dpnp_subtract_c<double, double, double>(r_sub_P, r, size, &size, ndim, P, size, &size, ndim, NULL);
+    dpnp_subtract_c<double, double, double>(r_sub_P, r, size, &size, ndim, P,
+                                            size, &size, ndim, NULL);
     dpnp_memory_free_c(r);
-    double* r_sub_P_add_Se = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    double *r_sub_P_add_Se =
+        (double *)dpnp_memory_alloc_c(size * sizeof(double));
     // r_sub_P_add_Se = r_sub_P + Se
-    dpnp_add_c<double, double, double>(r_sub_P_add_Se, r_sub_P, size, &size, ndim, Se, size, &size, ndim, NULL);
+    dpnp_add_c<double, double, double>(r_sub_P_add_Se, r_sub_P, size, &size,
+                                       ndim, Se, size, &size, ndim, NULL);
     dpnp_memory_free_c(r_sub_P);
     dpnp_memory_free_c(Se);
-    dpnp_copyto_c<double, double>(put, r_sub_P_add_Se, size); // put[:] = r_sub_P_add_Se
+    dpnp_copyto_c<double, double>(put, r_sub_P_add_Se,
+                                  size); // put[:] = r_sub_P_add_Se
     dpnp_memory_free_c(r_sub_P_add_Se);
 }
 
-int main(int, char**)
+int main(int, char **)
 {
     const size_t SIZE = 256;
 
@@ -197,29 +226,32 @@ int main(int, char**)
     const long PL = 10, PH = 50;
     const long SL = 10, SH = 50;
     const long TL = 1, TH = 2;
-    const double RISK_FREE = 0.1;
+    const double RISK_FREE  = 0.1;
     const double VOLATILITY = 0.2;
 
     dpnp_queue_initialize_c(QueueOptions::GPU_SELECTOR);
     std::cout << "SYCL queue is CPU: " << dpnp_queue_is_cpu_c() << std::endl;
 
-    double* price = (double*)dpnp_memory_alloc_c(SIZE * sizeof(double));
-    double* strike = (double*)dpnp_memory_alloc_c(SIZE * sizeof(double));
-    double* t = (double*)dpnp_memory_alloc_c(SIZE * sizeof(double));
+    double *price  = (double *)dpnp_memory_alloc_c(SIZE * sizeof(double));
+    double *strike = (double *)dpnp_memory_alloc_c(SIZE * sizeof(double));
+    double *t      = (double *)dpnp_memory_alloc_c(SIZE * sizeof(double));
 
-    dpnp_rng_srand_c(SEED);                           // np.random.seed(SEED)
-    dpnp_rng_uniform_c<double>(price, PL, PH, SIZE);  // np.random.uniform(PL, PH, SIZE)
-    dpnp_rng_uniform_c<double>(strike, SL, SH, SIZE); // np.random.uniform(SL, SH, SIZE)
-    dpnp_rng_uniform_c<double>(t, TL, TH, SIZE);      // np.random.uniform(TL, TH, SIZE)
+    dpnp_rng_srand_c(SEED); // np.random.seed(SEED)
+    dpnp_rng_uniform_c<double>(price, PL, PH,
+                               SIZE); // np.random.uniform(PL, PH, SIZE)
+    dpnp_rng_uniform_c<double>(strike, SL, SH,
+                               SIZE); // np.random.uniform(SL, SH, SIZE)
+    dpnp_rng_uniform_c<double>(t, TL, TH,
+                               SIZE); // np.random.uniform(TL, TH, SIZE)
 
-    double* zero = (double*)dpnp_memory_alloc_c(1 * sizeof(double));
-    zero[0] = 0.;
+    double *zero = (double *)dpnp_memory_alloc_c(1 * sizeof(double));
+    zero[0]      = 0.;
 
-    double* mone = (double*)dpnp_memory_alloc_c(1 * sizeof(double));
-    mone[0] = -1.;
+    double *mone = (double *)dpnp_memory_alloc_c(1 * sizeof(double));
+    mone[0]      = -1.;
 
-    double* call = (double*)dpnp_memory_alloc_c(SIZE * sizeof(double));
-    double* put = (double*)dpnp_memory_alloc_c(SIZE * sizeof(double));
+    double *call = (double *)dpnp_memory_alloc_c(SIZE * sizeof(double));
+    double *put  = (double *)dpnp_memory_alloc_c(SIZE * sizeof(double));
 
     dpnp_full_c<double>(zero, call, SIZE); // np.full(SIZE, 0., dtype=DTYPE)
     dpnp_full_c<double>(mone, put, SIZE);  // np.full(SIZE, -1., dtype=DTYPE)
@@ -230,14 +262,12 @@ int main(int, char**)
     black_scholes(price, strike, t, RISK_FREE, VOLATILITY, call, put, SIZE);
 
     std::cout << "call: ";
-    for (size_t i = 0; i < 10; ++i)
-    {
+    for (size_t i = 0; i < 10; ++i) {
         std::cout << call[i] << ", ";
     }
     std::cout << "..." << std::endl;
     std::cout << "put: ";
-    for (size_t i = 0; i < 10; ++i)
-    {
+    for (size_t i = 0; i < 10; ++i) {
         std::cout << put[i] << ", ";
     }
     std::cout << "..." << std::endl;

--- a/dpnp/backend/examples/example_experimental_iface.cpp
+++ b/dpnp/backend/examples/example_experimental_iface.cpp
@@ -30,7 +30,9 @@
  *
  * Possible compile line:
  * . /opt/intel/oneapi/setvars.sh
- * g++ -g dpnp/backend/examples/example_experimental_iface.cpp -Idpnp -Idpnp/backend/include -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o example_experimental_iface
+ * g++ -g dpnp/backend/examples/example_experimental_iface.cpp -Idpnp
+ * -Idpnp/backend/include -Ldpnp -Wl,-rpath='$ORIGIN'/dpnp -ldpnp_backend_c -o
+ * example_experimental_iface
  */
 
 #include <iostream>
@@ -38,19 +40,24 @@
 #include <dpnp_iface_fptr.hpp>
 // TODO #include <backend/backend_utils.hpp>
 
-int main(int, char**)
+int main(int, char **)
 {
-    void* result = get_backend_function_name("dpnp_dot", "float");
-    std::cout << "Result Dot() function pointer (by old interface): " << result << std::endl;
+    void *result = get_backend_function_name("dpnp_dot", "float");
+    std::cout << "Result Dot() function pointer (by old interface): " << result
+              << std::endl;
 
-    DPNPFuncData_t dpnp_dot_f = get_dpnp_function_ptr(DPNPFuncName::DPNP_FN_DOT, DPNPFuncType::DPNP_FT_LONG);
-    std::cout << "Result Dot() function pointer: " << dpnp_dot_f.ptr << " with return datatype "
-              << (size_t)dpnp_dot_f.return_type << std::endl;
+    DPNPFuncData_t dpnp_dot_f = get_dpnp_function_ptr(
+        DPNPFuncName::DPNP_FN_DOT, DPNPFuncType::DPNP_FT_LONG);
+    std::cout << "Result Dot() function pointer: " << dpnp_dot_f.ptr
+              << " with return datatype " << (size_t)dpnp_dot_f.return_type
+              << std::endl;
 
-    DPNPFuncData_t dpnp_add_f =
-        get_dpnp_function_ptr(DPNPFuncName::DPNP_FN_ADD, DPNPFuncType::DPNP_FT_FLOAT, DPNPFuncType::DPNP_FT_INT);
-    std::cout << "Result Add() function pointer: " << dpnp_add_f.ptr << " with return datatype "
-              << (size_t)dpnp_add_f.return_type << std::endl;
+    DPNPFuncData_t dpnp_add_f = get_dpnp_function_ptr(
+        DPNPFuncName::DPNP_FN_ADD, DPNPFuncType::DPNP_FT_FLOAT,
+        DPNPFuncType::DPNP_FT_INT);
+    std::cout << "Result Add() function pointer: " << dpnp_add_f.ptr
+              << " with return datatype " << (size_t)dpnp_add_f.return_type
+              << std::endl;
 
     return 0;
 }

--- a/dpnp/backend/extensions/lapack/heevd.cpp
+++ b/dpnp/backend/extensions/lapack/heevd.cpp
@@ -43,7 +43,7 @@ namespace ext
 namespace lapack
 {
 namespace mkl_lapack = oneapi::mkl::lapack;
-namespace py         = pybind11;
+namespace py = pybind11;
 namespace type_utils = dpctl::tensor::type_utils;
 
 typedef sycl::event (*heevd_impl_fn_ptr_t)(sycl::queue,
@@ -71,7 +71,7 @@ static sycl::event heevd_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
     type_utils::validate_type_for_device<RealT>(exec_q);
 
-    T *a     = reinterpret_cast<T *>(in_a);
+    T *a = reinterpret_cast<T *>(in_a);
     RealT *w = reinterpret_cast<RealT *>(out_w);
 
     const std::int64_t lda = std::max<size_t>(1UL, n);
@@ -212,7 +212,7 @@ std::pair<sycl::event, sycl::event>
     char *eig_vecs_data = eig_vecs.get_data();
     char *eig_vals_data = eig_vals.get_data();
 
-    const std::int64_t n            = eig_vecs_shape[0];
+    const std::int64_t n = eig_vecs_shape[0];
     const oneapi::mkl::job jobz_val = static_cast<oneapi::mkl::job>(jobz);
     const oneapi::mkl::uplo uplo_val =
         static_cast<oneapi::mkl::uplo>(upper_lower);

--- a/dpnp/backend/extensions/lapack/heevd.cpp
+++ b/dpnp/backend/extensions/lapack/heevd.cpp
@@ -23,7 +23,6 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //*****************************************************************************
 
-
 #include <pybind11/pybind11.h>
 
 // dpctl tensor headers
@@ -35,7 +34,6 @@
 
 #include "dpnp_utils.hpp"
 
-
 namespace dpnp
 {
 namespace backend
@@ -44,85 +42,87 @@ namespace ext
 {
 namespace lapack
 {
-
 namespace mkl_lapack = oneapi::mkl::lapack;
-namespace py = pybind11;
+namespace py         = pybind11;
 namespace type_utils = dpctl::tensor::type_utils;
 
 typedef sycl::event (*heevd_impl_fn_ptr_t)(sycl::queue,
                                            const oneapi::mkl::job,
                                            const oneapi::mkl::uplo,
                                            const std::int64_t,
-                                           char*,
-                                           char*,
-                                           std::vector<sycl::event>&,
-                                           const std::vector<sycl::event>&);
+                                           char *,
+                                           char *,
+                                           std::vector<sycl::event> &,
+                                           const std::vector<sycl::event> &);
 
-static heevd_impl_fn_ptr_t heevd_dispatch_table[dpctl_td_ns::num_types][dpctl_td_ns::num_types];
+static heevd_impl_fn_ptr_t heevd_dispatch_table[dpctl_td_ns::num_types]
+                                               [dpctl_td_ns::num_types];
 
 template <typename T, typename RealT>
 static sycl::event heevd_impl(sycl::queue exec_q,
                               const oneapi::mkl::job jobz,
                               const oneapi::mkl::uplo upper_lower,
                               const std::int64_t n,
-                              char* in_a,
-                              char* out_w,
-                              std::vector<sycl::event>& host_task_events,
-                              const std::vector<sycl::event>& depends)
+                              char *in_a,
+                              char *out_w,
+                              std::vector<sycl::event> &host_task_events,
+                              const std::vector<sycl::event> &depends)
 {
     type_utils::validate_type_for_device<T>(exec_q);
     type_utils::validate_type_for_device<RealT>(exec_q);
 
-    T* a = reinterpret_cast<T*>(in_a);
-    RealT* w = reinterpret_cast<RealT*>(out_w);
+    T *a     = reinterpret_cast<T *>(in_a);
+    RealT *w = reinterpret_cast<RealT *>(out_w);
 
     const std::int64_t lda = std::max<size_t>(1UL, n);
-    const std::int64_t scratchpad_size = mkl_lapack::heevd_scratchpad_size<T>(exec_q, jobz, upper_lower, n, lda);
-    T* scratchpad = nullptr;
+    const std::int64_t scratchpad_size =
+        mkl_lapack::heevd_scratchpad_size<T>(exec_q, jobz, upper_lower, n, lda);
+    T *scratchpad = nullptr;
 
     std::stringstream error_msg;
     std::int64_t info = 0;
 
     sycl::event heevd_event;
-    try
-    {
+    try {
         scratchpad = sycl::malloc_device<T>(scratchpad_size, exec_q);
 
         heevd_event = mkl_lapack::heevd(
             exec_q,
-            jobz,        // 'jobz == job::vec' means eigenvalues and eigenvectors are computed.
-            upper_lower, // 'upper_lower == job::upper' means the upper triangular part of A, or the lower triangular otherwise
+            jobz, // 'jobz == job::vec' means eigenvalues and eigenvectors are
+                  // computed.
+            upper_lower, // 'upper_lower == job::upper' means the upper
+                         // triangular part of A, or the lower triangular
+                         // otherwise
             n,           // The order of the matrix A (0 <= n)
-            a,           // Pointer to A, size (lda, *), where the 2nd dimension, must be at least max(1, n)
-                         // If 'jobz == job::vec', then on exit it will contain the eigenvectors of A
-            lda,         // The leading dimension of a, must be at least max(1, n)
-            w,           // Pointer to array of size at least n, it will contain the eigenvalues of A in ascending order
-            scratchpad,  // Pointer to scratchpad memory to be used by MKL routine for storing intermediate results
-            scratchpad_size,
-            depends);
-    }
-    catch (mkl_lapack::exception const& e)
-    {
-        error_msg << "Unexpected MKL exception caught during heevd() call:\nreason: " << e.what()
-                  << "\ninfo: " << e.info();
+            a, // Pointer to A, size (lda, *), where the 2nd dimension, must be
+               // at least max(1, n) If 'jobz == job::vec', then on exit it will
+               // contain the eigenvectors of A
+            lda, // The leading dimension of a, must be at least max(1, n)
+            w,   // Pointer to array of size at least n, it will contain the
+                 // eigenvalues of A in ascending order
+            scratchpad, // Pointer to scratchpad memory to be used by MKL
+                        // routine for storing intermediate results
+            scratchpad_size, depends);
+    } catch (mkl_lapack::exception const &e) {
+        error_msg
+            << "Unexpected MKL exception caught during heevd() call:\nreason: "
+            << e.what() << "\ninfo: " << e.info();
         info = e.info();
-    }
-    catch (sycl::exception const& e)
-    {
-        error_msg << "Unexpected SYCL exception caught during heevd() call:\n" << e.what();
+    } catch (sycl::exception const &e) {
+        error_msg << "Unexpected SYCL exception caught during heevd() call:\n"
+                  << e.what();
         info = -1;
     }
 
     if (info != 0) // an unexected error occurs
     {
-        if (scratchpad != nullptr)
-        {
+        if (scratchpad != nullptr) {
             sycl::free(scratchpad, exec_q);
         }
         throw std::runtime_error(error_msg.str());
     }
 
-    sycl::event clean_up_event = exec_q.submit([&](sycl::handler& cgh) {
+    sycl::event clean_up_event = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(heevd_event);
         auto ctx = exec_q.get_context();
         cgh.host_task([ctx, scratchpad]() { sycl::free(scratchpad, ctx); });
@@ -131,97 +131,99 @@ static sycl::event heevd_impl(sycl::queue exec_q,
     return heevd_event;
 }
 
-std::pair<sycl::event, sycl::event> heevd(sycl::queue exec_q,
-                                          const std::int8_t jobz,
-                                          const std::int8_t upper_lower,
-                                          dpctl::tensor::usm_ndarray eig_vecs,
-                                          dpctl::tensor::usm_ndarray eig_vals,
-                                          const std::vector<sycl::event>& depends)
+std::pair<sycl::event, sycl::event>
+    heevd(sycl::queue exec_q,
+          const std::int8_t jobz,
+          const std::int8_t upper_lower,
+          dpctl::tensor::usm_ndarray eig_vecs,
+          dpctl::tensor::usm_ndarray eig_vals,
+          const std::vector<sycl::event> &depends)
 {
     const int eig_vecs_nd = eig_vecs.get_ndim();
     const int eig_vals_nd = eig_vals.get_ndim();
 
-    if (eig_vecs_nd != 2)
-    {
+    if (eig_vecs_nd != 2) {
         throw py::value_error("Unexpected ndim=" + std::to_string(eig_vecs_nd) +
                               " of an output array with eigenvectors");
     }
-    else if (eig_vals_nd != 1)
-    {
+    else if (eig_vals_nd != 1) {
         throw py::value_error("Unexpected ndim=" + std::to_string(eig_vals_nd) +
                               " of an output array with eigenvalues");
     }
 
-    const py::ssize_t* eig_vecs_shape = eig_vecs.get_shape_raw();
-    const py::ssize_t* eig_vals_shape = eig_vals.get_shape_raw();
+    const py::ssize_t *eig_vecs_shape = eig_vecs.get_shape_raw();
+    const py::ssize_t *eig_vals_shape = eig_vals.get_shape_raw();
 
-    if (eig_vecs_shape[0] != eig_vecs_shape[1])
-    {
+    if (eig_vecs_shape[0] != eig_vecs_shape[1]) {
         throw py::value_error("Output array with eigenvectors with be square");
     }
-    else if (eig_vecs_shape[0] != eig_vals_shape[0])
-    {
-        throw py::value_error("Eigenvectors and eigenvalues have different shapes");
+    else if (eig_vecs_shape[0] != eig_vals_shape[0]) {
+        throw py::value_error(
+            "Eigenvectors and eigenvalues have different shapes");
     }
 
     size_t src_nelems(1);
 
-    for (int i = 0; i < eig_vecs_nd; ++i)
-    {
+    for (int i = 0; i < eig_vecs_nd; ++i) {
         src_nelems *= static_cast<size_t>(eig_vecs_shape[i]);
     }
 
-    if (src_nelems == 0)
-    {
+    if (src_nelems == 0) {
         // nothing to do
         return std::make_pair(sycl::event(), sycl::event());
     }
 
     // check compatibility of execution queue and allocation queue
-    if (!dpctl::utils::queues_are_compatible(exec_q, {eig_vecs, eig_vals}))
-    {
-        throw py::value_error("Execution queue is not compatible with allocation queues");
+    if (!dpctl::utils::queues_are_compatible(exec_q, {eig_vecs, eig_vals})) {
+        throw py::value_error(
+            "Execution queue is not compatible with allocation queues");
     }
 
-    auto const& overlap = dpctl::tensor::overlap::MemoryOverlap();
-    if (overlap(eig_vecs, eig_vals))
-    {
-        throw py::value_error("Arrays with eigenvectors and eigenvalues are overlapping segments of memory");
+    auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
+    if (overlap(eig_vecs, eig_vals)) {
+        throw py::value_error("Arrays with eigenvectors and eigenvalues are "
+                              "overlapping segments of memory");
     }
 
     bool is_eig_vecs_f_contig = eig_vecs.is_f_contiguous();
     bool is_eig_vals_c_contig = eig_vals.is_c_contiguous();
-    if (!is_eig_vecs_f_contig)
-    {
-        throw py::value_error("An array with input matrix / ouput eigenvectors must be F-contiguous");
+    if (!is_eig_vecs_f_contig) {
+        throw py::value_error("An array with input matrix / ouput eigenvectors "
+                              "must be F-contiguous");
     }
-    else if (!is_eig_vals_c_contig)
-    {
-        throw py::value_error("An array with output eigenvalues must be C-contiguous");
+    else if (!is_eig_vals_c_contig) {
+        throw py::value_error(
+            "An array with output eigenvalues must be C-contiguous");
     }
 
     auto array_types = dpctl_td_ns::usm_ndarray_types();
-    int eig_vecs_type_id = array_types.typenum_to_lookup_id(eig_vecs.get_typenum());
-    int eig_vals_type_id = array_types.typenum_to_lookup_id(eig_vals.get_typenum());
+    int eig_vecs_type_id =
+        array_types.typenum_to_lookup_id(eig_vecs.get_typenum());
+    int eig_vals_type_id =
+        array_types.typenum_to_lookup_id(eig_vals.get_typenum());
 
-    heevd_impl_fn_ptr_t heevd_fn = heevd_dispatch_table[eig_vecs_type_id][eig_vals_type_id];
-    if (heevd_fn == nullptr)
-    {
-        throw py::value_error("No heevd implementation defined for a pair of type for eigenvectors and eigenvalues");
+    heevd_impl_fn_ptr_t heevd_fn =
+        heevd_dispatch_table[eig_vecs_type_id][eig_vals_type_id];
+    if (heevd_fn == nullptr) {
+        throw py::value_error("No heevd implementation defined for a pair of "
+                              "type for eigenvectors and eigenvalues");
     }
 
-    char* eig_vecs_data = eig_vecs.get_data();
-    char* eig_vals_data = eig_vals.get_data();
+    char *eig_vecs_data = eig_vecs.get_data();
+    char *eig_vals_data = eig_vals.get_data();
 
-    const std::int64_t n = eig_vecs_shape[0];
+    const std::int64_t n            = eig_vecs_shape[0];
     const oneapi::mkl::job jobz_val = static_cast<oneapi::mkl::job>(jobz);
-    const oneapi::mkl::uplo uplo_val = static_cast<oneapi::mkl::uplo>(upper_lower);
+    const oneapi::mkl::uplo uplo_val =
+        static_cast<oneapi::mkl::uplo>(upper_lower);
 
     std::vector<sycl::event> host_task_events;
     sycl::event heevd_ev =
-        heevd_fn(exec_q, jobz_val, uplo_val, n, eig_vecs_data, eig_vals_data, host_task_events, depends);
+        heevd_fn(exec_q, jobz_val, uplo_val, n, eig_vecs_data, eig_vals_data,
+                 host_task_events, depends);
 
-    sycl::event args_ev = dpctl::utils::keep_args_alive(exec_q, {eig_vecs, eig_vals}, host_task_events);
+    sycl::event args_ev = dpctl::utils::keep_args_alive(
+        exec_q, {eig_vecs, eig_vals}, host_task_events);
     return std::make_pair(args_ev, heevd_ev);
 }
 
@@ -234,8 +236,7 @@ struct HeevdContigFactory
         {
             return heevd_impl<T, RealT>;
         }
-        else
-        {
+        else {
             return nullptr;
         }
     }
@@ -243,10 +244,12 @@ struct HeevdContigFactory
 
 void init_heevd_dispatch_table(void)
 {
-    dpctl_td_ns::DispatchTableBuilder<heevd_impl_fn_ptr_t, HeevdContigFactory, dpctl_td_ns::num_types> contig;
+    dpctl_td_ns::DispatchTableBuilder<heevd_impl_fn_ptr_t, HeevdContigFactory,
+                                      dpctl_td_ns::num_types>
+        contig;
     contig.populate_dispatch_table(heevd_dispatch_table);
 }
-}
-}
-}
-}
+} // namespace lapack
+} // namespace ext
+} // namespace backend
+} // namespace dpnp

--- a/dpnp/backend/extensions/lapack/heevd.hpp
+++ b/dpnp/backend/extensions/lapack/heevd.hpp
@@ -30,7 +30,6 @@
 
 #include <dpctl4pybind11.hpp>
 
-
 namespace dpnp
 {
 namespace backend
@@ -39,15 +38,16 @@ namespace ext
 {
 namespace lapack
 {
-    extern std::pair<sycl::event, sycl::event> heevd(sycl::queue exec_q,
-                                                     const std::int8_t jobz,
-                                                     const std::int8_t upper_lower,
-                                                     dpctl::tensor::usm_ndarray eig_vecs,
-                                                     dpctl::tensor::usm_ndarray eig_vals,
-                                                     const std::vector<sycl::event>& depends);
+extern std::pair<sycl::event, sycl::event>
+    heevd(sycl::queue exec_q,
+          const std::int8_t jobz,
+          const std::int8_t upper_lower,
+          dpctl::tensor::usm_ndarray eig_vecs,
+          dpctl::tensor::usm_ndarray eig_vals,
+          const std::vector<sycl::event> &depends);
 
-    extern void init_heevd_dispatch_table(void);
-}
-}
-}
-}
+extern void init_heevd_dispatch_table(void);
+} // namespace lapack
+} // namespace ext
+} // namespace backend
+} // namespace dpnp

--- a/dpnp/backend/extensions/lapack/lapack_py.cpp
+++ b/dpnp/backend/extensions/lapack/lapack_py.cpp
@@ -34,7 +34,7 @@
 #include "syevd.hpp"
 
 namespace lapack_ext = dpnp::backend::ext::lapack;
-namespace py = pybind11;
+namespace py         = pybind11;
 
 // populate dispatch vectors
 void init_dispatch_vectors(void)
@@ -53,25 +53,17 @@ PYBIND11_MODULE(_lapack_impl, m)
     init_dispatch_vectors();
     init_dispatch_tables();
 
-    m.def("_heevd",
-          &lapack_ext::heevd,
+    m.def("_heevd", &lapack_ext::heevd,
           "Call `heevd` from OneMKL LAPACK library to return "
           "the eigenvalues and eigenvectors of a complex Hermitian matrix",
-          py::arg("sycl_queue"),
-          py::arg("jobz"),
-          py::arg("upper_lower"),
-          py::arg("eig_vecs"),
-          py::arg("eig_vals"),
+          py::arg("sycl_queue"), py::arg("jobz"), py::arg("upper_lower"),
+          py::arg("eig_vecs"), py::arg("eig_vals"),
           py::arg("depends") = py::list());
 
-    m.def("_syevd",
-          &lapack_ext::syevd,
+    m.def("_syevd", &lapack_ext::syevd,
           "Call `syevd` from OneMKL LAPACK library to return "
           "the eigenvalues and eigenvectors of a real symmetric matrix",
-          py::arg("sycl_queue"),
-          py::arg("jobz"),
-          py::arg("upper_lower"),
-          py::arg("eig_vecs"),
-          py::arg("eig_vals"),
+          py::arg("sycl_queue"), py::arg("jobz"), py::arg("upper_lower"),
+          py::arg("eig_vecs"), py::arg("eig_vals"),
           py::arg("depends") = py::list());
 }

--- a/dpnp/backend/extensions/lapack/lapack_py.cpp
+++ b/dpnp/backend/extensions/lapack/lapack_py.cpp
@@ -34,7 +34,7 @@
 #include "syevd.hpp"
 
 namespace lapack_ext = dpnp::backend::ext::lapack;
-namespace py         = pybind11;
+namespace py = pybind11;
 
 // populate dispatch vectors
 void init_dispatch_vectors(void)

--- a/dpnp/backend/extensions/lapack/syevd.cpp
+++ b/dpnp/backend/extensions/lapack/syevd.cpp
@@ -23,7 +23,6 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //*****************************************************************************
 
-
 #include <pybind11/pybind11.h>
 
 // dpctl tensor headers
@@ -35,7 +34,6 @@
 
 #include "dpnp_utils.hpp"
 
-
 namespace dpnp
 {
 namespace backend
@@ -44,19 +42,18 @@ namespace ext
 {
 namespace lapack
 {
-
 namespace mkl_lapack = oneapi::mkl::lapack;
-namespace py = pybind11;
+namespace py         = pybind11;
 namespace type_utils = dpctl::tensor::type_utils;
 
 typedef sycl::event (*syevd_impl_fn_ptr_t)(sycl::queue,
                                            const oneapi::mkl::job,
                                            const oneapi::mkl::uplo,
                                            const std::int64_t,
-                                           char*,
-                                           char*,
-                                           std::vector<sycl::event>&,
-                                           const std::vector<sycl::event>&);
+                                           char *,
+                                           char *,
+                                           std::vector<sycl::event> &,
+                                           const std::vector<sycl::event> &);
 
 static syevd_impl_fn_ptr_t syevd_dispatch_vector[dpctl_td_ns::num_types];
 
@@ -65,63 +62,65 @@ static sycl::event syevd_impl(sycl::queue exec_q,
                               const oneapi::mkl::job jobz,
                               const oneapi::mkl::uplo upper_lower,
                               const std::int64_t n,
-                              char* in_a,
-                              char* out_w,
-                              std::vector<sycl::event>& host_task_events,
-                              const std::vector<sycl::event>& depends)
+                              char *in_a,
+                              char *out_w,
+                              std::vector<sycl::event> &host_task_events,
+                              const std::vector<sycl::event> &depends)
 {
     type_utils::validate_type_for_device<T>(exec_q);
 
-    T* a = reinterpret_cast<T*>(in_a);
-    T* w = reinterpret_cast<T*>(out_w);
+    T *a = reinterpret_cast<T *>(in_a);
+    T *w = reinterpret_cast<T *>(out_w);
 
     const std::int64_t lda = std::max<size_t>(1UL, n);
-    const std::int64_t scratchpad_size = mkl_lapack::syevd_scratchpad_size<T>(exec_q, jobz, upper_lower, n, lda);
-    T* scratchpad = nullptr;
+    const std::int64_t scratchpad_size =
+        mkl_lapack::syevd_scratchpad_size<T>(exec_q, jobz, upper_lower, n, lda);
+    T *scratchpad = nullptr;
 
     std::stringstream error_msg;
     std::int64_t info = 0;
 
     sycl::event syevd_event;
-    try
-    {
+    try {
         scratchpad = sycl::malloc_device<T>(scratchpad_size, exec_q);
 
         syevd_event = mkl_lapack::syevd(
             exec_q,
-            jobz,        // 'jobz == job::vec' means eigenvalues and eigenvectors are computed.
-            upper_lower, // 'upper_lower == job::upper' means the upper triangular part of A, or the lower triangular otherwise
+            jobz, // 'jobz == job::vec' means eigenvalues and eigenvectors are
+                  // computed.
+            upper_lower, // 'upper_lower == job::upper' means the upper
+                         // triangular part of A, or the lower triangular
+                         // otherwise
             n,           // The order of the matrix A (0 <= n)
-            a,           // Pointer to A, size (lda, *), where the 2nd dimension, must be at least max(1, n)
-                         // If 'jobz == job::vec', then on exit it will contain the eigenvectors of A
-            lda,         // The leading dimension of a, must be at least max(1, n)
-            w,           // Pointer to array of size at least n, it will contain the eigenvalues of A in ascending order
-            scratchpad,  // Pointer to scratchpad memory to be used by MKL routine for storing intermediate results
-            scratchpad_size,
-            depends);
-    }
-    catch (mkl_lapack::exception const& e)
-    {
-        error_msg << "Unexpected MKL exception caught during syevd() call:\nreason: " << e.what()
-                  << "\ninfo: " << e.info();
+            a, // Pointer to A, size (lda, *), where the 2nd dimension, must be
+               // at least max(1, n) If 'jobz == job::vec', then on exit it will
+               // contain the eigenvectors of A
+            lda, // The leading dimension of a, must be at least max(1, n)
+            w,   // Pointer to array of size at least n, it will contain the
+                 // eigenvalues of A in ascending order
+            scratchpad, // Pointer to scratchpad memory to be used by MKL
+                        // routine for storing intermediate results
+            scratchpad_size, depends);
+    } catch (mkl_lapack::exception const &e) {
+        error_msg
+            << "Unexpected MKL exception caught during syevd() call:\nreason: "
+            << e.what() << "\ninfo: " << e.info();
         info = e.info();
-    }
-    catch (sycl::exception const& e)
-    {
-        error_msg << "Unexpected SYCL exception caught during syevd() call:\n" << e.what();
+    } catch (sycl::exception const &e) {
+        error_msg << "Unexpected SYCL exception caught during syevd() call:\n"
+                  << e.what();
         info = -1;
     }
 
     if (info != 0) // an unexected error occurs
     {
-        if (scratchpad != nullptr)
-        {
+        if (scratchpad != nullptr) {
             sycl::free(scratchpad, exec_q);
         }
         throw std::runtime_error(error_msg.str());
     }
 
-    sycl::event clean_up_event = exec_q.submit([&](sycl::handler& cgh) {
+    sycl::event clean_up_event = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(syevd_event);
         auto ctx = exec_q.get_context();
         cgh.host_task([ctx, scratchpad]() { sycl::free(scratchpad, ctx); });
@@ -130,102 +129,103 @@ static sycl::event syevd_impl(sycl::queue exec_q,
     return syevd_event;
 }
 
-std::pair<sycl::event, sycl::event> syevd(sycl::queue exec_q,
-                                          const std::int8_t jobz,
-                                          const std::int8_t upper_lower,
-                                          dpctl::tensor::usm_ndarray eig_vecs,
-                                          dpctl::tensor::usm_ndarray eig_vals,
-                                          const std::vector<sycl::event>& depends)
+std::pair<sycl::event, sycl::event>
+    syevd(sycl::queue exec_q,
+          const std::int8_t jobz,
+          const std::int8_t upper_lower,
+          dpctl::tensor::usm_ndarray eig_vecs,
+          dpctl::tensor::usm_ndarray eig_vals,
+          const std::vector<sycl::event> &depends)
 {
     const int eig_vecs_nd = eig_vecs.get_ndim();
     const int eig_vals_nd = eig_vals.get_ndim();
 
-    if (eig_vecs_nd != 2)
-    {
+    if (eig_vecs_nd != 2) {
         throw py::value_error("Unexpected ndim=" + std::to_string(eig_vecs_nd) +
                               " of an output array with eigenvectors");
     }
-    else if (eig_vals_nd != 1)
-    {
+    else if (eig_vals_nd != 1) {
         throw py::value_error("Unexpected ndim=" + std::to_string(eig_vals_nd) +
                               " of an output array with eigenvalues");
     }
 
-    const py::ssize_t* eig_vecs_shape = eig_vecs.get_shape_raw();
-    const py::ssize_t* eig_vals_shape = eig_vals.get_shape_raw();
+    const py::ssize_t *eig_vecs_shape = eig_vecs.get_shape_raw();
+    const py::ssize_t *eig_vals_shape = eig_vals.get_shape_raw();
 
-    if (eig_vecs_shape[0] != eig_vecs_shape[1])
-    {
+    if (eig_vecs_shape[0] != eig_vecs_shape[1]) {
         throw py::value_error("Output array with eigenvectors with be square");
     }
-    else if (eig_vecs_shape[0] != eig_vals_shape[0])
-    {
-        throw py::value_error("Eigenvectors and eigenvalues have different shapes");
+    else if (eig_vecs_shape[0] != eig_vals_shape[0]) {
+        throw py::value_error(
+            "Eigenvectors and eigenvalues have different shapes");
     }
 
     size_t src_nelems(1);
 
-    for (int i = 0; i < eig_vecs_nd; ++i)
-    {
+    for (int i = 0; i < eig_vecs_nd; ++i) {
         src_nelems *= static_cast<size_t>(eig_vecs_shape[i]);
     }
 
-    if (src_nelems == 0)
-    {
+    if (src_nelems == 0) {
         // nothing to do
         return std::make_pair(sycl::event(), sycl::event());
     }
 
     // check compatibility of execution queue and allocation queue
-    if (!dpctl::utils::queues_are_compatible(exec_q, {eig_vecs, eig_vals}))
-    {
-        throw py::value_error("Execution queue is not compatible with allocation queues");
+    if (!dpctl::utils::queues_are_compatible(exec_q, {eig_vecs, eig_vals})) {
+        throw py::value_error(
+            "Execution queue is not compatible with allocation queues");
     }
 
-    auto const& overlap = dpctl::tensor::overlap::MemoryOverlap();
-    if (overlap(eig_vecs, eig_vals))
-    {
-        throw py::value_error("Arrays with eigenvectors and eigenvalues are overlapping segments of memory");
+    auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
+    if (overlap(eig_vecs, eig_vals)) {
+        throw py::value_error("Arrays with eigenvectors and eigenvalues are "
+                              "overlapping segments of memory");
     }
 
     bool is_eig_vecs_f_contig = eig_vecs.is_f_contiguous();
     bool is_eig_vals_c_contig = eig_vals.is_c_contiguous();
-    if (!is_eig_vecs_f_contig)
-    {
-        throw py::value_error("An array with input matrix / ouput eigenvectors must be F-contiguous");
+    if (!is_eig_vecs_f_contig) {
+        throw py::value_error("An array with input matrix / ouput eigenvectors "
+                              "must be F-contiguous");
     }
-    else if (!is_eig_vals_c_contig)
-    {
-        throw py::value_error("An array with output eigenvalues must be C-contiguous");
+    else if (!is_eig_vals_c_contig) {
+        throw py::value_error(
+            "An array with output eigenvalues must be C-contiguous");
     }
 
     auto array_types = dpctl_td_ns::usm_ndarray_types();
-    int eig_vecs_type_id = array_types.typenum_to_lookup_id(eig_vecs.get_typenum());
-    int eig_vals_type_id = array_types.typenum_to_lookup_id(eig_vals.get_typenum());
+    int eig_vecs_type_id =
+        array_types.typenum_to_lookup_id(eig_vecs.get_typenum());
+    int eig_vals_type_id =
+        array_types.typenum_to_lookup_id(eig_vals.get_typenum());
 
-    if (eig_vecs_type_id != eig_vals_type_id)
-    {
-        throw py::value_error("Types of eigenvectors and eigenvalues are missmatched");
+    if (eig_vecs_type_id != eig_vals_type_id) {
+        throw py::value_error(
+            "Types of eigenvectors and eigenvalues are missmatched");
     }
 
     syevd_impl_fn_ptr_t syevd_fn = syevd_dispatch_vector[eig_vecs_type_id];
-    if (syevd_fn == nullptr)
-    {
-        throw py::value_error("No syevd implementation defined for a type of eigenvectors and eigenvalues");
+    if (syevd_fn == nullptr) {
+        throw py::value_error("No syevd implementation defined for a type of "
+                              "eigenvectors and eigenvalues");
     }
 
-    char* eig_vecs_data = eig_vecs.get_data();
-    char* eig_vals_data = eig_vals.get_data();
+    char *eig_vecs_data = eig_vecs.get_data();
+    char *eig_vals_data = eig_vals.get_data();
 
-    const std::int64_t n = eig_vecs_shape[0];
+    const std::int64_t n            = eig_vecs_shape[0];
     const oneapi::mkl::job jobz_val = static_cast<oneapi::mkl::job>(jobz);
-    const oneapi::mkl::uplo uplo_val = static_cast<oneapi::mkl::uplo>(upper_lower);
+    const oneapi::mkl::uplo uplo_val =
+        static_cast<oneapi::mkl::uplo>(upper_lower);
 
     std::vector<sycl::event> host_task_events;
     sycl::event syevd_ev =
-        syevd_fn(exec_q, jobz_val, uplo_val, n, eig_vecs_data, eig_vals_data, host_task_events, depends);
+        syevd_fn(exec_q, jobz_val, uplo_val, n, eig_vecs_data, eig_vals_data,
+                 host_task_events, depends);
 
-    sycl::event args_ev = dpctl::utils::keep_args_alive(exec_q, {eig_vecs, eig_vals}, host_task_events);
+    sycl::event args_ev = dpctl::utils::keep_args_alive(
+        exec_q, {eig_vecs, eig_vals}, host_task_events);
     return std::make_pair(args_ev, syevd_ev);
 }
 
@@ -234,12 +234,10 @@ struct SyevdContigFactory
 {
     fnT get()
     {
-        if constexpr (types::SyevdTypePairSupportFactory<T>::is_defined)
-        {
+        if constexpr (types::SyevdTypePairSupportFactory<T>::is_defined) {
             return syevd_impl<T>;
         }
-        else
-        {
+        else {
             return nullptr;
         }
     }
@@ -247,10 +245,12 @@ struct SyevdContigFactory
 
 void init_syevd_dispatch_vector(void)
 {
-    dpctl_td_ns::DispatchVectorBuilder<syevd_impl_fn_ptr_t, SyevdContigFactory, dpctl_td_ns::num_types> contig;
+    dpctl_td_ns::DispatchVectorBuilder<syevd_impl_fn_ptr_t, SyevdContigFactory,
+                                       dpctl_td_ns::num_types>
+        contig;
     contig.populate_dispatch_vector(syevd_dispatch_vector);
 }
-}
-}
-}
-}
+} // namespace lapack
+} // namespace ext
+} // namespace backend
+} // namespace dpnp

--- a/dpnp/backend/extensions/lapack/syevd.cpp
+++ b/dpnp/backend/extensions/lapack/syevd.cpp
@@ -43,7 +43,7 @@ namespace ext
 namespace lapack
 {
 namespace mkl_lapack = oneapi::mkl::lapack;
-namespace py         = pybind11;
+namespace py = pybind11;
 namespace type_utils = dpctl::tensor::type_utils;
 
 typedef sycl::event (*syevd_impl_fn_ptr_t)(sycl::queue,
@@ -214,7 +214,7 @@ std::pair<sycl::event, sycl::event>
     char *eig_vecs_data = eig_vecs.get_data();
     char *eig_vals_data = eig_vals.get_data();
 
-    const std::int64_t n            = eig_vecs_shape[0];
+    const std::int64_t n = eig_vecs_shape[0];
     const oneapi::mkl::job jobz_val = static_cast<oneapi::mkl::job>(jobz);
     const oneapi::mkl::uplo uplo_val =
         static_cast<oneapi::mkl::uplo>(upper_lower);

--- a/dpnp/backend/extensions/lapack/syevd.hpp
+++ b/dpnp/backend/extensions/lapack/syevd.hpp
@@ -30,7 +30,6 @@
 
 #include <dpctl4pybind11.hpp>
 
-
 namespace dpnp
 {
 namespace backend
@@ -39,15 +38,16 @@ namespace ext
 {
 namespace lapack
 {
-    extern std::pair<sycl::event, sycl::event> syevd(sycl::queue exec_q,
-                                                     const std::int8_t jobz,
-                                                     const std::int8_t upper_lower,
-                                                     dpctl::tensor::usm_ndarray eig_vecs,
-                                                     dpctl::tensor::usm_ndarray eig_vals,
-                                                     const std::vector<sycl::event>& depends = {});
+extern std::pair<sycl::event, sycl::event>
+    syevd(sycl::queue exec_q,
+          const std::int8_t jobz,
+          const std::int8_t upper_lower,
+          dpctl::tensor::usm_ndarray eig_vecs,
+          dpctl::tensor::usm_ndarray eig_vals,
+          const std::vector<sycl::event> &depends = {});
 
-    extern void init_syevd_dispatch_vector(void);
-}
-}
-}
-}
+extern void init_syevd_dispatch_vector(void);
+} // namespace lapack
+} // namespace ext
+} // namespace backend
+} // namespace dpnp

--- a/dpnp/backend/extensions/lapack/types_matrix.hpp
+++ b/dpnp/backend/extensions/lapack/types_matrix.hpp
@@ -45,36 +45,43 @@ namespace types
 {
 /**
  * @brief A factory to define pairs of supported types for which
- * MKL LAPACK library provides support in oneapi::mkl::lapack::heevd<T, RealT> function.
+ * MKL LAPACK library provides support in oneapi::mkl::lapack::heevd<T, RealT>
+ * function.
  *
- * @tparam T Type of array containing input matrix A and an output array with eigenvectors.
+ * @tparam T Type of array containing input matrix A and an output array with
+ * eigenvectors.
  * @tparam RealT Type of output array containing eigenvalues of A.
  */
 template <typename T, typename RealT>
 struct HeevdTypePairSupportFactory
 {
-    static constexpr bool is_defined = std::disjunction<dpctl_td_ns::TypePairDefinedEntry<T, std::complex<double>, RealT, double>,
-                                                        dpctl_td_ns::TypePairDefinedEntry<T, std::complex<float>, RealT, float>,
-                                                        // fall-through
-                                                        dpctl_td_ns::NotDefinedEntry>::is_defined;
+    static constexpr bool is_defined = std::disjunction<
+        dpctl_td_ns::
+            TypePairDefinedEntry<T, std::complex<double>, RealT, double>,
+        dpctl_td_ns::TypePairDefinedEntry<T, std::complex<float>, RealT, float>,
+        // fall-through
+        dpctl_td_ns::NotDefinedEntry>::is_defined;
 };
 
 /**
  * @brief A factory to define pairs of supported types for which
- * MKL LAPACK library provides support in oneapi::mkl::lapack::syevd<T> function.
+ * MKL LAPACK library provides support in oneapi::mkl::lapack::syevd<T>
+ * function.
  *
- * @tparam T Type of array containing input matrix A and an output arrays with eigenvectors and eigenvectors.
+ * @tparam T Type of array containing input matrix A and an output arrays with
+ * eigenvectors and eigenvectors.
  */
 template <typename T>
 struct SyevdTypePairSupportFactory
 {
-    static constexpr bool is_defined = std::disjunction<dpctl_td_ns::TypePairDefinedEntry<T, double, T, double>,
-                                                        dpctl_td_ns::TypePairDefinedEntry<T, float, T, float>,
-                                                        // fall-through
-                                                        dpctl_td_ns::NotDefinedEntry>::is_defined;
+    static constexpr bool is_defined = std::disjunction<
+        dpctl_td_ns::TypePairDefinedEntry<T, double, T, double>,
+        dpctl_td_ns::TypePairDefinedEntry<T, float, T, float>,
+        // fall-through
+        dpctl_td_ns::NotDefinedEntry>::is_defined;
 };
-}
-}
-}
-}
-}
+} // namespace types
+} // namespace lapack
+} // namespace ext
+} // namespace backend
+} // namespace dpnp

--- a/dpnp/backend/extensions/vm/div.cpp
+++ b/dpnp/backend/extensions/vm/div.cpp
@@ -23,7 +23,6 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //*****************************************************************************
 
-
 #include <pybind11/pybind11.h>
 
 // dpctl tensor headers
@@ -35,7 +34,6 @@
 
 #include "dpnp_utils.hpp"
 
-
 namespace dpnp
 {
 namespace backend
@@ -44,29 +42,32 @@ namespace ext
 {
 namespace vm
 {
-
-namespace mkl_vm = oneapi::mkl::vm;
-namespace py = pybind11;
+namespace mkl_vm     = oneapi::mkl::vm;
+namespace py         = pybind11;
 namespace type_utils = dpctl::tensor::type_utils;
 
-typedef sycl::event (*div_impl_fn_ptr_t)(
-    sycl::queue, const std::int64_t, const char*, const char*, char*, const std::vector<sycl::event>&);
+typedef sycl::event (*div_impl_fn_ptr_t)(sycl::queue,
+                                         const std::int64_t,
+                                         const char *,
+                                         const char *,
+                                         char *,
+                                         const std::vector<sycl::event> &);
 
 static div_impl_fn_ptr_t div_dispatch_vector[dpctl_td_ns::num_types];
 
 template <typename T>
 static sycl::event div_impl(sycl::queue exec_q,
                             const std::int64_t n,
-                            const char* in_a,
-                            const char* in_b,
-                            char* out_y,
-                            const std::vector<sycl::event>& depends)
+                            const char *in_a,
+                            const char *in_b,
+                            char *out_y,
+                            const std::vector<sycl::event> &depends)
 {
     type_utils::validate_type_for_device<T>(exec_q);
 
-    const T* a = reinterpret_cast<const T*>(in_a);
-    const T* b = reinterpret_cast<const T*>(in_b);
-    T* y = reinterpret_cast<T*>(out_y);
+    const T *a = reinterpret_cast<const T *>(in_a);
+    const T *b = reinterpret_cast<const T *>(in_b);
+    T *y       = reinterpret_cast<T *>(out_y);
 
     return mkl_vm::div(exec_q,
                        n, // number of elements to be calculated
@@ -76,61 +77,59 @@ static sycl::event div_impl(sycl::queue exec_q,
                        depends);
 }
 
-std::pair<sycl::event, sycl::event> div(sycl::queue exec_q,
-                                        dpctl::tensor::usm_ndarray src1,
-                                        dpctl::tensor::usm_ndarray src2,
-                                        dpctl::tensor::usm_ndarray dst, // dst = op(src1, src2), elementwise
-                                        const std::vector<sycl::event>& depends)
+std::pair<sycl::event, sycl::event>
+    div(sycl::queue exec_q,
+        dpctl::tensor::usm_ndarray src1,
+        dpctl::tensor::usm_ndarray src2,
+        dpctl::tensor::usm_ndarray dst, // dst = op(src1, src2), elementwise
+        const std::vector<sycl::event> &depends)
 {
     // check type_nums
     int src1_typenum = src1.get_typenum();
     int src2_typenum = src2.get_typenum();
-    int dst_typenum = dst.get_typenum();
+    int dst_typenum  = dst.get_typenum();
 
     auto array_types = dpctl_td_ns::usm_ndarray_types();
-    int src1_typeid = array_types.typenum_to_lookup_id(src1_typenum);
-    int src2_typeid = array_types.typenum_to_lookup_id(src2_typenum);
-    int dst_typeid = array_types.typenum_to_lookup_id(dst_typenum);
+    int src1_typeid  = array_types.typenum_to_lookup_id(src1_typenum);
+    int src2_typeid  = array_types.typenum_to_lookup_id(src2_typenum);
+    int dst_typeid   = array_types.typenum_to_lookup_id(dst_typenum);
 
-    if (src1_typeid != src2_typeid || src2_typeid != dst_typeid)
-    {
-        throw py::value_error("Either any of input arrays or output array have different types");
+    if (src1_typeid != src2_typeid || src2_typeid != dst_typeid) {
+        throw py::value_error(
+            "Either any of input arrays or output array have different types");
     }
 
     // check that queues are compatible
-    if (!dpctl::utils::queues_are_compatible(exec_q, {src1, src2, dst}))
-    {
-        throw py::value_error("Execution queue is not compatible with allocation queues");
+    if (!dpctl::utils::queues_are_compatible(exec_q, {src1, src2, dst})) {
+        throw py::value_error(
+            "Execution queue is not compatible with allocation queues");
     }
 
     // check shapes, broadcasting is assumed done by caller
     // check that dimensions are the same
     int dst_nd = dst.get_ndim();
-    if (dst_nd != src1.get_ndim() || dst_nd != src2.get_ndim())
-    {
+    if (dst_nd != src1.get_ndim() || dst_nd != src2.get_ndim()) {
         throw py::value_error("Array dimensions are not the same.");
     }
 
     // check that shapes are the same
-    const py::ssize_t* src1_shape = src1.get_shape_raw();
-    const py::ssize_t* src2_shape = src2.get_shape_raw();
-    const py::ssize_t* dst_shape = dst.get_shape_raw();
+    const py::ssize_t *src1_shape = src1.get_shape_raw();
+    const py::ssize_t *src2_shape = src2.get_shape_raw();
+    const py::ssize_t *dst_shape  = dst.get_shape_raw();
     bool shapes_equal(true);
     size_t src_nelems(1);
 
-    for (int i = 0; i < dst_nd; ++i)
-    {
+    for (int i = 0; i < dst_nd; ++i) {
         src_nelems *= static_cast<size_t>(src1_shape[i]);
-        shapes_equal = shapes_equal && (src1_shape[i] == dst_shape[i] && src2_shape[i] == dst_shape[i]);
+        shapes_equal = shapes_equal && (src1_shape[i] == dst_shape[i] &&
+                                        src2_shape[i] == dst_shape[i]);
     }
-    if (!shapes_equal)
-    {
+    if (!shapes_equal) {
         throw py::value_error("Array shapes are not the same.");
     }
 
     // if nelems is zero, return
-    if (src_nelems == 0)
-    {
+    if (src_nelems == 0) {
         return std::make_pair(sycl::event(), sycl::event());
     }
 
@@ -138,9 +137,9 @@ std::pair<sycl::event, sycl::event> div(sycl::queue exec_q,
     auto dst_offsets = dst.get_minmax_offsets();
     // destination must be ample enough to accomodate all elements
     {
-        size_t range = static_cast<size_t>(dst_offsets.second - dst_offsets.first);
-        if (range + 1 < src_nelems)
-        {
+        size_t range =
+            static_cast<size_t>(dst_offsets.second - dst_offsets.first);
+        if (range + 1 < src_nelems) {
             throw py::value_error(
                 "Destination array can not accomodate all the "
                 "elements of source array.");
@@ -148,35 +147,35 @@ std::pair<sycl::event, sycl::event> div(sycl::queue exec_q,
     }
 
     // check memory overlap
-    auto const& overlap = dpctl::tensor::overlap::MemoryOverlap();
-    if (overlap(src1, dst) || overlap(src2, dst))
-    {
+    auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
+    if (overlap(src1, dst) || overlap(src2, dst)) {
         throw py::value_error("Arrays index overlapping segments of memory");
     }
 
-    const char* src1_data = src1.get_data();
-    const char* src2_data = src2.get_data();
-    char* dst_data = dst.get_data();
+    const char *src1_data = src1.get_data();
+    const char *src2_data = src2.get_data();
+    char *dst_data        = dst.get_data();
 
     // handle contiguous inputs
     bool is_src1_c_contig = src1.is_c_contiguous();
     bool is_src2_c_contig = src2.is_c_contiguous();
-    bool is_dst_c_contig = dst.is_c_contiguous();
+    bool is_dst_c_contig  = dst.is_c_contiguous();
 
-    bool all_c_contig = (is_src1_c_contig && is_src2_c_contig && is_dst_c_contig);
-    if (!all_c_contig)
-    {
+    bool all_c_contig =
+        (is_src1_c_contig && is_src2_c_contig && is_dst_c_contig);
+    if (!all_c_contig) {
         throw py::value_error("Input and outpur arrays must be C-contiguous");
     }
 
     auto div_fn = div_dispatch_vector[dst_typeid];
-    if (div_fn == nullptr)
-    {
+    if (div_fn == nullptr) {
         throw py::value_error("No div implementation defined");
     }
-    sycl::event sum_ev = div_fn(exec_q, src_nelems, src1_data, src2_data, dst_data, depends);
+    sycl::event sum_ev =
+        div_fn(exec_q, src_nelems, src1_data, src2_data, dst_data, depends);
 
-    sycl::event ht_ev = dpctl::utils::keep_args_alive(exec_q, {src1, src2, dst}, {sum_ev});
+    sycl::event ht_ev =
+        dpctl::utils::keep_args_alive(exec_q, {src1, src2, dst}, {sum_ev});
     return std::make_pair(ht_ev, sum_ev);
     return std::make_pair(sycl::event(), sycl::event());
 }
@@ -190,63 +189,56 @@ bool can_call_div(sycl::queue exec_q,
     // check type_nums
     int src1_typenum = src1.get_typenum();
     int src2_typenum = src2.get_typenum();
-    int dst_typenum = dst.get_typenum();
+    int dst_typenum  = dst.get_typenum();
 
     auto array_types = dpctl_td_ns::usm_ndarray_types();
-    int src1_typeid = array_types.typenum_to_lookup_id(src1_typenum);
-    int src2_typeid = array_types.typenum_to_lookup_id(src2_typenum);
-    int dst_typeid = array_types.typenum_to_lookup_id(dst_typenum);
+    int src1_typeid  = array_types.typenum_to_lookup_id(src1_typenum);
+    int src2_typeid  = array_types.typenum_to_lookup_id(src2_typenum);
+    int dst_typeid   = array_types.typenum_to_lookup_id(dst_typenum);
 
     // types must be the same
-    if (src1_typeid != src2_typeid || src2_typeid != dst_typeid)
-    {
+    if (src1_typeid != src2_typeid || src2_typeid != dst_typeid) {
         return false;
     }
 
     // OneMKL VM functions perform a copy on host if no double type support
-    if (!exec_q.get_device().has(sycl::aspect::fp64))
-    {
+    if (!exec_q.get_device().has(sycl::aspect::fp64)) {
         return false;
     }
 
     // check that queues are compatible
-    if (!dpctl::utils::queues_are_compatible(exec_q, {src1, src2, dst}))
-    {
+    if (!dpctl::utils::queues_are_compatible(exec_q, {src1, src2, dst})) {
         return false;
     }
 
     // dimensions must be the same
     int dst_nd = dst.get_ndim();
-    if (dst_nd != src1.get_ndim() || dst_nd != src2.get_ndim())
-    {
+    if (dst_nd != src1.get_ndim() || dst_nd != src2.get_ndim()) {
         return false;
     }
-    else if (dst_nd == 0)
-    {
+    else if (dst_nd == 0) {
         // don't call OneMKL for 0d arrays
         return false;
     }
 
     // shapes must be the same
-    const py::ssize_t* src1_shape = src1.get_shape_raw();
-    const py::ssize_t* src2_shape = src2.get_shape_raw();
-    const py::ssize_t* dst_shape = dst.get_shape_raw();
+    const py::ssize_t *src1_shape = src1.get_shape_raw();
+    const py::ssize_t *src2_shape = src2.get_shape_raw();
+    const py::ssize_t *dst_shape  = dst.get_shape_raw();
     bool shapes_equal(true);
     size_t src_nelems(1);
 
-    for (int i = 0; i < dst_nd; ++i)
-    {
+    for (int i = 0; i < dst_nd; ++i) {
         src_nelems *= static_cast<size_t>(src1_shape[i]);
-        shapes_equal = shapes_equal && (src1_shape[i] == dst_shape[i] && src2_shape[i] == dst_shape[i]);
+        shapes_equal = shapes_equal && (src1_shape[i] == dst_shape[i] &&
+                                        src2_shape[i] == dst_shape[i]);
     }
-    if (!shapes_equal)
-    {
+    if (!shapes_equal) {
         return false;
     }
 
     // if nelems is zero, return false
-    if (src_nelems == 0)
-    {
+    if (src_nelems == 0) {
         return false;
     }
 
@@ -254,40 +246,38 @@ bool can_call_div(sycl::queue exec_q,
     auto dst_offsets = dst.get_minmax_offsets();
     // destination must be ample enough to accomodate all elements
     {
-        size_t range = static_cast<size_t>(dst_offsets.second - dst_offsets.first);
-        if (range + 1 < src_nelems)
-        {
+        size_t range =
+            static_cast<size_t>(dst_offsets.second - dst_offsets.first);
+        if (range + 1 < src_nelems) {
             return false;
         }
     }
 
     // check memory overlap
-    auto const& overlap = dpctl::tensor::overlap::MemoryOverlap();
-    if (overlap(src1, dst) || overlap(src2, dst))
-    {
+    auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
+    if (overlap(src1, dst) || overlap(src2, dst)) {
         return false;
     }
 
     // suppport only contiguous inputs
     bool is_src1_c_contig = src1.is_c_contiguous();
     bool is_src2_c_contig = src2.is_c_contiguous();
-    bool is_dst_c_contig = dst.is_c_contiguous();
+    bool is_dst_c_contig  = dst.is_c_contiguous();
 
-    bool all_c_contig = (is_src1_c_contig && is_src2_c_contig && is_dst_c_contig);
-    if (!all_c_contig)
-    {
+    bool all_c_contig =
+        (is_src1_c_contig && is_src2_c_contig && is_dst_c_contig);
+    if (!all_c_contig) {
         return false;
     }
 
     // MKL function is not defined for the type
-    if (div_dispatch_vector[src1_typeid] == nullptr)
-    {
+    if (div_dispatch_vector[src1_typeid] == nullptr) {
         return false;
     }
     return true;
 #else
-    // In OneMKL 2023.1.0 the call of oneapi::mkl::vm::div() is going to dead lock
-    // inside ~usm_wrapper_to_host()->{...; q_->wait_and_throw(); ...}
+    // In OneMKL 2023.1.0 the call of oneapi::mkl::vm::div() is going to dead
+    // lock inside ~usm_wrapper_to_host()->{...; q_->wait_and_throw(); ...}
 
     (void)exec_q;
     (void)src1;
@@ -302,12 +292,10 @@ struct DivContigFactory
 {
     fnT get()
     {
-        if constexpr (types::DivTypePairSupportFactory<T>::is_defined)
-        {
+        if constexpr (types::DivTypePairSupportFactory<T>::is_defined) {
             return div_impl<T>;
         }
-        else
-        {
+        else {
             return nullptr;
         }
     }
@@ -315,7 +303,9 @@ struct DivContigFactory
 
 void init_div_dispatch_vector(void)
 {
-    dpctl_td_ns::DispatchVectorBuilder<div_impl_fn_ptr_t, DivContigFactory, dpctl_td_ns::num_types> contig;
+    dpctl_td_ns::DispatchVectorBuilder<div_impl_fn_ptr_t, DivContigFactory,
+                                       dpctl_td_ns::num_types>
+        contig;
     contig.populate_dispatch_vector(div_dispatch_vector);
 }
 } // namespace vm

--- a/dpnp/backend/extensions/vm/div.cpp
+++ b/dpnp/backend/extensions/vm/div.cpp
@@ -42,8 +42,8 @@ namespace ext
 {
 namespace vm
 {
-namespace mkl_vm     = oneapi::mkl::vm;
-namespace py         = pybind11;
+namespace mkl_vm = oneapi::mkl::vm;
+namespace py = pybind11;
 namespace type_utils = dpctl::tensor::type_utils;
 
 typedef sycl::event (*div_impl_fn_ptr_t)(sycl::queue,
@@ -67,7 +67,7 @@ static sycl::event div_impl(sycl::queue exec_q,
 
     const T *a = reinterpret_cast<const T *>(in_a);
     const T *b = reinterpret_cast<const T *>(in_b);
-    T *y       = reinterpret_cast<T *>(out_y);
+    T *y = reinterpret_cast<T *>(out_y);
 
     return mkl_vm::div(exec_q,
                        n, // number of elements to be calculated
@@ -87,12 +87,12 @@ std::pair<sycl::event, sycl::event>
     // check type_nums
     int src1_typenum = src1.get_typenum();
     int src2_typenum = src2.get_typenum();
-    int dst_typenum  = dst.get_typenum();
+    int dst_typenum = dst.get_typenum();
 
     auto array_types = dpctl_td_ns::usm_ndarray_types();
-    int src1_typeid  = array_types.typenum_to_lookup_id(src1_typenum);
-    int src2_typeid  = array_types.typenum_to_lookup_id(src2_typenum);
-    int dst_typeid   = array_types.typenum_to_lookup_id(dst_typenum);
+    int src1_typeid = array_types.typenum_to_lookup_id(src1_typenum);
+    int src2_typeid = array_types.typenum_to_lookup_id(src2_typenum);
+    int dst_typeid = array_types.typenum_to_lookup_id(dst_typenum);
 
     if (src1_typeid != src2_typeid || src2_typeid != dst_typeid) {
         throw py::value_error(
@@ -115,7 +115,7 @@ std::pair<sycl::event, sycl::event>
     // check that shapes are the same
     const py::ssize_t *src1_shape = src1.get_shape_raw();
     const py::ssize_t *src2_shape = src2.get_shape_raw();
-    const py::ssize_t *dst_shape  = dst.get_shape_raw();
+    const py::ssize_t *dst_shape = dst.get_shape_raw();
     bool shapes_equal(true);
     size_t src_nelems(1);
 
@@ -154,12 +154,12 @@ std::pair<sycl::event, sycl::event>
 
     const char *src1_data = src1.get_data();
     const char *src2_data = src2.get_data();
-    char *dst_data        = dst.get_data();
+    char *dst_data = dst.get_data();
 
     // handle contiguous inputs
     bool is_src1_c_contig = src1.is_c_contiguous();
     bool is_src2_c_contig = src2.is_c_contiguous();
-    bool is_dst_c_contig  = dst.is_c_contiguous();
+    bool is_dst_c_contig = dst.is_c_contiguous();
 
     bool all_c_contig =
         (is_src1_c_contig && is_src2_c_contig && is_dst_c_contig);
@@ -189,12 +189,12 @@ bool can_call_div(sycl::queue exec_q,
     // check type_nums
     int src1_typenum = src1.get_typenum();
     int src2_typenum = src2.get_typenum();
-    int dst_typenum  = dst.get_typenum();
+    int dst_typenum = dst.get_typenum();
 
     auto array_types = dpctl_td_ns::usm_ndarray_types();
-    int src1_typeid  = array_types.typenum_to_lookup_id(src1_typenum);
-    int src2_typeid  = array_types.typenum_to_lookup_id(src2_typenum);
-    int dst_typeid   = array_types.typenum_to_lookup_id(dst_typenum);
+    int src1_typeid = array_types.typenum_to_lookup_id(src1_typenum);
+    int src2_typeid = array_types.typenum_to_lookup_id(src2_typenum);
+    int dst_typeid = array_types.typenum_to_lookup_id(dst_typenum);
 
     // types must be the same
     if (src1_typeid != src2_typeid || src2_typeid != dst_typeid) {
@@ -224,7 +224,7 @@ bool can_call_div(sycl::queue exec_q,
     // shapes must be the same
     const py::ssize_t *src1_shape = src1.get_shape_raw();
     const py::ssize_t *src2_shape = src2.get_shape_raw();
-    const py::ssize_t *dst_shape  = dst.get_shape_raw();
+    const py::ssize_t *dst_shape = dst.get_shape_raw();
     bool shapes_equal(true);
     size_t src_nelems(1);
 
@@ -262,7 +262,7 @@ bool can_call_div(sycl::queue exec_q,
     // suppport only contiguous inputs
     bool is_src1_c_contig = src1.is_c_contiguous();
     bool is_src2_c_contig = src2.is_c_contiguous();
-    bool is_dst_c_contig  = dst.is_c_contiguous();
+    bool is_dst_c_contig = dst.is_c_contiguous();
 
     bool all_c_contig =
         (is_src1_c_contig && is_src2_c_contig && is_dst_c_contig);

--- a/dpnp/backend/extensions/vm/div.hpp
+++ b/dpnp/backend/extensions/vm/div.hpp
@@ -39,18 +39,19 @@ namespace ext
 {
 namespace vm
 {
-    extern std::pair<sycl::event, sycl::event> div(sycl::queue exec_q,
-                                                   dpctl::tensor::usm_ndarray src1,
-                                                   dpctl::tensor::usm_ndarray src2,
-                                                   dpctl::tensor::usm_ndarray dst,
-                                                   const std::vector<sycl::event>& depends);
+extern std::pair<sycl::event, sycl::event>
+    div(sycl::queue exec_q,
+        dpctl::tensor::usm_ndarray src1,
+        dpctl::tensor::usm_ndarray src2,
+        dpctl::tensor::usm_ndarray dst,
+        const std::vector<sycl::event> &depends);
 
-    extern bool can_call_div(sycl::queue exec_q,
-                             dpctl::tensor::usm_ndarray src1,
-                             dpctl::tensor::usm_ndarray src2,
-                             dpctl::tensor::usm_ndarray dst);
+extern bool can_call_div(sycl::queue exec_q,
+                         dpctl::tensor::usm_ndarray src1,
+                         dpctl::tensor::usm_ndarray src2,
+                         dpctl::tensor::usm_ndarray dst);
 
-    extern void init_div_dispatch_vector(void);
+extern void init_div_dispatch_vector(void);
 } // namespace vm
 } // namespace ext
 } // namespace backend

--- a/dpnp/backend/extensions/vm/types_matrix.hpp
+++ b/dpnp/backend/extensions/vm/types_matrix.hpp
@@ -43,23 +43,29 @@ namespace vm
 {
 namespace types
 {
-    /**
-     * @brief A factory to define pairs of supported types for which
-     * MKL VM library provides support in oneapi::mkl::vm::div<T> function.
-     *
-     * @tparam T Type of input vectors `a` and `b` and of result vector `y`.
-     */
-    template <typename T>
-    struct DivTypePairSupportFactory
-    {
-        static constexpr bool is_defined = std::disjunction<
-            dpctl_td_ns::TypePairDefinedEntry<T, std::complex<double>, T, std::complex<double>>,
-            dpctl_td_ns::TypePairDefinedEntry<T, std::complex<float>, T, std::complex<float>>,
-            dpctl_td_ns::TypePairDefinedEntry<T, double, T, double>,
-            dpctl_td_ns::TypePairDefinedEntry<T, float, T, float>,
-            // fall-through
-            dpctl_td_ns::NotDefinedEntry>::is_defined;
-    };
+/**
+ * @brief A factory to define pairs of supported types for which
+ * MKL VM library provides support in oneapi::mkl::vm::div<T> function.
+ *
+ * @tparam T Type of input vectors `a` and `b` and of result vector `y`.
+ */
+template <typename T>
+struct DivTypePairSupportFactory
+{
+    static constexpr bool is_defined = std::disjunction<
+        dpctl_td_ns::TypePairDefinedEntry<T,
+                                          std::complex<double>,
+                                          T,
+                                          std::complex<double>>,
+        dpctl_td_ns::TypePairDefinedEntry<T,
+                                          std::complex<float>,
+                                          T,
+                                          std::complex<float>>,
+        dpctl_td_ns::TypePairDefinedEntry<T, double, T, double>,
+        dpctl_td_ns::TypePairDefinedEntry<T, float, T, float>,
+        // fall-through
+        dpctl_td_ns::NotDefinedEntry>::is_defined;
+};
 } // namespace types
 } // namespace vm
 } // namespace ext

--- a/dpnp/backend/extensions/vm/vm_py.cpp
+++ b/dpnp/backend/extensions/vm/vm_py.cpp
@@ -33,7 +33,7 @@
 #include "div.hpp"
 
 namespace vm_ext = dpnp::backend::ext::vm;
-namespace py = pybind11;
+namespace py     = pybind11;
 
 // populate dispatch vectors
 void init_dispatch_vectors(void)
@@ -42,30 +42,23 @@ void init_dispatch_vectors(void)
 }
 
 // populate dispatch tables
-void init_dispatch_tables(void)
-{
-}
+void init_dispatch_tables(void) {}
 
 PYBIND11_MODULE(_vm_impl, m)
 {
     init_dispatch_vectors();
     init_dispatch_tables();
 
-    m.def("_div",
-          &vm_ext::div,
-          "Call `div` from OneMKL VM library to performs element by element division "
+    m.def("_div", &vm_ext::div,
+          "Call `div` from OneMKL VM library to performs element by element "
+          "division "
           "of vector `src1` by vector `src2` to resulting vector `dst`",
-          py::arg("sycl_queue"),
-          py::arg("src1"),
-          py::arg("src2"),
-          py::arg("dst"),
-          py::arg("depends") = py::list());
+          py::arg("sycl_queue"), py::arg("src1"), py::arg("src2"),
+          py::arg("dst"), py::arg("depends") = py::list());
 
-    m.def("_can_call_div",
-          &vm_ext::can_call_div,
-          "Check input arrays to answer if `div` function from OneMKL VM library can be used",
-          py::arg("sycl_queue"),
-          py::arg("src1"),
-          py::arg("src2"),
+    m.def("_can_call_div", &vm_ext::can_call_div,
+          "Check input arrays to answer if `div` function from OneMKL VM "
+          "library can be used",
+          py::arg("sycl_queue"), py::arg("src1"), py::arg("src2"),
           py::arg("dst"));
 }

--- a/dpnp/backend/extensions/vm/vm_py.cpp
+++ b/dpnp/backend/extensions/vm/vm_py.cpp
@@ -33,7 +33,7 @@
 #include "div.hpp"
 
 namespace vm_ext = dpnp::backend::ext::vm;
-namespace py     = pybind11;
+namespace py = pybind11;
 
 // populate dispatch vectors
 void init_dispatch_vectors(void)

--- a/dpnp/backend/include/dpnp_gen_1arg_1type_tbl.hpp
+++ b/dpnp/backend/include/dpnp_gen_1arg_1type_tbl.hpp
@@ -39,69 +39,67 @@
 
 #ifdef _SECTION_DOCUMENTATION_GENERATION_
 
-#define MACRO_1ARG_1TYPE_OP(__name__, __operation1__, __operation2__)                                                   \
-    /** @ingroup BACKEND_API                                                                                         */ \
-    /** @brief Per element operation function __name__                                                               */ \
-    /**                                                                                                              */ \
-    /** Function "__name__" executes operator "__operation1__" over each element of the array                        */ \
-    /**                                                                                                              */ \
-    /** @param[in]  q_ref              Reference to SYCL queue.                                                      */ \
-    /** @param[out] result_out         Output array.                                                                 */ \
-    /** @param[in]  result_size        Output array size.                                                            */ \
-    /** @param[in]  result_ndim        Number of output array dimensions.                                            */ \
-    /** @param[in]  result_shape       Output array shape.                                                           */ \
-    /** @param[in]  result_strides     Output array strides.                                                         */ \
-    /** @param[in]  input1_in          Input array 1.                                                                */ \
-    /** @param[in]  input1_size        Input array 1 size.                                                           */ \
-    /** @param[in]  input1_ndim        Number of input array 1 dimensions.                                           */ \
-    /** @param[in]  input1_shape       Input array 1 shape.                                                          */ \
-    /** @param[in]  input1_strides     Input array 1 strides.                                                        */ \
-    /** @param[in]  where              Where condition.                                                              */ \
-    /** @param[in]  dep_event_vec_ref  Reference to vector of SYCL events.                                           */ \
-    template <typename _DataType>                                                                                       \
-    DPCTLSyclEventRef __name__(DPCTLSyclQueueRef q_ref,                                                                 \
-                               void* result_out,                                                                        \
-                               const size_t result_size,                                                                \
-                               const size_t result_ndim,                                                                \
-                               const shape_elem_type* result_shape,                                                     \
-                               const shape_elem_type* result_strides,                                                   \
-                               const void* input1_in,                                                                   \
-                               const size_t input1_size,                                                                \
-                               const size_t input1_ndim,                                                                \
-                               const shape_elem_type* input1_shape,                                                     \
-                               const shape_elem_type* input1_strides,                                                   \
-                               const size_t* where,                                                                     \
-                               const DPCTLEventVectorRef dep_event_vec_ref);                                            \
-                                                                                                                        \
-    template <typename _DataType>                                                                                       \
-    void __name__(void* result_out,                                                                                     \
-                  const size_t result_size,                                                                             \
-                  const size_t result_ndim,                                                                             \
-                  const shape_elem_type* result_shape,                                                                  \
-                  const shape_elem_type* result_strides,                                                                \
-                  const void* input1_in,                                                                                \
-                  const size_t input1_size,                                                                             \
-                  const size_t input1_ndim,                                                                             \
-                  const shape_elem_type* input1_shape,                                                                  \
-                  const shape_elem_type* input1_strides,                                                                \
-                  const size_t* where);
+#define MACRO_1ARG_1TYPE_OP(__name__, __operation1__, __operation2__)          \
+    /** @ingroup BACKEND_API */                                                \
+    /** @brief Per element operation function __name__ */                      \
+    /** */                                                                     \
+    /** Function "__name__" executes operator "__operation1__" over            \
+     * each element of the array                        */                     \
+    /** */                                                                     \
+    /** @param[in]  q_ref              Reference to SYCL queue. */             \
+    /** @param[out] result_out         Output array. */                        \
+    /** @param[in]  result_size        Output array size. */                   \
+    /** @param[in]  result_ndim        Number of output array                  \
+     * dimensions. */                                                          \
+    /** @param[in]  result_shape       Output array shape. */                  \
+    /** @param[in]  result_strides     Output array strides. */                \
+    /** @param[in]  input1_in          Input array 1. */                       \
+    /** @param[in]  input1_size        Input array 1 size. */                  \
+    /** @param[in]  input1_ndim        Number of input array 1                 \
+     * dimensions. */                                                          \
+    /** @param[in]  input1_shape       Input array 1 shape. */                 \
+    /** @param[in]  input1_strides     Input array 1 strides. */               \
+    /** @param[in]  where              Where condition. */                     \
+    /** @param[in]  dep_event_vec_ref  Reference to vector of SYCL             \
+     * events. */                                                              \
+    template <typename _DataType>                                              \
+    DPCTLSyclEventRef __name__(                                                \
+        DPCTLSyclQueueRef q_ref, void *result_out, const size_t result_size,   \
+        const size_t result_ndim, const shape_elem_type *result_shape,         \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const size_t *where,            \
+        const DPCTLEventVectorRef dep_event_vec_ref);                          \
+                                                                               \
+    template <typename _DataType>                                              \
+    void __name__(                                                             \
+        void *result_out, const size_t result_size, const size_t result_ndim,  \
+        const shape_elem_type *result_shape,                                   \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const size_t *where);
 
 #endif // _SECTION_DOCUMENTATION_GENERATION_
 
-MACRO_1ARG_1TYPE_OP(dpnp_conjugate_c, std::conj(input_elem), q.submit(kernel_func))
+MACRO_1ARG_1TYPE_OP(dpnp_conjugate_c,
+                    std::conj(input_elem),
+                    q.submit(kernel_func))
 MACRO_1ARG_1TYPE_OP(dpnp_copy_c, input_elem, q.submit(kernel_func))
 MACRO_1ARG_1TYPE_OP(dpnp_erf_c,
                     dispatch_erf_op(input_elem),
                     oneapi::mkl::vm::erf(q, input1_size, input1_data, result))
 MACRO_1ARG_1TYPE_OP(dpnp_negative_c, -input_elem, q.submit(kernel_func))
-MACRO_1ARG_1TYPE_OP(dpnp_recip_c,
-                    _DataType(1) / input_elem,
-                    q.submit(kernel_func)) // error: no member named 'recip' in namespace 'sycl'
+MACRO_1ARG_1TYPE_OP(
+    dpnp_recip_c,
+    _DataType(1) / input_elem,
+    q.submit(kernel_func)) // error: no member named 'recip' in namespace 'sycl'
 MACRO_1ARG_1TYPE_OP(dpnp_sign_c,
                     dispatch_sign_op(input_elem),
                     q.submit(kernel_func)) // no sycl::sign for int and long
 MACRO_1ARG_1TYPE_OP(dpnp_square_c,
-                    input_elem* input_elem,
+                    input_elem *input_elem,
                     oneapi::mkl::vm::sqr(q, input1_size, input1_data, result))
 
 #undef MACRO_1ARG_1TYPE_OP
@@ -121,39 +119,38 @@ MACRO_1ARG_1TYPE_OP(dpnp_square_c,
 
 #ifdef _SECTION_DOCUMENTATION_GENERATION_
 
-#define MACRO_1ARG_1TYPE_LOGIC_OP(__name__, __operation__)                                                             \
-    /** @ingroup BACKEND_API                                                                                         */ \
-    /** @brief Per element operation function __name__                                                               */ \
-    /**                                                                                                              */ \
-    /** Function "__name__" executes operator "__operation__" over corresponding elements of input array             */ \
-    /**                                                                                                              */ \
-    /** @param[in]  q_ref              Reference to SYCL queue.                                                      */ \
-    /** @param[out] result_out         Output array.                                                                 */ \
-    /** @param[in]  result_size        Output array size.                                                            */ \
-    /** @param[in]  result_ndim        Number of output array dimensions.                                            */ \
-    /** @param[in]  result_shape       Output array shape.                                                           */ \
-    /** @param[in]  result_strides     Output array strides.                                                         */ \
-    /** @param[in]  input1_in          Input array 1.                                                                */ \
-    /** @param[in]  input1_size        Input array 1 size.                                                           */ \
-    /** @param[in]  input1_ndim        Number of input array 1 dimensions.                                           */ \
-    /** @param[in]  input1_shape       Input array 1 shape.                                                          */ \
-    /** @param[in]  input1_strides     Input array 1 strides.                                                        */ \
-    /** @param[in]  where              Where condition.                                                              */ \
-    /** @param[in]  dep_event_vec_ref  Reference to vector of SYCL events.                                           */ \
-    template <typename _DataType_input1>                                                                                \
-    DPCTLSyclEventRef __name__(DPCTLSyclQueueRef q_ref,                                                                 \
-                               void* result_out,                                                                        \
-                               const size_t result_size,                                                                \
-                               const size_t result_ndim,                                                                \
-                               const shape_elem_type* result_shape,                                                     \
-                               const shape_elem_type* result_strides,                                                   \
-                               const void* input1_in,                                                                   \
-                               const size_t input1_size,                                                                \
-                               const size_t input1_ndim,                                                                \
-                               const shape_elem_type* input1_shape,                                                     \
-                               const shape_elem_type* input1_strides,                                                   \
-                               const size_t* where,                                                                     \
-                               const DPCTLEventVectorRef dep_event_vec_ref);
+#define MACRO_1ARG_1TYPE_LOGIC_OP(__name__, __operation__)                     \
+    /** @ingroup BACKEND_API */                                                \
+    /** @brief Per element operation function __name__ */                      \
+    /** */                                                                     \
+    /** Function "__name__" executes operator "__operation__" over             \
+     * corresponding elements of input array             */                    \
+    /** */                                                                     \
+    /** @param[in]  q_ref              Reference to SYCL queue. */             \
+    /** @param[out] result_out         Output array. */                        \
+    /** @param[in]  result_size        Output array size. */                   \
+    /** @param[in]  result_ndim        Number of output array                  \
+     * dimensions. */                                                          \
+    /** @param[in]  result_shape       Output array shape. */                  \
+    /** @param[in]  result_strides     Output array strides. */                \
+    /** @param[in]  input1_in          Input array 1. */                       \
+    /** @param[in]  input1_size        Input array 1 size. */                  \
+    /** @param[in]  input1_ndim        Number of input array 1                 \
+     * dimensions. */                                                          \
+    /** @param[in]  input1_shape       Input array 1 shape. */                 \
+    /** @param[in]  input1_strides     Input array 1 strides. */               \
+    /** @param[in]  where              Where condition. */                     \
+    /** @param[in]  dep_event_vec_ref  Reference to vector of SYCL             \
+     * events. */                                                              \
+    template <typename _DataType_input1>                                       \
+    DPCTLSyclEventRef __name__(                                                \
+        DPCTLSyclQueueRef q_ref, void *result_out, const size_t result_size,   \
+        const size_t result_ndim, const shape_elem_type *result_shape,         \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const size_t *where,            \
+        const DPCTLEventVectorRef dep_event_vec_ref);
 
 #endif // _SECTION_DOCUMENTATION_GENERATION_
 

--- a/dpnp/backend/include/dpnp_gen_1arg_2type_tbl.hpp
+++ b/dpnp/backend/include/dpnp_gen_1arg_2type_tbl.hpp
@@ -41,73 +41,71 @@
 
 #ifdef _SECTION_DOCUMENTATION_GENERATION_
 
-#define MACRO_1ARG_2TYPES_OP(__name__, __operation1__, __operation2__)                                                  \
-    /** @ingroup BACKEND_API                                                                                         */ \
-    /** @brief Per element operation function __name__                                                               */ \
-    /**                                                                                                              */ \
-    /** Function "__name__" executes operator "__operation1__" over each element of the array                        */ \
-    /**                                                                                                              */ \
-    /** @param[in]  q_ref              Reference to SYCL queue.                                                      */ \
-    /** @param[out] result_out         Output array.                                                                 */ \
-    /** @param[in]  result_size        Output array size.                                                            */ \
-    /** @param[in]  result_ndim        Number of output array dimensions.                                            */ \
-    /** @param[in]  result_shape       Output array shape.                                                           */ \
-    /** @param[in]  result_strides     Output array strides.                                                         */ \
-    /** @param[in]  input1_in          Input array 1.                                                                */ \
-    /** @param[in]  input1_size        Input array 1 size.                                                           */ \
-    /** @param[in]  input1_ndim        Number of input array 1 dimensions.                                           */ \
-    /** @param[in]  input1_shape       Input array 1 shape.                                                          */ \
-    /** @param[in]  input1_strides     Input array 1 strides.                                                        */ \
-    /** @param[in]  where              Where condition.                                                              */ \
-    /** @param[in]  dep_event_vec_ref  Reference to vector of SYCL events.                                           */ \
-    template <typename _DataType_input, typename _DataType_output>                                                      \
-    DPCTLSyclEventRef __name__(DPCTLSyclQueueRef q_ref,                                                                 \
-                               void* result_out,                                                                        \
-                               const size_t result_size,                                                                \
-                               const size_t result_ndim,                                                                \
-                               const shape_elem_type* result_shape,                                                     \
-                               const shape_elem_type* result_strides,                                                   \
-                               const void* input1_in,                                                                   \
-                               const size_t input1_size,                                                                \
-                               const size_t input1_ndim,                                                                \
-                               const shape_elem_type* input1_shape,                                                     \
-                               const shape_elem_type* input1_strides,                                                   \
-                               const size_t* where,                                                                     \
-                               const DPCTLEventVectorRef dep_event_vec_ref);                                            \
-                                                                                                                        \
-    template <typename _DataType_input, typename _DataType_output>                                                      \
-    void __name__(void* result_out,                                                                                     \
-                  const size_t result_size,                                                                             \
-                  const size_t result_ndim,                                                                             \
-                  const shape_elem_type* result_shape,                                                                  \
-                  const shape_elem_type* result_strides,                                                                \
-                  const void* input1_in,                                                                                \
-                  const size_t input1_size,                                                                             \
-                  const size_t input1_ndim,                                                                             \
-                  const shape_elem_type* input1_shape,                                                                  \
-                  const shape_elem_type* input1_strides,                                                                \
-                  const size_t* where);
+#define MACRO_1ARG_2TYPES_OP(__name__, __operation1__, __operation2__)         \
+    /** @ingroup BACKEND_API */                                                \
+    /** @brief Per element operation function __name__ */                      \
+    /** */                                                                     \
+    /** Function "__name__" executes operator "__operation1__" over each       \
+     * element of the array                        */                          \
+    /** */                                                                     \
+    /** @param[in]  q_ref              Reference to SYCL queue. */             \
+    /** @param[out] result_out         Output array. */                        \
+    /** @param[in]  result_size        Output array size. */                   \
+    /** @param[in]  result_ndim        Number of output array dimensions.      \
+     */                                                                        \
+    /** @param[in]  result_shape       Output array shape. */                  \
+    /** @param[in]  result_strides     Output array strides. */                \
+    /** @param[in]  input1_in          Input array 1. */                       \
+    /** @param[in]  input1_size        Input array 1 size. */                  \
+    /** @param[in]  input1_ndim        Number of input array 1 dimensions.     \
+     */                                                                        \
+    /** @param[in]  input1_shape       Input array 1 shape. */                 \
+    /** @param[in]  input1_strides     Input array 1 strides. */               \
+    /** @param[in]  where              Where condition. */                     \
+    /** @param[in]  dep_event_vec_ref  Reference to vector of SYCL events.     \
+     */                                                                        \
+    template <typename _DataType_input, typename _DataType_output>             \
+    DPCTLSyclEventRef __name__(                                                \
+        DPCTLSyclQueueRef q_ref, void *result_out, const size_t result_size,   \
+        const size_t result_ndim, const shape_elem_type *result_shape,         \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const size_t *where,            \
+        const DPCTLEventVectorRef dep_event_vec_ref);                          \
+                                                                               \
+    template <typename _DataType_input, typename _DataType_output>             \
+    void __name__(                                                             \
+        void *result_out, const size_t result_size, const size_t result_ndim,  \
+        const shape_elem_type *result_shape,                                   \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const size_t *where);
 
 #endif
 
 MACRO_1ARG_2TYPES_OP(dpnp_acos_c,
                      sycl::acos(input_elem),
                      oneapi::mkl::vm::acos(q, input1_size, input1_data, result))
-MACRO_1ARG_2TYPES_OP(dpnp_acosh_c,
-                     sycl::acosh(input_elem),
-                     oneapi::mkl::vm::acosh(q, input1_size, input1_data, result))
+MACRO_1ARG_2TYPES_OP(
+    dpnp_acosh_c,
+    sycl::acosh(input_elem),
+    oneapi::mkl::vm::acosh(q, input1_size, input1_data, result))
 MACRO_1ARG_2TYPES_OP(dpnp_asin_c,
                      sycl::asin(input_elem),
                      oneapi::mkl::vm::asin(q, input1_size, input1_data, result))
-MACRO_1ARG_2TYPES_OP(dpnp_asinh_c,
-                     sycl::asinh(input_elem),
-                     oneapi::mkl::vm::asinh(q, input1_size, input1_data, result))
+MACRO_1ARG_2TYPES_OP(
+    dpnp_asinh_c,
+    sycl::asinh(input_elem),
+    oneapi::mkl::vm::asinh(q, input1_size, input1_data, result))
 MACRO_1ARG_2TYPES_OP(dpnp_atan_c,
                      sycl::atan(input_elem),
                      oneapi::mkl::vm::atan(q, input1_size, input1_data, result))
-MACRO_1ARG_2TYPES_OP(dpnp_atanh_c,
-                     sycl::atanh(input_elem),
-                     oneapi::mkl::vm::atanh(q, input1_size, input1_data, result))
+MACRO_1ARG_2TYPES_OP(
+    dpnp_atanh_c,
+    sycl::atanh(input_elem),
+    oneapi::mkl::vm::atanh(q, input1_size, input1_data, result))
 MACRO_1ARG_2TYPES_OP(dpnp_cbrt_c,
                      sycl::cbrt(input_elem),
                      oneapi::mkl::vm::cbrt(q, input1_size, input1_data, result))
@@ -121,35 +119,43 @@ MACRO_1ARG_2TYPES_OP(dpnp_cos_c,
 MACRO_1ARG_2TYPES_OP(dpnp_cosh_c,
                      sycl::cosh(input_elem),
                      oneapi::mkl::vm::cosh(q, input1_size, input1_data, result))
-MACRO_1ARG_2TYPES_OP(dpnp_degrees_c, sycl::degrees(input_elem), q.submit(kernel_func))
+MACRO_1ARG_2TYPES_OP(dpnp_degrees_c,
+                     sycl::degrees(input_elem),
+                     q.submit(kernel_func))
 MACRO_1ARG_2TYPES_OP(dpnp_exp2_c,
                      sycl::exp2(input_elem),
                      oneapi::mkl::vm::exp2(q, input1_size, input1_data, result))
 MACRO_1ARG_2TYPES_OP(dpnp_exp_c,
                      sycl::exp(input_elem),
                      oneapi::mkl::vm::exp(q, input1_size, input1_data, result))
-MACRO_1ARG_2TYPES_OP(dpnp_expm1_c,
-                     sycl::expm1(input_elem),
-                     oneapi::mkl::vm::expm1(q, input1_size, input1_data, result))
+MACRO_1ARG_2TYPES_OP(
+    dpnp_expm1_c,
+    sycl::expm1(input_elem),
+    oneapi::mkl::vm::expm1(q, input1_size, input1_data, result))
 MACRO_1ARG_2TYPES_OP(dpnp_fabs_c,
                      sycl::fabs(input_elem),
                      oneapi::mkl::vm::abs(q, input1_size, input1_data, result))
-MACRO_1ARG_2TYPES_OP(dpnp_floor_c,
-                     sycl::floor(input_elem),
-                     oneapi::mkl::vm::floor(q, input1_size, input1_data, result))
-MACRO_1ARG_2TYPES_OP(dpnp_log10_c,
-                     sycl::log10(input_elem),
-                     oneapi::mkl::vm::log10(q, input1_size, input1_data, result))
-MACRO_1ARG_2TYPES_OP(dpnp_log1p_c,
-                     sycl::log1p(input_elem),
-                     oneapi::mkl::vm::log1p(q, input1_size, input1_data, result))
+MACRO_1ARG_2TYPES_OP(
+    dpnp_floor_c,
+    sycl::floor(input_elem),
+    oneapi::mkl::vm::floor(q, input1_size, input1_data, result))
+MACRO_1ARG_2TYPES_OP(
+    dpnp_log10_c,
+    sycl::log10(input_elem),
+    oneapi::mkl::vm::log10(q, input1_size, input1_data, result))
+MACRO_1ARG_2TYPES_OP(
+    dpnp_log1p_c,
+    sycl::log1p(input_elem),
+    oneapi::mkl::vm::log1p(q, input1_size, input1_data, result))
 MACRO_1ARG_2TYPES_OP(dpnp_log2_c,
                      sycl::log2(input_elem),
                      oneapi::mkl::vm::log2(q, input1_size, input1_data, result))
 MACRO_1ARG_2TYPES_OP(dpnp_log_c,
                      sycl::log(input_elem),
                      oneapi::mkl::vm::ln(q, input1_size, input1_data, result))
-MACRO_1ARG_2TYPES_OP(dpnp_radians_c, sycl::radians(input_elem), q.submit(kernel_func))
+MACRO_1ARG_2TYPES_OP(dpnp_radians_c,
+                     sycl::radians(input_elem),
+                     q.submit(kernel_func))
 MACRO_1ARG_2TYPES_OP(dpnp_sin_c,
                      sycl::sin(input_elem),
                      oneapi::mkl::vm::sin(q, input1_size, input1_data, result))
@@ -165,8 +171,9 @@ MACRO_1ARG_2TYPES_OP(dpnp_tan_c,
 MACRO_1ARG_2TYPES_OP(dpnp_tanh_c,
                      sycl::tanh(input_elem),
                      oneapi::mkl::vm::tanh(q, input1_size, input1_data, result))
-MACRO_1ARG_2TYPES_OP(dpnp_trunc_c,
-                     sycl::trunc(input_elem),
-                     oneapi::mkl::vm::trunc(q, input1_size, input1_data, result))
+MACRO_1ARG_2TYPES_OP(
+    dpnp_trunc_c,
+    sycl::trunc(input_elem),
+    oneapi::mkl::vm::trunc(q, input1_size, input1_data, result))
 
 #undef MACRO_1ARG_2TYPES_OP

--- a/dpnp/backend/include/dpnp_gen_2arg_1type_tbl.hpp
+++ b/dpnp/backend/include/dpnp_gen_2arg_1type_tbl.hpp
@@ -40,71 +40,63 @@
 
 #ifdef _SECTION_DOCUMENTATION_GENERATION_
 
-#define MACRO_2ARG_1TYPE_OP(__name__, __operation__)                                                                    \
-    /** @ingroup BACKEND_API                                                                                         */ \
-    /** @brief Element wise operation function __name__                                                              */ \
-    /**                                                                                                              */ \
-    /** Function "__name__" executes operator "__operation__" over corresponding elements of input arrays            */ \
-    /**                                                                                                              */ \
-    /** @param[in]  q_ref              Reference to SYCL queue.                                                      */ \
-    /** @param[out] result_out         Output array.                                                                 */ \
-    /** @param[in]  result_size        Output array size.                                                            */ \
-    /** @param[in]  result_ndim        Number of output array dimensions.                                            */ \
-    /** @param[in]  result_shape       Output array shape.                                                           */ \
-    /** @param[in]  result_strides     Output array strides.                                                         */ \
-    /** @param[in]  input1_in          Input array 1.                                                                */ \
-    /** @param[in]  input1_size        Input array 1 size.                                                           */ \
-    /** @param[in]  input1_ndim        Number of input array 1 dimensions.                                           */ \
-    /** @param[in]  input1_shape       Input array 1 shape.                                                          */ \
-    /** @param[in]  input1_strides     Input array 1 strides.                                                        */ \
-    /** @param[in]  input2_in          Input array 2.                                                                */ \
-    /** @param[in]  input2_size        Input array 2 size.                                                           */ \
-    /** @param[in]  input2_ndim        Number of input array 2 dimensions.                                           */ \
-    /** @param[in]  input2_shape       Input array 2 shape.                                                          */ \
-    /** @param[in]  input2_strides     Input array 2 strides.                                                        */ \
-    /** @param[in]  where              Where condition.                                                              */ \
-    /** @param[in]  dep_event_vec_ref  Reference to vector of SYCL events.                                           */ \
-    template <typename _DataType>                                                                                       \
-    DPCTLSyclEventRef __name__(DPCTLSyclQueueRef q_ref,                                                                 \
-                               void* result_out,                                                                        \
-                               const size_t result_size,                                                                \
-                               const size_t result_ndim,                                                                \
-                               const shape_elem_type* result_shape,                                                     \
-                               const shape_elem_type* result_strides,                                                   \
-                               const void* input1_in,                                                                   \
-                               const size_t input1_size,                                                                \
-                               const size_t input1_ndim,                                                                \
-                               const shape_elem_type* input1_shape,                                                     \
-                               const shape_elem_type* input1_strides,                                                   \
-                               const void* input2_in,                                                                   \
-                               const size_t input2_size,                                                                \
-                               const size_t input2_ndim,                                                                \
-                               const shape_elem_type* input2_shape,                                                     \
-                               const shape_elem_type* input2_strides,                                                   \
-                               const size_t* where,                                                                     \
-                               const DPCTLEventVectorRef dep_event_vec_ref);                                            \
-                                                                                                                        \
-    template <typename _DataType>                                                                                       \
-    void __name__(void* result_out,                                                                                     \
-                  const size_t result_size,                                                                             \
-                  const size_t result_ndim,                                                                             \
-                  const shape_elem_type* result_shape,                                                                  \
-                  const shape_elem_type* result_strides,                                                                \
-                  const void* input1_in,                                                                                \
-                  const size_t input1_size,                                                                             \
-                  const size_t input1_ndim,                                                                             \
-                  const shape_elem_type* input1_shape,                                                                  \
-                  const shape_elem_type* input1_strides,                                                                \
-                  const void* input2_in,                                                                                \
-                  const size_t input2_size,                                                                             \
-                  const size_t input2_ndim,                                                                             \
-                  const shape_elem_type* input2_shape,                                                                  \
-                  const shape_elem_type* input2_strides,                                                                \
-                  const size_t* where);
+#define MACRO_2ARG_1TYPE_OP(__name__, __operation__)                           \
+    /** @ingroup BACKEND_API */                                                \
+    /** @brief Element wise operation function __name__ */                     \
+    /** */                                                                     \
+    /** Function "__name__" executes operator "__operation__" over             \
+     * corresponding elements of input arrays            */                    \
+    /** */                                                                     \
+    /** @param[in]  q_ref              Reference to SYCL queue. */             \
+    /** @param[out] result_out         Output array. */                        \
+    /** @param[in]  result_size        Output array size. */                   \
+    /** @param[in]  result_ndim        Number of output array dimensions.      \
+     */                                                                        \
+    /** @param[in]  result_shape       Output array shape. */                  \
+    /** @param[in]  result_strides     Output array strides. */                \
+    /** @param[in]  input1_in          Input array 1. */                       \
+    /** @param[in]  input1_size        Input array 1 size. */                  \
+    /** @param[in]  input1_ndim        Number of input array 1 dimensions.     \
+     */                                                                        \
+    /** @param[in]  input1_shape       Input array 1 shape. */                 \
+    /** @param[in]  input1_strides     Input array 1 strides. */               \
+    /** @param[in]  input2_in          Input array 2. */                       \
+    /** @param[in]  input2_size        Input array 2 size. */                  \
+    /** @param[in]  input2_ndim        Number of input array 2 dimensions.     \
+     */                                                                        \
+    /** @param[in]  input2_shape       Input array 2 shape. */                 \
+    /** @param[in]  input2_strides     Input array 2 strides. */               \
+    /** @param[in]  where              Where condition. */                     \
+    /** @param[in]  dep_event_vec_ref  Reference to vector of SYCL events.     \
+     */                                                                        \
+    template <typename _DataType>                                              \
+    DPCTLSyclEventRef __name__(                                                \
+        DPCTLSyclQueueRef q_ref, void *result_out, const size_t result_size,   \
+        const size_t result_ndim, const shape_elem_type *result_shape,         \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const void *input2_in,          \
+        const size_t input2_size, const size_t input2_ndim,                    \
+        const shape_elem_type *input2_shape,                                   \
+        const shape_elem_type *input2_strides, const size_t *where,            \
+        const DPCTLEventVectorRef dep_event_vec_ref);                          \
+                                                                               \
+    template <typename _DataType>                                              \
+    void __name__(                                                             \
+        void *result_out, const size_t result_size, const size_t result_ndim,  \
+        const shape_elem_type *result_shape,                                   \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const void *input2_in,          \
+        const size_t input2_size, const size_t input2_ndim,                    \
+        const shape_elem_type *input2_shape,                                   \
+        const shape_elem_type *input2_strides, const size_t *where);
 
 #endif
 
-MACRO_2ARG_1TYPE_OP(dpnp_bitwise_and_c, input1_elem & input2_elem)
+MACRO_2ARG_1TYPE_OP(dpnp_bitwise_and_c, input1_elem &input2_elem)
 MACRO_2ARG_1TYPE_OP(dpnp_bitwise_or_c, input1_elem | input2_elem)
 MACRO_2ARG_1TYPE_OP(dpnp_bitwise_xor_c, input1_elem ^ input2_elem)
 MACRO_2ARG_1TYPE_OP(dpnp_left_shift_c, input1_elem << input2_elem)

--- a/dpnp/backend/include/dpnp_gen_2arg_2type_tbl.hpp
+++ b/dpnp/backend/include/dpnp_gen_2arg_2type_tbl.hpp
@@ -40,49 +40,47 @@
 
 #ifdef _SECTION_DOCUMENTATION_GENERATION_
 
-#define MACRO_2ARG_2TYPES_LOGIC_OP(__name__, __operation__)                                                             \
-    /** @ingroup BACKEND_API                                                                                         */ \
-    /** @brief Per element operation function __name__                                                               */ \
-    /**                                                                                                              */ \
-    /** Function "__name__" executes operator "__operation__" over corresponding elements of input arrays            */ \
-    /**                                                                                                              */ \
-    /** @param[in]  q_ref              Reference to SYCL queue.                                                      */ \
-    /** @param[out] result_out         Output array.                                                                 */ \
-    /** @param[in]  result_size        Output array size.                                                            */ \
-    /** @param[in]  result_ndim        Number of output array dimensions.                                            */ \
-    /** @param[in]  result_shape       Output array shape.                                                           */ \
-    /** @param[in]  result_strides     Output array strides.                                                         */ \
-    /** @param[in]  input1_in          Input array 1.                                                                */ \
-    /** @param[in]  input1_size        Input array 1 size.                                                           */ \
-    /** @param[in]  input1_ndim        Number of input array 1 dimensions.                                           */ \
-    /** @param[in]  input1_shape       Input array 1 shape.                                                          */ \
-    /** @param[in]  input1_strides     Input array 1 strides.                                                        */ \
-    /** @param[in]  input2_in          Input array 2.                                                                */ \
-    /** @param[in]  input2_size        Input array 2 size.                                                           */ \
-    /** @param[in]  input2_ndim        Number of input array 2 dimensions.                                           */ \
-    /** @param[in]  input2_shape       Input array 2 shape.                                                          */ \
-    /** @param[in]  input2_strides     Input array 2 strides.                                                        */ \
-    /** @param[in]  where              Where condition.                                                              */ \
-    /** @param[in]  dep_event_vec_ref  Reference to vector of SYCL events.                                           */ \
-    template <typename _DataType_input1, typename _DataType_input2>                                                     \
-    DPCTLSyclEventRef __name__(DPCTLSyclQueueRef q_ref,                                                                 \
-                               void* result_out,                                                                        \
-                               const size_t result_size,                                                                \
-                               const size_t result_ndim,                                                                \
-                               const shape_elem_type* result_shape,                                                     \
-                               const shape_elem_type* result_strides,                                                   \
-                               const void* input1_in,                                                                   \
-                               const size_t input1_size,                                                                \
-                               const size_t input1_ndim,                                                                \
-                               const shape_elem_type* input1_shape,                                                     \
-                               const shape_elem_type* input1_strides,                                                   \
-                               const void* input2_in,                                                                   \
-                               const size_t input2_size,                                                                \
-                               const size_t input2_ndim,                                                                \
-                               const shape_elem_type* input2_shape,                                                     \
-                               const shape_elem_type* input2_strides,                                                   \
-                               const size_t* where,                                                                     \
-                               const DPCTLEventVectorRef dep_event_vec_ref);
+#define MACRO_2ARG_2TYPES_LOGIC_OP(__name__, __operation__)                    \
+    /** @ingroup BACKEND_API */                                                \
+    /** @brief Per element operation function __name__ */                      \
+    /** */                                                                     \
+    /** Function "__name__" executes operator "__operation__" over             \
+     * corresponding elements of input arrays            */                    \
+    /** */                                                                     \
+    /** @param[in]  q_ref              Reference to SYCL queue. */             \
+    /** @param[out] result_out         Output array. */                        \
+    /** @param[in]  result_size        Output array size. */                   \
+    /** @param[in]  result_ndim        Number of output array dimensions.      \
+     */                                                                        \
+    /** @param[in]  result_shape       Output array shape. */                  \
+    /** @param[in]  result_strides     Output array strides. */                \
+    /** @param[in]  input1_in          Input array 1. */                       \
+    /** @param[in]  input1_size        Input array 1 size. */                  \
+    /** @param[in]  input1_ndim        Number of input array 1 dimensions.     \
+     */                                                                        \
+    /** @param[in]  input1_shape       Input array 1 shape. */                 \
+    /** @param[in]  input1_strides     Input array 1 strides. */               \
+    /** @param[in]  input2_in          Input array 2. */                       \
+    /** @param[in]  input2_size        Input array 2 size. */                  \
+    /** @param[in]  input2_ndim        Number of input array 2 dimensions.     \
+     */                                                                        \
+    /** @param[in]  input2_shape       Input array 2 shape. */                 \
+    /** @param[in]  input2_strides     Input array 2 strides. */               \
+    /** @param[in]  where              Where condition. */                     \
+    /** @param[in]  dep_event_vec_ref  Reference to vector of SYCL events.     \
+     */                                                                        \
+    template <typename _DataType_input1, typename _DataType_input2>            \
+    DPCTLSyclEventRef __name__(                                                \
+        DPCTLSyclQueueRef q_ref, void *result_out, const size_t result_size,   \
+        const size_t result_ndim, const shape_elem_type *result_shape,         \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const void *input2_in,          \
+        const size_t input2_size, const size_t input2_ndim,                    \
+        const shape_elem_type *input2_shape,                                   \
+        const shape_elem_type *input2_strides, const size_t *where,            \
+        const DPCTLEventVectorRef dep_event_vec_ref);
 
 #endif
 
@@ -91,9 +89,10 @@ MACRO_2ARG_2TYPES_LOGIC_OP(dpnp_greater_c, input1_elem > input2_elem)
 MACRO_2ARG_2TYPES_LOGIC_OP(dpnp_greater_equal_c, input1_elem >= input2_elem)
 MACRO_2ARG_2TYPES_LOGIC_OP(dpnp_less_c, input1_elem < input2_elem)
 MACRO_2ARG_2TYPES_LOGIC_OP(dpnp_less_equal_c, input1_elem <= input2_elem)
-MACRO_2ARG_2TYPES_LOGIC_OP(dpnp_logical_and_c, input1_elem && input2_elem)
+MACRO_2ARG_2TYPES_LOGIC_OP(dpnp_logical_and_c, input1_elem &&input2_elem)
 MACRO_2ARG_2TYPES_LOGIC_OP(dpnp_logical_or_c, input1_elem || input2_elem)
-MACRO_2ARG_2TYPES_LOGIC_OP(dpnp_logical_xor_c, (!!input1_elem) != (!!input2_elem))
+MACRO_2ARG_2TYPES_LOGIC_OP(dpnp_logical_xor_c,
+                           (!!input1_elem) != (!!input2_elem))
 MACRO_2ARG_2TYPES_LOGIC_OP(dpnp_not_equal_c, input1_elem != input2_elem)
 
 #undef MACRO_2ARG_2TYPES_LOGIC_OP

--- a/dpnp/backend/include/dpnp_gen_2arg_3type_tbl.hpp
+++ b/dpnp/backend/include/dpnp_gen_2arg_3type_tbl.hpp
@@ -44,68 +44,62 @@
 
 #ifdef _SECTION_DOCUMENTATION_GENERATION_
 
-#define MACRO_2ARG_3TYPES_OP(                                                                                           \
-    __name__, __operation__, __vec_operation__, __vec_types__, __mkl_operation__, __mkl_types__)                        \
-    /** @ingroup BACKEND_API                                                                                         */ \
-    /** @brief Per element operation function __name__                                                               */ \
-    /**                                                                                                              */ \
-    /** Function "__name__" executes operator "__operation__" over corresponding elements of input arrays            */ \
-    /**                                                                                                              */ \
-    /** @param[in]  q_ref              Reference to SYCL queue.                                                      */ \
-    /** @param[out] result_out         Output array.                                                                 */ \
-    /** @param[in]  result_size        Output array size.                                                            */ \
-    /** @param[in]  result_ndim        Number of output array dimensions.                                            */ \
-    /** @param[in]  result_shape       Output array shape.                                                           */ \
-    /** @param[in]  result_strides     Output array strides.                                                         */ \
-    /** @param[in]  input1_in          Input array 1.                                                                */ \
-    /** @param[in]  input1_size        Input array 1 size.                                                           */ \
-    /** @param[in]  input1_ndim        Number of input array 1 dimensions.                                           */ \
-    /** @param[in]  input1_shape       Input array 1 shape.                                                          */ \
-    /** @param[in]  input1_strides     Input array 1 strides.                                                        */ \
-    /** @param[in]  input2_in          Input array 2.                                                                */ \
-    /** @param[in]  input2_size        Input array 2 size.                                                           */ \
-    /** @param[in]  input2_ndim        Number of input array 2 dimensions.                                           */ \
-    /** @param[in]  input2_shape       Input array 2 shape.                                                          */ \
-    /** @param[in]  input2_strides     Input array 2 strides.                                                        */ \
-    /** @param[in]  where              Where condition.                                                              */ \
-    /** @param[in]  dep_event_vec_ref  Reference to vector of SYCL events.                                           */ \
-    template <typename _DataType_input1, typename _DataType_input2, typename _DataType_output>                          \
-    DPCTLSyclEventRef __name__(DPCTLSyclQueueRef q_ref,                                                                 \
-                               void* result_out,                                                                        \
-                               const size_t result_size,                                                                \
-                               const size_t result_ndim,                                                                \
-                               const shape_elem_type* result_shape,                                                     \
-                               const shape_elem_type* result_strides,                                                   \
-                               const void* input1_in,                                                                   \
-                               const size_t input1_size,                                                                \
-                               const size_t input1_ndim,                                                                \
-                               const shape_elem_type* input1_shape,                                                     \
-                               const shape_elem_type* input1_strides,                                                   \
-                               const void* input2_in,                                                                   \
-                               const size_t input2_size,                                                                \
-                               const size_t input2_ndim,                                                                \
-                               const shape_elem_type* input2_shape,                                                     \
-                               const shape_elem_type* input2_strides,                                                   \
-                               const size_t* where,                                                                     \
-                               const DPCTLEventVectorRef dep_event_vec_ref);                                            \
-                                                                                                                        \
-    template <typename _DataType_input1, typename _DataType_input2, typename _DataType_output>                          \
-    void __name__(void* result_out,                                                                                     \
-                  const size_t result_size,                                                                             \
-                  const size_t result_ndim,                                                                             \
-                  const shape_elem_type* result_shape,                                                                  \
-                  const shape_elem_type* result_strides,                                                                \
-                  const void* input1_in,                                                                                \
-                  const size_t input1_size,                                                                             \
-                  const size_t input1_ndim,                                                                             \
-                  const shape_elem_type* input1_shape,                                                                  \
-                  const shape_elem_type* input1_strides,                                                                \
-                  const void* input2_in,                                                                                \
-                  const size_t input2_size,                                                                             \
-                  const size_t input2_ndim,                                                                             \
-                  const shape_elem_type* input2_shape,                                                                  \
-                  const shape_elem_type* input2_strides,                                                                \
-                  const size_t* where)
+#define MACRO_2ARG_3TYPES_OP(__name__, __operation__, __vec_operation__,       \
+                             __vec_types__, __mkl_operation__, __mkl_types__)  \
+    /** @ingroup BACKEND_API */                                                \
+    /** @brief Per element operation function __name__ */                      \
+    /** */                                                                     \
+    /** Function "__name__" executes operator "__operation__" over             \
+     * corresponding elements of input arrays            */                    \
+    /** */                                                                     \
+    /** @param[in]  q_ref              Reference to SYCL queue. */             \
+    /** @param[out] result_out         Output array. */                        \
+    /** @param[in]  result_size        Output array size. */                   \
+    /** @param[in]  result_ndim        Number of output array dimensions.      \
+     */                                                                        \
+    /** @param[in]  result_shape       Output array shape. */                  \
+    /** @param[in]  result_strides     Output array strides. */                \
+    /** @param[in]  input1_in          Input array 1. */                       \
+    /** @param[in]  input1_size        Input array 1 size. */                  \
+    /** @param[in]  input1_ndim        Number of input array 1 dimensions.     \
+     */                                                                        \
+    /** @param[in]  input1_shape       Input array 1 shape. */                 \
+    /** @param[in]  input1_strides     Input array 1 strides. */               \
+    /** @param[in]  input2_in          Input array 2. */                       \
+    /** @param[in]  input2_size        Input array 2 size. */                  \
+    /** @param[in]  input2_ndim        Number of input array 2 dimensions.     \
+     */                                                                        \
+    /** @param[in]  input2_shape       Input array 2 shape. */                 \
+    /** @param[in]  input2_strides     Input array 2 strides. */               \
+    /** @param[in]  where              Where condition. */                     \
+    /** @param[in]  dep_event_vec_ref  Reference to vector of SYCL events.     \
+     */                                                                        \
+    template <typename _DataType_input1, typename _DataType_input2,            \
+              typename _DataType_output>                                       \
+    DPCTLSyclEventRef __name__(                                                \
+        DPCTLSyclQueueRef q_ref, void *result_out, const size_t result_size,   \
+        const size_t result_ndim, const shape_elem_type *result_shape,         \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const void *input2_in,          \
+        const size_t input2_size, const size_t input2_ndim,                    \
+        const shape_elem_type *input2_shape,                                   \
+        const shape_elem_type *input2_strides, const size_t *where,            \
+        const DPCTLEventVectorRef dep_event_vec_ref);                          \
+                                                                               \
+    template <typename _DataType_input1, typename _DataType_input2,            \
+              typename _DataType_output>                                       \
+    void __name__(                                                             \
+        void *result_out, const size_t result_size, const size_t result_ndim,  \
+        const shape_elem_type *result_shape,                                   \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const void *input2_in,          \
+        const size_t input2_size, const size_t input2_ndim,                    \
+        const shape_elem_type *input2_shape,                                   \
+        const shape_elem_type *input2_strides, const size_t *where)
 
 #endif
 
@@ -114,7 +108,10 @@ MACRO_2ARG_3TYPES_OP(dpnp_add_c,
                      x1 + x2,
                      MACRO_UNPACK_TYPES(bool, std::int32_t, std::int64_t),
                      oneapi::mkl::vm::add,
-                     MACRO_UNPACK_TYPES(float, double, std::complex<float>, std::complex<double>))
+                     MACRO_UNPACK_TYPES(float,
+                                        double,
+                                        std::complex<float>,
+                                        std::complex<double>))
 
 MACRO_2ARG_3TYPES_OP(dpnp_arctan2_c,
                      sycl::atan2((double)input1_elem, (double)input2_elem),
@@ -135,7 +132,10 @@ MACRO_2ARG_3TYPES_OP(dpnp_divide_c,
                      x1 / x2,
                      MACRO_UNPACK_TYPES(bool, std::int32_t, std::int64_t),
                      oneapi::mkl::vm::div,
-                     MACRO_UNPACK_TYPES(float, double, std::complex<float>, std::complex<double>))
+                     MACRO_UNPACK_TYPES(float,
+                                        double,
+                                        std::complex<float>,
+                                        std::complex<double>))
 
 MACRO_2ARG_3TYPES_OP(dpnp_fmod_c,
                      sycl::fmod((double)input1_elem, (double)input2_elem),
@@ -165,28 +165,40 @@ MACRO_2ARG_3TYPES_OP(dpnp_minimum_c,
                      oneapi::mkl::vm::fmin,
                      MACRO_UNPACK_TYPES(float, double))
 
-// "multiply" needs to be standalone kernel (not autogenerated) due to complex algorithm. This is not an element wise.
-// pytest "tests/third_party/cupy/creation_tests/test_ranges.py::TestMgrid::test_mgrid3"
-// requires multiplication shape1[10] with shape2[10,1] and result expected as shape[10,10]
+// "multiply" needs to be standalone kernel (not autogenerated) due to complex
+// algorithm. This is not an element wise. pytest
+// "tests/third_party/cupy/creation_tests/test_ranges.py::TestMgrid::test_mgrid3"
+// requires multiplication shape1[10] with shape2[10,1] and result expected as
+// shape[10,10]
 MACRO_2ARG_3TYPES_OP(dpnp_multiply_c,
-                     input1_elem * input2_elem,
-                     x1 * x2,
+                     input1_elem *input2_elem,
+                     x1 *x2,
                      MACRO_UNPACK_TYPES(bool, std::int32_t, std::int64_t),
                      oneapi::mkl::vm::mul,
-                     MACRO_UNPACK_TYPES(float, double, std::complex<float>, std::complex<double>))
+                     MACRO_UNPACK_TYPES(float,
+                                        double,
+                                        std::complex<float>,
+                                        std::complex<double>))
 
 MACRO_2ARG_3TYPES_OP(dpnp_power_c,
-                     static_cast<_DataType_output>(std::pow(input1_elem, input2_elem)),
+                     static_cast<_DataType_output>(std::pow(input1_elem,
+                                                            input2_elem)),
                      sycl::pow(x1, x2),
                      MACRO_UNPACK_TYPES(float, double),
                      oneapi::mkl::vm::pow,
-                     MACRO_UNPACK_TYPES(float, double, std::complex<float>, std::complex<double>))
+                     MACRO_UNPACK_TYPES(float,
+                                        double,
+                                        std::complex<float>,
+                                        std::complex<double>))
 
 MACRO_2ARG_3TYPES_OP(dpnp_subtract_c,
                      input1_elem - input2_elem,
                      x1 - x2,
                      MACRO_UNPACK_TYPES(bool, std::int32_t, std::int64_t),
                      oneapi::mkl::vm::sub,
-                     MACRO_UNPACK_TYPES(float, double, std::complex<float>, std::complex<double>))
+                     MACRO_UNPACK_TYPES(float,
+                                        double,
+                                        std::complex<float>,
+                                        std::complex<double>))
 
 #undef MACRO_2ARG_3TYPES_OP

--- a/dpnp/backend/include/dpnp_iface.hpp
+++ b/dpnp/backend/include/dpnp_iface.hpp
@@ -25,11 +25,12 @@
 
 /*
  * This header file is for interface Cython with C++.
- * It should not contains any backend specific headers (like SYCL or math library) because
- * all included headers will be exposed in Cython compilation procedure
+ * It should not contains any backend specific headers (like SYCL or math
+ * library) because all included headers will be exposed in Cython compilation
+ * procedure
  *
- * We would like to avoid backend specific things in higher level Cython modules.
- * Any backend interface functions and types should be defined here.
+ * We would like to avoid backend specific things in higher level Cython
+ * modules. Any backend interface functions and types should be defined here.
  *
  * Also, this file should contains documentation on functions and types
  * which are used in the interface
@@ -71,14 +72,15 @@ typedef ssize_t shape_elem_type;
  * @ingroup BACKEND_API
  * @brief SYCL queue initialization selector.
  *
- * The structure defines the parameters that are used for the library initialization
- * by @ref dpnp_queue_initialize_c "dpnp_queue_initialize".
+ * The structure defines the parameters that are used for the library
+ * initialization by @ref dpnp_queue_initialize_c "dpnp_queue_initialize".
  */
 enum class QueueOptions : uint32_t
 {
     CPU_SELECTOR, /**< CPU side execution mode */
     GPU_SELECTOR, /**< Intel GPU side execution mode */
-    AUTO_SELECTOR /**< Automatic selection based on environment variable with @ref CPU_SELECTOR default */
+    AUTO_SELECTOR /**< Automatic selection based on environment variable with
+                     @ref CPU_SELECTOR default */
 };
 
 /**
@@ -87,9 +89,11 @@ enum class QueueOptions : uint32_t
  *
  * Global SYCL queue initialization.
  *
- * @param [in]  selector       Select type @ref QueueOptions of the SYCL queue. Default @ref AUTO_SELECTOR
+ * @param [in]  selector       Select type @ref QueueOptions of the SYCL queue.
+ * Default @ref AUTO_SELECTOR
  */
-INP_DLLEXPORT void dpnp_queue_initialize_c(QueueOptions selector = QueueOptions::AUTO_SELECTOR);
+INP_DLLEXPORT void dpnp_queue_initialize_c(
+    QueueOptions selector = QueueOptions::AUTO_SELECTOR);
 
 /**
  * @ingroup BACKEND_API
@@ -108,16 +112,22 @@ INP_DLLEXPORT size_t dpnp_queue_is_cpu_c();
  * @param [in]  size_in_bytes  Number of bytes for requested memory allocation.
  * @param [in]  q_ref          Reference to SYCL queue.
  *
- * @return  A pointer to newly created memory on @ref dpnp_queue_initialize_c "initialized SYCL device".
+ * @return  A pointer to newly created memory on @ref dpnp_queue_initialize_c
+ * "initialized SYCL device".
  */
-INP_DLLEXPORT char* dpnp_memory_alloc_c(DPCTLSyclQueueRef q_ref, size_t size_in_bytes);
-INP_DLLEXPORT char* dpnp_memory_alloc_c(size_t size_in_bytes);
+INP_DLLEXPORT char *dpnp_memory_alloc_c(DPCTLSyclQueueRef q_ref,
+                                        size_t size_in_bytes);
+INP_DLLEXPORT char *dpnp_memory_alloc_c(size_t size_in_bytes);
 
-INP_DLLEXPORT void dpnp_memory_free_c(DPCTLSyclQueueRef q_ref, void* ptr);
-INP_DLLEXPORT void dpnp_memory_free_c(void* ptr);
+INP_DLLEXPORT void dpnp_memory_free_c(DPCTLSyclQueueRef q_ref, void *ptr);
+INP_DLLEXPORT void dpnp_memory_free_c(void *ptr);
 
-INP_DLLEXPORT void dpnp_memory_memcpy_c(DPCTLSyclQueueRef q_ref, void* dst, const void* src, size_t size_in_bytes);
-INP_DLLEXPORT void dpnp_memory_memcpy_c(void* dst, const void* src, size_t size_in_bytes);
+INP_DLLEXPORT void dpnp_memory_memcpy_c(DPCTLSyclQueueRef q_ref,
+                                        void *dst,
+                                        const void *src,
+                                        size_t size_in_bytes);
+INP_DLLEXPORT void
+    dpnp_memory_memcpy_c(void *dst, const void *src, size_t size_in_bytes);
 /**
  * @ingroup BACKEND_API
  * @brief Test whether all array elements along a given axis evaluate to True.
@@ -129,14 +139,16 @@ INP_DLLEXPORT void dpnp_memory_memcpy_c(void* dst, const void* src, size_t size_
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType, typename _ResultType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_all_c(DPCTLSyclQueueRef q_ref,
-                                           const void* array,
-                                           void* result,
-                                           const size_t size,
-                                           const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_all_c(DPCTLSyclQueueRef q_ref,
+               const void *array,
+               void *result,
+               const size_t size,
+               const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType, typename _ResultType>
-INP_DLLEXPORT void dpnp_all_c(const void* array, void* result, const size_t size);
+INP_DLLEXPORT void
+    dpnp_all_c(const void *array, void *result, const size_t size);
 
 /**
  * @ingroup BACKEND_API
@@ -152,18 +164,23 @@ INP_DLLEXPORT void dpnp_all_c(const void* array, void* result, const size_t size
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType1, typename _DataType2, typename _ResultType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_allclose_c(DPCTLSyclQueueRef q_ref,
-                                                const void* array1_in,
-                                                const void* array2_in,
-                                                void* result1,
-                                                const size_t size,
-                                                double rtol,
-                                                double atol,
-                                                const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_allclose_c(DPCTLSyclQueueRef q_ref,
+                    const void *array1_in,
+                    const void *array2_in,
+                    void *result1,
+                    const size_t size,
+                    double rtol,
+                    double atol,
+                    const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType1, typename _DataType2, typename _ResultType>
-INP_DLLEXPORT void dpnp_allclose_c(
-    const void* array1_in, const void* array2_in, void* result1, const size_t size, double rtol, double atol);
+INP_DLLEXPORT void dpnp_allclose_c(const void *array1_in,
+                                   const void *array2_in,
+                                   void *result1,
+                                   const size_t size,
+                                   double rtol,
+                                   double atol);
 
 /**
  * @ingroup BACKEND_API
@@ -176,14 +193,16 @@ INP_DLLEXPORT void dpnp_allclose_c(
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType, typename _ResultType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_any_c(DPCTLSyclQueueRef q_ref,
-                                           const void* array,
-                                           void* result,
-                                           const size_t size,
-                                           const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_any_c(DPCTLSyclQueueRef q_ref,
+               const void *array,
+               void *result,
+               const size_t size,
+               const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType, typename _ResultType>
-INP_DLLEXPORT void dpnp_any_c(const void* array, void* result, const size_t size);
+INP_DLLEXPORT void
+    dpnp_any_c(const void *array, void *result, const size_t size);
 
 /**
  * @ingroup BACKEND_API
@@ -199,15 +218,17 @@ INP_DLLEXPORT void dpnp_any_c(const void* array, void* result, const size_t size
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_arange_c(DPCTLSyclQueueRef q_ref,
-                                              size_t start,
-                                              size_t step,
-                                              void* result1,
-                                              size_t size,
-                                              const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_arange_c(DPCTLSyclQueueRef q_ref,
+                  size_t start,
+                  size_t step,
+                  void *result1,
+                  size_t size,
+                  const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_arange_c(size_t start, size_t step, void* result1, size_t size);
+INP_DLLEXPORT void
+    dpnp_arange_c(size_t start, size_t step, void *result1, size_t size);
 
 /**
  * @ingroup BACKEND_API
@@ -220,14 +241,16 @@ INP_DLLEXPORT void dpnp_arange_c(size_t start, size_t step, void* result1, size_
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType, typename _ResultType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_astype_c(DPCTLSyclQueueRef q_ref,
-                                              const void* array,
-                                              void* result,
-                                              const size_t size,
-                                              const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_astype_c(DPCTLSyclQueueRef q_ref,
+                  const void *array,
+                  void *result,
+                  const size_t size,
+                  const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType, typename _ResultType>
-INP_DLLEXPORT void dpnp_astype_c(const void* array, void* result, const size_t size);
+INP_DLLEXPORT void
+    dpnp_astype_c(const void *array, void *result, const size_t size);
 
 /**
  * @ingroup BACKEND_API
@@ -240,14 +263,15 @@ INP_DLLEXPORT void dpnp_astype_c(const void* array, void* result, const size_t s
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_full_c(DPCTLSyclQueueRef q_ref,
-                                            void* array_in,
-                                            void* result,
-                                            const size_t size,
-                                            const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_full_c(DPCTLSyclQueueRef q_ref,
+                void *array_in,
+                void *result,
+                const size_t size,
+                const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_full_c(void* array_in, void* result, const size_t size);
+INP_DLLEXPORT void dpnp_full_c(void *array_in, void *result, const size_t size);
 
 /**
  * @ingroup BACKEND_API
@@ -260,14 +284,15 @@ INP_DLLEXPORT void dpnp_full_c(void* array_in, void* result, const size_t size);
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_full_like_c(DPCTLSyclQueueRef q_ref,
-                                                 void* array_in,
-                                                 void* result,
-                                                 size_t size,
-                                                 const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_full_like_c(DPCTLSyclQueueRef q_ref,
+                     void *array_in,
+                     void *result,
+                     size_t size,
+                     const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_full_like_c(void* array_in, void* result, size_t size);
+INP_DLLEXPORT void dpnp_full_like_c(void *array_in, void *result, size_t size);
 
 /**
  * @ingroup BACKEND_API
@@ -294,40 +319,41 @@ INP_DLLEXPORT void dpnp_full_like_c(void* array_in, void* result, size_t size);
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_matmul_c(DPCTLSyclQueueRef q_ref,
-                                              void* result_out,
-                                              const size_t result_size,
-                                              const size_t result_ndim,
-                                              const shape_elem_type* result_shape,
-                                              const shape_elem_type* result_strides,
-                                              const void* input1_in,
-                                              const size_t input1_size,
-                                              const size_t input1_ndim,
-                                              const shape_elem_type* input1_shape,
-                                              const shape_elem_type* input1_strides,
-                                              const void* input2_in,
-                                              const size_t input2_size,
-                                              const size_t input2_ndim,
-                                              const shape_elem_type* input2_shape,
-                                              const shape_elem_type* input2_strides,
-                                              const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_matmul_c(DPCTLSyclQueueRef q_ref,
+                  void *result_out,
+                  const size_t result_size,
+                  const size_t result_ndim,
+                  const shape_elem_type *result_shape,
+                  const shape_elem_type *result_strides,
+                  const void *input1_in,
+                  const size_t input1_size,
+                  const size_t input1_ndim,
+                  const shape_elem_type *input1_shape,
+                  const shape_elem_type *input1_strides,
+                  const void *input2_in,
+                  const size_t input2_size,
+                  const size_t input2_ndim,
+                  const shape_elem_type *input2_shape,
+                  const shape_elem_type *input2_strides,
+                  const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_matmul_c(void* result_out,
+INP_DLLEXPORT void dpnp_matmul_c(void *result_out,
                                  const size_t result_size,
                                  const size_t result_ndim,
-                                 const shape_elem_type* result_shape,
-                                 const shape_elem_type* result_strides,
-                                 const void* input1_in,
+                                 const shape_elem_type *result_shape,
+                                 const shape_elem_type *result_strides,
+                                 const void *input1_in,
                                  const size_t input1_size,
                                  const size_t input1_ndim,
-                                 const shape_elem_type* input1_shape,
-                                 const shape_elem_type* input1_strides,
-                                 const void* input2_in,
+                                 const shape_elem_type *input1_shape,
+                                 const shape_elem_type *input1_strides,
+                                 const void *input2_in,
                                  const size_t input2_size,
                                  const size_t input2_ndim,
-                                 const shape_elem_type* input2_shape,
-                                 const shape_elem_type* input2_strides);
+                                 const shape_elem_type *input2_shape,
+                                 const shape_elem_type *input2_strides);
 
 /**
  * @ingroup BACKEND_API
@@ -342,16 +368,21 @@ INP_DLLEXPORT void dpnp_matmul_c(void* result_out,
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_nanvar_c(DPCTLSyclQueueRef q_ref,
-                                              void* array,
-                                              void* mask_arr,
-                                              void* result,
-                                              const size_t result_size,
-                                              size_t size,
-                                              const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_nanvar_c(DPCTLSyclQueueRef q_ref,
+                  void *array,
+                  void *mask_arr,
+                  void *result,
+                  const size_t result_size,
+                  size_t size,
+                  const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_nanvar_c(void* array, void* mask_arr, void* result, const size_t result_size, size_t size);
+INP_DLLEXPORT void dpnp_nanvar_c(void *array,
+                                 void *mask_arr,
+                                 void *result,
+                                 const size_t result_size,
+                                 size_t size);
 
 /**
  * @ingroup BACKEND_API
@@ -367,20 +398,21 @@ INP_DLLEXPORT void dpnp_nanvar_c(void* array, void* mask_arr, void* result, cons
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_nonzero_c(DPCTLSyclQueueRef q_ref,
-                                               const void* array1,
-                                               void* result1,
-                                               const size_t result_size,
-                                               const shape_elem_type* shape,
-                                               const size_t ndim,
-                                               const size_t j,
-                                               const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_nonzero_c(DPCTLSyclQueueRef q_ref,
+                   const void *array1,
+                   void *result1,
+                   const size_t result_size,
+                   const shape_elem_type *shape,
+                   const size_t ndim,
+                   const size_t j,
+                   const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_nonzero_c(const void* array1,
-                                  void* result1,
+INP_DLLEXPORT void dpnp_nonzero_c(const void *array1,
+                                  void *result1,
                                   const size_t result_size,
-                                  const shape_elem_type* shape,
+                                  const shape_elem_type *shape,
                                   const size_t ndim,
                                   const size_t j);
 
@@ -395,14 +427,16 @@ INP_DLLEXPORT void dpnp_nonzero_c(const void* array1,
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_elemwise_absolute_c(DPCTLSyclQueueRef q_ref,
-                                                         const void* input1_in,
-                                                         void* result1,
-                                                         size_t size,
-                                                         const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_elemwise_absolute_c(DPCTLSyclQueueRef q_ref,
+                             const void *input1_in,
+                             void *result1,
+                             size_t size,
+                             const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_elemwise_absolute_c(const void* input1_in, void* result1, size_t size);
+INP_DLLEXPORT void
+    dpnp_elemwise_absolute_c(const void *input1_in, void *result1, size_t size);
 
 /**
  * @ingroup BACKEND_API
@@ -426,41 +460,46 @@ INP_DLLEXPORT void dpnp_elemwise_absolute_c(const void* input1_in, void* result1
  * @param [in]  input2_strides      Strides of second input array.
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_dot_c(DPCTLSyclQueueRef q_ref,
-                                           void* result_out,
-                                           const size_t result_size,
-                                           const size_t result_ndim,
-                                           const shape_elem_type* result_shape,
-                                           const shape_elem_type* result_strides,
-                                           const void* input1_in,
-                                           const size_t input1_size,
-                                           const size_t input1_ndim,
-                                           const shape_elem_type* input1_shape,
-                                           const shape_elem_type* input1_strides,
-                                           const void* input2_in,
-                                           const size_t input2_size,
-                                           const size_t input2_ndim,
-                                           const shape_elem_type* input2_shape,
-                                           const shape_elem_type* input2_strides,
-                                           const DPCTLEventVectorRef dep_event_vec_ref);
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_dot_c(DPCTLSyclQueueRef q_ref,
+               void *result_out,
+               const size_t result_size,
+               const size_t result_ndim,
+               const shape_elem_type *result_shape,
+               const shape_elem_type *result_strides,
+               const void *input1_in,
+               const size_t input1_size,
+               const size_t input1_ndim,
+               const shape_elem_type *input1_shape,
+               const shape_elem_type *input1_strides,
+               const void *input2_in,
+               const size_t input2_size,
+               const size_t input2_ndim,
+               const shape_elem_type *input2_shape,
+               const shape_elem_type *input2_strides,
+               const DPCTLEventVectorRef dep_event_vec_ref);
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
-INP_DLLEXPORT void dpnp_dot_c(void* result_out,
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
+INP_DLLEXPORT void dpnp_dot_c(void *result_out,
                               const size_t result_size,
                               const size_t result_ndim,
-                              const shape_elem_type* result_shape,
-                              const shape_elem_type* result_strides,
-                              const void* input1_in,
+                              const shape_elem_type *result_shape,
+                              const shape_elem_type *result_strides,
+                              const void *input1_in,
                               const size_t input1_size,
                               const size_t input1_ndim,
-                              const shape_elem_type* input1_shape,
-                              const shape_elem_type* input1_strides,
-                              const void* input2_in,
+                              const shape_elem_type *input1_shape,
+                              const shape_elem_type *input1_strides,
+                              const void *input2_in,
                               const size_t input2_size,
                               const size_t input2_ndim,
-                              const shape_elem_type* input2_shape,
-                              const shape_elem_type* input2_strides);
+                              const shape_elem_type *input2_shape,
+                              const shape_elem_type *input2_strides);
 
 /**
  * @ingroup BACKEND_API
@@ -479,31 +518,36 @@ INP_DLLEXPORT void dpnp_dot_c(void* result_out,
  * @param [in]  where               Mask array.
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_cross_c(DPCTLSyclQueueRef q_ref,
-                                             void* result_out,
-                                             const void* input1_in,
-                                             const size_t input1_size,
-                                             const shape_elem_type* input1_shape,
-                                             const size_t input1_shape_ndim,
-                                             const void* input2_in,
-                                             const size_t input2_size,
-                                             const shape_elem_type* input2_shape,
-                                             const size_t input2_shape_ndim,
-                                             const size_t* where,
-                                             const DPCTLEventVectorRef dep_event_vec_ref);
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_cross_c(DPCTLSyclQueueRef q_ref,
+                 void *result_out,
+                 const void *input1_in,
+                 const size_t input1_size,
+                 const shape_elem_type *input1_shape,
+                 const size_t input1_shape_ndim,
+                 const void *input2_in,
+                 const size_t input2_size,
+                 const shape_elem_type *input2_shape,
+                 const size_t input2_shape_ndim,
+                 const size_t *where,
+                 const DPCTLEventVectorRef dep_event_vec_ref);
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
-INP_DLLEXPORT void dpnp_cross_c(void* result_out,
-                                const void* input1_in,
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
+INP_DLLEXPORT void dpnp_cross_c(void *result_out,
+                                const void *input1_in,
                                 const size_t input1_size,
-                                const shape_elem_type* input1_shape,
+                                const shape_elem_type *input1_shape,
                                 const size_t input1_shape_ndim,
-                                const void* input2_in,
+                                const void *input2_in,
                                 const size_t input2_size,
-                                const shape_elem_type* input2_shape,
+                                const shape_elem_type *input2_shape,
                                 const size_t input2_shape_ndim,
-                                const size_t* where);
+                                const size_t *where);
 
 /**
  * @ingroup BACKEND_API
@@ -517,14 +561,15 @@ INP_DLLEXPORT void dpnp_cross_c(void* result_out,
  *
  */
 template <typename _DataType_input, typename _DataType_output>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_cumprod_c(DPCTLSyclQueueRef q_ref,
-                                               void* array1_in,
-                                               void* result1,
-                                               size_t size,
-                                               const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_cumprod_c(DPCTLSyclQueueRef q_ref,
+                   void *array1_in,
+                   void *result1,
+                   size_t size,
+                   const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType_input, typename _DataType_output>
-INP_DLLEXPORT void dpnp_cumprod_c(void* array1_in, void* result1, size_t size);
+INP_DLLEXPORT void dpnp_cumprod_c(void *array1_in, void *result1, size_t size);
 
 /**
  * @ingroup BACKEND_API
@@ -538,14 +583,15 @@ INP_DLLEXPORT void dpnp_cumprod_c(void* array1_in, void* result1, size_t size);
  *
  */
 template <typename _DataType_input, typename _DataType_output>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_cumsum_c(DPCTLSyclQueueRef q_ref,
-                                              void* array1_in,
-                                              void* result1,
-                                              size_t size,
-                                              const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_cumsum_c(DPCTLSyclQueueRef q_ref,
+                  void *array1_in,
+                  void *result1,
+                  size_t size,
+                  const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType_input, typename _DataType_output>
-INP_DLLEXPORT void dpnp_cumsum_c(void* array1_in, void* result1, size_t size);
+INP_DLLEXPORT void dpnp_cumsum_c(void *array1_in, void *result1, size_t size);
 
 /**
  * @ingroup BACKEND_API
@@ -566,74 +612,79 @@ INP_DLLEXPORT void dpnp_cumsum_c(void* array1_in, void* result1, size_t size);
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType_input, typename _DataType_output>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_ediff1d_c(DPCTLSyclQueueRef q_ref,
-                                               void* result_out,
-                                               const size_t result_size,
-                                               const size_t result_ndim,
-                                               const shape_elem_type* result_shape,
-                                               const shape_elem_type* result_strides,
-                                               const void* input1_in,
-                                               const size_t input1_size,
-                                               const size_t input1_ndim,
-                                               const shape_elem_type* input1_shape,
-                                               const shape_elem_type* input1_strides,
-                                               const size_t* where,
-                                               const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_ediff1d_c(DPCTLSyclQueueRef q_ref,
+                   void *result_out,
+                   const size_t result_size,
+                   const size_t result_ndim,
+                   const shape_elem_type *result_shape,
+                   const shape_elem_type *result_strides,
+                   const void *input1_in,
+                   const size_t input1_size,
+                   const size_t input1_ndim,
+                   const shape_elem_type *input1_shape,
+                   const shape_elem_type *input1_strides,
+                   const size_t *where,
+                   const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType_input, typename _DataType_output>
-INP_DLLEXPORT void dpnp_ediff1d_c(void* result_out,
+INP_DLLEXPORT void dpnp_ediff1d_c(void *result_out,
                                   const size_t result_size,
                                   const size_t result_ndim,
-                                  const shape_elem_type* result_shape,
-                                  const shape_elem_type* result_strides,
-                                  const void* input1_in,
+                                  const shape_elem_type *result_shape,
+                                  const shape_elem_type *result_strides,
+                                  const void *input1_in,
                                   const size_t input1_size,
                                   const size_t input1_ndim,
-                                  const shape_elem_type* input1_shape,
-                                  const shape_elem_type* input1_strides,
-                                  const size_t* where);
+                                  const shape_elem_type *input1_shape,
+                                  const shape_elem_type *input1_strides,
+                                  const size_t *where);
 
 /**
  * @ingroup BACKEND_API
  * @brief Compute summary of input array elements.
  *
- * Input array is expected as @ref _DataType_input type and assume result as @ref _DataType_output type.
- * The function creates no memory.
+ * Input array is expected as @ref _DataType_input type and assume result as
+ * @ref _DataType_output type. The function creates no memory.
  *
  * Empty @ref input_shape means scalar.
  *
  * @param [in]  q_ref             Reference to SYCL queue.
- * @param [out] result_out        Output array pointer. @ref _DataType_output type is expected
- * @param [in]  input_in          Input array pointer. @ref _DataType_input type is expected
+ * @param [out] result_out        Output array pointer. @ref _DataType_output
+ * type is expected
+ * @param [in]  input_in          Input array pointer. @ref _DataType_input type
+ * is expected
  * @param [in]  input_shape       Shape of @ref input_in
  * @param [in]  input_shape_ndim  Number of elements in @ref input_shape
  * @param [in]  axes              Array of axes to apply to @ref input_shape
  * @param [in]  axes_ndim         Number of elements in @ref axes
- * @param [in]  initial           Pointer to initial value for the algorithm. @ref _DataType_input is expected
+ * @param [in]  initial           Pointer to initial value for the algorithm.
+ * @ref _DataType_input is expected
  * @param [in]  where             mask array
  * @param [in]  dep_event_vec_ref Reference to vector of SYCL events.
  */
 template <typename _DataType_output, typename _DataType_input>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_sum_c(DPCTLSyclQueueRef q_ref,
-                                           void* result_out,
-                                           const void* input_in,
-                                           const shape_elem_type* input_shape,
-                                           const size_t input_shape_ndim,
-                                           const shape_elem_type* axes,
-                                           const size_t axes_ndim,
-                                           const void* initial,
-                                           const long* where,
-                                           const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_sum_c(DPCTLSyclQueueRef q_ref,
+               void *result_out,
+               const void *input_in,
+               const shape_elem_type *input_shape,
+               const size_t input_shape_ndim,
+               const shape_elem_type *axes,
+               const size_t axes_ndim,
+               const void *initial,
+               const long *where,
+               const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType_output, typename _DataType_input>
-INP_DLLEXPORT void dpnp_sum_c(void* result_out,
-                              const void* input_in,
-                              const shape_elem_type* input_shape,
+INP_DLLEXPORT void dpnp_sum_c(void *result_out,
+                              const void *input_in,
+                              const shape_elem_type *input_shape,
                               const size_t input_shape_ndim,
-                              const shape_elem_type* axes,
+                              const shape_elem_type *axes,
                               const size_t axes_ndim,
-                              const void* initial,
-                              const long* where);
+                              const void *initial,
+                              const long *where);
 
 /**
  * @ingroup BACKEND_API
@@ -647,14 +698,16 @@ INP_DLLEXPORT void dpnp_sum_c(void* result_out,
  *
  */
 template <typename _DataType_input, typename _DataType_output>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_count_nonzero_c(DPCTLSyclQueueRef q_ref,
-                                                     void* array1_in,
-                                                     void* result1_out,
-                                                     size_t size,
-                                                     const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_count_nonzero_c(DPCTLSyclQueueRef q_ref,
+                         void *array1_in,
+                         void *result1_out,
+                         size_t size,
+                         const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType_input, typename _DataType_output>
-INP_DLLEXPORT void dpnp_count_nonzero_c(void* array1_in, void* result1_out, size_t size);
+INP_DLLEXPORT void
+    dpnp_count_nonzero_c(void *array1_in, void *result1_out, size_t size);
 
 /**
  * @ingroup BACKEND_API
@@ -670,18 +723,23 @@ INP_DLLEXPORT void dpnp_count_nonzero_c(void* array1_in, void* result1_out, size
  * @param [in]  dep_event_vec_ref Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_partition_c(DPCTLSyclQueueRef q_ref,
-                                                 void* array,
-                                                 void* array2,
-                                                 void* result,
-                                                 const size_t kth,
-                                                 const shape_elem_type* shape,
-                                                 const size_t ndim,
-                                                 const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_partition_c(DPCTLSyclQueueRef q_ref,
+                     void *array,
+                     void *array2,
+                     void *result,
+                     const size_t kth,
+                     const shape_elem_type *shape,
+                     const size_t ndim,
+                     const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_partition_c(
-    void* array, void* array2, void* result, const size_t kth, const shape_elem_type* shape, const size_t ndim);
+INP_DLLEXPORT void dpnp_partition_c(void *array,
+                                    void *array2,
+                                    void *result,
+                                    const size_t kth,
+                                    const shape_elem_type *shape,
+                                    const size_t ndim);
 
 /**
  * @ingroup BACKEND_API
@@ -696,58 +754,67 @@ INP_DLLEXPORT void dpnp_partition_c(
  * @param [in]  dep_event_vec_ref Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_place_c(DPCTLSyclQueueRef q_ref,
-                                             void* arr,
-                                             long* mask,
-                                             void* vals,
-                                             const size_t arr_size,
-                                             const size_t vals_size,
-                                             const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_place_c(DPCTLSyclQueueRef q_ref,
+                 void *arr,
+                 long *mask,
+                 void *vals,
+                 const size_t arr_size,
+                 const size_t vals_size,
+                 const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_place_c(void* arr, long* mask, void* vals, const size_t arr_size, const size_t vals_size);
+INP_DLLEXPORT void dpnp_place_c(void *arr,
+                                long *mask,
+                                void *vals,
+                                const size_t arr_size,
+                                const size_t vals_size);
 
 /**
  * @ingroup BACKEND_API
  * @brief Compute Product of input array elements.
  *
- * Input array is expected as @ref _DataType_input type and assume result as @ref _DataType_output type.
- * The function creates no memory.
+ * Input array is expected as @ref _DataType_input type and assume result as
+ * @ref _DataType_output type. The function creates no memory.
  *
  * Empty @ref input_shape means scalar.
  *
  * @param [in]  q_ref             Reference to SYCL queue.
- * @param [out] result_out        Output array pointer. @ref _DataType_output type is expected
- * @param [in]  input_in          Input array pointer. @ref _DataType_input type is expected
+ * @param [out] result_out        Output array pointer. @ref _DataType_output
+ * type is expected
+ * @param [in]  input_in          Input array pointer. @ref _DataType_input type
+ * is expected
  * @param [in]  input_shape       Shape of @ref input_in
  * @param [in]  input_shape_ndim  Number of elements in @ref input_shape
  * @param [in]  axes              Array of axes to apply to @ref input_shape
  * @param [in]  axes_ndim         Number of elements in @ref axes
- * @param [in]  initial           Pointer to initial value for the algorithm. @ref _DataType_input is expected
+ * @param [in]  initial           Pointer to initial value for the algorithm.
+ * @ref _DataType_input is expected
  * @param [in]  where             mask array
  * @param [in]  dep_event_vec_ref Reference to vector of SYCL events.
  */
 template <typename _DataType_output, typename _DataType_input>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_prod_c(DPCTLSyclQueueRef q_ref,
-                                            void* result_out,
-                                            const void* input_in,
-                                            const shape_elem_type* input_shape,
-                                            const size_t input_shape_ndim,
-                                            const shape_elem_type* axes,
-                                            const size_t axes_ndim,
-                                            const void* initial,
-                                            const long* where,
-                                            const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_prod_c(DPCTLSyclQueueRef q_ref,
+                void *result_out,
+                const void *input_in,
+                const shape_elem_type *input_shape,
+                const size_t input_shape_ndim,
+                const shape_elem_type *axes,
+                const size_t axes_ndim,
+                const void *initial,
+                const long *where,
+                const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType_output, typename _DataType_input>
-INP_DLLEXPORT void dpnp_prod_c(void* result_out,
-                               const void* input_in,
-                               const shape_elem_type* input_shape,
+INP_DLLEXPORT void dpnp_prod_c(void *result_out,
+                               const void *input_in,
+                               const shape_elem_type *input_shape,
                                const size_t input_shape_ndim,
-                               const shape_elem_type* axes,
+                               const shape_elem_type *axes,
                                const size_t axes_ndim,
-                               const void* initial,
-                               const long* where);
+                               const void *initial,
+                               const long *where);
 
 /**
  * @ingroup BACKEND_API
@@ -769,33 +836,34 @@ INP_DLLEXPORT void dpnp_prod_c(void* result_out,
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_ptp_c(DPCTLSyclQueueRef q_ref,
-                                           void* result_out,
-                                           const size_t result_size,
-                                           const size_t result_ndim,
-                                           const shape_elem_type* result_shape,
-                                           const shape_elem_type* result_strides,
-                                           const void* input_in,
-                                           const size_t input_size,
-                                           const size_t input_ndim,
-                                           const shape_elem_type* input_shape,
-                                           const shape_elem_type* input_strides,
-                                           const shape_elem_type* axis,
-                                           const size_t naxis,
-                                           const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_ptp_c(DPCTLSyclQueueRef q_ref,
+               void *result_out,
+               const size_t result_size,
+               const size_t result_ndim,
+               const shape_elem_type *result_shape,
+               const shape_elem_type *result_strides,
+               const void *input_in,
+               const size_t input_size,
+               const size_t input_ndim,
+               const shape_elem_type *input_shape,
+               const shape_elem_type *input_strides,
+               const shape_elem_type *axis,
+               const size_t naxis,
+               const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_ptp_c(void* result_out,
+INP_DLLEXPORT void dpnp_ptp_c(void *result_out,
                               const size_t result_size,
                               const size_t result_ndim,
-                              const shape_elem_type* result_shape,
-                              const shape_elem_type* result_strides,
-                              const void* input_in,
+                              const shape_elem_type *result_shape,
+                              const shape_elem_type *result_strides,
+                              const void *input_in,
                               const size_t input_size,
                               const size_t input_ndim,
-                              const shape_elem_type* input_shape,
-                              const shape_elem_type* input_strides,
-                              const shape_elem_type* axis,
+                              const shape_elem_type *input_shape,
+                              const shape_elem_type *input_strides,
+                              const shape_elem_type *axis,
                               const size_t naxis);
 
 /**
@@ -812,26 +880,33 @@ INP_DLLEXPORT void dpnp_ptp_c(void* result_out,
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType, typename _IndecesType, typename _ValueType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_put_c(DPCTLSyclQueueRef q_ref,
-                                           void* array,
-                                           void* ind,
-                                           void* v,
-                                           const size_t size,
-                                           const size_t size_ind,
-                                           const size_t size_v,
-                                           const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_put_c(DPCTLSyclQueueRef q_ref,
+               void *array,
+               void *ind,
+               void *v,
+               const size_t size,
+               const size_t size_ind,
+               const size_t size_v,
+               const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType, typename _IndecesType, typename _ValueType>
-INP_DLLEXPORT void
-    dpnp_put_c(void* array, void* ind, void* v, const size_t size, const size_t size_ind, const size_t size_v);
+INP_DLLEXPORT void dpnp_put_c(void *array,
+                              void *ind,
+                              void *v,
+                              const size_t size,
+                              const size_t size_ind,
+                              const size_t size_v);
 
 /**
  * @ingroup BACKEND_API
- * @brief Put values into the destination array by matching 1d index and data slices.
+ * @brief Put values into the destination array by matching 1d index and data
+ * slices.
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [in]  arr_in              Input array.
- * @param [in]  indices_in          Indices to change along each 1d slice of arr.
+ * @param [in]  indices_in          Indices to change along each 1d slice of
+ * arr.
  * @param [in]  values_in           Values to insert at those indices.
  * @param [in]  axis                The axis to take 1d slices along.
  * @param [in]  shape               Shape of input array.
@@ -841,23 +916,24 @@ INP_DLLEXPORT void
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_put_along_axis_c(DPCTLSyclQueueRef q_ref,
-                                                      void* arr_in,
-                                                      long* indices_in,
-                                                      void* values_in,
-                                                      size_t axis,
-                                                      const shape_elem_type* shape,
-                                                      size_t ndim,
-                                                      size_t size_indices,
-                                                      size_t values_size,
-                                                      const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_put_along_axis_c(DPCTLSyclQueueRef q_ref,
+                          void *arr_in,
+                          long *indices_in,
+                          void *values_in,
+                          size_t axis,
+                          const shape_elem_type *shape,
+                          size_t ndim,
+                          size_t size_indices,
+                          size_t values_size,
+                          const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_put_along_axis_c(void* arr_in,
-                                         long* indices_in,
-                                         void* values_in,
+INP_DLLEXPORT void dpnp_put_along_axis_c(void *arr_in,
+                                         long *indices_in,
+                                         void *values_in,
                                          size_t axis,
-                                         const shape_elem_type* shape,
+                                         const shape_elem_type *shape,
                                          size_t ndim,
                                          size_t size_indices,
                                          size_t values_size);
@@ -868,21 +944,24 @@ INP_DLLEXPORT void dpnp_put_along_axis_c(void* arr_in,
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [in]  array_in            Input array[size][size]
- * @param [out] result1             The eigenvalues, each repeated according to its multiplicity
+ * @param [out] result1             The eigenvalues, each repeated according to
+ * its multiplicity
  * @param [out] result2             The normalized (unit "length") eigenvectors
  * @param [in]  size                One dimension of square [size][size] array
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType, typename _ResultType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_eig_c(DPCTLSyclQueueRef q_ref,
-                                           const void* array_in,
-                                           void* result1,
-                                           void* result2,
-                                           size_t size,
-                                           const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_eig_c(DPCTLSyclQueueRef q_ref,
+               const void *array_in,
+               void *result1,
+               void *result2,
+               size_t size,
+               const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType, typename _ResultType>
-INP_DLLEXPORT void dpnp_eig_c(const void* array_in, void* result1, void* result2, size_t size);
+INP_DLLEXPORT void
+    dpnp_eig_c(const void *array_in, void *result1, void *result2, size_t size);
 
 /**
  * @ingroup BACKEND_API
@@ -890,39 +969,45 @@ INP_DLLEXPORT void dpnp_eig_c(const void* array_in, void* result1, void* result2
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [in]  array_in            Input array[size][size]
- * @param [out] result1             The eigenvalues, each repeated according to its multiplicity
+ * @param [out] result1             The eigenvalues, each repeated according to
+ * its multiplicity
  * @param [in]  size                One dimension of square [size][size] array
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType, typename _ResultType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_eigvals_c(DPCTLSyclQueueRef q_ref,
-                                               const void* array_in,
-                                               void* result1,
-                                               size_t size,
-                                               const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_eigvals_c(DPCTLSyclQueueRef q_ref,
+                   const void *array_in,
+                   void *result1,
+                   size_t size,
+                   const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType, typename _ResultType>
-INP_DLLEXPORT void dpnp_eigvals_c(const void* array_in, void* result1, size_t size);
+INP_DLLEXPORT void
+    dpnp_eigvals_c(const void *array_in, void *result1, size_t size);
 
 /**
  * @ingroup BACKEND_API
  * @brief Return a 2-D array with ones on the diagonal and zeros elsewhere.
  *
  * @param [in]  q_ref               Reference to SYCL queue.
- * @param [out] result              The eigenvalues, each repeated according to its multiplicity
+ * @param [out] result              The eigenvalues, each repeated according to
+ * its multiplicity
  * @param [in]  k                   Index of the diagonal
  * @param [in]  shape               Shape of result
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_eye_c(DPCTLSyclQueueRef q_ref,
-                                           void* result,
-                                           int k,
-                                           const shape_elem_type* res_shape,
-                                           const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_eye_c(DPCTLSyclQueueRef q_ref,
+               void *result,
+               int k,
+               const shape_elem_type *res_shape,
+               const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_eye_c(void* result, int k, const shape_elem_type* res_shape);
+INP_DLLEXPORT void
+    dpnp_eye_c(void *result, int k, const shape_elem_type *res_shape);
 
 /**
  * @ingroup BACKEND_API
@@ -935,14 +1020,15 @@ INP_DLLEXPORT void dpnp_eye_c(void* result, int k, const shape_elem_type* res_sh
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType, typename _idx_DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_argsort_c(DPCTLSyclQueueRef q_ref,
-                                               void* array,
-                                               void* result,
-                                               size_t size,
-                                               const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_argsort_c(DPCTLSyclQueueRef q_ref,
+                   void *array,
+                   void *result,
+                   size_t size,
+                   const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType, typename _idx_DataType>
-INP_DLLEXPORT void dpnp_argsort_c(void* array, void* result, size_t size);
+INP_DLLEXPORT void dpnp_argsort_c(void *array, void *result, size_t size);
 
 /**
  * @ingroup BACKEND_API
@@ -952,24 +1038,30 @@ INP_DLLEXPORT void dpnp_argsort_c(void* array, void* result, size_t size);
  * @param [out] result              Output array.
  * @param [in]  array               Input array with data.
  * @param [in]  v                   Input values to insert into array.
- * @param [in]  side                Param for choosing a case of searching for elements.
+ * @param [in]  side                Param for choosing a case of searching for
+ * elements.
  * @param [in]  arr_size            Number of elements in input arrays.
  * @param [in]  v_size              Number of elements in input values arrays.
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType, typename _IndexingType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_searchsorted_c(DPCTLSyclQueueRef q_ref,
-                                                    void* result,
-                                                    const void* array,
-                                                    const void* v,
-                                                    bool side,
-                                                    const size_t arr_size,
-                                                    const size_t v_size,
-                                                    const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_searchsorted_c(DPCTLSyclQueueRef q_ref,
+                        void *result,
+                        const void *array,
+                        const void *v,
+                        bool side,
+                        const size_t arr_size,
+                        const size_t v_size,
+                        const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType, typename _IndexingType>
-INP_DLLEXPORT void dpnp_searchsorted_c(
-    void* result, const void* array, const void* v, bool side, const size_t arr_size, const size_t v_size);
+INP_DLLEXPORT void dpnp_searchsorted_c(void *result,
+                                       const void *array,
+                                       const void *v,
+                                       bool side,
+                                       const size_t arr_size,
+                                       const size_t v_size);
 
 /**
  * @ingroup BACKEND_API
@@ -982,14 +1074,15 @@ INP_DLLEXPORT void dpnp_searchsorted_c(
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_sort_c(DPCTLSyclQueueRef q_ref,
-                                            void* array,
-                                            void* result,
-                                            size_t size,
-                                            const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_sort_c(DPCTLSyclQueueRef q_ref,
+                void *array,
+                void *result,
+                size_t size,
+                const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_sort_c(void* array, void* result, size_t size);
+INP_DLLEXPORT void dpnp_sort_c(void *array, void *result, size_t size);
 
 /**
  * @ingroup BACKEND_API
@@ -1003,15 +1096,19 @@ INP_DLLEXPORT void dpnp_sort_c(void* array, void* result, size_t size);
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_cholesky_c(DPCTLSyclQueueRef q_ref,
-                                                void* array1_in,
-                                                void* result1,
-                                                const size_t size,
-                                                const size_t data_size,
-                                                const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_cholesky_c(DPCTLSyclQueueRef q_ref,
+                    void *array1_in,
+                    void *result1,
+                    const size_t size,
+                    const size_t data_size,
+                    const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_cholesky_c(void* array1_in, void* result1, const size_t size, const size_t data_size);
+INP_DLLEXPORT void dpnp_cholesky_c(void *array1_in,
+                                   void *result1,
+                                   const size_t size,
+                                   const size_t data_size);
 
 /**
  * @ingroup BACKEND_API
@@ -1030,31 +1127,36 @@ INP_DLLEXPORT void dpnp_cholesky_c(void* array1_in, void* result1, const size_t 
  * @param [in]  where               Mask array.
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_correlate_c(DPCTLSyclQueueRef q_ref,
-                                                 void* result_out,
-                                                 const void* input1_in,
-                                                 const size_t input1_size,
-                                                 const shape_elem_type* input1_shape,
-                                                 const size_t input1_shape_ndim,
-                                                 const void* input2_in,
-                                                 const size_t input2_size,
-                                                 const shape_elem_type* input2_shape,
-                                                 const size_t input2_shape_ndim,
-                                                 const size_t* where,
-                                                 const DPCTLEventVectorRef dep_event_vec_ref);
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_correlate_c(DPCTLSyclQueueRef q_ref,
+                     void *result_out,
+                     const void *input1_in,
+                     const size_t input1_size,
+                     const shape_elem_type *input1_shape,
+                     const size_t input1_shape_ndim,
+                     const void *input2_in,
+                     const size_t input2_size,
+                     const shape_elem_type *input2_shape,
+                     const size_t input2_shape_ndim,
+                     const size_t *where,
+                     const DPCTLEventVectorRef dep_event_vec_ref);
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
-INP_DLLEXPORT void dpnp_correlate_c(void* result_out,
-                                    const void* input1_in,
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
+INP_DLLEXPORT void dpnp_correlate_c(void *result_out,
+                                    const void *input1_in,
                                     const size_t input1_size,
-                                    const shape_elem_type* input1_shape,
+                                    const shape_elem_type *input1_shape,
                                     const size_t input1_shape_ndim,
-                                    const void* input2_in,
+                                    const void *input2_in,
                                     const size_t input2_size,
-                                    const shape_elem_type* input2_shape,
+                                    const shape_elem_type *input2_shape,
                                     const size_t input2_shape_ndim,
-                                    const size_t* where);
+                                    const size_t *where);
 
 /**
  * @ingroup BACKEND_API
@@ -1068,15 +1170,17 @@ INP_DLLEXPORT void dpnp_correlate_c(void* result_out,
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_cov_c(DPCTLSyclQueueRef q_ref,
-                                           void* array1_in,
-                                           void* result1,
-                                           size_t nrows,
-                                           size_t ncols,
-                                           const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_cov_c(DPCTLSyclQueueRef q_ref,
+               void *array1_in,
+               void *result1,
+               size_t nrows,
+               size_t ncols,
+               const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_cov_c(void* array1_in, void* result1, size_t nrows, size_t ncols);
+INP_DLLEXPORT void
+    dpnp_cov_c(void *array1_in, void *result1, size_t nrows, size_t ncols);
 
 /**
  * @ingroup BACKEND_API
@@ -1090,19 +1194,24 @@ INP_DLLEXPORT void dpnp_cov_c(void* array1_in, void* result1, size_t nrows, size
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_det_c(DPCTLSyclQueueRef q_ref,
-                                           void* array1_in,
-                                           void* result1,
-                                           shape_elem_type* shape,
-                                           size_t ndim,
-                                           const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_det_c(DPCTLSyclQueueRef q_ref,
+               void *array1_in,
+               void *result1,
+               shape_elem_type *shape,
+               size_t ndim,
+               const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_det_c(void* array1_in, void* result1, shape_elem_type* shape, size_t ndim);
+INP_DLLEXPORT void dpnp_det_c(void *array1_in,
+                              void *result1,
+                              shape_elem_type *shape,
+                              size_t ndim);
 
 /**
  * @ingroup BACKEND_API
- * @brief Construct an array from an index array and a list of arrays to choose from.
+ * @brief Construct an array from an index array and a list of arrays to choose
+ * from.
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result1             Output array.
@@ -1114,18 +1223,23 @@ INP_DLLEXPORT void dpnp_det_c(void* array1_in, void* result1, shape_elem_type* s
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType1, typename _DataType2>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_choose_c(DPCTLSyclQueueRef q_ref,
-                                              void* result1,
-                                              void* array1_in,
-                                              void** choices,
-                                              size_t size,
-                                              size_t choices_size,
-                                              size_t choice_size,
-                                              const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_choose_c(DPCTLSyclQueueRef q_ref,
+                  void *result1,
+                  void *array1_in,
+                  void **choices,
+                  size_t size,
+                  size_t choices_size,
+                  size_t choice_size,
+                  const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType1, typename _DataType2>
-INP_DLLEXPORT void
-    dpnp_choose_c(void* result1, void* array1_in, void** choices, size_t size, size_t choices_size, size_t choice_size);
+INP_DLLEXPORT void dpnp_choose_c(void *result1,
+                                 void *array1_in,
+                                 void **choices,
+                                 size_t size,
+                                 size_t choices_size,
+                                 size_t choice_size);
 
 /**
  * @ingroup BACKEND_API
@@ -1142,22 +1256,23 @@ INP_DLLEXPORT void
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_diag_c(DPCTLSyclQueueRef q_ref,
-                                            void* array,
-                                            void* result,
-                                            const int k,
-                                            shape_elem_type* shape,
-                                            shape_elem_type* res_shape,
-                                            const size_t ndim,
-                                            const size_t res_ndim,
-                                            const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_diag_c(DPCTLSyclQueueRef q_ref,
+                void *array,
+                void *result,
+                const int k,
+                shape_elem_type *shape,
+                shape_elem_type *res_shape,
+                const size_t ndim,
+                const size_t res_ndim,
+                const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_diag_c(void* array,
-                               void* result,
+INP_DLLEXPORT void dpnp_diag_c(void *array,
+                               void *result,
                                const int k,
-                               shape_elem_type* shape,
-                               shape_elem_type* res_shape,
+                               shape_elem_type *shape,
+                               shape_elem_type *res_shape,
                                const size_t ndim,
                                const size_t res_ndim);
 
@@ -1171,13 +1286,14 @@ INP_DLLEXPORT void dpnp_diag_c(void* array,
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_diag_indices_c(DPCTLSyclQueueRef q_ref,
-                                                    void* result1,
-                                                    size_t size,
-                                                    const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_diag_indices_c(DPCTLSyclQueueRef q_ref,
+                        void *result1,
+                        size_t size,
+                        const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_diag_indices_c(void* result1, size_t size);
+INP_DLLEXPORT void dpnp_diag_indices_c(void *result1, size_t size);
 
 /**
  * @ingroup BACKEND_API
@@ -1187,30 +1303,32 @@ INP_DLLEXPORT void dpnp_diag_indices_c(void* result1, size_t size);
  * @param [in]  array1_in           Input array with data.
  * @param [in]  input1_size         Input1 data size.
  * @param [out] result1             Output array.
- * @param [in]  offset              Offset of the diagonal from the main diagonal.
+ * @param [in]  offset              Offset of the diagonal from the main
+ * diagonal.
  * @param [in]  shape               Shape of input array.
  * @param [in]  res_shape           Shape of output array.
  * @param [in]  res_ndim            Number of elements in shape.
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_diagonal_c(DPCTLSyclQueueRef q_ref,
-                                                void* array1_in,
-                                                const size_t input1_size,
-                                                void* result1,
-                                                const size_t offset,
-                                                shape_elem_type* shape,
-                                                shape_elem_type* res_shape,
-                                                const size_t res_ndim,
-                                                const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_diagonal_c(DPCTLSyclQueueRef q_ref,
+                    void *array1_in,
+                    const size_t input1_size,
+                    void *result1,
+                    const size_t offset,
+                    shape_elem_type *shape,
+                    shape_elem_type *res_shape,
+                    const size_t res_ndim,
+                    const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_diagonal_c(void* array1_in,
+INP_DLLEXPORT void dpnp_diagonal_c(void *array1_in,
                                    const size_t input1_size,
-                                   void* result1,
+                                   void *result1,
                                    const size_t offset,
-                                   shape_elem_type* shape,
-                                   shape_elem_type* res_shape,
+                                   shape_elem_type *shape,
+                                   shape_elem_type *res_shape,
                                    const size_t res_ndim);
 
 /**
@@ -1219,17 +1337,19 @@ INP_DLLEXPORT void dpnp_diagonal_c(void* array1_in,
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result1             Output array.
- * @param [in]  n                   Number of rows (and columns) in n x n output.
+ * @param [in]  n                   Number of rows (and columns) in n x n
+ * output.
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_identity_c(DPCTLSyclQueueRef q_ref,
-                                                void* result1,
-                                                const size_t n,
-                                                const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_identity_c(DPCTLSyclQueueRef q_ref,
+                    void *result1,
+                    const size_t n,
+                    const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_identity_c(void* result1, const size_t n);
+INP_DLLEXPORT void dpnp_identity_c(void *result1, const size_t n);
 
 /**
  * @ingroup BACKEND_API
@@ -1242,14 +1362,15 @@ INP_DLLEXPORT void dpnp_identity_c(void* result1, const size_t n);
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_initval_c(DPCTLSyclQueueRef q_ref,
-                                               void* result1,
-                                               void* value,
-                                               size_t size,
-                                               const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_initval_c(DPCTLSyclQueueRef q_ref,
+                   void *result1,
+                   void *value,
+                   size_t size,
+                   const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_initval_c(void* result1, void* value, size_t size);
+INP_DLLEXPORT void dpnp_initval_c(void *result1, void *value, size_t size);
 
 /**
  * @ingroup BACKEND_API
@@ -1263,15 +1384,19 @@ INP_DLLEXPORT void dpnp_initval_c(void* result1, void* value, size_t size);
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType, typename _ResultType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_inv_c(DPCTLSyclQueueRef q_ref,
-                                           void* array1_in,
-                                           void* result1,
-                                           shape_elem_type* shape,
-                                           size_t ndim,
-                                           const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_inv_c(DPCTLSyclQueueRef q_ref,
+               void *array1_in,
+               void *result1,
+               shape_elem_type *shape,
+               size_t ndim,
+               const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType, typename _ResultType>
-INP_DLLEXPORT void dpnp_inv_c(void* array1_in, void* result1, shape_elem_type* shape, size_t ndim);
+INP_DLLEXPORT void dpnp_inv_c(void *array1_in,
+                              void *result1,
+                              shape_elem_type *shape,
+                              size_t ndim);
 
 /**
  * @ingroup BACKEND_API
@@ -1285,15 +1410,19 @@ INP_DLLEXPORT void dpnp_inv_c(void* array1_in, void* result1, shape_elem_type* s
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_matrix_rank_c(DPCTLSyclQueueRef q_ref,
-                                                   void* array1_in,
-                                                   void* result1,
-                                                   shape_elem_type* shape,
-                                                   size_t ndim,
-                                                   const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_matrix_rank_c(DPCTLSyclQueueRef q_ref,
+                       void *array1_in,
+                       void *result1,
+                       shape_elem_type *shape,
+                       size_t ndim,
+                       const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_matrix_rank_c(void* array1_in, void* result1, shape_elem_type* shape, size_t ndim);
+INP_DLLEXPORT void dpnp_matrix_rank_c(void *array1_in,
+                                      void *result1,
+                                      shape_elem_type *shape,
+                                      size_t ndim);
 
 /**
  * @ingroup BACKEND_API
@@ -1310,23 +1439,24 @@ INP_DLLEXPORT void dpnp_matrix_rank_c(void* array1_in, void* result1, shape_elem
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_max_c(DPCTLSyclQueueRef q_ref,
-                                           void* array1_in,
-                                           void* result1,
-                                           const size_t result_size,
-                                           const shape_elem_type* shape,
-                                           size_t ndim,
-                                           const shape_elem_type* axis,
-                                           size_t naxis,
-                                           const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_max_c(DPCTLSyclQueueRef q_ref,
+               void *array1_in,
+               void *result1,
+               const size_t result_size,
+               const shape_elem_type *shape,
+               size_t ndim,
+               const shape_elem_type *axis,
+               size_t naxis,
+               const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_max_c(void* array1_in,
-                              void* result1,
+INP_DLLEXPORT void dpnp_max_c(void *array1_in,
+                              void *result1,
                               const size_t result_size,
-                              const shape_elem_type* shape,
+                              const shape_elem_type *shape,
                               size_t ndim,
-                              const shape_elem_type* axis,
+                              const shape_elem_type *axis,
                               size_t naxis);
 
 /**
@@ -1343,18 +1473,23 @@ INP_DLLEXPORT void dpnp_max_c(void* array1_in,
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType, typename _ResultType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_mean_c(DPCTLSyclQueueRef q_ref,
-                                            void* array,
-                                            void* result,
-                                            const shape_elem_type* shape,
-                                            size_t ndim,
-                                            const shape_elem_type* axis,
-                                            size_t naxis,
-                                            const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_mean_c(DPCTLSyclQueueRef q_ref,
+                void *array,
+                void *result,
+                const shape_elem_type *shape,
+                size_t ndim,
+                const shape_elem_type *axis,
+                size_t naxis,
+                const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType, typename _ResultType>
-INP_DLLEXPORT void dpnp_mean_c(
-    void* array, void* result, const shape_elem_type* shape, size_t ndim, const shape_elem_type* axis, size_t naxis);
+INP_DLLEXPORT void dpnp_mean_c(void *array,
+                               void *result,
+                               const shape_elem_type *shape,
+                               size_t ndim,
+                               const shape_elem_type *axis,
+                               size_t naxis);
 
 /**
  * @ingroup BACKEND_API
@@ -1370,18 +1505,23 @@ INP_DLLEXPORT void dpnp_mean_c(
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType, typename _ResultType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_median_c(DPCTLSyclQueueRef q_ref,
-                                              void* array,
-                                              void* result,
-                                              const shape_elem_type* shape,
-                                              size_t ndim,
-                                              const shape_elem_type* axis,
-                                              size_t naxis,
-                                              const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_median_c(DPCTLSyclQueueRef q_ref,
+                  void *array,
+                  void *result,
+                  const shape_elem_type *shape,
+                  size_t ndim,
+                  const shape_elem_type *axis,
+                  size_t naxis,
+                  const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType, typename _ResultType>
-INP_DLLEXPORT void dpnp_median_c(
-    void* array, void* result, const shape_elem_type* shape, size_t ndim, const shape_elem_type* axis, size_t naxis);
+INP_DLLEXPORT void dpnp_median_c(void *array,
+                                 void *result,
+                                 const shape_elem_type *shape,
+                                 size_t ndim,
+                                 const shape_elem_type *axis,
+                                 size_t naxis);
 
 /**
  * @ingroup BACKEND_API
@@ -1398,23 +1538,24 @@ INP_DLLEXPORT void dpnp_median_c(
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_min_c(DPCTLSyclQueueRef q_ref,
-                                           void* array,
-                                           void* result,
-                                           const size_t result_size,
-                                           const shape_elem_type* shape,
-                                           size_t ndim,
-                                           const shape_elem_type* axis,
-                                           size_t naxis,
-                                           const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_min_c(DPCTLSyclQueueRef q_ref,
+               void *array,
+               void *result,
+               const size_t result_size,
+               const shape_elem_type *shape,
+               size_t ndim,
+               const shape_elem_type *axis,
+               size_t naxis,
+               const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_min_c(void* array,
-                              void* result,
+INP_DLLEXPORT void dpnp_min_c(void *array,
+                              void *result,
                               const size_t result_size,
-                              const shape_elem_type* shape,
+                              const shape_elem_type *shape,
                               size_t ndim,
-                              const shape_elem_type* axis,
+                              const shape_elem_type *axis,
                               size_t naxis);
 
 /**
@@ -1428,14 +1569,15 @@ INP_DLLEXPORT void dpnp_min_c(void* array,
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType, typename _idx_DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_argmax_c(DPCTLSyclQueueRef q_ref,
-                                              void* array,
-                                              void* result,
-                                              size_t size,
-                                              const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_argmax_c(DPCTLSyclQueueRef q_ref,
+                  void *array,
+                  void *result,
+                  size_t size,
+                  const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType, typename _idx_DataType>
-INP_DLLEXPORT void dpnp_argmax_c(void* array, void* result, size_t size);
+INP_DLLEXPORT void dpnp_argmax_c(void *array, void *result, size_t size);
 
 /**
  * @ingroup BACKEND_API
@@ -1448,14 +1590,15 @@ INP_DLLEXPORT void dpnp_argmax_c(void* array, void* result, size_t size);
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType, typename _idx_DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_argmin_c(DPCTLSyclQueueRef q_ref,
-                                              void* array,
-                                              void* result,
-                                              size_t size,
-                                              const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_argmin_c(DPCTLSyclQueueRef q_ref,
+                  void *array,
+                  void *result,
+                  size_t size,
+                  const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType, typename _idx_DataType>
-INP_DLLEXPORT void dpnp_argmin_c(void* array, void* result, size_t size);
+INP_DLLEXPORT void dpnp_argmin_c(void *array, void *result, size_t size);
 
 /**
  * @ingroup BACKEND_API
@@ -1465,19 +1608,24 @@ INP_DLLEXPORT void dpnp_argmin_c(void* array, void* result, size_t size);
  * @param [in]  input_in            Input array with data.
  * @param [out] result_out          Output array with indeces.
  * @param [in]  input_size          Number of elements in input arrays.
- * @param [in]  decimals            Number of decimal places to round. Support only with default value 0.
+ * @param [in]  decimals            Number of decimal places to round. Support
+ * only with default value 0.
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_around_c(DPCTLSyclQueueRef q_ref,
-                                              const void* input_in,
-                                              void* result_out,
-                                              const size_t input_size,
-                                              const int decimals,
-                                              const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_around_c(DPCTLSyclQueueRef q_ref,
+                  const void *input_in,
+                  void *result_out,
+                  const size_t input_size,
+                  const int decimals,
+                  const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_around_c(const void* input_in, void* result_out, const size_t input_size, const int decimals);
+INP_DLLEXPORT void dpnp_around_c(const void *input_in,
+                                 void *result_out,
+                                 const size_t input_size,
+                                 const int decimals);
 
 /**
  * @ingroup BACKEND_API
@@ -1494,22 +1642,23 @@ INP_DLLEXPORT void dpnp_around_c(const void* input_in, void* result_out, const s
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType, typename _ResultType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_std_c(DPCTLSyclQueueRef q_ref,
-                                           void* array,
-                                           void* result,
-                                           const shape_elem_type* shape,
-                                           size_t ndim,
-                                           const shape_elem_type* axis,
-                                           size_t naxis,
-                                           size_t ddof,
-                                           const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_std_c(DPCTLSyclQueueRef q_ref,
+               void *array,
+               void *result,
+               const shape_elem_type *shape,
+               size_t ndim,
+               const shape_elem_type *axis,
+               size_t naxis,
+               size_t ddof,
+               const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType, typename _ResultType>
-INP_DLLEXPORT void dpnp_std_c(void* array,
-                              void* result,
-                              const shape_elem_type* shape,
+INP_DLLEXPORT void dpnp_std_c(void *array,
+                              void *result,
+                              const shape_elem_type *shape,
                               size_t ndim,
-                              const shape_elem_type* axis,
+                              const shape_elem_type *axis,
                               size_t naxis,
                               size_t ddof);
 
@@ -1526,16 +1675,21 @@ INP_DLLEXPORT void dpnp_std_c(void* array,
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType, typename _IndecesType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_take_c(DPCTLSyclQueueRef q_ref,
-                                            void* array,
-                                            const size_t array1_size,
-                                            void* indices,
-                                            void* result,
-                                            size_t size,
-                                            const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_take_c(DPCTLSyclQueueRef q_ref,
+                void *array,
+                const size_t array1_size,
+                void *indices,
+                void *result,
+                size_t size,
+                const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType, typename _IndecesType>
-INP_DLLEXPORT void dpnp_take_c(void* array, const size_t array1_size, void* indices, void* result, size_t size);
+INP_DLLEXPORT void dpnp_take_c(void *array,
+                               const size_t array1_size,
+                               void *indices,
+                               void *result,
+                               size_t size);
 
 /**
  * @ingroup BACKEND_API
@@ -1549,37 +1703,45 @@ INP_DLLEXPORT void dpnp_take_c(void* array, const size_t array1_size, void* indi
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType, typename _ResultType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_trace_c(DPCTLSyclQueueRef q_ref,
-                                             const void* array,
-                                             void* result,
-                                             const shape_elem_type* shape,
-                                             const size_t ndim,
-                                             const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_trace_c(DPCTLSyclQueueRef q_ref,
+                 const void *array,
+                 void *result,
+                 const shape_elem_type *shape,
+                 const size_t ndim,
+                 const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType, typename _ResultType>
-INP_DLLEXPORT void dpnp_trace_c(const void* array, void* result, const shape_elem_type* shape, const size_t ndim);
+INP_DLLEXPORT void dpnp_trace_c(const void *array,
+                                void *result,
+                                const shape_elem_type *shape,
+                                const size_t ndim);
 
 /**
  * @ingroup BACKEND_API
- * @brief An array with ones at and below the given diagonal and zeros elsewhere.
+ * @brief An array with ones at and below the given diagonal and zeros
+ * elsewhere.
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
  * @param [in]  N                   Number of rows in the array.
  * @param [in]  M                   Number of columns in the array.
- * @param [in]  k                   The sub-diagonal at and below which the array is filled.
+ * @param [in]  k                   The sub-diagonal at and below which the
+ * array is filled.
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_tri_c(DPCTLSyclQueueRef q_ref,
-                                           void* result,
-                                           const size_t N,
-                                           const size_t M,
-                                           const int k,
-                                           const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_tri_c(DPCTLSyclQueueRef q_ref,
+               void *result,
+               const size_t N,
+               const size_t M,
+               const int k,
+               const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_tri_c(void* result, const size_t N, const size_t M, const int k);
+INP_DLLEXPORT void
+    dpnp_tri_c(void *result, const size_t N, const size_t M, const int k);
 
 /**
  * @ingroup BACKEND_API
@@ -1596,22 +1758,23 @@ INP_DLLEXPORT void dpnp_tri_c(void* result, const size_t N, const size_t M, cons
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_tril_c(DPCTLSyclQueueRef q_ref,
-                                            void* array,
-                                            void* result,
-                                            const int k,
-                                            shape_elem_type* shape,
-                                            shape_elem_type* res_shape,
-                                            const size_t ndim,
-                                            const size_t res_ndim,
-                                            const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_tril_c(DPCTLSyclQueueRef q_ref,
+                void *array,
+                void *result,
+                const int k,
+                shape_elem_type *shape,
+                shape_elem_type *res_shape,
+                const size_t ndim,
+                const size_t res_ndim,
+                const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_tril_c(void* array,
-                               void* result,
+INP_DLLEXPORT void dpnp_tril_c(void *array,
+                               void *result,
                                const int k,
-                               shape_elem_type* shape,
-                               shape_elem_type* res_shape,
+                               shape_elem_type *shape,
+                               shape_elem_type *res_shape,
                                const size_t ndim,
                                const size_t res_ndim);
 
@@ -1630,22 +1793,23 @@ INP_DLLEXPORT void dpnp_tril_c(void* array,
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_triu_c(DPCTLSyclQueueRef q_ref,
-                                            void* array,
-                                            void* result,
-                                            const int k,
-                                            shape_elem_type* shape,
-                                            shape_elem_type* res_shape,
-                                            const size_t ndim,
-                                            const size_t res_ndim,
-                                            const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_triu_c(DPCTLSyclQueueRef q_ref,
+                void *array,
+                void *result,
+                const int k,
+                shape_elem_type *shape,
+                shape_elem_type *res_shape,
+                const size_t ndim,
+                const size_t res_ndim,
+                const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_triu_c(void* array,
-                               void* result,
+INP_DLLEXPORT void dpnp_triu_c(void *array,
+                               void *result,
                                const int k,
-                               shape_elem_type* shape,
-                               shape_elem_type* res_shape,
+                               shape_elem_type *shape,
+                               shape_elem_type *res_shape,
                                const size_t ndim,
                                const size_t res_ndim);
 
@@ -1664,22 +1828,23 @@ INP_DLLEXPORT void dpnp_triu_c(void* array,
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType, typename _ResultType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_var_c(DPCTLSyclQueueRef q_ref,
-                                           void* array,
-                                           void* result,
-                                           const shape_elem_type* shape,
-                                           size_t ndim,
-                                           const shape_elem_type* axis,
-                                           size_t naxis,
-                                           size_t ddof,
-                                           const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_var_c(DPCTLSyclQueueRef q_ref,
+               void *array,
+               void *result,
+               const shape_elem_type *shape,
+               size_t ndim,
+               const shape_elem_type *axis,
+               size_t naxis,
+               size_t ddof,
+               const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType, typename _ResultType>
-INP_DLLEXPORT void dpnp_var_c(void* array,
-                              void* result,
-                              const shape_elem_type* shape,
+INP_DLLEXPORT void dpnp_var_c(void *array,
+                              void *result,
+                              const shape_elem_type *shape,
                               size_t ndim,
-                              const shape_elem_type* axis,
+                              const shape_elem_type *axis,
                               size_t naxis,
                               size_t ddof);
 
@@ -1694,180 +1859,133 @@ INP_DLLEXPORT void dpnp_var_c(void* array,
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_invert_c(DPCTLSyclQueueRef q_ref,
-                                              void* array1_in,
-                                              void* result,
-                                              size_t size,
-                                              const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_invert_c(DPCTLSyclQueueRef q_ref,
+                  void *array1_in,
+                  void *result,
+                  size_t size,
+                  const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_invert_c(void* array1_in, void* result, size_t size);
+INP_DLLEXPORT void dpnp_invert_c(void *array1_in, void *result, size_t size);
 
-#define MACRO_2ARG_1TYPE_OP(__name__, __operation__)                                                                   \
-    template <typename _DataType>                                                                                      \
-    INP_DLLEXPORT DPCTLSyclEventRef __name__(DPCTLSyclQueueRef q_ref,                                                  \
-                                             void* result_out,                                                         \
-                                             const size_t result_size,                                                 \
-                                             const size_t result_ndim,                                                 \
-                                             const shape_elem_type* result_shape,                                      \
-                                             const shape_elem_type* result_strides,                                    \
-                                             const void* input1_in,                                                    \
-                                             const size_t input1_size,                                                 \
-                                             const size_t input1_ndim,                                                 \
-                                             const shape_elem_type* input1_shape,                                      \
-                                             const shape_elem_type* input1_strides,                                    \
-                                             const void* input2_in,                                                    \
-                                             const size_t input2_size,                                                 \
-                                             const size_t input2_ndim,                                                 \
-                                             const shape_elem_type* input2_shape,                                      \
-                                             const shape_elem_type* input2_strides,                                    \
-                                             const size_t* where,                                                      \
-                                             const DPCTLEventVectorRef dep_event_vec_ref);                             \
-                                                                                                                       \
-    template <typename _DataType>                                                                                      \
-    INP_DLLEXPORT void __name__(void* result_out,                                                                      \
-                                const size_t result_size,                                                              \
-                                const size_t result_ndim,                                                              \
-                                const shape_elem_type* result_shape,                                                   \
-                                const shape_elem_type* result_strides,                                                 \
-                                const void* input1_in,                                                                 \
-                                const size_t input1_size,                                                              \
-                                const size_t input1_ndim,                                                              \
-                                const shape_elem_type* input1_shape,                                                   \
-                                const shape_elem_type* input1_strides,                                                 \
-                                const void* input2_in,                                                                 \
-                                const size_t input2_size,                                                              \
-                                const size_t input2_ndim,                                                              \
-                                const shape_elem_type* input2_shape,                                                   \
-                                const shape_elem_type* input2_strides,                                                 \
-                                const size_t* where);
+#define MACRO_2ARG_1TYPE_OP(__name__, __operation__)                           \
+    template <typename _DataType>                                              \
+    INP_DLLEXPORT DPCTLSyclEventRef __name__(                                  \
+        DPCTLSyclQueueRef q_ref, void *result_out, const size_t result_size,   \
+        const size_t result_ndim, const shape_elem_type *result_shape,         \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const void *input2_in,          \
+        const size_t input2_size, const size_t input2_ndim,                    \
+        const shape_elem_type *input2_shape,                                   \
+        const shape_elem_type *input2_strides, const size_t *where,            \
+        const DPCTLEventVectorRef dep_event_vec_ref);                          \
+                                                                               \
+    template <typename _DataType>                                              \
+    INP_DLLEXPORT void __name__(                                               \
+        void *result_out, const size_t result_size, const size_t result_ndim,  \
+        const shape_elem_type *result_shape,                                   \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const void *input2_in,          \
+        const size_t input2_size, const size_t input2_ndim,                    \
+        const shape_elem_type *input2_shape,                                   \
+        const shape_elem_type *input2_strides, const size_t *where);
 
 #include <dpnp_gen_2arg_1type_tbl.hpp>
 
-#define MACRO_1ARG_1TYPE_OP(__name__, __operation1__, __operation2__)                                                  \
-    template <typename _DataType>                                                                                      \
-    INP_DLLEXPORT DPCTLSyclEventRef __name__(DPCTLSyclQueueRef q_ref,                                                  \
-                                             void* result_out,                                                         \
-                                             const size_t result_size,                                                 \
-                                             const size_t result_ndim,                                                 \
-                                             const shape_elem_type* result_shape,                                      \
-                                             const shape_elem_type* result_strides,                                    \
-                                             const void* input1_in,                                                    \
-                                             const size_t input1_size,                                                 \
-                                             const size_t input1_ndim,                                                 \
-                                             const shape_elem_type* input1_shape,                                      \
-                                             const shape_elem_type* input1_strides,                                    \
-                                             const size_t* where,                                                      \
-                                             const DPCTLEventVectorRef dep_event_vec_ref);                             \
-                                                                                                                       \
-    template <typename _DataType>                                                                                      \
-    INP_DLLEXPORT void __name__(void* result_out,                                                                      \
-                                const size_t result_size,                                                              \
-                                const size_t result_ndim,                                                              \
-                                const shape_elem_type* result_shape,                                                   \
-                                const shape_elem_type* result_strides,                                                 \
-                                const void* input1_in,                                                                 \
-                                const size_t input1_size,                                                              \
-                                const size_t input1_ndim,                                                              \
-                                const shape_elem_type* input1_shape,                                                   \
-                                const shape_elem_type* input1_strides,                                                 \
-                                const size_t* where);
+#define MACRO_1ARG_1TYPE_OP(__name__, __operation1__, __operation2__)          \
+    template <typename _DataType>                                              \
+    INP_DLLEXPORT DPCTLSyclEventRef __name__(                                  \
+        DPCTLSyclQueueRef q_ref, void *result_out, const size_t result_size,   \
+        const size_t result_ndim, const shape_elem_type *result_shape,         \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const size_t *where,            \
+        const DPCTLEventVectorRef dep_event_vec_ref);                          \
+                                                                               \
+    template <typename _DataType>                                              \
+    INP_DLLEXPORT void __name__(                                               \
+        void *result_out, const size_t result_size, const size_t result_ndim,  \
+        const shape_elem_type *result_shape,                                   \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const size_t *where);
 
 #include <dpnp_gen_1arg_1type_tbl.hpp>
 
-#define MACRO_1ARG_2TYPES_OP(__name__, __operation1__, __operation2__)                                                 \
-    template <typename _DataType_input, typename _DataType_output>                                                     \
-    INP_DLLEXPORT DPCTLSyclEventRef __name__(DPCTLSyclQueueRef q_ref,                                                  \
-                                             void* result_out,                                                         \
-                                             const size_t result_size,                                                 \
-                                             const size_t result_ndim,                                                 \
-                                             const shape_elem_type* result_shape,                                      \
-                                             const shape_elem_type* result_strides,                                    \
-                                             const void* input1_in,                                                    \
-                                             const size_t input1_size,                                                 \
-                                             const size_t input1_ndim,                                                 \
-                                             const shape_elem_type* input1_shape,                                      \
-                                             const shape_elem_type* input1_strides,                                    \
-                                             const size_t* where,                                                      \
-                                             const DPCTLEventVectorRef dep_event_vec_ref);                             \
-                                                                                                                       \
-    template <typename _DataType_input, typename _DataType_output>                                                     \
-    INP_DLLEXPORT void __name__(void* result_out,                                                                      \
-                                const size_t result_size,                                                              \
-                                const size_t result_ndim,                                                              \
-                                const shape_elem_type* result_shape,                                                   \
-                                const shape_elem_type* result_strides,                                                 \
-                                const void* input1_in,                                                                 \
-                                const size_t input1_size,                                                              \
-                                const size_t input1_ndim,                                                              \
-                                const shape_elem_type* input1_shape,                                                   \
-                                const shape_elem_type* input1_strides,                                                 \
-                                const size_t* where);
+#define MACRO_1ARG_2TYPES_OP(__name__, __operation1__, __operation2__)         \
+    template <typename _DataType_input, typename _DataType_output>             \
+    INP_DLLEXPORT DPCTLSyclEventRef __name__(                                  \
+        DPCTLSyclQueueRef q_ref, void *result_out, const size_t result_size,   \
+        const size_t result_ndim, const shape_elem_type *result_shape,         \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const size_t *where,            \
+        const DPCTLEventVectorRef dep_event_vec_ref);                          \
+                                                                               \
+    template <typename _DataType_input, typename _DataType_output>             \
+    INP_DLLEXPORT void __name__(                                               \
+        void *result_out, const size_t result_size, const size_t result_ndim,  \
+        const shape_elem_type *result_shape,                                   \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const size_t *where);
 
 #include <dpnp_gen_1arg_2type_tbl.hpp>
 
-#define MACRO_2ARG_2TYPES_LOGIC_OP(__name__, __operation__)                                                           \
-    template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>                         \
-    INP_DLLEXPORT DPCTLSyclEventRef __name__(DPCTLSyclQueueRef q_ref,                                                  \
-                                             void* result_out,                                                         \
-                                             const size_t result_size,                                                 \
-                                             const size_t result_ndim,                                                 \
-                                             const shape_elem_type* result_shape,                                      \
-                                             const shape_elem_type* result_strides,                                    \
-                                             const void* input1_in,                                                    \
-                                             const size_t input1_size,                                                 \
-                                             const size_t input1_ndim,                                                 \
-                                             const shape_elem_type* input1_shape,                                      \
-                                             const shape_elem_type* input1_strides,                                    \
-                                             const void* input2_in,                                                    \
-                                             const size_t input2_size,                                                 \
-                                             const size_t input2_ndim,                                                 \
-                                             const shape_elem_type* input2_shape,                                      \
-                                             const shape_elem_type* input2_strides,                                    \
-                                             const size_t* where,                                                      \
-                                             const DPCTLEventVectorRef dep_event_vec_ref);
+#define MACRO_2ARG_2TYPES_LOGIC_OP(__name__, __operation__)                    \
+    template <typename _DataType_output, typename _DataType_input1,            \
+              typename _DataType_input2>                                       \
+    INP_DLLEXPORT DPCTLSyclEventRef __name__(                                  \
+        DPCTLSyclQueueRef q_ref, void *result_out, const size_t result_size,   \
+        const size_t result_ndim, const shape_elem_type *result_shape,         \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const void *input2_in,          \
+        const size_t input2_size, const size_t input2_ndim,                    \
+        const shape_elem_type *input2_shape,                                   \
+        const shape_elem_type *input2_strides, const size_t *where,            \
+        const DPCTLEventVectorRef dep_event_vec_ref);
 
 #include <dpnp_gen_2arg_2type_tbl.hpp>
 
-#define MACRO_2ARG_3TYPES_OP(                                                                                          \
-    __name__, __operation__, __vec_operation__, __vec_types__, __mkl_operation__, __mkl_types__)                       \
-    template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>                         \
-    INP_DLLEXPORT DPCTLSyclEventRef __name__(DPCTLSyclQueueRef q_ref,                                                  \
-                                             void* result_out,                                                         \
-                                             const size_t result_size,                                                 \
-                                             const size_t result_ndim,                                                 \
-                                             const shape_elem_type* result_shape,                                      \
-                                             const shape_elem_type* result_strides,                                    \
-                                             const void* input1_in,                                                    \
-                                             const size_t input1_size,                                                 \
-                                             const size_t input1_ndim,                                                 \
-                                             const shape_elem_type* input1_shape,                                      \
-                                             const shape_elem_type* input1_strides,                                    \
-                                             const void* input2_in,                                                    \
-                                             const size_t input2_size,                                                 \
-                                             const size_t input2_ndim,                                                 \
-                                             const shape_elem_type* input2_shape,                                      \
-                                             const shape_elem_type* input2_strides,                                    \
-                                             const size_t* where,                                                      \
-                                             const DPCTLEventVectorRef dep_event_vec_ref);                             \
-                                                                                                                       \
-    template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>                         \
-    INP_DLLEXPORT void __name__(void* result_out,                                                                      \
-                                const size_t result_size,                                                              \
-                                const size_t result_ndim,                                                              \
-                                const shape_elem_type* result_shape,                                                   \
-                                const shape_elem_type* result_strides,                                                 \
-                                const void* input1_in,                                                                 \
-                                const size_t input1_size,                                                              \
-                                const size_t input1_ndim,                                                              \
-                                const shape_elem_type* input1_shape,                                                   \
-                                const shape_elem_type* input1_strides,                                                 \
-                                const void* input2_in,                                                                 \
-                                const size_t input2_size,                                                              \
-                                const size_t input2_ndim,                                                              \
-                                const shape_elem_type* input2_shape,                                                   \
-                                const shape_elem_type* input2_strides,                                                 \
-                                const size_t* where);
+#define MACRO_2ARG_3TYPES_OP(__name__, __operation__, __vec_operation__,       \
+                             __vec_types__, __mkl_operation__, __mkl_types__)  \
+    template <typename _DataType_output, typename _DataType_input1,            \
+              typename _DataType_input2>                                       \
+    INP_DLLEXPORT DPCTLSyclEventRef __name__(                                  \
+        DPCTLSyclQueueRef q_ref, void *result_out, const size_t result_size,   \
+        const size_t result_ndim, const shape_elem_type *result_shape,         \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const void *input2_in,          \
+        const size_t input2_size, const size_t input2_ndim,                    \
+        const shape_elem_type *input2_shape,                                   \
+        const shape_elem_type *input2_strides, const size_t *where,            \
+        const DPCTLEventVectorRef dep_event_vec_ref);                          \
+                                                                               \
+    template <typename _DataType_output, typename _DataType_input1,            \
+              typename _DataType_input2>                                       \
+    INP_DLLEXPORT void __name__(                                               \
+        void *result_out, const size_t result_size, const size_t result_ndim,  \
+        const shape_elem_type *result_shape,                                   \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const void *input2_in,          \
+        const size_t input2_size, const size_t input2_ndim,                    \
+        const shape_elem_type *input2_shape,                                   \
+        const shape_elem_type *input2_strides, const size_t *where);
 
 #include <dpnp_gen_2arg_3type_tbl.hpp>
 
@@ -1883,15 +2001,19 @@ INP_DLLEXPORT void dpnp_invert_c(void* array1_in, void* result, size_t size);
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_fill_diagonal_c(DPCTLSyclQueueRef q_ref,
-                                                     void* array1_in,
-                                                     void* val,
-                                                     shape_elem_type* shape,
-                                                     const size_t ndim,
-                                                     const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_fill_diagonal_c(DPCTLSyclQueueRef q_ref,
+                         void *array1_in,
+                         void *val,
+                         shape_elem_type *shape,
+                         const size_t ndim,
+                         const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_fill_diagonal_c(void* array1_in, void* val, shape_elem_type* shape, const size_t ndim);
+INP_DLLEXPORT void dpnp_fill_diagonal_c(void *array1_in,
+                                        void *val,
+                                        shape_elem_type *shape,
+                                        const size_t ndim);
 
 /**
  * @ingroup BACKEND_API
@@ -1910,31 +2032,36 @@ INP_DLLEXPORT void dpnp_fill_diagonal_c(void* array1_in, void* val, shape_elem_t
  * @param [in]  where               Mask array.
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
-template <typename _DataType_input1, typename _DataType_input2, typename _DataType_output>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_floor_divide_c(DPCTLSyclQueueRef q_ref,
-                                                    void* result_out,
-                                                    const void* input1_in,
-                                                    const size_t input1_size,
-                                                    const shape_elem_type* input1_shape,
-                                                    const size_t input1_shape_ndim,
-                                                    const void* input2_in,
-                                                    const size_t input2_size,
-                                                    const shape_elem_type* input2_shape,
-                                                    const size_t input2_shape_ndim,
-                                                    const size_t* where,
-                                                    const DPCTLEventVectorRef dep_event_vec_ref);
+template <typename _DataType_input1,
+          typename _DataType_input2,
+          typename _DataType_output>
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_floor_divide_c(DPCTLSyclQueueRef q_ref,
+                        void *result_out,
+                        const void *input1_in,
+                        const size_t input1_size,
+                        const shape_elem_type *input1_shape,
+                        const size_t input1_shape_ndim,
+                        const void *input2_in,
+                        const size_t input2_size,
+                        const shape_elem_type *input2_shape,
+                        const size_t input2_shape_ndim,
+                        const size_t *where,
+                        const DPCTLEventVectorRef dep_event_vec_ref);
 
-template <typename _DataType_input1, typename _DataType_input2, typename _DataType_output>
-INP_DLLEXPORT void dpnp_floor_divide_c(void* result_out,
-                                       const void* input1_in,
+template <typename _DataType_input1,
+          typename _DataType_input2,
+          typename _DataType_output>
+INP_DLLEXPORT void dpnp_floor_divide_c(void *result_out,
+                                       const void *input1_in,
                                        const size_t input1_size,
-                                       const shape_elem_type* input1_shape,
+                                       const shape_elem_type *input1_shape,
                                        const size_t input1_shape_ndim,
-                                       const void* input2_in,
+                                       const void *input2_in,
                                        const size_t input2_size,
-                                       const shape_elem_type* input2_shape,
+                                       const shape_elem_type *input2_shape,
                                        const size_t input2_shape_ndim,
-                                       const size_t* where);
+                                       const size_t *where);
 
 /**
  * @ingroup BACKEND_API
@@ -1948,15 +2075,19 @@ INP_DLLEXPORT void dpnp_floor_divide_c(void* result_out,
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType_input, typename _DataType_output>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_modf_c(DPCTLSyclQueueRef q_ref,
-                                            void* array1_in,
-                                            void* result1_out,
-                                            void* result2_out,
-                                            size_t size,
-                                            const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_modf_c(DPCTLSyclQueueRef q_ref,
+                void *array1_in,
+                void *result1_out,
+                void *result2_out,
+                size_t size,
+                const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType_input, typename _DataType_output>
-INP_DLLEXPORT void dpnp_modf_c(void* array1_in, void* result1_out, void* result2_out, size_t size);
+INP_DLLEXPORT void dpnp_modf_c(void *array1_in,
+                               void *result1_out,
+                               void *result2_out,
+                               size_t size);
 
 /**
  * @ingroup BACKEND_API
@@ -1968,13 +2099,14 @@ INP_DLLEXPORT void dpnp_modf_c(void* array1_in, void* result1_out, void* result2
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_ones_c(DPCTLSyclQueueRef q_ref,
-                                            void* result,
-                                            size_t size,
-                                            const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_ones_c(DPCTLSyclQueueRef q_ref,
+                void *result,
+                size_t size,
+                const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_ones_c(void* result, size_t size);
+INP_DLLEXPORT void dpnp_ones_c(void *result, size_t size);
 
 /**
  * @ingroup BACKEND_API
@@ -1986,13 +2118,14 @@ INP_DLLEXPORT void dpnp_ones_c(void* result, size_t size);
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_ones_like_c(DPCTLSyclQueueRef q_ref,
-                                                 void* result,
-                                                 size_t size,
-                                                 const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_ones_like_c(DPCTLSyclQueueRef q_ref,
+                     void *result,
+                     size_t size,
+                     const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_ones_like_c(void* result, size_t size);
+INP_DLLEXPORT void dpnp_ones_like_c(void *result, size_t size);
 
 /**
  * @ingroup BACKEND_API
@@ -2011,31 +2144,36 @@ INP_DLLEXPORT void dpnp_ones_like_c(void* result, size_t size);
  * @param [in]  where               Mask array.
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_remainder_c(DPCTLSyclQueueRef q_ref,
-                                                 void* result_out,
-                                                 const void* input1_in,
-                                                 const size_t input1_size,
-                                                 const shape_elem_type* input1_shape,
-                                                 const size_t input1_shape_ndim,
-                                                 const void* input2_in,
-                                                 const size_t input2_size,
-                                                 const shape_elem_type* input2_shape,
-                                                 const size_t input2_shape_ndim,
-                                                 const size_t* where,
-                                                 const DPCTLEventVectorRef dep_event_vec_ref);
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_remainder_c(DPCTLSyclQueueRef q_ref,
+                     void *result_out,
+                     const void *input1_in,
+                     const size_t input1_size,
+                     const shape_elem_type *input1_shape,
+                     const size_t input1_shape_ndim,
+                     const void *input2_in,
+                     const size_t input2_size,
+                     const shape_elem_type *input2_shape,
+                     const size_t input2_shape_ndim,
+                     const size_t *where,
+                     const DPCTLEventVectorRef dep_event_vec_ref);
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
-INP_DLLEXPORT void dpnp_remainder_c(void* result_out,
-                                    const void* input1_in,
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
+INP_DLLEXPORT void dpnp_remainder_c(void *result_out,
+                                    const void *input1_in,
                                     const size_t input1_size,
-                                    const shape_elem_type* input1_shape,
+                                    const shape_elem_type *input1_shape,
                                     const size_t input1_shape_ndim,
-                                    const void* input2_in,
+                                    const void *input2_in,
                                     const size_t input2_size,
-                                    const shape_elem_type* input2_shape,
+                                    const shape_elem_type *input2_shape,
                                     const size_t input2_shape_ndim,
-                                    const size_t* where);
+                                    const size_t *where);
 
 /**
  * @ingroup BACKEND_API
@@ -2049,49 +2187,57 @@ INP_DLLEXPORT void dpnp_remainder_c(void* result_out,
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_repeat_c(DPCTLSyclQueueRef q_ref,
-                                              const void* array_in,
-                                              void* result,
-                                              const size_t repeats,
-                                              const size_t size,
-                                              const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_repeat_c(DPCTLSyclQueueRef q_ref,
+                  const void *array_in,
+                  void *result,
+                  const size_t repeats,
+                  const size_t size,
+                  const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_repeat_c(const void* array_in, void* result, const size_t repeats, const size_t size);
+INP_DLLEXPORT void dpnp_repeat_c(const void *array_in,
+                                 void *result,
+                                 const size_t repeats,
+                                 const size_t size);
 
 /**
  * @ingroup BACKEND_API
- * @brief transpose function. Permute axes of the input to the output with elements permutation.
+ * @brief transpose function. Permute axes of the input to the output with
+ * elements permutation.
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [in]  array1_in           Input array.
  * @param [in]  input_shape         Input shape.
  * @param [in]  result_shape        Output shape.
- * @param [in]  permute_axes        Order of axis by it's id as it should be presented in output.
+ * @param [in]  permute_axes        Order of axis by it's id as it should be
+ * presented in output.
  * @param [in]  ndim                Number of elements in shapes and axes.
  * @param [out] result1             Output array.
  * @param [in]  size                Number of elements in input arrays.
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_elemwise_transpose_c(DPCTLSyclQueueRef q_ref,
-                                                          void* array1_in,
-                                                          const shape_elem_type* input_shape,
-                                                          const shape_elem_type* result_shape,
-                                                          const shape_elem_type* permute_axes,
-                                                          size_t ndim,
-                                                          void* result1,
-                                                          size_t size,
-                                                          const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_elemwise_transpose_c(DPCTLSyclQueueRef q_ref,
+                              void *array1_in,
+                              const shape_elem_type *input_shape,
+                              const shape_elem_type *result_shape,
+                              const shape_elem_type *permute_axes,
+                              size_t ndim,
+                              void *result1,
+                              size_t size,
+                              const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_elemwise_transpose_c(void* array1_in,
-                                             const shape_elem_type* input_shape,
-                                             const shape_elem_type* result_shape,
-                                             const shape_elem_type* permute_axes,
-                                             size_t ndim,
-                                             void* result1,
-                                             size_t size);
+INP_DLLEXPORT void
+    dpnp_elemwise_transpose_c(void *array1_in,
+                              const shape_elem_type *input_shape,
+                              const shape_elem_type *result_shape,
+                              const shape_elem_type *permute_axes,
+                              size_t ndim,
+                              void *result1,
+                              size_t size);
 
 /**
  * @ingroup BACKEND_API
@@ -2107,19 +2253,28 @@ INP_DLLEXPORT void dpnp_elemwise_transpose_c(void* array1_in,
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  *
  */
-template <typename _DataType_input1, typename _DataType_input2, typename _DataType_output>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_trapz_c(DPCTLSyclQueueRef q_ref,
-                                             const void* array1_in,
-                                             const void* array2_in,
-                                             void* result1,
-                                             double dx,
-                                             size_t array1_size,
-                                             size_t array2_size,
-                                             const DPCTLEventVectorRef dep_event_vec_ref);
+template <typename _DataType_input1,
+          typename _DataType_input2,
+          typename _DataType_output>
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_trapz_c(DPCTLSyclQueueRef q_ref,
+                 const void *array1_in,
+                 const void *array2_in,
+                 void *result1,
+                 double dx,
+                 size_t array1_size,
+                 size_t array2_size,
+                 const DPCTLEventVectorRef dep_event_vec_ref);
 
-template <typename _DataType_input1, typename _DataType_input2, typename _DataType_output>
-INP_DLLEXPORT void dpnp_trapz_c(
-    const void* array1_in, const void* array2_in, void* result1, double dx, size_t array1_size, size_t array2_size);
+template <typename _DataType_input1,
+          typename _DataType_input2,
+          typename _DataType_output>
+INP_DLLEXPORT void dpnp_trapz_c(const void *array1_in,
+                                const void *array2_in,
+                                void *result1,
+                                double dx,
+                                size_t array1_size,
+                                size_t array2_size);
 
 /**
  * @ingroup BACKEND_API
@@ -2135,17 +2290,21 @@ INP_DLLEXPORT void dpnp_trapz_c(
  *
  */
 template <typename _DataType_input, typename _DataType_output>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_vander_c(DPCTLSyclQueueRef q_ref,
-                                              const void* array1_in,
-                                              void* result1,
-                                              const size_t size_in,
-                                              const size_t N,
-                                              const int increasing,
-                                              const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_vander_c(DPCTLSyclQueueRef q_ref,
+                  const void *array1_in,
+                  void *result1,
+                  const size_t size_in,
+                  const size_t N,
+                  const int increasing,
+                  const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType_input, typename _DataType_output>
-INP_DLLEXPORT void
-    dpnp_vander_c(const void* array1_in, void* result1, const size_t size_in, const size_t N, const int increasing);
+INP_DLLEXPORT void dpnp_vander_c(const void *array1_in,
+                                 void *result1,
+                                 const size_t size_in,
+                                 const size_t N,
+                                 const int increasing);
 
 /**
  * @ingroup BACKEND_API
@@ -2157,13 +2316,14 @@ INP_DLLEXPORT void
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_zeros_c(DPCTLSyclQueueRef q_ref,
-                                             void* result,
-                                             size_t size,
-                                             const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_zeros_c(DPCTLSyclQueueRef q_ref,
+                 void *result,
+                 size_t size,
+                 const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_zeros_c(void* result, size_t size);
+INP_DLLEXPORT void dpnp_zeros_c(void *result, size_t size);
 
 /**
  * @ingroup BACKEND_API
@@ -2175,12 +2335,13 @@ INP_DLLEXPORT void dpnp_zeros_c(void* result, size_t size);
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_zeros_like_c(DPCTLSyclQueueRef q_ref,
-                                                  void* result,
-                                                  size_t size,
-                                                  const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_zeros_like_c(DPCTLSyclQueueRef q_ref,
+                      void *result,
+                      size_t size,
+                      const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_zeros_like_c(void* result, size_t size);
+INP_DLLEXPORT void dpnp_zeros_like_c(void *result, size_t size);
 
 #endif // BACKEND_IFACE_H

--- a/dpnp/backend/include/dpnp_iface_fft.hpp
+++ b/dpnp/backend/include/dpnp_iface_fft.hpp
@@ -25,11 +25,12 @@
 
 /*
  * This header file is for interface Cython with C++.
- * It should not contains any backend specific headers (like SYCL or math library) because
- * all included headers will be exposed in Cython compilation procedure
+ * It should not contains any backend specific headers (like SYCL or math
+ * library) because all included headers will be exposed in Cython compilation
+ * procedure
  *
- * We would like to avoid backend specific things in higher level Cython modules.
- * Any backend interface functions and types should be defined here.
+ * We would like to avoid backend specific things in higher level Cython
+ * modules. Any backend interface functions and types should be defined here.
  *
  * Also, this file should contains documentation on functions and types
  * which are used in the interface
@@ -56,38 +57,41 @@
  * @param[in]  array1_in           Input array.
  * @param[out] result_out          Output array.
  * @param[in]  input_shape         Array with shape information for input array.
- * @param[in]  result_shape        Array with shape information for result array.
- * @param[in]  shape_size          Number of elements in @ref input_shape or @ref result_shape arrays.
+ * @param[in]  result_shape        Array with shape information for result
+ *                                 array.
+ * @param[in]  shape_size          Number of elements in @ref input_shape or
+ *                                  @ref result_shape arrays.
  * @param[in]  axis                Axis ID to compute by.
  * @param[in]  input_boundarie     Limit number of elements for @ref axis.
  * @param[in]  inverse             Using inverse algorithm.
- * @param[in]  norm                Normalization mode. 0 - backward, 1 - forward, 2 - ortho.
+ * @param[in]  norm                Normalization mode. 0 - backward, 1 -
+ *                                 forward, 2 - ortho.
  * @param[in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType_input, typename _DataType_output>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_fft_fft_c(DPCTLSyclQueueRef q_ref,
-                                               const void* array1_in,
-                                               void* result_out,
-                                               const shape_elem_type* input_shape,
-                                               const shape_elem_type* result_shape,
-                                               size_t shape_size,
-                                               long axis,
-                                               long input_boundarie,
-                                               size_t inverse,
-                                               const size_t norm,
-                                               const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_fft_fft_c(DPCTLSyclQueueRef q_ref,
+                   const void *array1_in,
+                   void *result_out,
+                   const shape_elem_type *input_shape,
+                   const shape_elem_type *result_shape,
+                   size_t shape_size,
+                   long axis,
+                   long input_boundarie,
+                   size_t inverse,
+                   const size_t norm,
+                   const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType_input, typename _DataType_output>
-INP_DLLEXPORT void dpnp_fft_fft_c(const void* array1_in,
-                                  void* result_out,
-                                  const shape_elem_type* input_shape,
-                                  const shape_elem_type* output_shape,
+INP_DLLEXPORT void dpnp_fft_fft_c(const void *array1_in,
+                                  void *result_out,
+                                  const shape_elem_type *input_shape,
+                                  const shape_elem_type *output_shape,
                                   size_t shape_size,
                                   long axis,
                                   long input_boundarie,
                                   size_t inverse,
                                   const size_t norm);
-
 
 /**
  * @ingroup BACKEND_FFT_API
@@ -99,32 +103,36 @@ INP_DLLEXPORT void dpnp_fft_fft_c(const void* array1_in,
  * @param[in]  array1_in           Input array.
  * @param[out] result_out          Output array.
  * @param[in]  input_shape         Array with shape information for input array.
- * @param[in]  result_shape        Array with shape information for result array.
- * @param[in]  shape_size          Number of elements in @ref input_shape or @ref result_shape arrays.
+ * @param[in]  result_shape        Array with shape information for result
+ *                                 array.
+ * @param[in]  shape_size          Number of elements in @ref input_shape or
+ *                                 @ref result_shape arrays.
  * @param[in]  axis                Axis ID to compute by.
  * @param[in]  input_boundarie     Limit number of elements for @ref axis.
  * @param[in]  inverse             Using inverse algorithm.
- * @param[in]  norm                Normalization mode. 0 - backward, 1 - forward, 2 - ortho.
+ * @param[in]  norm                Normalization mode. 0 - backward, 1 -
+ *                                 forward, 2 - ortho.
  * @param[in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType_input, typename _DataType_output>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_fft_rfft_c(DPCTLSyclQueueRef q_ref,
-                                                const void* array1_in,
-                                                void* result_out,
-                                                const shape_elem_type* input_shape,
-                                                const shape_elem_type* result_shape,
-                                                size_t shape_size,
-                                                long axis,
-                                                long input_boundarie,
-                                                size_t inverse,
-                                                const size_t norm,
-                                                const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_fft_rfft_c(DPCTLSyclQueueRef q_ref,
+                    const void *array1_in,
+                    void *result_out,
+                    const shape_elem_type *input_shape,
+                    const shape_elem_type *result_shape,
+                    size_t shape_size,
+                    long axis,
+                    long input_boundarie,
+                    size_t inverse,
+                    const size_t norm,
+                    const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType_input, typename _DataType_output>
-INP_DLLEXPORT void dpnp_fft_fft_c(const void* array1_in,
-                                  void* result_out,
-                                  const shape_elem_type* input_shape,
-                                  const shape_elem_type* output_shape,
+INP_DLLEXPORT void dpnp_fft_fft_c(const void *array1_in,
+                                  void *result_out,
+                                  const shape_elem_type *input_shape,
+                                  const shape_elem_type *output_shape,
                                   size_t shape_size,
                                   long axis,
                                   long input_boundarie,

--- a/dpnp/backend/include/dpnp_iface_fptr.hpp
+++ b/dpnp/backend/include/dpnp_iface_fptr.hpp
@@ -25,11 +25,12 @@
 
 /*
  * This header file is for interface Cython with C++.
- * It should not contains any backend specific headers (like SYCL or math library) because
- * all included headers will be exposed in Cython compilation procedure
+ * It should not contains any backend specific headers (like SYCL or math
+ * library) because all included headers will be exposed in Cython compilation
+ * procedure
  *
- * We would like to avoid backend specific things in higher level Cython modules.
- * Any backend interface functions and types should be defined here.
+ * We would like to avoid backend specific things in higher level Cython
+ * modules. Any backend interface functions and types should be defined here.
  *
  * Also, this file should contains documentation on functions and types
  * which are used in the interface
@@ -57,324 +58,477 @@
  */
 enum class DPNPFuncName : size_t
 {
-    DPNP_FN_NONE,                         /**< Very first element of the enumeration */
-    DPNP_FN_ABSOLUTE,                     /**< Used in numpy.absolute() impl  */
-    DPNP_FN_ABSOLUTE_EXT,                 /**< Used in numpy.absolute() impl, requires extra parameters */
-    DPNP_FN_ADD,                          /**< Used in numpy.add() impl  */
-    DPNP_FN_ADD_EXT,                      /**< Used in numpy.add() impl, requires extra parameters */
-    DPNP_FN_ALL,                          /**< Used in numpy.all() impl  */
-    DPNP_FN_ALL_EXT,                      /**< Used in numpy.all() impl, requires extra parameters */
-    DPNP_FN_ALLCLOSE,                     /**< Used in numpy.allclose() impl  */
-    DPNP_FN_ALLCLOSE_EXT,                 /**< Used in numpy.allclose() impl, requires extra parameters */
-    DPNP_FN_ANY,                          /**< Used in numpy.any() impl  */
-    DPNP_FN_ANY_EXT,                      /**< Used in numpy.any() impl, requires extra parameters */
-    DPNP_FN_ARANGE,                       /**< Used in numpy.arange() impl  */
-    DPNP_FN_ARCCOS,                       /**< Used in numpy.arccos() impl  */
-    DPNP_FN_ARCCOS_EXT,                   /**< Used in numpy.arccos() impl, requires extra parameters */
-    DPNP_FN_ARCCOSH,                      /**< Used in numpy.arccosh() impl  */
-    DPNP_FN_ARCCOSH_EXT,                  /**< Used in numpy.arccosh() impl, requires extra parameters */
-    DPNP_FN_ARCSIN,                       /**< Used in numpy.arcsin() impl  */
-    DPNP_FN_ARCSIN_EXT,                   /**< Used in numpy.arcsin() impl, requires extra parameters */
-    DPNP_FN_ARCSINH,                      /**< Used in numpy.arcsinh() impl  */
-    DPNP_FN_ARCSINH_EXT,                  /**< Used in numpy.arcsinh() impl, requires extra parameters */
-    DPNP_FN_ARCTAN,                       /**< Used in numpy.arctan() impl  */
-    DPNP_FN_ARCTAN_EXT,                   /**< Used in numpy.arctan() impl, requires extra parameters */
-    DPNP_FN_ARCTAN2,                      /**< Used in numpy.arctan2() impl  */
-    DPNP_FN_ARCTAN2_EXT,                  /**< Used in numpy.arctan2() impl, requires extra parameters */
-    DPNP_FN_ARCTANH,                      /**< Used in numpy.arctanh() impl  */
-    DPNP_FN_ARCTANH_EXT,                  /**< Used in numpy.arctanh() impl, requires extra parameters */
-    DPNP_FN_ARGMAX,                       /**< Used in numpy.argmax() impl  */
-    DPNP_FN_ARGMAX_EXT,                   /**< Used in numpy.argmax() impl, requires extra parameters */
-    DPNP_FN_ARGMIN,                       /**< Used in numpy.argmin() impl  */
-    DPNP_FN_ARGMIN_EXT,                   /**< Used in numpy.argmin() impl, requires extra parameters */
-    DPNP_FN_ARGSORT,                      /**< Used in numpy.argsort() impl  */
-    DPNP_FN_ARGSORT_EXT,                  /**< Used in numpy.argsort() impl, requires extra parameters */
-    DPNP_FN_AROUND,                       /**< Used in numpy.around() impl  */
-    DPNP_FN_AROUND_EXT,                   /**< Used in numpy.around() impl, requires extra parameters */
-    DPNP_FN_ASTYPE,                       /**< Used in numpy.astype() impl  */
-    DPNP_FN_ASTYPE_EXT,                   /**< Used in numpy.astype() impl, requires extra parameters */
-    DPNP_FN_BITWISE_AND,                  /**< Used in numpy.bitwise_and() impl  */
-    DPNP_FN_BITWISE_AND_EXT,              /**< Used in numpy.bitwise_and() impl, requires extra parameters */
-    DPNP_FN_BITWISE_OR,                   /**< Used in numpy.bitwise_or() impl  */
-    DPNP_FN_BITWISE_OR_EXT,               /**< Used in numpy.bitwise_or() impl, requires extra parameters */
-    DPNP_FN_BITWISE_XOR,                  /**< Used in numpy.bitwise_xor() impl  */
-    DPNP_FN_BITWISE_XOR_EXT,              /**< Used in numpy.bitwise_xor() impl, requires extra parameters */
-    DPNP_FN_CBRT,                         /**< Used in numpy.cbrt() impl  */
-    DPNP_FN_CBRT_EXT,                     /**< Used in numpy.cbrt() impl, requires extra parameters */
-    DPNP_FN_CEIL,                         /**< Used in numpy.ceil() impl  */
-    DPNP_FN_CEIL_EXT,                     /**< Used in numpy.ceil() impl, requires extra parameters */
-    DPNP_FN_CHOLESKY,                     /**< Used in numpy.linalg.cholesky() impl  */
-    DPNP_FN_CHOLESKY_EXT,                 /**< Used in numpy.linalg.cholesky() impl, requires extra parameters */
-    DPNP_FN_CONJIGUATE,                   /**< Used in numpy.conjugate() impl  */
-    DPNP_FN_CONJIGUATE_EXT,               /**< Used in numpy.conjugate() impl, requires extra parameters */
-    DPNP_FN_CHOOSE,                       /**< Used in numpy.choose() impl  */
-    DPNP_FN_CHOOSE_EXT,                   /**< Used in numpy.choose() impl, requires extra parameters */
-    DPNP_FN_COPY,                         /**< Used in numpy.copy() impl  */
-    DPNP_FN_COPY_EXT,                     /**< Used in numpy.copy() impl, requires extra parameters */
-    DPNP_FN_COPYSIGN,                     /**< Used in numpy.copysign() impl  */
-    DPNP_FN_COPYSIGN_EXT,                 /**< Used in numpy.copysign() impl, requires extra parameters */
-    DPNP_FN_COPYTO,                       /**< Used in numpy.copyto() impl  */
-    DPNP_FN_COPYTO_EXT,                   /**< Used in numpy.copyto() impl, requires extra parameters */
-    DPNP_FN_CORRELATE,                    /**< Used in numpy.correlate() impl  */
-    DPNP_FN_CORRELATE_EXT,                /**< Used in numpy.correlate() impl, requires extra parameters */
-    DPNP_FN_COS,                          /**< Used in numpy.cos() impl  */
-    DPNP_FN_COS_EXT,                      /**< Used in numpy.cos() impl, requires extra parameters */
-    DPNP_FN_COSH,                         /**< Used in numpy.cosh() impl  */
-    DPNP_FN_COSH_EXT,                     /**< Used in numpy.cosh() impl, requires extra parameters */
-    DPNP_FN_COUNT_NONZERO,                /**< Used in numpy.count_nonzero() impl  */
-    DPNP_FN_COUNT_NONZERO_EXT,            /**< Used in numpy.count_nonzero() impl, requires extra parameters */
-    DPNP_FN_COV,                          /**< Used in numpy.cov() impl  */
-    DPNP_FN_CROSS,                        /**< Used in numpy.cross() impl  */
-    DPNP_FN_CROSS_EXT,                    /**< Used in numpy.cross() impl, requires extra parameters */
-    DPNP_FN_CUMPROD,                      /**< Used in numpy.cumprod() impl  */
-    DPNP_FN_CUMPROD_EXT,                  /**< Used in numpy.cumprod() impl, requires extra parameters */
-    DPNP_FN_CUMSUM,                       /**< Used in numpy.cumsum() impl  */
-    DPNP_FN_CUMSUM_EXT,                   /**< Used in numpy.cumsum() impl, requires extra parameters */
-    DPNP_FN_DEGREES,                      /**< Used in numpy.degrees() impl  */
-    DPNP_FN_DEGREES_EXT,                  /**< Used in numpy.degrees() impl, requires extra parameters */
-    DPNP_FN_DET,                          /**< Used in numpy.linalg.det() impl  */
-    DPNP_FN_DET_EXT,                      /**< Used in numpy.linalg.det() impl, requires extra parameters */
-    DPNP_FN_DIAG,                         /**< Used in numpy.diag() impl  */
-    DPNP_FN_DIAG_EXT,                     /**< Used in numpy.diag() impl, requires extra parameters */
-    DPNP_FN_DIAG_INDICES,                 /**< Used in numpy.diag_indices() impl  */
-    DPNP_FN_DIAG_INDICES_EXT,             /**< Used in numpy.diag_indices() impl, requires extra parameters */
-    DPNP_FN_DIAGONAL,                     /**< Used in numpy.diagonal() impl  */
-    DPNP_FN_DIAGONAL_EXT,                 /**< Used in numpy.diagonal() impl, requires extra parameters */
-    DPNP_FN_DIVIDE,                       /**< Used in numpy.divide() impl  */
-    DPNP_FN_DIVIDE_EXT,                   /**< Used in numpy.divide() impl, requires extra parameters */
-    DPNP_FN_DOT,                          /**< Used in numpy.dot() impl  */
-    DPNP_FN_DOT_EXT,                      /**< Used in numpy.dot() impl, requires extra parameters */
-    DPNP_FN_EDIFF1D,                      /**< Used in numpy.ediff1d() impl  */
-    DPNP_FN_EDIFF1D_EXT,                  /**< Used in numpy.ediff1d() impl, requires extra parameters */
-    DPNP_FN_EIG,                          /**< Used in numpy.linalg.eig() impl  */
-    DPNP_FN_EIG_EXT,                      /**< Used in numpy.linalg.eig() impl, requires extra parameters */
-    DPNP_FN_EIGVALS,                      /**< Used in numpy.linalg.eigvals() impl  */
-    DPNP_FN_EIGVALS_EXT,                  /**< Used in numpy.linalg.eigvals() impl, requires extra parameters */
-    DPNP_FN_EQUAL_EXT,                    /**< Used in numpy.equal() impl, requires extra parameters */
-    DPNP_FN_ERF,                          /**< Used in scipy.special.erf impl  */
-    DPNP_FN_ERF_EXT,                      /**< Used in scipy.special.erf impl, requires extra parameters */
-    DPNP_FN_EYE,                          /**< Used in numpy.eye() impl  */
-    DPNP_FN_EXP,                          /**< Used in numpy.exp() impl  */
-    DPNP_FN_EXP_EXT,                      /**< Used in numpy.exp() impl, requires extra parameters */
-    DPNP_FN_EXP2,                         /**< Used in numpy.exp2() impl  */
-    DPNP_FN_EXP2_EXT,                     /**< Used in numpy.exp2() impl, requires extra parameters */
-    DPNP_FN_EXPM1,                        /**< Used in numpy.expm1() impl  */
-    DPNP_FN_EXPM1_EXT,                    /**< Used in numpy.expm1() impl, requires extra parameters */
-    DPNP_FN_FABS,                         /**< Used in numpy.fabs() impl  */
-    DPNP_FN_FABS_EXT,                     /**< Used in numpy.fabs() impl, requires extra parameters */
-    DPNP_FN_FFT_FFT,                      /**< Used in numpy.fft.fft() impl  */
-    DPNP_FN_FFT_FFT_EXT,                  /**< Used in numpy.fft.fft() impl, requires extra parameters */
-    DPNP_FN_FFT_RFFT,                     /**< Used in numpy.fft.rfft() impl  */
-    DPNP_FN_FFT_RFFT_EXT,                 /**< Used in numpy.fft.rfft() impl, requires extra parameters */
-    DPNP_FN_FILL_DIAGONAL,                /**< Used in numpy.fill_diagonal() impl  */
-    DPNP_FN_FILL_DIAGONAL_EXT,            /**< Used in numpy.fill_diagonal() impl, requires extra parameters */
-    DPNP_FN_FLATTEN,                      /**< Used in numpy.flatten() impl  */
-    DPNP_FN_FLATTEN_EXT,                  /**< Used in numpy.flatten() impl, requires extra parameters  */
-    DPNP_FN_FLOOR,                        /**< Used in numpy.floor() impl  */
-    DPNP_FN_FLOOR_EXT,                    /**< Used in numpy.floor() impl, requires extra parameters  */
-    DPNP_FN_FLOOR_DIVIDE,                 /**< Used in numpy.floor_divide() impl  */
-    DPNP_FN_FLOOR_DIVIDE_EXT,             /**< Used in numpy.floor_divide() impl, requires extra parameters  */
-    DPNP_FN_FMOD,                         /**< Used in numpy.fmod() impl  */
-    DPNP_FN_FMOD_EXT,                     /**< Used in numpy.fmod() impl, requires extra parameters  */
-    DPNP_FN_FULL,                         /**< Used in numpy.full() impl  */
-    DPNP_FN_FULL_LIKE,                    /**< Used in numpy.full_like() impl  */
-    DPNP_FN_GREATER_EXT,                  /**< Used in numpy.greater() impl, requires extra parameters */
-    DPNP_FN_GREATER_EQUAL_EXT,            /**< Used in numpy.greater_equal() impl, requires extra parameters */
-    DPNP_FN_HYPOT,                        /**< Used in numpy.hypot() impl  */
-    DPNP_FN_HYPOT_EXT,                    /**< Used in numpy.hypot() impl, requires extra parameters  */
-    DPNP_FN_IDENTITY,                     /**< Used in numpy.identity() impl  */
-    DPNP_FN_IDENTITY_EXT,                 /**< Used in numpy.identity() impl, requires extra parameters  */
-    DPNP_FN_INITVAL,                      /**< Used in numpy ones, ones_like, zeros, zeros_like impls  */
-    DPNP_FN_INITVAL_EXT,                  /**< Used in numpy ones, ones_like, zeros, zeros_like impls  */
-    DPNP_FN_INV,                          /**< Used in numpy.linalg.inv() impl  */
-    DPNP_FN_INV_EXT,                      /**< Used in numpy.linalg.inv() impl, requires extra parameters  */
-    DPNP_FN_INVERT,                       /**< Used in numpy.invert() impl  */
-    DPNP_FN_INVERT_EXT,                   /**< Used in numpy.invert() impl, requires extra parameters  */
-    DPNP_FN_KRON,                         /**< Used in numpy.kron() impl  */
-    DPNP_FN_KRON_EXT,                     /**< Used in numpy.kron() impl, requires extra parameters  */
-    DPNP_FN_LEFT_SHIFT,                   /**< Used in numpy.left_shift() impl  */
-    DPNP_FN_LEFT_SHIFT_EXT,               /**< Used in numpy.left_shift() impl, requires extra parameters  */
-    DPNP_FN_LESS_EXT,                     /**< Used in numpy.less() impl, requires extra parameters */
-    DPNP_FN_LESS_EQUAL_EXT,               /**< Used in numpy.less_equal() impl, requires extra parameters */
-    DPNP_FN_LOG,                          /**< Used in numpy.log() impl  */
-    DPNP_FN_LOG_EXT,                      /**< Used in numpy.log() impl, requires extra parameters  */
-    DPNP_FN_LOG10,                        /**< Used in numpy.log10() impl  */
-    DPNP_FN_LOG10_EXT,                    /**< Used in numpy.log10() impl, requires extra parameters  */
-    DPNP_FN_LOG2,                         /**< Used in numpy.log2() impl  */
-    DPNP_FN_LOG2_EXT,                     /**< Used in numpy.log2() impl, requires extra parameters  */
-    DPNP_FN_LOG1P,                        /**< Used in numpy.log1p() impl  */
-    DPNP_FN_LOG1P_EXT,                    /**< Used in numpy.log1p() impl, requires extra parameters  */
-    DPNP_FN_LOGICAL_AND_EXT,              /**< Used in numpy.logical_and() impl, requires extra parameters */
-    DPNP_FN_LOGICAL_NOT_EXT,              /**< Used in numpy.logical_not() impl, requires extra parameters */
-    DPNP_FN_LOGICAL_OR_EXT,               /**< Used in numpy.logical_or() impl, requires extra parameters */
-    DPNP_FN_LOGICAL_XOR_EXT,              /**< Used in numpy.logical_xor() impl, requires extra parameters */
-    DPNP_FN_MATMUL,                       /**< Used in numpy.matmul() impl  */
-    DPNP_FN_MATMUL_EXT,                   /**< Used in numpy.matmul() impl, requires extra parameters */
-    DPNP_FN_MATRIX_RANK,                  /**< Used in numpy.linalg.matrix_rank() impl  */
-    DPNP_FN_MATRIX_RANK_EXT,              /**< Used in numpy.linalg.matrix_rank() impl, requires extra parameters */
-    DPNP_FN_MAX,                          /**< Used in numpy.max() impl  */
-    DPNP_FN_MAX_EXT,                      /**< Used in numpy.max() impl, requires extra parameters */
-    DPNP_FN_MAXIMUM,                      /**< Used in numpy.maximum() impl  */
-    DPNP_FN_MAXIMUM_EXT,                  /**< Used in numpy.maximum() impl , requires extra parameters */
-    DPNP_FN_MEAN,                         /**< Used in numpy.mean() impl  */
-    DPNP_FN_MEDIAN,                       /**< Used in numpy.median() impl  */
-    DPNP_FN_MEDIAN_EXT,                   /**< Used in numpy.median() impl, requires extra parameters */
-    DPNP_FN_MIN,                          /**< Used in numpy.min() impl  */
-    DPNP_FN_MIN_EXT,                      /**< Used in numpy.min() impl, requires extra parameters */
-    DPNP_FN_MINIMUM,                      /**< Used in numpy.minimum() impl  */
-    DPNP_FN_MINIMUM_EXT,                  /**< Used in numpy.minimum() impl, requires extra parameters */
-    DPNP_FN_MODF,                         /**< Used in numpy.modf() impl  */
-    DPNP_FN_MODF_EXT,                     /**< Used in numpy.modf() impl, requires extra parameters */
-    DPNP_FN_MULTIPLY,                     /**< Used in numpy.multiply() impl  */
-    DPNP_FN_MULTIPLY_EXT,                 /**< Used in numpy.multiply() impl, requires extra parameters */
-    DPNP_FN_NANVAR,                       /**< Used in numpy.nanvar() impl  */
-    DPNP_FN_NANVAR_EXT,                   /**< Used in numpy.nanvar() impl, requires extra parameters */
-    DPNP_FN_NEGATIVE,                     /**< Used in numpy.negative() impl  */
-    DPNP_FN_NEGATIVE_EXT,                 /**< Used in numpy.negative() impl, requires extra parameters */
-    DPNP_FN_NONZERO,                      /**< Used in numpy.nonzero() impl  */
-    DPNP_FN_NOT_EQUAL_EXT,                /**< Used in numpy.not_equal() impl, requires extra parameters */
-    DPNP_FN_ONES,                         /**< Used in numpy.ones() impl */
-    DPNP_FN_ONES_LIKE,                    /**< Used in numpy.ones_like() impl */
-    DPNP_FN_PARTITION,                    /**< Used in numpy.partition() impl */
-    DPNP_FN_PARTITION_EXT,                /**< Used in numpy.partition() impl, requires extra parameters */
-    DPNP_FN_PLACE,                        /**< Used in numpy.place() impl  */
-    DPNP_FN_POWER,                        /**< Used in numpy.power() impl  */
-    DPNP_FN_POWER_EXT,                    /**< Used in numpy.power() impl, requires extra parameters */
-    DPNP_FN_PROD,                         /**< Used in numpy.prod() impl  */
-    DPNP_FN_PROD_EXT,                     /**< Used in numpy.prod() impl, requires extra parameters */
-    DPNP_FN_PTP,                          /**< Used in numpy.ptp() impl  */
-    DPNP_FN_PTP_EXT,                      /**< Used in numpy.ptp() impl, requires extra parameters */
-    DPNP_FN_PUT,                          /**< Used in numpy.put() impl  */
-    DPNP_FN_PUT_EXT,                      /**< Used in numpy.put() impl, requires extra parameters */
-    DPNP_FN_PUT_ALONG_AXIS,               /**< Used in numpy.put_along_axis() impl  */
-    DPNP_FN_PUT_ALONG_AXIS_EXT,           /**< Used in numpy.put_along_axis() impl, requires extra parameters */
-    DPNP_FN_QR,                           /**< Used in numpy.linalg.qr() impl  */
-    DPNP_FN_QR_EXT,                       /**< Used in numpy.linalg.qr() impl, requires extra parameters */
-    DPNP_FN_RADIANS,                      /**< Used in numpy.radians() impl  */
-    DPNP_FN_RADIANS_EXT,                  /**< Used in numpy.radians() impl, requires extra parameters */
-    DPNP_FN_REMAINDER,                    /**< Used in numpy.remainder() impl  */
-    DPNP_FN_REMAINDER_EXT,                /**< Used in numpy.remainder() impl, requires extra parameters */
-    DPNP_FN_RECIP,                        /**< Used in numpy.recip() impl  */
-    DPNP_FN_RECIP_EXT,                    /**< Used in numpy.recip() impl, requires extra parameters */
-    DPNP_FN_REPEAT,                       /**< Used in numpy.repeat() impl  */
-    DPNP_FN_REPEAT_EXT,                   /**< Used in numpy.repeat() impl, requires extra parameters */
-    DPNP_FN_RIGHT_SHIFT,                  /**< Used in numpy.right_shift() impl  */
-    DPNP_FN_RIGHT_SHIFT_EXT,              /**< Used in numpy.right_shift() impl, requires extra parameters */
-    DPNP_FN_RNG_BETA,                     /**< Used in numpy.random.beta() impl  */
-    DPNP_FN_RNG_BETA_EXT,                 /**< Used in numpy.random.beta() impl, requires extra parameters */
-    DPNP_FN_RNG_BINOMIAL,                 /**< Used in numpy.random.binomial() impl  */
-    DPNP_FN_RNG_BINOMIAL_EXT,             /**< Used in numpy.random.binomial() impl, requires extra parameters */
-    DPNP_FN_RNG_CHISQUARE,                /**< Used in numpy.random.chisquare() impl  */
-    DPNP_FN_RNG_CHISQUARE_EXT,            /**< Used in numpy.random.chisquare() impl, requires extra parameters */
-    DPNP_FN_RNG_EXPONENTIAL,              /**< Used in numpy.random.exponential() impl  */
-    DPNP_FN_RNG_EXPONENTIAL_EXT,          /**< Used in numpy.random.exponential() impl, requires extra parameters */
-    DPNP_FN_RNG_F,                        /**< Used in numpy.random.f() impl  */
-    DPNP_FN_RNG_F_EXT,                    /**< Used in numpy.random.f() impl, requires extra parameters */
-    DPNP_FN_RNG_GAMMA,                    /**< Used in numpy.random.gamma() impl  */
-    DPNP_FN_RNG_GAMMA_EXT,                /**< Used in numpy.random.gamma() impl, requires extra parameters */
-    DPNP_FN_RNG_GAUSSIAN,                 /**< Used in numpy.random.randn() impl  */
-    DPNP_FN_RNG_GAUSSIAN_EXT,             /**< Used in numpy.random.randn() impl, requires extra parameters */
-    DPNP_FN_RNG_GEOMETRIC,                /**< Used in numpy.random.geometric() impl  */
-    DPNP_FN_RNG_GEOMETRIC_EXT,            /**< Used in numpy.random.geometric() impl, requires extra parameters */
-    DPNP_FN_RNG_GUMBEL,                   /**< Used in numpy.random.gumbel() impl  */
-    DPNP_FN_RNG_GUMBEL_EXT,               /**< Used in numpy.random.gumbel() impl, requires extra parameters */
-    DPNP_FN_RNG_HYPERGEOMETRIC,           /**< Used in numpy.random.hypergeometric() impl  */
-    DPNP_FN_RNG_HYPERGEOMETRIC_EXT,       /**< Used in numpy.random.hypergeometric() impl, requires extra parameters */
-    DPNP_FN_RNG_LAPLACE,                  /**< Used in numpy.random.laplace() impl  */
-    DPNP_FN_RNG_LAPLACE_EXT,              /**< Used in numpy.random.laplace() impl  */
-    DPNP_FN_RNG_LOGISTIC,                 /**< Used in numpy.random.logistic() impl  */
-    DPNP_FN_RNG_LOGISTIC_EXT,             /**< Used in numpy.random.logistic() impl, requires extra parameters */
-    DPNP_FN_RNG_LOGNORMAL,                /**< Used in numpy.random.lognormal() impl  */
-    DPNP_FN_RNG_LOGNORMAL_EXT,            /**< Used in numpy.random.lognormal() impl, requires extra parameters */
-    DPNP_FN_RNG_MULTINOMIAL,              /**< Used in numpy.random.multinomial() impl  */
-    DPNP_FN_RNG_MULTINOMIAL_EXT,          /**< Used in numpy.random.multinomial() impl, requires extra parameters */
-    DPNP_FN_RNG_MULTIVARIATE_NORMAL,      /**< Used in numpy.random.multivariate_normal() impl  */
-    DPNP_FN_RNG_MULTIVARIATE_NORMAL_EXT,  /**< Used in numpy.random.multivariate_normal() impl  */
-    DPNP_FN_RNG_NEGATIVE_BINOMIAL,        /**< Used in numpy.random.negative_binomial() impl  */
-    DPNP_FN_RNG_NEGATIVE_BINOMIAL_EXT,    /**< Used in numpy.random.negative_binomial() impl  */
-    DPNP_FN_RNG_NONCENTRAL_CHISQUARE,     /**< Used in numpy.random.noncentral_chisquare() impl  */
-    DPNP_FN_RNG_NONCENTRAL_CHISQUARE_EXT, /**< Used in numpy.random.noncentral_chisquare() impl  */
-    DPNP_FN_RNG_NORMAL,                   /**< Used in numpy.random.normal() impl  */
-    DPNP_FN_RNG_NORMAL_EXT,               /**< Used in numpy.random.normal() impl, requires extra parameters */
-    DPNP_FN_RNG_PARETO,                   /**< Used in numpy.random.pareto() impl  */
-    DPNP_FN_RNG_PARETO_EXT,               /**< Used in numpy.random.pareto() impl, requires extra parameters */
-    DPNP_FN_RNG_POISSON,                  /**< Used in numpy.random.poisson() impl  */
-    DPNP_FN_RNG_POISSON_EXT,              /**< Used in numpy.random.poisson() impl, requires extra parameters */
-    DPNP_FN_RNG_POWER,                    /**< Used in numpy.random.power() impl  */
-    DPNP_FN_RNG_POWER_EXT,                /**< Used in numpy.random.power() impl, requires extra parameters */
-    DPNP_FN_RNG_RAYLEIGH,                 /**< Used in numpy.random.rayleigh() impl  */
-    DPNP_FN_RNG_RAYLEIGH_EXT,             /**< Used in numpy.random.rayleigh() impl, requires extra parameters */
-    DPNP_FN_RNG_SRAND,                    /**< Used in numpy.random.seed() impl  */
-    DPNP_FN_RNG_SRAND_EXT,                /**< Used in numpy.random.seed() impl, requires extra parameters */
-    DPNP_FN_RNG_SHUFFLE,                  /**< Used in numpy.random.shuffle() impl  */
-    DPNP_FN_RNG_SHUFFLE_EXT,              /**< Used in numpy.random.shuffle() impl, requires extra parameters */
-    DPNP_FN_RNG_STANDARD_CAUCHY,          /**< Used in numpy.random.standard_cauchy() impl  */
-    DPNP_FN_RNG_STANDARD_CAUCHY_EXT,      /**< Used in numpy.random.standard_cauchy() impl  */
-    DPNP_FN_RNG_STANDARD_EXPONENTIAL,     /**< Used in numpy.random.standard_exponential() impl  */
-    DPNP_FN_RNG_STANDARD_EXPONENTIAL_EXT, /**< Used in numpy.random.standard_exponential() impl  */
-    DPNP_FN_RNG_STANDARD_GAMMA,           /**< Used in numpy.random.standard_gamma() impl  */
-    DPNP_FN_RNG_STANDARD_GAMMA_EXT,       /**< Used in numpy.random.standard_gamma() impl, requires extra parameters */
-    DPNP_FN_RNG_STANDARD_NORMAL,          /**< Used in numpy.random.standard_normal() impl  */
-    DPNP_FN_RNG_STANDARD_T,               /**< Used in numpy.random.standard_t() impl  */
-    DPNP_FN_RNG_STANDARD_T_EXT,           /**< Used in numpy.random.standard_t() impl, requires extra parameters */
-    DPNP_FN_RNG_TRIANGULAR,               /**< Used in numpy.random.triangular() impl  */
-    DPNP_FN_RNG_TRIANGULAR_EXT,           /**< Used in numpy.random.triangular() impl, requires extra parameters */
-    DPNP_FN_RNG_UNIFORM,                  /**< Used in numpy.random.uniform() impl  */
-    DPNP_FN_RNG_UNIFORM_EXT,              /**< Used in numpy.random.uniform() impl, requires extra parameters */
-    DPNP_FN_RNG_VONMISES,                 /**< Used in numpy.random.vonmises() impl  */
-    DPNP_FN_RNG_VONMISES_EXT,             /**< Used in numpy.random.vonmises() impl, requires extra parameters */
-    DPNP_FN_RNG_WALD,                     /**< Used in numpy.random.wald() impl  */
-    DPNP_FN_RNG_WALD_EXT,                 /**< Used in numpy.random.wald() impl, requires extra parameters */
-    DPNP_FN_RNG_WEIBULL,                  /**< Used in numpy.random.weibull() impl  */
-    DPNP_FN_RNG_WEIBULL_EXT,              /**< Used in numpy.random.weibull() impl, requires extra parameters */
-    DPNP_FN_RNG_ZIPF,                     /**< Used in numpy.random.zipf() impl  */
-    DPNP_FN_RNG_ZIPF_EXT,                 /**< Used in numpy.random.zipf() impl, requires extra parameters */
-    DPNP_FN_SEARCHSORTED,                 /**< Used in numpy.searchsorted() impl  */
-    DPNP_FN_SEARCHSORTED_EXT,             /**< Used in numpy.searchsorted() impl, requires extra parameters */
-    DPNP_FN_SIGN,                         /**< Used in numpy.sign() impl  */
-    DPNP_FN_SIGN_EXT,                     /**< Used in numpy.sign() impl, requires extra parameters */
-    DPNP_FN_SIN,                          /**< Used in numpy.sin() impl  */
-    DPNP_FN_SIN_EXT,                      /**< Used in numpy.sin() impl, requires extra parameters */
-    DPNP_FN_SINH,                         /**< Used in numpy.sinh() impl  */
-    DPNP_FN_SINH_EXT,                     /**< Used in numpy.sinh() impl, requires extra parameters */
-    DPNP_FN_SORT,                         /**< Used in numpy.sort() impl  */
-    DPNP_FN_SORT_EXT,                     /**< Used in numpy.sort() impl, requires extra parameters */
-    DPNP_FN_SQRT,                         /**< Used in numpy.sqrt() impl  */
-    DPNP_FN_SQRT_EXT,                     /**< Used in numpy.sqrt() impl, requires extra parameters */
-    DPNP_FN_SQUARE,                       /**< Used in numpy.square() impl  */
-    DPNP_FN_SQUARE_EXT,                   /**< Used in numpy.square() impl, requires extra parameters */
-    DPNP_FN_STD,                          /**< Used in numpy.std() impl  */
-    DPNP_FN_STD_EXT,                      /**< Used in numpy.std() impl, requires extra parameters */
-    DPNP_FN_SUBTRACT,                     /**< Used in numpy.subtract() impl  */
-    DPNP_FN_SUBTRACT_EXT,                 /**< Used in numpy.subtract() impl, requires extra parameters */
-    DPNP_FN_SUM,                          /**< Used in numpy.sum() impl  */
-    DPNP_FN_SUM_EXT,                      /**< Used in numpy.sum() impl, requires extra parameters */
-    DPNP_FN_SVD,                          /**< Used in numpy.linalg.svd() impl  */
-    DPNP_FN_SVD_EXT,                      /**< Used in numpy.linalg.svd() impl, requires extra parameters */
-    DPNP_FN_TAKE,                         /**< Used in numpy.take() impl  */
-    DPNP_FN_TAKE_EXT,                     /**< Used in numpy.take() impl, requires extra parameters */
-    DPNP_FN_TAN,                          /**< Used in numpy.tan() impl  */
-    DPNP_FN_TAN_EXT,                      /**< Used in numpy.tan() impl, requires extra parameters */
-    DPNP_FN_TANH,                         /**< Used in numpy.tanh() impl  */
-    DPNP_FN_TANH_EXT,                     /**< Used in numpy.tanh() impl, requires extra parameters */
-    DPNP_FN_TRANSPOSE,                    /**< Used in numpy.transpose() impl  */
-    DPNP_FN_TRACE,                        /**< Used in numpy.trace() impl  */
-    DPNP_FN_TRACE_EXT,                    /**< Used in numpy.trace() impl, requires extra parameters */
-    DPNP_FN_TRAPZ,                        /**< Used in numpy.trapz() impl  */
-    DPNP_FN_TRAPZ_EXT,                    /**< Used in numpy.trapz() impl, requires extra parameters */
-    DPNP_FN_TRI,                          /**< Used in numpy.tri() impl  */
-    DPNP_FN_TRI_EXT,                      /**< Used in numpy.tri() impl, requires extra parameters */
-    DPNP_FN_TRIL,                         /**< Used in numpy.tril() impl  */
-    DPNP_FN_TRIU,                         /**< Used in numpy.triu() impl  */
-    DPNP_FN_TRUNC,                        /**< Used in numpy.trunc() impl  */
-    DPNP_FN_TRUNC_EXT,                    /**< Used in numpy.trunc() impl, requires extra parameters */
-    DPNP_FN_VANDER,                       /**< Used in numpy.vander() impl  */
-    DPNP_FN_VANDER_EXT,                   /**< Used in numpy.vander() impl, requires extra parameters */
-    DPNP_FN_VAR,                          /**< Used in numpy.var() impl  */
-    DPNP_FN_VAR_EXT,                      /**< Used in numpy.var() impl, requires extra parameters */
-    DPNP_FN_ZEROS,                        /**< Used in numpy.zeros() impl */
-    DPNP_FN_ZEROS_LIKE,                   /**< Used in numpy.zeros_like() impl */
-    DPNP_FN_LAST,                         /**< The latest element of the enumeration */
+    DPNP_FN_NONE,         /**< Very first element of the enumeration */
+    DPNP_FN_ABSOLUTE,     /**< Used in numpy.absolute() impl  */
+    DPNP_FN_ABSOLUTE_EXT, /**< Used in numpy.absolute() impl, requires extra
+                             parameters */
+    DPNP_FN_ADD,          /**< Used in numpy.add() impl  */
+    DPNP_FN_ADD_EXT, /**< Used in numpy.add() impl, requires extra parameters */
+    DPNP_FN_ALL,     /**< Used in numpy.all() impl  */
+    DPNP_FN_ALL_EXT, /**< Used in numpy.all() impl, requires extra parameters */
+    DPNP_FN_ALLCLOSE,     /**< Used in numpy.allclose() impl  */
+    DPNP_FN_ALLCLOSE_EXT, /**< Used in numpy.allclose() impl, requires extra
+                             parameters */
+    DPNP_FN_ANY,          /**< Used in numpy.any() impl  */
+    DPNP_FN_ANY_EXT, /**< Used in numpy.any() impl, requires extra parameters */
+    DPNP_FN_ARANGE,  /**< Used in numpy.arange() impl  */
+    DPNP_FN_ARCCOS,  /**< Used in numpy.arccos() impl  */
+    DPNP_FN_ARCCOS_EXT,      /**< Used in numpy.arccos() impl, requires extra
+                                parameters */
+    DPNP_FN_ARCCOSH,         /**< Used in numpy.arccosh() impl  */
+    DPNP_FN_ARCCOSH_EXT,     /**< Used in numpy.arccosh() impl, requires extra
+                                parameters */
+    DPNP_FN_ARCSIN,          /**< Used in numpy.arcsin() impl  */
+    DPNP_FN_ARCSIN_EXT,      /**< Used in numpy.arcsin() impl, requires extra
+                                parameters */
+    DPNP_FN_ARCSINH,         /**< Used in numpy.arcsinh() impl  */
+    DPNP_FN_ARCSINH_EXT,     /**< Used in numpy.arcsinh() impl, requires extra
+                                parameters */
+    DPNP_FN_ARCTAN,          /**< Used in numpy.arctan() impl  */
+    DPNP_FN_ARCTAN_EXT,      /**< Used in numpy.arctan() impl, requires extra
+                                parameters */
+    DPNP_FN_ARCTAN2,         /**< Used in numpy.arctan2() impl  */
+    DPNP_FN_ARCTAN2_EXT,     /**< Used in numpy.arctan2() impl, requires extra
+                                parameters */
+    DPNP_FN_ARCTANH,         /**< Used in numpy.arctanh() impl  */
+    DPNP_FN_ARCTANH_EXT,     /**< Used in numpy.arctanh() impl, requires extra
+                                parameters */
+    DPNP_FN_ARGMAX,          /**< Used in numpy.argmax() impl  */
+    DPNP_FN_ARGMAX_EXT,      /**< Used in numpy.argmax() impl, requires extra
+                                parameters */
+    DPNP_FN_ARGMIN,          /**< Used in numpy.argmin() impl  */
+    DPNP_FN_ARGMIN_EXT,      /**< Used in numpy.argmin() impl, requires extra
+                                parameters */
+    DPNP_FN_ARGSORT,         /**< Used in numpy.argsort() impl  */
+    DPNP_FN_ARGSORT_EXT,     /**< Used in numpy.argsort() impl, requires extra
+                                parameters */
+    DPNP_FN_AROUND,          /**< Used in numpy.around() impl  */
+    DPNP_FN_AROUND_EXT,      /**< Used in numpy.around() impl, requires extra
+                                parameters */
+    DPNP_FN_ASTYPE,          /**< Used in numpy.astype() impl  */
+    DPNP_FN_ASTYPE_EXT,      /**< Used in numpy.astype() impl, requires extra
+                                parameters */
+    DPNP_FN_BITWISE_AND,     /**< Used in numpy.bitwise_and() impl  */
+    DPNP_FN_BITWISE_AND_EXT, /**< Used in numpy.bitwise_and() impl, requires
+                                extra parameters */
+    DPNP_FN_BITWISE_OR,      /**< Used in numpy.bitwise_or() impl  */
+    DPNP_FN_BITWISE_OR_EXT, /**< Used in numpy.bitwise_or() impl, requires extra
+                               parameters */
+    DPNP_FN_BITWISE_XOR,    /**< Used in numpy.bitwise_xor() impl  */
+    DPNP_FN_BITWISE_XOR_EXT, /**< Used in numpy.bitwise_xor() impl, requires
+                                extra parameters */
+    DPNP_FN_CBRT,            /**< Used in numpy.cbrt() impl  */
+    DPNP_FN_CBRT_EXT, /**< Used in numpy.cbrt() impl, requires extra parameters
+                       */
+    DPNP_FN_CEIL,     /**< Used in numpy.ceil() impl  */
+    DPNP_FN_CEIL_EXT, /**< Used in numpy.ceil() impl, requires extra parameters
+                       */
+    DPNP_FN_CHOLESKY, /**< Used in numpy.linalg.cholesky() impl  */
+    DPNP_FN_CHOLESKY_EXT,   /**< Used in numpy.linalg.cholesky() impl, requires
+                               extra parameters */
+    DPNP_FN_CONJIGUATE,     /**< Used in numpy.conjugate() impl  */
+    DPNP_FN_CONJIGUATE_EXT, /**< Used in numpy.conjugate() impl, requires extra
+                               parameters */
+    DPNP_FN_CHOOSE,         /**< Used in numpy.choose() impl  */
+    DPNP_FN_CHOOSE_EXT,     /**< Used in numpy.choose() impl, requires extra
+                               parameters */
+    DPNP_FN_COPY,           /**< Used in numpy.copy() impl  */
+    DPNP_FN_COPY_EXT, /**< Used in numpy.copy() impl, requires extra parameters
+                       */
+    DPNP_FN_COPYSIGN, /**< Used in numpy.copysign() impl  */
+    DPNP_FN_COPYSIGN_EXT,  /**< Used in numpy.copysign() impl, requires extra
+                              parameters */
+    DPNP_FN_COPYTO,        /**< Used in numpy.copyto() impl  */
+    DPNP_FN_COPYTO_EXT,    /**< Used in numpy.copyto() impl, requires extra
+                              parameters */
+    DPNP_FN_CORRELATE,     /**< Used in numpy.correlate() impl  */
+    DPNP_FN_CORRELATE_EXT, /**< Used in numpy.correlate() impl, requires extra
+                              parameters */
+    DPNP_FN_COS,           /**< Used in numpy.cos() impl  */
+    DPNP_FN_COS_EXT, /**< Used in numpy.cos() impl, requires extra parameters */
+    DPNP_FN_COSH,    /**< Used in numpy.cosh() impl  */
+    DPNP_FN_COSH_EXT, /**< Used in numpy.cosh() impl, requires extra parameters
+                       */
+    DPNP_FN_COUNT_NONZERO,     /**< Used in numpy.count_nonzero() impl  */
+    DPNP_FN_COUNT_NONZERO_EXT, /**< Used in numpy.count_nonzero() impl, requires
+                                  extra parameters */
+    DPNP_FN_COV,               /**< Used in numpy.cov() impl  */
+    DPNP_FN_CROSS,             /**< Used in numpy.cross() impl  */
+    DPNP_FN_CROSS_EXT,         /**< Used in numpy.cross() impl, requires extra
+                                  parameters */
+    DPNP_FN_CUMPROD,           /**< Used in numpy.cumprod() impl  */
+    DPNP_FN_CUMPROD_EXT,       /**< Used in numpy.cumprod() impl, requires extra
+                                  parameters */
+    DPNP_FN_CUMSUM,            /**< Used in numpy.cumsum() impl  */
+    DPNP_FN_CUMSUM_EXT,        /**< Used in numpy.cumsum() impl, requires extra
+                                  parameters */
+    DPNP_FN_DEGREES,           /**< Used in numpy.degrees() impl  */
+    DPNP_FN_DEGREES_EXT,       /**< Used in numpy.degrees() impl, requires extra
+                                  parameters */
+    DPNP_FN_DET,               /**< Used in numpy.linalg.det() impl  */
+    DPNP_FN_DET_EXT,  /**< Used in numpy.linalg.det() impl, requires extra
+                         parameters */
+    DPNP_FN_DIAG,     /**< Used in numpy.diag() impl  */
+    DPNP_FN_DIAG_EXT, /**< Used in numpy.diag() impl, requires extra parameters
+                       */
+    DPNP_FN_DIAG_INDICES,     /**< Used in numpy.diag_indices() impl  */
+    DPNP_FN_DIAG_INDICES_EXT, /**< Used in numpy.diag_indices() impl, requires
+                                 extra parameters */
+    DPNP_FN_DIAGONAL,         /**< Used in numpy.diagonal() impl  */
+    DPNP_FN_DIAGONAL_EXT,     /**< Used in numpy.diagonal() impl, requires extra
+                                 parameters */
+    DPNP_FN_DIVIDE,           /**< Used in numpy.divide() impl  */
+    DPNP_FN_DIVIDE_EXT,       /**< Used in numpy.divide() impl, requires extra
+                                 parameters */
+    DPNP_FN_DOT,              /**< Used in numpy.dot() impl  */
+    DPNP_FN_DOT_EXT, /**< Used in numpy.dot() impl, requires extra parameters */
+    DPNP_FN_EDIFF1D, /**< Used in numpy.ediff1d() impl  */
+    DPNP_FN_EDIFF1D_EXT, /**< Used in numpy.ediff1d() impl, requires extra
+                            parameters */
+    DPNP_FN_EIG,         /**< Used in numpy.linalg.eig() impl  */
+    DPNP_FN_EIG_EXT,     /**< Used in numpy.linalg.eig() impl, requires extra
+                            parameters */
+    DPNP_FN_EIGVALS,     /**< Used in numpy.linalg.eigvals() impl  */
+    DPNP_FN_EIGVALS_EXT, /**< Used in numpy.linalg.eigvals() impl, requires
+                            extra parameters */
+    DPNP_FN_EQUAL_EXT,   /**< Used in numpy.equal() impl, requires extra
+                            parameters */
+    DPNP_FN_ERF,         /**< Used in scipy.special.erf impl  */
+    DPNP_FN_ERF_EXT,     /**< Used in scipy.special.erf impl, requires extra
+                            parameters */
+    DPNP_FN_EYE,         /**< Used in numpy.eye() impl  */
+    DPNP_FN_EXP,         /**< Used in numpy.exp() impl  */
+    DPNP_FN_EXP_EXT, /**< Used in numpy.exp() impl, requires extra parameters */
+    DPNP_FN_EXP2,    /**< Used in numpy.exp2() impl  */
+    DPNP_FN_EXP2_EXT,  /**< Used in numpy.exp2() impl, requires extra parameters
+                        */
+    DPNP_FN_EXPM1,     /**< Used in numpy.expm1() impl  */
+    DPNP_FN_EXPM1_EXT, /**< Used in numpy.expm1() impl, requires extra
+                          parameters */
+    DPNP_FN_FABS,      /**< Used in numpy.fabs() impl  */
+    DPNP_FN_FABS_EXT,  /**< Used in numpy.fabs() impl, requires extra parameters
+                        */
+    DPNP_FN_FFT_FFT,   /**< Used in numpy.fft.fft() impl  */
+    DPNP_FN_FFT_FFT_EXT,   /**< Used in numpy.fft.fft() impl, requires extra
+                              parameters */
+    DPNP_FN_FFT_RFFT,      /**< Used in numpy.fft.rfft() impl  */
+    DPNP_FN_FFT_RFFT_EXT,  /**< Used in numpy.fft.rfft() impl, requires extra
+                              parameters */
+    DPNP_FN_FILL_DIAGONAL, /**< Used in numpy.fill_diagonal() impl  */
+    DPNP_FN_FILL_DIAGONAL_EXT, /**< Used in numpy.fill_diagonal() impl, requires
+                                  extra parameters */
+    DPNP_FN_FLATTEN,           /**< Used in numpy.flatten() impl  */
+    DPNP_FN_FLATTEN_EXT,       /**< Used in numpy.flatten() impl, requires extra
+                                  parameters  */
+    DPNP_FN_FLOOR,             /**< Used in numpy.floor() impl  */
+    DPNP_FN_FLOOR_EXT,         /**< Used in numpy.floor() impl, requires extra
+                                  parameters  */
+    DPNP_FN_FLOOR_DIVIDE,      /**< Used in numpy.floor_divide() impl  */
+    DPNP_FN_FLOOR_DIVIDE_EXT,  /**< Used in numpy.floor_divide() impl, requires
+                                  extra parameters  */
+    DPNP_FN_FMOD,              /**< Used in numpy.fmod() impl  */
+    DPNP_FN_FMOD_EXT,  /**< Used in numpy.fmod() impl, requires extra parameters
+                        */
+    DPNP_FN_FULL,      /**< Used in numpy.full() impl  */
+    DPNP_FN_FULL_LIKE, /**< Used in numpy.full_like() impl  */
+    DPNP_FN_GREATER_EXT,       /**< Used in numpy.greater() impl, requires extra
+                                  parameters */
+    DPNP_FN_GREATER_EQUAL_EXT, /**< Used in numpy.greater_equal() impl, requires
+                                  extra parameters */
+    DPNP_FN_HYPOT,             /**< Used in numpy.hypot() impl  */
+    DPNP_FN_HYPOT_EXT,         /**< Used in numpy.hypot() impl, requires extra
+                                  parameters  */
+    DPNP_FN_IDENTITY,          /**< Used in numpy.identity() impl  */
+    DPNP_FN_IDENTITY_EXT, /**< Used in numpy.identity() impl, requires extra
+                             parameters  */
+    DPNP_FN_INITVAL, /**< Used in numpy ones, ones_like, zeros, zeros_like impls
+                      */
+    DPNP_FN_INITVAL_EXT, /**< Used in numpy ones, ones_like, zeros, zeros_like
+                            impls  */
+    DPNP_FN_INV,         /**< Used in numpy.linalg.inv() impl  */
+    DPNP_FN_INV_EXT,     /**< Used in numpy.linalg.inv() impl, requires extra
+                            parameters  */
+    DPNP_FN_INVERT,      /**< Used in numpy.invert() impl  */
+    DPNP_FN_INVERT_EXT,  /**< Used in numpy.invert() impl, requires extra
+                            parameters  */
+    DPNP_FN_KRON,        /**< Used in numpy.kron() impl  */
+    DPNP_FN_KRON_EXT, /**< Used in numpy.kron() impl, requires extra parameters
+                       */
+    DPNP_FN_LEFT_SHIFT,     /**< Used in numpy.left_shift() impl  */
+    DPNP_FN_LEFT_SHIFT_EXT, /**< Used in numpy.left_shift() impl, requires extra
+                               parameters  */
+    DPNP_FN_LESS_EXT, /**< Used in numpy.less() impl, requires extra parameters
+                       */
+    DPNP_FN_LESS_EQUAL_EXT, /**< Used in numpy.less_equal() impl, requires extra
+                               parameters */
+    DPNP_FN_LOG,            /**< Used in numpy.log() impl  */
+    DPNP_FN_LOG_EXT, /**< Used in numpy.log() impl, requires extra parameters */
+    DPNP_FN_LOG10,   /**< Used in numpy.log10() impl  */
+    DPNP_FN_LOG10_EXT, /**< Used in numpy.log10() impl, requires extra
+                          parameters  */
+    DPNP_FN_LOG2,      /**< Used in numpy.log2() impl  */
+    DPNP_FN_LOG2_EXT,  /**< Used in numpy.log2() impl, requires extra parameters
+                        */
+    DPNP_FN_LOG1P,     /**< Used in numpy.log1p() impl  */
+    DPNP_FN_LOG1P_EXT, /**< Used in numpy.log1p() impl, requires extra
+                          parameters  */
+    DPNP_FN_LOGICAL_AND_EXT, /**< Used in numpy.logical_and() impl, requires
+                                extra parameters */
+    DPNP_FN_LOGICAL_NOT_EXT, /**< Used in numpy.logical_not() impl, requires
+                                extra parameters */
+    DPNP_FN_LOGICAL_OR_EXT, /**< Used in numpy.logical_or() impl, requires extra
+                               parameters */
+    DPNP_FN_LOGICAL_XOR_EXT, /**< Used in numpy.logical_xor() impl, requires
+                                extra parameters */
+    DPNP_FN_MATMUL,          /**< Used in numpy.matmul() impl  */
+    DPNP_FN_MATMUL_EXT,      /**< Used in numpy.matmul() impl, requires extra
+                                parameters */
+    DPNP_FN_MATRIX_RANK,     /**< Used in numpy.linalg.matrix_rank() impl  */
+    DPNP_FN_MATRIX_RANK_EXT, /**< Used in numpy.linalg.matrix_rank() impl,
+                                requires extra parameters */
+    DPNP_FN_MAX,             /**< Used in numpy.max() impl  */
+    DPNP_FN_MAX_EXT, /**< Used in numpy.max() impl, requires extra parameters */
+    DPNP_FN_MAXIMUM, /**< Used in numpy.maximum() impl  */
+    DPNP_FN_MAXIMUM_EXT, /**< Used in numpy.maximum() impl , requires extra
+                            parameters */
+    DPNP_FN_MEAN,        /**< Used in numpy.mean() impl  */
+    DPNP_FN_MEDIAN,      /**< Used in numpy.median() impl  */
+    DPNP_FN_MEDIAN_EXT,  /**< Used in numpy.median() impl, requires extra
+                            parameters */
+    DPNP_FN_MIN,         /**< Used in numpy.min() impl  */
+    DPNP_FN_MIN_EXT, /**< Used in numpy.min() impl, requires extra parameters */
+    DPNP_FN_MINIMUM, /**< Used in numpy.minimum() impl  */
+    DPNP_FN_MINIMUM_EXT, /**< Used in numpy.minimum() impl, requires extra
+                            parameters */
+    DPNP_FN_MODF,        /**< Used in numpy.modf() impl  */
+    DPNP_FN_MODF_EXT, /**< Used in numpy.modf() impl, requires extra parameters
+                       */
+    DPNP_FN_MULTIPLY, /**< Used in numpy.multiply() impl  */
+    DPNP_FN_MULTIPLY_EXT,  /**< Used in numpy.multiply() impl, requires extra
+                              parameters */
+    DPNP_FN_NANVAR,        /**< Used in numpy.nanvar() impl  */
+    DPNP_FN_NANVAR_EXT,    /**< Used in numpy.nanvar() impl, requires extra
+                              parameters */
+    DPNP_FN_NEGATIVE,      /**< Used in numpy.negative() impl  */
+    DPNP_FN_NEGATIVE_EXT,  /**< Used in numpy.negative() impl, requires extra
+                              parameters */
+    DPNP_FN_NONZERO,       /**< Used in numpy.nonzero() impl  */
+    DPNP_FN_NOT_EQUAL_EXT, /**< Used in numpy.not_equal() impl, requires extra
+                              parameters */
+    DPNP_FN_ONES,          /**< Used in numpy.ones() impl */
+    DPNP_FN_ONES_LIKE,     /**< Used in numpy.ones_like() impl */
+    DPNP_FN_PARTITION,     /**< Used in numpy.partition() impl */
+    DPNP_FN_PARTITION_EXT, /**< Used in numpy.partition() impl, requires extra
+                              parameters */
+    DPNP_FN_PLACE,         /**< Used in numpy.place() impl  */
+    DPNP_FN_POWER,         /**< Used in numpy.power() impl  */
+    DPNP_FN_POWER_EXT,     /**< Used in numpy.power() impl, requires extra
+                              parameters */
+    DPNP_FN_PROD,          /**< Used in numpy.prod() impl  */
+    DPNP_FN_PROD_EXT, /**< Used in numpy.prod() impl, requires extra parameters
+                       */
+    DPNP_FN_PTP,      /**< Used in numpy.ptp() impl  */
+    DPNP_FN_PTP_EXT, /**< Used in numpy.ptp() impl, requires extra parameters */
+    DPNP_FN_PUT,     /**< Used in numpy.put() impl  */
+    DPNP_FN_PUT_EXT, /**< Used in numpy.put() impl, requires extra parameters */
+    DPNP_FN_PUT_ALONG_AXIS,     /**< Used in numpy.put_along_axis() impl  */
+    DPNP_FN_PUT_ALONG_AXIS_EXT, /**< Used in numpy.put_along_axis() impl,
+                                   requires extra parameters */
+    DPNP_FN_QR,                 /**< Used in numpy.linalg.qr() impl  */
+    DPNP_FN_QR_EXT,          /**< Used in numpy.linalg.qr() impl, requires extra
+                                parameters */
+    DPNP_FN_RADIANS,         /**< Used in numpy.radians() impl  */
+    DPNP_FN_RADIANS_EXT,     /**< Used in numpy.radians() impl, requires extra
+                                parameters */
+    DPNP_FN_REMAINDER,       /**< Used in numpy.remainder() impl  */
+    DPNP_FN_REMAINDER_EXT,   /**< Used in numpy.remainder() impl, requires extra
+                                parameters */
+    DPNP_FN_RECIP,           /**< Used in numpy.recip() impl  */
+    DPNP_FN_RECIP_EXT,       /**< Used in numpy.recip() impl, requires extra
+                                parameters */
+    DPNP_FN_REPEAT,          /**< Used in numpy.repeat() impl  */
+    DPNP_FN_REPEAT_EXT,      /**< Used in numpy.repeat() impl, requires extra
+                                parameters */
+    DPNP_FN_RIGHT_SHIFT,     /**< Used in numpy.right_shift() impl  */
+    DPNP_FN_RIGHT_SHIFT_EXT, /**< Used in numpy.right_shift() impl, requires
+                                extra parameters */
+    DPNP_FN_RNG_BETA,        /**< Used in numpy.random.beta() impl  */
+    DPNP_FN_RNG_BETA_EXT, /**< Used in numpy.random.beta() impl, requires extra
+                             parameters */
+    DPNP_FN_RNG_BINOMIAL, /**< Used in numpy.random.binomial() impl  */
+    DPNP_FN_RNG_BINOMIAL_EXT,  /**< Used in numpy.random.binomial() impl,
+                                  requires extra parameters */
+    DPNP_FN_RNG_CHISQUARE,     /**< Used in numpy.random.chisquare() impl  */
+    DPNP_FN_RNG_CHISQUARE_EXT, /**< Used in numpy.random.chisquare() impl,
+                                  requires extra parameters */
+    DPNP_FN_RNG_EXPONENTIAL,   /**< Used in numpy.random.exponential() impl  */
+    DPNP_FN_RNG_EXPONENTIAL_EXT, /**< Used in numpy.random.exponential() impl,
+                                    requires extra parameters */
+    DPNP_FN_RNG_F,               /**< Used in numpy.random.f() impl  */
+    DPNP_FN_RNG_F_EXT,        /**< Used in numpy.random.f() impl, requires extra
+                                 parameters */
+    DPNP_FN_RNG_GAMMA,        /**< Used in numpy.random.gamma() impl  */
+    DPNP_FN_RNG_GAMMA_EXT,    /**< Used in numpy.random.gamma() impl, requires
+                                 extra parameters */
+    DPNP_FN_RNG_GAUSSIAN,     /**< Used in numpy.random.randn() impl  */
+    DPNP_FN_RNG_GAUSSIAN_EXT, /**< Used in numpy.random.randn() impl, requires
+                                 extra parameters */
+    DPNP_FN_RNG_GEOMETRIC,    /**< Used in numpy.random.geometric() impl  */
+    DPNP_FN_RNG_GEOMETRIC_EXT, /**< Used in numpy.random.geometric() impl,
+                                  requires extra parameters */
+    DPNP_FN_RNG_GUMBEL,        /**< Used in numpy.random.gumbel() impl  */
+    DPNP_FN_RNG_GUMBEL_EXT,    /**< Used in numpy.random.gumbel() impl, requires
+                                  extra parameters */
+    DPNP_FN_RNG_HYPERGEOMETRIC, /**< Used in numpy.random.hypergeometric() impl
+                                 */
+    DPNP_FN_RNG_HYPERGEOMETRIC_EXT, /**< Used in numpy.random.hypergeometric()
+                                       impl, requires extra parameters */
+    DPNP_FN_RNG_LAPLACE,            /**< Used in numpy.random.laplace() impl  */
+    DPNP_FN_RNG_LAPLACE_EXT,        /**< Used in numpy.random.laplace() impl  */
+    DPNP_FN_RNG_LOGISTIC,      /**< Used in numpy.random.logistic() impl  */
+    DPNP_FN_RNG_LOGISTIC_EXT,  /**< Used in numpy.random.logistic() impl,
+                                  requires extra parameters */
+    DPNP_FN_RNG_LOGNORMAL,     /**< Used in numpy.random.lognormal() impl  */
+    DPNP_FN_RNG_LOGNORMAL_EXT, /**< Used in numpy.random.lognormal() impl,
+                                  requires extra parameters */
+    DPNP_FN_RNG_MULTINOMIAL,   /**< Used in numpy.random.multinomial() impl  */
+    DPNP_FN_RNG_MULTINOMIAL_EXT, /**< Used in numpy.random.multinomial() impl,
+                                    requires extra parameters */
+    DPNP_FN_RNG_MULTIVARIATE_NORMAL,     /**< Used in
+                                            numpy.random.multivariate_normal() impl
+                                          */
+    DPNP_FN_RNG_MULTIVARIATE_NORMAL_EXT, /**< Used in
+                                            numpy.random.multivariate_normal()
+                                            impl  */
+    DPNP_FN_RNG_NEGATIVE_BINOMIAL, /**< Used in numpy.random.negative_binomial()
+                                      impl  */
+    DPNP_FN_RNG_NEGATIVE_BINOMIAL_EXT,    /**< Used in
+                                             numpy.random.negative_binomial() impl
+                                           */
+    DPNP_FN_RNG_NONCENTRAL_CHISQUARE,     /**< Used in
+                                             numpy.random.noncentral_chisquare()
+                                             impl  */
+    DPNP_FN_RNG_NONCENTRAL_CHISQUARE_EXT, /**< Used in
+                                             numpy.random.noncentral_chisquare()
+                                             impl  */
+    DPNP_FN_RNG_NORMAL,       /**< Used in numpy.random.normal() impl  */
+    DPNP_FN_RNG_NORMAL_EXT,   /**< Used in numpy.random.normal() impl, requires
+                                 extra parameters */
+    DPNP_FN_RNG_PARETO,       /**< Used in numpy.random.pareto() impl  */
+    DPNP_FN_RNG_PARETO_EXT,   /**< Used in numpy.random.pareto() impl, requires
+                                 extra parameters */
+    DPNP_FN_RNG_POISSON,      /**< Used in numpy.random.poisson() impl  */
+    DPNP_FN_RNG_POISSON_EXT,  /**< Used in numpy.random.poisson() impl, requires
+                                 extra parameters */
+    DPNP_FN_RNG_POWER,        /**< Used in numpy.random.power() impl  */
+    DPNP_FN_RNG_POWER_EXT,    /**< Used in numpy.random.power() impl, requires
+                                 extra parameters */
+    DPNP_FN_RNG_RAYLEIGH,     /**< Used in numpy.random.rayleigh() impl  */
+    DPNP_FN_RNG_RAYLEIGH_EXT, /**< Used in numpy.random.rayleigh() impl,
+                                 requires extra parameters */
+    DPNP_FN_RNG_SRAND,        /**< Used in numpy.random.seed() impl  */
+    DPNP_FN_RNG_SRAND_EXT, /**< Used in numpy.random.seed() impl, requires extra
+                              parameters */
+    DPNP_FN_RNG_SHUFFLE,   /**< Used in numpy.random.shuffle() impl  */
+    DPNP_FN_RNG_SHUFFLE_EXT, /**< Used in numpy.random.shuffle() impl, requires
+                                extra parameters */
+    DPNP_FN_RNG_STANDARD_CAUCHY,     /**< Used in numpy.random.standard_cauchy()
+                                        impl  */
+    DPNP_FN_RNG_STANDARD_CAUCHY_EXT, /**< Used in numpy.random.standard_cauchy()
+                                        impl  */
+    DPNP_FN_RNG_STANDARD_EXPONENTIAL,     /**< Used in
+                                             numpy.random.standard_exponential()
+                                             impl  */
+    DPNP_FN_RNG_STANDARD_EXPONENTIAL_EXT, /**< Used in
+                                             numpy.random.standard_exponential()
+                                             impl  */
+    DPNP_FN_RNG_STANDARD_GAMMA, /**< Used in numpy.random.standard_gamma() impl
+                                 */
+    DPNP_FN_RNG_STANDARD_GAMMA_EXT, /**< Used in numpy.random.standard_gamma()
+                                       impl, requires extra parameters */
+    DPNP_FN_RNG_STANDARD_NORMAL,    /**< Used in numpy.random.standard_normal()
+                                       impl  */
+    DPNP_FN_RNG_STANDARD_T,     /**< Used in numpy.random.standard_t() impl  */
+    DPNP_FN_RNG_STANDARD_T_EXT, /**< Used in numpy.random.standard_t() impl,
+                                   requires extra parameters */
+    DPNP_FN_RNG_TRIANGULAR,     /**< Used in numpy.random.triangular() impl  */
+    DPNP_FN_RNG_TRIANGULAR_EXT, /**< Used in numpy.random.triangular() impl,
+                                   requires extra parameters */
+    DPNP_FN_RNG_UNIFORM,        /**< Used in numpy.random.uniform() impl  */
+    DPNP_FN_RNG_UNIFORM_EXT,  /**< Used in numpy.random.uniform() impl, requires
+                                 extra parameters */
+    DPNP_FN_RNG_VONMISES,     /**< Used in numpy.random.vonmises() impl  */
+    DPNP_FN_RNG_VONMISES_EXT, /**< Used in numpy.random.vonmises() impl,
+                                 requires extra parameters */
+    DPNP_FN_RNG_WALD,         /**< Used in numpy.random.wald() impl  */
+    DPNP_FN_RNG_WALD_EXT, /**< Used in numpy.random.wald() impl, requires extra
+                             parameters */
+    DPNP_FN_RNG_WEIBULL,  /**< Used in numpy.random.weibull() impl  */
+    DPNP_FN_RNG_WEIBULL_EXT, /**< Used in numpy.random.weibull() impl, requires
+                                extra parameters */
+    DPNP_FN_RNG_ZIPF,        /**< Used in numpy.random.zipf() impl  */
+    DPNP_FN_RNG_ZIPF_EXT, /**< Used in numpy.random.zipf() impl, requires extra
+                             parameters */
+    DPNP_FN_SEARCHSORTED, /**< Used in numpy.searchsorted() impl  */
+    DPNP_FN_SEARCHSORTED_EXT, /**< Used in numpy.searchsorted() impl, requires
+                                 extra parameters */
+    DPNP_FN_SIGN,             /**< Used in numpy.sign() impl  */
+    DPNP_FN_SIGN_EXT, /**< Used in numpy.sign() impl, requires extra parameters
+                       */
+    DPNP_FN_SIN,      /**< Used in numpy.sin() impl  */
+    DPNP_FN_SIN_EXT, /**< Used in numpy.sin() impl, requires extra parameters */
+    DPNP_FN_SINH,    /**< Used in numpy.sinh() impl  */
+    DPNP_FN_SINH_EXT, /**< Used in numpy.sinh() impl, requires extra parameters
+                       */
+    DPNP_FN_SORT,     /**< Used in numpy.sort() impl  */
+    DPNP_FN_SORT_EXT, /**< Used in numpy.sort() impl, requires extra parameters
+                       */
+    DPNP_FN_SQRT,     /**< Used in numpy.sqrt() impl  */
+    DPNP_FN_SQRT_EXT, /**< Used in numpy.sqrt() impl, requires extra parameters
+                       */
+    DPNP_FN_SQUARE,   /**< Used in numpy.square() impl  */
+    DPNP_FN_SQUARE_EXT, /**< Used in numpy.square() impl, requires extra
+                           parameters */
+    DPNP_FN_STD,        /**< Used in numpy.std() impl  */
+    DPNP_FN_STD_EXT, /**< Used in numpy.std() impl, requires extra parameters */
+    DPNP_FN_SUBTRACT,     /**< Used in numpy.subtract() impl  */
+    DPNP_FN_SUBTRACT_EXT, /**< Used in numpy.subtract() impl, requires extra
+                             parameters */
+    DPNP_FN_SUM,          /**< Used in numpy.sum() impl  */
+    DPNP_FN_SUM_EXT, /**< Used in numpy.sum() impl, requires extra parameters */
+    DPNP_FN_SVD,     /**< Used in numpy.linalg.svd() impl  */
+    DPNP_FN_SVD_EXT, /**< Used in numpy.linalg.svd() impl, requires extra
+                        parameters */
+    DPNP_FN_TAKE,    /**< Used in numpy.take() impl  */
+    DPNP_FN_TAKE_EXT, /**< Used in numpy.take() impl, requires extra parameters
+                       */
+    DPNP_FN_TAN,      /**< Used in numpy.tan() impl  */
+    DPNP_FN_TAN_EXT, /**< Used in numpy.tan() impl, requires extra parameters */
+    DPNP_FN_TANH,    /**< Used in numpy.tanh() impl  */
+    DPNP_FN_TANH_EXT,  /**< Used in numpy.tanh() impl, requires extra parameters
+                        */
+    DPNP_FN_TRANSPOSE, /**< Used in numpy.transpose() impl  */
+    DPNP_FN_TRACE,     /**< Used in numpy.trace() impl  */
+    DPNP_FN_TRACE_EXT, /**< Used in numpy.trace() impl, requires extra
+                          parameters */
+    DPNP_FN_TRAPZ,     /**< Used in numpy.trapz() impl  */
+    DPNP_FN_TRAPZ_EXT, /**< Used in numpy.trapz() impl, requires extra
+                          parameters */
+    DPNP_FN_TRI,       /**< Used in numpy.tri() impl  */
+    DPNP_FN_TRI_EXT, /**< Used in numpy.tri() impl, requires extra parameters */
+    DPNP_FN_TRIL,    /**< Used in numpy.tril() impl  */
+    DPNP_FN_TRIU,    /**< Used in numpy.triu() impl  */
+    DPNP_FN_TRUNC,   /**< Used in numpy.trunc() impl  */
+    DPNP_FN_TRUNC_EXT,  /**< Used in numpy.trunc() impl, requires extra
+                           parameters */
+    DPNP_FN_VANDER,     /**< Used in numpy.vander() impl  */
+    DPNP_FN_VANDER_EXT, /**< Used in numpy.vander() impl, requires extra
+                           parameters */
+    DPNP_FN_VAR,        /**< Used in numpy.var() impl  */
+    DPNP_FN_VAR_EXT, /**< Used in numpy.var() impl, requires extra parameters */
+    DPNP_FN_ZEROS,   /**< Used in numpy.zeros() impl */
+    DPNP_FN_ZEROS_LIKE, /**< Used in numpy.zeros_like() impl */
+    DPNP_FN_LAST,       /**< The latest element of the enumeration */
 };
 
 /**
@@ -386,18 +540,19 @@ enum class DPNPFuncName : size_t
  */
 enum class DPNPFuncType : size_t
 {
-    DPNP_FT_NONE,     /**< Very first element of the enumeration */
-    DPNP_FT_BOOL,     /**< analog of numpy.bool_ or bool */
-    DPNP_FT_INT,      /**< analog of numpy.int32 or int */
-    DPNP_FT_LONG,     /**< analog of numpy.int64 or long */
-    DPNP_FT_FLOAT,    /**< analog of numpy.float32 or float */
-    DPNP_FT_DOUBLE,   /**< analog of numpy.float32 or double */
-    DPNP_FT_CMPLX64,  /**< analog of numpy.complex64 or std::complex<float> */
-    DPNP_FT_CMPLX128  /**< analog of numpy.complex128 or std::complex<double> */
+    DPNP_FT_NONE,    /**< Very first element of the enumeration */
+    DPNP_FT_BOOL,    /**< analog of numpy.bool_ or bool */
+    DPNP_FT_INT,     /**< analog of numpy.int32 or int */
+    DPNP_FT_LONG,    /**< analog of numpy.int64 or long */
+    DPNP_FT_FLOAT,   /**< analog of numpy.float32 or float */
+    DPNP_FT_DOUBLE,  /**< analog of numpy.float32 or double */
+    DPNP_FT_CMPLX64, /**< analog of numpy.complex64 or std::complex<float> */
+    DPNP_FT_CMPLX128 /**< analog of numpy.complex128 or std::complex<double> */
 };
 
 /**
- * This operator is needed for compatibility with Cython 0.29 which has a bug in Enum handling
+ * This operator is needed for compatibility with Cython 0.29 which has a bug in
+ * Enum handling
  * TODO needs to be deleted in future
  */
 INP_DLLEXPORT
@@ -412,52 +567,58 @@ size_t operator-(DPNPFuncType lhs, DPNPFuncType rhs);
  */
 typedef struct DPNPFuncData
 {
-    DPNPFuncData(const DPNPFuncType gen_type, void* gen_ptr, const DPNPFuncType type_no_fp64, void* ptr_no_fp64)
-        : return_type(gen_type)
-        , ptr(gen_ptr)
-        , return_type_no_fp64(type_no_fp64)
-        , ptr_no_fp64(ptr_no_fp64)
+    DPNPFuncData(const DPNPFuncType gen_type,
+                 void *gen_ptr,
+                 const DPNPFuncType type_no_fp64,
+                 void *ptr_no_fp64)
+        : return_type(gen_type), ptr(gen_ptr),
+          return_type_no_fp64(type_no_fp64), ptr_no_fp64(ptr_no_fp64)
     {
     }
-    DPNPFuncData(const DPNPFuncType gen_type, void* gen_ptr)
+    DPNPFuncData(const DPNPFuncType gen_type, void *gen_ptr)
         : DPNPFuncData(gen_type, gen_ptr, DPNPFuncType::DPNP_FT_NONE, nullptr)
     {
     }
-    DPNPFuncData()
-        : DPNPFuncData(DPNPFuncType::DPNP_FT_NONE, nullptr)
-    {
-    }
+    DPNPFuncData() : DPNPFuncData(DPNPFuncType::DPNP_FT_NONE, nullptr) {}
 
-    DPNPFuncType return_type;         /**< return type identifier which expected by the @ref ptr function */
-    void* ptr;                        /**< C++ backend function pointer */
-    DPNPFuncType return_type_no_fp64; /**< alternative return type identifier when no fp64 support by device */
-    void* ptr_no_fp64;                /**< alternative C++ backend function pointer when no fp64 support by device */
+    DPNPFuncType return_type; /**< return type identifier which expected by the
+                                 @ref ptr function */
+    void *ptr;                /**< C++ backend function pointer */
+    DPNPFuncType return_type_no_fp64; /**< alternative return type identifier
+                                         when no fp64 support by device */
+    void *ptr_no_fp64; /**< alternative C++ backend function pointer when no
+                          fp64 support by device */
 } DPNPFuncData_t;
 
 /**
  * @ingroup BACKEND_API
  * @brief get runtime pointer to selected function
  *
- * Runtime pointer to the backend API function from storage map<name, map<first_type, map<second_type, DPNPFuncData_t>>>
+ * Runtime pointer to the backend API function from storage map<name,
+ * map<first_type, map<second_type, DPNPFuncData_t>>>
  *
  * @param [in]  name         Name of the function in storage
  * @param [in]  first_type   First type of the storage
  * @param [in]  second_type  Second type of the storage
  *
- * @return Struct @ref DPNPFuncData_t with information about the backend API function.
+ * @return Struct @ref DPNPFuncData_t with information about the backend API
+ * function.
  */
 INP_DLLEXPORT
-DPNPFuncData_t get_dpnp_function_ptr(DPNPFuncName name,
-                                     DPNPFuncType first_type,
-                                     DPNPFuncType second_type = DPNPFuncType::DPNP_FT_NONE);
+DPNPFuncData_t get_dpnp_function_ptr(
+    DPNPFuncName name,
+    DPNPFuncType first_type,
+    DPNPFuncType second_type = DPNPFuncType::DPNP_FT_NONE);
 
 /**
  * @ingroup BACKEND_API
  * @brief get runtime pointer to selected function
  *
- * Same interface function as @ref get_dpnp_function_ptr with a bit diffrent interface
+ * Same interface function as @ref get_dpnp_function_ptr with a bit diffrent
+ * interface
  *
- * @param [out] result_type  Type of the result provided by the backend API function
+ * @param [out] result_type  Type of the result provided by the backend API
+ * function
  * @param [in]  name         Name of the function in storage
  * @param [in]  first_type   First type of the storage
  * @param [in]  second_type  Second type of the storage
@@ -465,18 +626,20 @@ DPNPFuncData_t get_dpnp_function_ptr(DPNPFuncName name,
  * @return pointer to the backend API function.
  */
 INP_DLLEXPORT
-void* get_dpnp_function_ptr1(DPNPFuncType& result_type,
-                             DPNPFuncName name,
-                             DPNPFuncType first_type,
-                             DPNPFuncType second_type = DPNPFuncType::DPNP_FT_NONE);
+void *get_dpnp_function_ptr1(
+    DPNPFuncType &result_type,
+    DPNPFuncName name,
+    DPNPFuncType first_type,
+    DPNPFuncType second_type = DPNPFuncType::DPNP_FT_NONE);
 
 /**
  * DEPRECATED.
  * Experimental interface. DO NOT USE IT!
  *
- * parameter @ref type_name will be converted into var_args or char *[] with extra length parameter
+ * parameter @ref type_name will be converted into var_args or char *[] with
+ * extra length parameter
  */
 INP_DLLEXPORT
-void* get_backend_function_name(const char* func_name, const char* type_name);
+void *get_backend_function_name(const char *func_name, const char *type_name);
 
 #endif // BACKEND_IFACE_FPTR_H

--- a/dpnp/backend/include/dpnp_iface_random.hpp
+++ b/dpnp/backend/include/dpnp_iface_random.hpp
@@ -25,11 +25,12 @@
 
 /*
  * This header file is for interface Cython with C++.
- * It should not contains any backend specific headers (like SYCL or math library) because
- * all included headers will be exposed in Cython compilation procedure
+ * It should not contains any backend specific headers (like SYCL or math
+ * library) because all included headers will be exposed in Cython compilation
+ * procedure
  *
- * We would like to avoid backend specific things in higher level Cython modules.
- * Any backend interface functions and types should be defined here.
+ * We would like to avoid backend specific things in higher level Cython
+ * modules. Any backend interface functions and types should be defined here.
  *
  * Also, this file should contains documentation on functions and types
  * which are used in the interface
@@ -48,7 +49,8 @@
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (beta distribution)
+ * @brief math library implementation of random number generator (beta
+ * distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -58,19 +60,24 @@
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_beta_c(DPCTLSyclQueueRef q_ref,
-                                                void* result,
-                                                const _DataType a,
-                                                const _DataType b,
-                                                const size_t size,
-                                                const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_beta_c(DPCTLSyclQueueRef q_ref,
+                    void *result,
+                    const _DataType a,
+                    const _DataType b,
+                    const size_t size,
+                    const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_beta_c(void* result, const _DataType a, const _DataType b, const size_t size);
+INP_DLLEXPORT void dpnp_rng_beta_c(void *result,
+                                   const _DataType a,
+                                   const _DataType b,
+                                   const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (binomial distribution)
+ * @brief math library implementation of random number generator (binomial
+ * distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -80,19 +87,24 @@ INP_DLLEXPORT void dpnp_rng_beta_c(void* result, const _DataType a, const _DataT
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_binomial_c(DPCTLSyclQueueRef q_ref,
-                                                    void* result,
-                                                    const int ntrial,
-                                                    const double p,
-                                                    const size_t size,
-                                                    const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_binomial_c(DPCTLSyclQueueRef q_ref,
+                        void *result,
+                        const int ntrial,
+                        const double p,
+                        const size_t size,
+                        const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_binomial_c(void* result, const int ntrial, const double p, const size_t size);
+INP_DLLEXPORT void dpnp_rng_binomial_c(void *result,
+                                       const int ntrial,
+                                       const double p,
+                                       const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (chi-square distribution)
+ * @brief math library implementation of random number generator (chi-square
+ * distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -101,18 +113,21 @@ INP_DLLEXPORT void dpnp_rng_binomial_c(void* result, const int ntrial, const dou
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_chisquare_c(DPCTLSyclQueueRef q_ref,
-                                                     void* result,
-                                                     const int df,
-                                                     const size_t size,
-                                                     const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_chisquare_c(DPCTLSyclQueueRef q_ref,
+                         void *result,
+                         const int df,
+                         const size_t size,
+                         const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_chisquare_c(void* result, const int df, const size_t size);
+INP_DLLEXPORT void
+    dpnp_rng_chisquare_c(void *result, const int df, const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (exponential distribution)
+ * @brief math library implementation of random number generator (exponential
+ * distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -121,18 +136,22 @@ INP_DLLEXPORT void dpnp_rng_chisquare_c(void* result, const int df, const size_t
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_exponential_c(DPCTLSyclQueueRef q_ref,
-                                                       void* result,
-                                                       const _DataType beta,
-                                                       const size_t size,
-                                                       const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_exponential_c(DPCTLSyclQueueRef q_ref,
+                           void *result,
+                           const _DataType beta,
+                           const size_t size,
+                           const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_exponential_c(void* result, const _DataType beta, const size_t size);
+INP_DLLEXPORT void dpnp_rng_exponential_c(void *result,
+                                          const _DataType beta,
+                                          const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (F distribution)
+ * @brief math library implementation of random number generator (F
+ * distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -142,19 +161,24 @@ INP_DLLEXPORT void dpnp_rng_exponential_c(void* result, const _DataType beta, co
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_f_c(DPCTLSyclQueueRef q_ref,
-                                             void* result,
-                                             const _DataType df_num,
-                                             const _DataType df_den,
-                                             const size_t size,
-                                             const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_f_c(DPCTLSyclQueueRef q_ref,
+                 void *result,
+                 const _DataType df_num,
+                 const _DataType df_den,
+                 const size_t size,
+                 const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_f_c(void* result, const _DataType df_num, const _DataType df_den, const size_t size);
+INP_DLLEXPORT void dpnp_rng_f_c(void *result,
+                                const _DataType df_num,
+                                const _DataType df_den,
+                                const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (gamma distribution)
+ * @brief math library implementation of random number generator (gamma
+ * distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -164,19 +188,24 @@ INP_DLLEXPORT void dpnp_rng_f_c(void* result, const _DataType df_num, const _Dat
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_gamma_c(DPCTLSyclQueueRef q_ref,
-                                                 void* result,
-                                                 const _DataType shape,
-                                                 const _DataType scale,
-                                                 const size_t size,
-                                                 const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_gamma_c(DPCTLSyclQueueRef q_ref,
+                     void *result,
+                     const _DataType shape,
+                     const _DataType scale,
+                     const size_t size,
+                     const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_gamma_c(void* result, const _DataType shape, const _DataType scale, const size_t size);
+INP_DLLEXPORT void dpnp_rng_gamma_c(void *result,
+                                    const _DataType shape,
+                                    const _DataType scale,
+                                    const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (gaussian continious distribution)
+ * @brief math library implementation of random number generator (gaussian
+ * continious distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -186,61 +215,77 @@ INP_DLLEXPORT void dpnp_rng_gamma_c(void* result, const _DataType shape, const _
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_gaussian_c(DPCTLSyclQueueRef q_ref,
-                                                    void* result,
-                                                    const _DataType mean,
-                                                    const _DataType stddev,
-                                                    const size_t size,
-                                                    const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_gaussian_c(DPCTLSyclQueueRef q_ref,
+                        void *result,
+                        const _DataType mean,
+                        const _DataType stddev,
+                        const size_t size,
+                        const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_gaussian_c(void* result, const _DataType mean, const _DataType stddev, const size_t size);
+INP_DLLEXPORT void dpnp_rng_gaussian_c(void *result,
+                                       const _DataType mean,
+                                       const _DataType stddev,
+                                       const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (Geometric distribution)
+ * @brief math library implementation of random number generator (Geometric
+ * distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
- * @param [in]  p                   The probability of success of an individual trial.
+ * @param [in]  p                   The probability of success of an individual
+ * trial.
  * @param [in]  size                Number of elements in `result` arrays.
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_geometric_c(DPCTLSyclQueueRef q_ref,
-                                                     void* result,
-                                                     const float p,
-                                                     const size_t size,
-                                                     const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_geometric_c(DPCTLSyclQueueRef q_ref,
+                         void *result,
+                         const float p,
+                         const size_t size,
+                         const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_geometric_c(void* result, const float p, const size_t size);
+INP_DLLEXPORT void
+    dpnp_rng_geometric_c(void *result, const float p, const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (Gumbel distribution)
+ * @brief math library implementation of random number generator (Gumbel
+ * distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
- * @param [in]  loc                 The location of the mode of the distribution.
- * @param [in]  scale               The scale parameter of the distribution. Default is 1.
+ * @param [in]  loc                 The location of the mode of the
+ * distribution.
+ * @param [in]  scale               The scale parameter of the distribution.
+ * Default is 1.
  * @param [in]  size                Number of elements in `result` arrays.
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_gumbel_c(DPCTLSyclQueueRef q_ref,
-                                                  void* result,
-                                                  const double loc,
-                                                  const double scale,
-                                                  const size_t size,
-                                                  const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_gumbel_c(DPCTLSyclQueueRef q_ref,
+                      void *result,
+                      const double loc,
+                      const double scale,
+                      const size_t size,
+                      const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_gumbel_c(void* result, const double loc, const double scale, const size_t size);
+INP_DLLEXPORT void dpnp_rng_gumbel_c(void *result,
+                                     const double loc,
+                                     const double scale,
+                                     const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (hypergeometric distribution)
+ * @brief math library implementation of random number generator (hypergeometric
+ * distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -251,20 +296,26 @@ INP_DLLEXPORT void dpnp_rng_gumbel_c(void* result, const double loc, const doubl
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_hypergeometric_c(DPCTLSyclQueueRef q_ref,
-                                                          void* result,
-                                                          const int l,
-                                                          const int s,
-                                                          const int m,
-                                                          const size_t size,
-                                                          const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_hypergeometric_c(DPCTLSyclQueueRef q_ref,
+                              void *result,
+                              const int l,
+                              const int s,
+                              const int m,
+                              const size_t size,
+                              const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_hypergeometric_c(void* result, const int l, const int s, const int m, const size_t size);
+INP_DLLEXPORT void dpnp_rng_hypergeometric_c(void *result,
+                                             const int l,
+                                             const int s,
+                                             const int m,
+                                             const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (laplace distribution)
+ * @brief math library implementation of random number generator (laplace
+ * distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -274,19 +325,24 @@ INP_DLLEXPORT void dpnp_rng_hypergeometric_c(void* result, const int l, const in
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_laplace_c(DPCTLSyclQueueRef q_ref,
-                                                   void* result,
-                                                   const double loc,
-                                                   const double scale,
-                                                   const size_t size,
-                                                   const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_laplace_c(DPCTLSyclQueueRef q_ref,
+                       void *result,
+                       const double loc,
+                       const double scale,
+                       const size_t size,
+                       const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_laplace_c(void* result, const double loc, const double scale, const size_t size);
+INP_DLLEXPORT void dpnp_rng_laplace_c(void *result,
+                                      const double loc,
+                                      const double scale,
+                                      const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (logistic distribution)
+ * @brief math library implementation of random number generator (logistic
+ * distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -296,19 +352,24 @@ INP_DLLEXPORT void dpnp_rng_laplace_c(void* result, const double loc, const doub
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_logistic_c(DPCTLSyclQueueRef q_ref,
-                                                    void* result,
-                                                    const double loc,
-                                                    double const scale,
-                                                    const size_t size,
-                                                    const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_logistic_c(DPCTLSyclQueueRef q_ref,
+                        void *result,
+                        const double loc,
+                        double const scale,
+                        const size_t size,
+                        const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_logistic_c(void* result, const double loc, double const scale, const size_t size);
+INP_DLLEXPORT void dpnp_rng_logistic_c(void *result,
+                                       const double loc,
+                                       double const scale,
+                                       const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (lognormal distribution)
+ * @brief math library implementation of random number generator (lognormal
+ * distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -318,19 +379,24 @@ INP_DLLEXPORT void dpnp_rng_logistic_c(void* result, const double loc, double co
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_lognormal_c(DPCTLSyclQueueRef q_ref,
-                                                     void* result,
-                                                     const _DataType mean,
-                                                     const _DataType stddev,
-                                                     const size_t size,
-                                                     const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_lognormal_c(DPCTLSyclQueueRef q_ref,
+                         void *result,
+                         const _DataType mean,
+                         const _DataType stddev,
+                         const size_t size,
+                         const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_lognormal_c(void* result, const _DataType mean, const _DataType stddev, const size_t size);
+INP_DLLEXPORT void dpnp_rng_lognormal_c(void *result,
+                                        const _DataType mean,
+                                        const _DataType stddev,
+                                        const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (multinomial distribution)
+ * @brief math library implementation of random number generator (multinomial
+ * distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -341,21 +407,26 @@ INP_DLLEXPORT void dpnp_rng_lognormal_c(void* result, const _DataType mean, cons
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_multinomial_c(DPCTLSyclQueueRef q_ref,
-                                                       void* result,
-                                                       const int ntrial,
-                                                       const double* p_in,
-                                                       const size_t p_size,
-                                                       const size_t size,
-                                                       const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_multinomial_c(DPCTLSyclQueueRef q_ref,
+                           void *result,
+                           const int ntrial,
+                           const double *p_in,
+                           const size_t p_size,
+                           const size_t size,
+                           const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_multinomial_c(
-    void* result, const int ntrial, const double* p_in, const size_t p_size, const size_t size);
+INP_DLLEXPORT void dpnp_rng_multinomial_c(void *result,
+                                          const int ntrial,
+                                          const double *p_in,
+                                          const size_t p_size,
+                                          const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (multivariate normal distribution)
+ * @brief math library implementation of random number generator (multivariate
+ * normal distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -368,51 +439,59 @@ INP_DLLEXPORT void dpnp_rng_multinomial_c(
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_multivariate_normal_c(DPCTLSyclQueueRef q_ref,
-                                                               void* result,
-                                                               const int dimen,
-                                                               const double* mean_in,
-                                                               const size_t mean_size,
-                                                               const double* cov_in,
-                                                               const size_t cov_size,
-                                                               const size_t size,
-                                                               const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_multivariate_normal_c(DPCTLSyclQueueRef q_ref,
+                                   void *result,
+                                   const int dimen,
+                                   const double *mean_in,
+                                   const size_t mean_size,
+                                   const double *cov_in,
+                                   const size_t cov_size,
+                                   const size_t size,
+                                   const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_multivariate_normal_c(void* result,
+INP_DLLEXPORT void dpnp_rng_multivariate_normal_c(void *result,
                                                   const int dimen,
-                                                  const double* mean_in,
+                                                  const double *mean_in,
                                                   const size_t mean_size,
-                                                  const double* cov_in,
+                                                  const double *cov_in,
                                                   const size_t cov_size,
                                                   const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (negative binomial distribution)
+ * @brief math library implementation of random number generator (negative
+ * binomial distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
  * @param [in]  a                   The first distribution parameter a, > 0.
- * @param [in]  p                   The second distribution parameter p, >= 0 and <=1.
+ * @param [in]  p                   The second distribution parameter p, >= 0
+ * and <=1.
  * @param [in]  size                Number of elements in `result` arrays.
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  *
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_negative_binomial_c(DPCTLSyclQueueRef q_ref,
-                                                             void* result,
-                                                             const double a,
-                                                             const double p,
-                                                             const size_t size,
-                                                             const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_negative_binomial_c(DPCTLSyclQueueRef q_ref,
+                                 void *result,
+                                 const double a,
+                                 const double p,
+                                 const size_t size,
+                                 const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_negative_binomial_c(void* result, const double a, const double p, const size_t size);
+INP_DLLEXPORT void dpnp_rng_negative_binomial_c(void *result,
+                                                const double a,
+                                                const double p,
+                                                const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (noncentral chisquare distribution)
+ * @brief math library implementation of random number generator (noncentral
+ * chisquare distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -422,20 +501,24 @@ INP_DLLEXPORT void dpnp_rng_negative_binomial_c(void* result, const double a, co
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_noncentral_chisquare_c(DPCTLSyclQueueRef q_ref,
-                                                                void* result,
-                                                                const _DataType df,
-                                                                const _DataType nonc,
-                                                                const size_t size,
-                                                                const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_noncentral_chisquare_c(
+    DPCTLSyclQueueRef q_ref,
+    void *result,
+    const _DataType df,
+    const _DataType nonc,
+    const size_t size,
+    const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void
-    dpnp_rng_noncentral_chisquare_c(void* result, const _DataType df, const _DataType nonc, const size_t size);
+INP_DLLEXPORT void dpnp_rng_noncentral_chisquare_c(void *result,
+                                                   const _DataType df,
+                                                   const _DataType nonc,
+                                                   const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (normal continious distribution)
+ * @brief math library implementation of random number generator (normal
+ * continious distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result_out          Output array.
@@ -446,20 +529,25 @@ INP_DLLEXPORT void
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_normal_c(DPCTLSyclQueueRef q_ref,
-                                                  void* result_out,
-                                                  const double mean,
-                                                  const double stddev,
-                                                  const int64_t size,
-                                                  void* random_state_in,
-                                                  const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_normal_c(DPCTLSyclQueueRef q_ref,
+                      void *result_out,
+                      const double mean,
+                      const double stddev,
+                      const int64_t size,
+                      void *random_state_in,
+                      const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_normal_c(void* result, const _DataType mean, const _DataType stddev, const size_t size);
+INP_DLLEXPORT void dpnp_rng_normal_c(void *result,
+                                     const _DataType mean,
+                                     const _DataType stddev,
+                                     const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (Pareto distribution)
+ * @brief math library implementation of random number generator (Pareto
+ * distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -468,18 +556,21 @@ INP_DLLEXPORT void dpnp_rng_normal_c(void* result, const _DataType mean, const _
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_pareto_c(DPCTLSyclQueueRef q_ref,
-                                                  void* result,
-                                                  const double alpha,
-                                                  const size_t size,
-                                                  const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_pareto_c(DPCTLSyclQueueRef q_ref,
+                      void *result,
+                      const double alpha,
+                      const size_t size,
+                      const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_pareto_c(void* result, const double alpha, const size_t size);
+INP_DLLEXPORT void
+    dpnp_rng_pareto_c(void *result, const double alpha, const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (poisson distribution)
+ * @brief math library implementation of random number generator (poisson
+ * distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -488,18 +579,21 @@ INP_DLLEXPORT void dpnp_rng_pareto_c(void* result, const double alpha, const siz
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_poisson_c(DPCTLSyclQueueRef q_ref,
-                                                   void* result,
-                                                   const double lambda,
-                                                   const size_t size,
-                                                   const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_poisson_c(DPCTLSyclQueueRef q_ref,
+                       void *result,
+                       const double lambda,
+                       const size_t size,
+                       const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_poisson_c(void* result, const double lambda, const size_t size);
+INP_DLLEXPORT void
+    dpnp_rng_poisson_c(void *result, const double lambda, const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (power distribution)
+ * @brief math library implementation of random number generator (power
+ * distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -508,18 +602,21 @@ INP_DLLEXPORT void dpnp_rng_poisson_c(void* result, const double lambda, const s
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_power_c(DPCTLSyclQueueRef q_ref,
-                                                 void* result,
-                                                 const double alpha,
-                                                 const size_t size,
-                                                 const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_power_c(DPCTLSyclQueueRef q_ref,
+                     void *result,
+                     const double alpha,
+                     const size_t size,
+                     const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_power_c(void* result, const double alpha, const size_t size);
+INP_DLLEXPORT void
+    dpnp_rng_power_c(void *result, const double alpha, const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (rayleigh distribution)
+ * @brief math library implementation of random number generator (rayleigh
+ * distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -528,14 +625,16 @@ INP_DLLEXPORT void dpnp_rng_power_c(void* result, const double alpha, const size
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_rayleigh_c(DPCTLSyclQueueRef q_ref,
-                                                    void* result,
-                                                    const _DataType scale,
-                                                    const size_t size,
-                                                    const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_rayleigh_c(DPCTLSyclQueueRef q_ref,
+                        void *result,
+                        const _DataType scale,
+                        const size_t size,
+                        const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_rayleigh_c(void* result, const _DataType scale, const size_t size);
+INP_DLLEXPORT void
+    dpnp_rng_rayleigh_c(void *result, const _DataType scale, const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
@@ -544,23 +643,29 @@ INP_DLLEXPORT void dpnp_rng_rayleigh_c(void* result, const _DataType scale, cons
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Input/output array.
  * @param [in]  itemsize            Length of `result` array element in bytes.
- * @param [in]  ndim                Number of array dimensions in `result` arrays.
- * @param [in]  high_dim_size       Number of elements in `result` arrays higer dimension, or len(result).
+ * @param [in]  ndim                Number of array dimensions in `result`
+ * arrays.
+ * @param [in]  high_dim_size       Number of elements in `result` arrays higer
+ * dimension, or len(result).
  * @param [in]  size                Number of elements in `result` arrays.
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_shuffle_c(DPCTLSyclQueueRef q_ref,
-                                                   void* result,
-                                                   const size_t itemsize,
-                                                   const size_t ndim,
-                                                   const size_t high_dim_size,
-                                                   const size_t size,
-                                                   const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_shuffle_c(DPCTLSyclQueueRef q_ref,
+                       void *result,
+                       const size_t itemsize,
+                       const size_t ndim,
+                       const size_t high_dim_size,
+                       const size_t size,
+                       const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_shuffle_c(
-    void* result, const size_t itemsize, const size_t ndim, const size_t high_dim_size, const size_t size);
+INP_DLLEXPORT void dpnp_rng_shuffle_c(void *result,
+                                      const size_t itemsize,
+                                      const size_t ndim,
+                                      const size_t high_dim_size,
+                                      const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
@@ -572,7 +677,8 @@ INP_DLLEXPORT void dpnp_rng_srand_c(size_t seed = 1);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (standard cauchy distribution)
+ * @brief math library implementation of random number generator (standard
+ * cauchy distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -580,17 +686,19 @@ INP_DLLEXPORT void dpnp_rng_srand_c(size_t seed = 1);
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_standard_cauchy_c(DPCTLSyclQueueRef q_ref,
-                                                           void* result,
-                                                           const size_t size,
-                                                           const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_standard_cauchy_c(DPCTLSyclQueueRef q_ref,
+                               void *result,
+                               const size_t size,
+                               const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_standard_cauchy_c(void* result, const size_t size);
+INP_DLLEXPORT void dpnp_rng_standard_cauchy_c(void *result, const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (standard exponential distribution)
+ * @brief math library implementation of random number generator (standard
+ * exponential distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -598,17 +706,20 @@ INP_DLLEXPORT void dpnp_rng_standard_cauchy_c(void* result, const size_t size);
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_standard_exponential_c(DPCTLSyclQueueRef q_ref,
-                                                                void* result,
-                                                                const size_t size,
-                                                                const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_standard_exponential_c(
+    DPCTLSyclQueueRef q_ref,
+    void *result,
+    const size_t size,
+    const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_standard_exponential_c(void* result, const size_t size);
+INP_DLLEXPORT void dpnp_rng_standard_exponential_c(void *result,
+                                                   const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (standard gamma distribution)
+ * @brief math library implementation of random number generator (standard gamma
+ * distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -617,18 +728,22 @@ INP_DLLEXPORT void dpnp_rng_standard_exponential_c(void* result, const size_t si
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_standard_gamma_c(DPCTLSyclQueueRef q_ref,
-                                                          void* result,
-                                                          const _DataType shape,
-                                                          const size_t size,
-                                                          const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_standard_gamma_c(DPCTLSyclQueueRef q_ref,
+                              void *result,
+                              const _DataType shape,
+                              const size_t size,
+                              const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_standard_gamma_c(void* result, const _DataType shape, const size_t size);
+INP_DLLEXPORT void dpnp_rng_standard_gamma_c(void *result,
+                                             const _DataType shape,
+                                             const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (standard normal distribution)
+ * @brief math library implementation of random number generator (standard
+ * normal distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result_out          Output array.
@@ -636,11 +751,12 @@ INP_DLLEXPORT void dpnp_rng_standard_gamma_c(void* result, const _DataType shape
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_standard_normal_c(void* result, const size_t size);
+INP_DLLEXPORT void dpnp_rng_standard_normal_c(void *result, const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (standard Student's t distribution)
+ * @brief math library implementation of random number generator (standard
+ * Student's t distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -649,43 +765,52 @@ INP_DLLEXPORT void dpnp_rng_standard_normal_c(void* result, const size_t size);
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_standard_t_c(DPCTLSyclQueueRef q_ref,
-                                                      void* result,
-                                                      const _DataType df,
-                                                      const size_t size,
-                                                      const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_standard_t_c(DPCTLSyclQueueRef q_ref,
+                          void *result,
+                          const _DataType df,
+                          const size_t size,
+                          const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_standard_t_c(void* result, const _DataType df, const size_t size);
+INP_DLLEXPORT void
+    dpnp_rng_standard_t_c(void *result, const _DataType df, const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (Triangular distribution)
+ * @brief math library implementation of random number generator (Triangular
+ * distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
  * @param [in]  x_min               Lower limit.
- * @param [in]  x_mode              The value where the peak of the distribution occurs.
+ * @param [in]  x_mode              The value where the peak of the distribution
+ * occurs.
  * @param [in]  x_max               Upper limit.
  * @param [in]  size                Number of elements in `result` arrays.
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_triangular_c(DPCTLSyclQueueRef q_ref,
-                                                      void* result,
-                                                      const _DataType x_min,
-                                                      const _DataType x_mode,
-                                                      const _DataType x_max,
-                                                      const size_t size,
-                                                      const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_triangular_c(DPCTLSyclQueueRef q_ref,
+                          void *result,
+                          const _DataType x_min,
+                          const _DataType x_mode,
+                          const _DataType x_max,
+                          const size_t size,
+                          const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_triangular_c(
-    void* result, const _DataType x_min, const _DataType x_mode, const _DataType x_max, const size_t size);
+INP_DLLEXPORT void dpnp_rng_triangular_c(void *result,
+                                         const _DataType x_min,
+                                         const _DataType x_mode,
+                                         const _DataType x_max,
+                                         const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (uniform distribution)
+ * @brief math library implementation of random number generator (uniform
+ * distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result_out          Output array.
@@ -696,20 +821,25 @@ INP_DLLEXPORT void dpnp_rng_triangular_c(
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_uniform_c(DPCTLSyclQueueRef q_ref,
-                                                   void* result_out,
-                                                   const double low,
-                                                   const double high,
-                                                   const int64_t size,
-                                                   void* random_state_in,
-                                                   const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_uniform_c(DPCTLSyclQueueRef q_ref,
+                       void *result_out,
+                       const double low,
+                       const double high,
+                       const int64_t size,
+                       void *random_state_in,
+                       const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_uniform_c(void* result, const long low, const long high, const size_t size);
+INP_DLLEXPORT void dpnp_rng_uniform_c(void *result,
+                                      const long low,
+                                      const long high,
+                                      const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (Vonmises distribution)
+ * @brief math library implementation of random number generator (Vonmises
+ * distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -719,19 +849,24 @@ INP_DLLEXPORT void dpnp_rng_uniform_c(void* result, const long low, const long h
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_vonmises_c(DPCTLSyclQueueRef q_ref,
-                                                    void* result,
-                                                    const _DataType mu,
-                                                    const _DataType kappa,
-                                                    const size_t size,
-                                                    const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_vonmises_c(DPCTLSyclQueueRef q_ref,
+                        void *result,
+                        const _DataType mu,
+                        const _DataType kappa,
+                        const size_t size,
+                        const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_vonmises_c(void* result, const _DataType mu, const _DataType kappa, const size_t size);
+INP_DLLEXPORT void dpnp_rng_vonmises_c(void *result,
+                                       const _DataType mu,
+                                       const _DataType kappa,
+                                       const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (Wald's distribution)
+ * @brief math library implementation of random number generator (Wald's
+ * distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -741,19 +876,24 @@ INP_DLLEXPORT void dpnp_rng_vonmises_c(void* result, const _DataType mu, const _
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_wald_c(DPCTLSyclQueueRef q_ref,
-                                                void* result,
-                                                const _DataType mean,
-                                                const _DataType scale,
-                                                size_t size,
-                                                const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_wald_c(DPCTLSyclQueueRef q_ref,
+                    void *result,
+                    const _DataType mean,
+                    const _DataType scale,
+                    size_t size,
+                    const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_wald_c(void* result, const _DataType mean, const _DataType scale, size_t size);
+INP_DLLEXPORT void dpnp_rng_wald_c(void *result,
+                                   const _DataType mean,
+                                   const _DataType scale,
+                                   size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (weibull distribution)
+ * @brief math library implementation of random number generator (weibull
+ * distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -762,18 +902,21 @@ INP_DLLEXPORT void dpnp_rng_wald_c(void* result, const _DataType mean, const _Da
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_weibull_c(DPCTLSyclQueueRef q_ref,
-                                                   void* result,
-                                                   const double alpha,
-                                                   const size_t size,
-                                                   const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_weibull_c(DPCTLSyclQueueRef q_ref,
+                       void *result,
+                       const double alpha,
+                       const size_t size,
+                       const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_weibull_c(void* result, const double alpha, const size_t size);
+INP_DLLEXPORT void
+    dpnp_rng_weibull_c(void *result, const double alpha, const size_t size);
 
 /**
  * @ingroup BACKEND_RANDOM_API
- * @brief math library implementation of random number generator (Zipf distribution)
+ * @brief math library implementation of random number generator (Zipf
+ * distribution)
  *
  * @param [in]  q_ref               Reference to SYCL queue.
  * @param [out] result              Output array.
@@ -782,13 +925,15 @@ INP_DLLEXPORT void dpnp_rng_weibull_c(void* result, const double alpha, const si
  * @param [in]  dep_event_vec_ref   Reference to vector of SYCL events.
  */
 template <typename _DataType>
-INP_DLLEXPORT DPCTLSyclEventRef dpnp_rng_zipf_c(DPCTLSyclQueueRef q_ref,
-                                                void* result,
-                                                const _DataType a,
-                                                const size_t size,
-                                                const DPCTLEventVectorRef dep_event_vec_ref);
+INP_DLLEXPORT DPCTLSyclEventRef
+    dpnp_rng_zipf_c(DPCTLSyclQueueRef q_ref,
+                    void *result,
+                    const _DataType a,
+                    const size_t size,
+                    const DPCTLEventVectorRef dep_event_vec_ref);
 
 template <typename _DataType>
-INP_DLLEXPORT void dpnp_rng_zipf_c(void* result, const _DataType a, const size_t size);
+INP_DLLEXPORT void
+    dpnp_rng_zipf_c(void *result, const _DataType a, const size_t size);
 
 #endif // BACKEND_IFACE_RANDOM_H

--- a/dpnp/backend/kernels/dpnp_krnl_arraycreation.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_arraycreation.cpp
@@ -38,11 +38,12 @@ template <typename _DataType>
 DPCTLSyclEventRef dpnp_arange_c(DPCTLSyclQueueRef q_ref,
                                 size_t start,
                                 size_t step,
-                                void* result1,
+                                void *result1,
                                 size_t size,
                                 const DPCTLEventVectorRef dep_event_vec_ref)
 {
-    // parameter `size` used instead `stop` to avoid dependency on array length calculation algorithm
+    // parameter `size` used instead `stop` to avoid dependency on array length
+    // calculation algorithm
     // TODO: floating point (and negatives) types from `start` and `step`
 
     // avoid warning unused variable
@@ -50,17 +51,16 @@ DPCTLSyclEventRef dpnp_arange_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
     sycl::event event;
 
     validate_type_for_device<_DataType>(q);
 
-    _DataType* result = reinterpret_cast<_DataType*>(result1);
+    _DataType *result = reinterpret_cast<_DataType *>(result1);
 
     sycl::range<1> gws(size);
     auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
@@ -69,71 +69,69 @@ DPCTLSyclEventRef dpnp_arange_c(DPCTLSyclQueueRef q_ref,
         result[i] = start + i * step;
     };
 
-    auto kernel_func = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class dpnp_arange_c_kernel<_DataType>>(gws, kernel_parallel_for_func);
+    auto kernel_func = [&](sycl::handler &cgh) {
+        cgh.parallel_for<class dpnp_arange_c_kernel<_DataType>>(
+            gws, kernel_parallel_for_func);
     };
 
-    event = q.submit(kernel_func);
+    event     = q.submit(kernel_func);
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
 
     return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType>
-void dpnp_arange_c(size_t start, size_t step, void* result1, size_t size)
+void dpnp_arange_c(size_t start, size_t step, void *result1, size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_arange_c<_DataType>(q_ref,
-                                                           start,
-                                                           step,
-                                                           result1,
-                                                           size,
-                                                           dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_arange_c<_DataType>(
+        q_ref, start, step, result1, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_arange_default_c)(size_t, size_t, void*, size_t) = dpnp_arange_c<_DataType>;
+void (*dpnp_arange_default_c)(size_t, size_t, void *, size_t) =
+    dpnp_arange_c<_DataType>;
 
-// Explicit instantiation of the function, since dpnp_arange_c() is used by other template functions,
-// but implicit instantiation is not applied anymore.
+// Explicit instantiation of the function, since dpnp_arange_c() is used by
+// other template functions, but implicit instantiation is not applied anymore.
 template DPCTLSyclEventRef dpnp_arange_c<int32_t>(DPCTLSyclQueueRef,
                                                   size_t,
                                                   size_t,
-                                                  void*,
+                                                  void *,
                                                   size_t,
                                                   const DPCTLEventVectorRef);
 
 template DPCTLSyclEventRef dpnp_arange_c<int64_t>(DPCTLSyclQueueRef,
                                                   size_t,
                                                   size_t,
-                                                  void*,
+                                                  void *,
                                                   size_t,
                                                   const DPCTLEventVectorRef);
 
 template DPCTLSyclEventRef dpnp_arange_c<float>(DPCTLSyclQueueRef,
                                                 size_t,
                                                 size_t,
-                                                void*,
+                                                void *,
                                                 size_t,
                                                 const DPCTLEventVectorRef);
 
 template DPCTLSyclEventRef dpnp_arange_c<double>(DPCTLSyclQueueRef,
                                                  size_t,
                                                  size_t,
-                                                 void*,
+                                                 void *,
                                                  size_t,
                                                  const DPCTLEventVectorRef);
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_diag_c(DPCTLSyclQueueRef q_ref,
-                              void* v_in,
-                              void* result1,
+                              void *v_in,
+                              void *result1,
                               const int k,
-                              shape_elem_type* shape,
-                              shape_elem_type* res_shape,
+                              shape_elem_type *shape,
+                              shape_elem_type *res_shape,
                               const size_t ndim,
                               const size_t res_ndim,
                               const DPCTLEventVectorRef dep_event_vec_ref)
@@ -143,88 +141,82 @@ DPCTLSyclEventRef dpnp_diag_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     validate_type_for_device<_DataType>(q);
 
-    const size_t input1_size = std::accumulate(shape, shape + ndim, 1, std::multiplies<shape_elem_type>());
-    const size_t result_size = std::accumulate(res_shape, res_shape + res_ndim, 1, std::multiplies<shape_elem_type>());
-    DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref,v_in, input1_size, true);
-    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref,result1, result_size, true, true);
-    _DataType* v = input1_ptr.get_ptr();
-    _DataType* result = result_ptr.get_ptr();
+    const size_t input1_size = std::accumulate(
+        shape, shape + ndim, 1, std::multiplies<shape_elem_type>());
+    const size_t result_size = std::accumulate(
+        res_shape, res_shape + res_ndim, 1, std::multiplies<shape_elem_type>());
+    DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, v_in, input1_size, true);
+    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, result_size, true,
+                                            true);
+    _DataType *v      = input1_ptr.get_ptr();
+    _DataType *result = result_ptr.get_ptr();
 
     size_t init0 = std::max(0, -k);
     size_t init1 = std::max(0, k);
 
-    if (ndim == 1)
-    {
-        for (size_t i = 0; i < static_cast<size_t>(shape[0]); ++i)
-        {
-            size_t ind = (init0 + i) * res_shape[1] + init1 + i;
+    if (ndim == 1) {
+        for (size_t i = 0; i < static_cast<size_t>(shape[0]); ++i) {
+            size_t ind  = (init0 + i) * res_shape[1] + init1 + i;
             result[ind] = v[i];
         }
     }
-    else
-    {
-        for (size_t i = 0; i < static_cast<size_t>(res_shape[0]); ++i)
-        {
+    else {
+        for (size_t i = 0; i < static_cast<size_t>(res_shape[0]); ++i) {
             size_t ind = (init0 + i) * shape[1] + init1 + i;
-            result[i] = v[ind];
+            result[i]  = v[ind];
         }
     }
     return event_ref;
 }
 
 template <typename _DataType>
-void dpnp_diag_c(void* v_in,
-                 void* result1,
+void dpnp_diag_c(void *v_in,
+                 void *result1,
                  const int k,
-                 shape_elem_type* shape,
-                 shape_elem_type* res_shape,
+                 shape_elem_type *shape,
+                 shape_elem_type *res_shape,
                  const size_t ndim,
                  const size_t res_ndim)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_diag_c<_DataType>(q_ref,
-                                                         v_in,
-                                                         result1,
-                                                         k,
-                                                         shape,
-                                                         res_shape,
-                                                         ndim,
-                                                         res_ndim,
-                                                         dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_diag_c<_DataType>(q_ref, v_in, result1, k, shape, res_shape, ndim,
+                               res_ndim, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_diag_default_c)(void*,
-                            void*,
+void (*dpnp_diag_default_c)(void *,
+                            void *,
                             const int,
-                            shape_elem_type*,
-                            shape_elem_type*,
+                            shape_elem_type *,
+                            shape_elem_type *,
                             const size_t,
                             const size_t) = dpnp_diag_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_diag_ext_c)(DPCTLSyclQueueRef,
-                                     void*,
-                                     void*,
+                                     void *,
+                                     void *,
                                      const int,
-                                     shape_elem_type*,
-                                     shape_elem_type*,
+                                     shape_elem_type *,
+                                     shape_elem_type *,
                                      const size_t,
                                      const size_t,
-                                     const DPCTLEventVectorRef) = dpnp_diag_c<_DataType>;
+                                     const DPCTLEventVectorRef) =
+    dpnp_diag_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_eye_c(DPCTLSyclQueueRef q_ref,
-                             void* result1,
+                             void *result1,
                              int k,
-                             const shape_elem_type* res_shape,
+                             const shape_elem_type *res_shape,
                              const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
@@ -232,24 +224,23 @@ DPCTLSyclEventRef dpnp_eye_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (result1 == nullptr)
-    {
+    if (result1 == nullptr) {
         return event_ref;
     }
 
-    if (res_shape == nullptr)
-    {
+    if (res_shape == nullptr) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     validate_type_for_device<_DataType>(q);
 
     size_t result_size = res_shape[0] * res_shape[1];
 
-    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref,result1, result_size, true, true);
-    _DataType* result = result_ptr.get_ptr();
+    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, result_size, true,
+                                            true);
+    _DataType *result = result_ptr.get_ptr();
 
     int diag_val_;
     diag_val_ = std::min((int)res_shape[0], (int)res_shape[1]);
@@ -258,14 +249,12 @@ DPCTLSyclEventRef dpnp_eye_c(DPCTLSyclQueueRef q_ref,
 
     size_t diag_val = (diag_val_ < 0) ? 0 : (size_t)diag_val_;
 
-    for (size_t i = 0; i < result_size; ++i)
-    {
+    for (size_t i = 0; i < result_size; ++i) {
         result[i] = 0;
-        for (size_t j = 0; j < diag_val; ++j)
-        {
-            size_t ind = (k >= 0) ? (j * res_shape[1] + j + k) : (j - k) * res_shape[1] + j;
-            if (i == ind)
-            {
+        for (size_t j = 0; j < diag_val; ++j) {
+            size_t ind = (k >= 0) ? (j * res_shape[1] + j + k)
+                                  : (j - k) * res_shape[1] + j;
+            if (i == ind) {
                 result[i] = 1;
                 break;
             }
@@ -276,82 +265,81 @@ DPCTLSyclEventRef dpnp_eye_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_eye_c(void* result1, int k, const shape_elem_type* res_shape)
+void dpnp_eye_c(void *result1, int k, const shape_elem_type *res_shape)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_eye_c<_DataType>(q_ref,
-                                                        result1,
-                                                        k,
-                                                        res_shape,
-                                                        dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_eye_c<_DataType>(q_ref, result1, k, res_shape, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_eye_default_c)(void*, int, const shape_elem_type*) = dpnp_eye_c<_DataType>;
+void (*dpnp_eye_default_c)(void *,
+                           int,
+                           const shape_elem_type *) = dpnp_eye_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_full_c(DPCTLSyclQueueRef q_ref,
-                              void* array_in,
-                              void* result,
+                              void *array_in,
+                              void *result,
                               const size_t size,
                               const DPCTLEventVectorRef dep_event_vec_ref)
 {
-    return dpnp_initval_c<_DataType>(q_ref, result, array_in, size, dep_event_vec_ref);
+    return dpnp_initval_c<_DataType>(q_ref, result, array_in, size,
+                                     dep_event_vec_ref);
 }
 
 template <typename _DataType>
-void dpnp_full_c(void* array_in, void* result, const size_t size)
+void dpnp_full_c(void *array_in, void *result, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_full_c<_DataType>(q_ref,
-                                                         array_in,
-                                                         result,
-                                                         size,
-                                                         dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_full_c<_DataType>(
+        q_ref, array_in, result, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_full_default_c)(void*, void*, const size_t) = dpnp_full_c<_DataType>;
+void (*dpnp_full_default_c)(void *,
+                            void *,
+                            const size_t) = dpnp_full_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_full_like_c(DPCTLSyclQueueRef q_ref,
-                                   void* array_in,
-                                   void* result,
+                                   void *array_in,
+                                   void *result,
                                    const size_t size,
                                    const DPCTLEventVectorRef dep_event_vec_ref)
 {
-    return dpnp_full_c<_DataType>(q_ref, array_in, result, size, dep_event_vec_ref);
+    return dpnp_full_c<_DataType>(q_ref, array_in, result, size,
+                                  dep_event_vec_ref);
 }
 
 template <typename _DataType>
-void dpnp_full_like_c(void* array_in, void* result, const size_t size)
+void dpnp_full_like_c(void *array_in, void *result, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_full_like_c<_DataType>(q_ref,
-                                                              array_in,
-                                                              result,
-                                                              size,
-                                                              dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_full_like_c<_DataType>(
+        q_ref, array_in, result, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_full_like_default_c)(void*, void*, const size_t) = dpnp_full_like_c<_DataType>;
+void (*dpnp_full_like_default_c)(void *,
+                                 void *,
+                                 const size_t) = dpnp_full_like_c<_DataType>;
 
 template <typename _KernelNameSpecialization>
 class dpnp_identity_c_kernel;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_identity_c(DPCTLSyclQueueRef q_ref,
-                                  void* result1,
+                                  void *result1,
                                   const size_t n,
                                   const DPCTLEventVectorRef dep_event_vec_ref)
 {
@@ -360,72 +348,74 @@ DPCTLSyclEventRef dpnp_identity_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (n == 0)
-    {
+    if (n == 0) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
     sycl::event event;
 
     validate_type_for_device<_DataType>(q);
 
-    _DataType* result = static_cast<_DataType *>(result1);
+    _DataType *result = static_cast<_DataType *>(result1);
 
     sycl::range<2> gws(n, n);
     auto kernel_parallel_for_func = [=](sycl::id<2> global_id) {
-        size_t i = global_id[0];
-        size_t j = global_id[1];
+        size_t i          = global_id[0];
+        size_t j          = global_id[1];
         result[i * n + j] = i == j;
     };
 
-    auto kernel_func = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class dpnp_identity_c_kernel<_DataType>>(gws, kernel_parallel_for_func);
+    auto kernel_func = [&](sycl::handler &cgh) {
+        cgh.parallel_for<class dpnp_identity_c_kernel<_DataType>>(
+            gws, kernel_parallel_for_func);
     };
 
-    event = q.submit(kernel_func);
+    event     = q.submit(kernel_func);
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
 
     return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType>
-void dpnp_identity_c(void* result1, const size_t n)
+void dpnp_identity_c(void *result1, const size_t n)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_identity_c<_DataType>(q_ref,
-                                                             result1,
-                                                             n,
-                                                             dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_identity_c<_DataType>(q_ref, result1, n, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_identity_default_c)(void*, const size_t) = dpnp_identity_c<_DataType>;
+void (*dpnp_identity_default_c)(void *,
+                                const size_t) = dpnp_identity_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_identity_ext_c)(DPCTLSyclQueueRef,
-                                         void*,
+                                         void *,
                                          const size_t,
-                                         const DPCTLEventVectorRef) = dpnp_identity_c<_DataType>;
+                                         const DPCTLEventVectorRef) =
+    dpnp_identity_c<_DataType>;
 
 template <typename _DataType>
 class dpnp_ones_c_kernel;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_ones_c(DPCTLSyclQueueRef q_ref,
-                              void* result,
+                              void *result,
                               size_t size,
                               const DPCTLEventVectorRef dep_event_vec_ref)
 {
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    _DataType* fill_value = reinterpret_cast<_DataType*>(sycl::malloc_shared(sizeof(_DataType), q));
+    _DataType *fill_value = reinterpret_cast<_DataType *>(
+        sycl::malloc_shared(sizeof(_DataType), q));
     fill_value[0] = 1;
 
-    DPCTLSyclEventRef event_ref = dpnp_initval_c<_DataType>(q_ref, result, fill_value, size, dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref = dpnp_initval_c<_DataType>(
+        q_ref, result, fill_value, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 
@@ -435,24 +425,22 @@ DPCTLSyclEventRef dpnp_ones_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_ones_c(void* result, size_t size)
+void dpnp_ones_c(void *result, size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_ones_c<_DataType>(q_ref,
-                                                         result,
-                                                         size,
-                                                         dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_ones_c<_DataType>(q_ref, result, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_ones_default_c)(void*, size_t) = dpnp_ones_c<_DataType>;
+void (*dpnp_ones_default_c)(void *, size_t) = dpnp_ones_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_ones_like_c(DPCTLSyclQueueRef q_ref,
-                                   void* result,
+                                   void *result,
                                    size_t size,
                                    const DPCTLEventVectorRef dep_event_vec_ref)
 {
@@ -460,34 +448,32 @@ DPCTLSyclEventRef dpnp_ones_like_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_ones_like_c(void* result, size_t size)
+void dpnp_ones_like_c(void *result, size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_ones_like_c<_DataType>(q_ref,
-                                                              result,
-                                                              size,
-                                                              dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_ones_like_c<_DataType>(q_ref, result, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_ones_like_default_c)(void*, size_t) = dpnp_ones_like_c<_DataType>;
+void (*dpnp_ones_like_default_c)(void *, size_t) = dpnp_ones_like_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_ptp_c(DPCTLSyclQueueRef q_ref,
-                             void* result1_out,
+                             void *result1_out,
                              const size_t result_size,
                              const size_t result_ndim,
-                             const shape_elem_type* result_shape,
-                             const shape_elem_type* result_strides,
-                             const void* input1_in,
+                             const shape_elem_type *result_shape,
+                             const shape_elem_type *result_strides,
+                             const void *input1_in,
                              const size_t input_size,
                              const size_t input_ndim,
-                             const shape_elem_type* input_shape,
-                             const shape_elem_type* input_strides,
-                             const shape_elem_type* axis,
+                             const shape_elem_type *input_shape,
+                             const shape_elem_type *input_strides,
+                             const shape_elem_type *axis,
                              const size_t naxis,
                              const DPCTLEventVectorRef dep_event_vec_ref)
 {
@@ -497,55 +483,46 @@ DPCTLSyclEventRef dpnp_ptp_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    DPCTLSyclEventRef e1_ref = nullptr;
-    DPCTLSyclEventRef e2_ref = nullptr;
-    DPCTLSyclEventRef e3_ref = nullptr;
+    DPCTLSyclEventRef e1_ref    = nullptr;
+    DPCTLSyclEventRef e2_ref    = nullptr;
+    DPCTLSyclEventRef e3_ref    = nullptr;
 
-    if ((input1_in == nullptr) || (result1_out == nullptr))
-    {
+    if ((input1_in == nullptr) || (result1_out == nullptr)) {
         return event_ref;
     }
 
-    if (input_ndim < 1)
-    {
+    if (input_ndim < 1) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     validate_type_for_device<_DataType>(q);
 
-    DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref,input1_in, input_size, true);
-    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref,result1_out, result_size, false, true);
-    _DataType* arr = input1_ptr.get_ptr();
-    _DataType* result = result_ptr.get_ptr();
+    DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, input1_in, input_size, true);
+    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1_out, result_size,
+                                            false, true);
+    _DataType *arr    = input1_ptr.get_ptr();
+    _DataType *result = result_ptr.get_ptr();
 
-    _DataType* min_arr = reinterpret_cast<_DataType*>(sycl::malloc_shared(result_size * sizeof(_DataType), q));
-    _DataType* max_arr = reinterpret_cast<_DataType*>(sycl::malloc_shared(result_size * sizeof(_DataType), q));
+    _DataType *min_arr = reinterpret_cast<_DataType *>(
+        sycl::malloc_shared(result_size * sizeof(_DataType), q));
+    _DataType *max_arr = reinterpret_cast<_DataType *>(
+        sycl::malloc_shared(result_size * sizeof(_DataType), q));
 
-    e1_ref = dpnp_min_c<_DataType>(q_ref, arr, min_arr, result_size, input_shape, input_ndim, axis, naxis, NULL);
-    e2_ref = dpnp_max_c<_DataType>(q_ref, arr, max_arr, result_size, input_shape, input_ndim, axis, naxis, NULL);
+    e1_ref = dpnp_min_c<_DataType>(q_ref, arr, min_arr, result_size,
+                                   input_shape, input_ndim, axis, naxis, NULL);
+    e2_ref = dpnp_max_c<_DataType>(q_ref, arr, max_arr, result_size,
+                                   input_shape, input_ndim, axis, naxis, NULL);
 
-    shape_elem_type* _strides =
-        reinterpret_cast<shape_elem_type*>(sycl::malloc_shared(result_ndim * sizeof(shape_elem_type), q));
+    shape_elem_type *_strides = reinterpret_cast<shape_elem_type *>(
+        sycl::malloc_shared(result_ndim * sizeof(shape_elem_type), q));
     get_shape_offsets_inkernel(result_shape, result_ndim, _strides);
 
-    e3_ref = dpnp_subtract_c<_DataType, _DataType, _DataType>(q_ref, result,
-							      result_size,
-							      result_ndim,
-							      result_shape,
-							      result_strides,
-							      max_arr,
-							      result_size,
-							      result_ndim,
-							      result_shape,
-							      _strides,
-							      min_arr,
-							      result_size,
-							      result_ndim,
-							      result_shape,
-							      _strides,
-							      NULL, NULL);
+    e3_ref = dpnp_subtract_c<_DataType, _DataType, _DataType>(
+        q_ref, result, result_size, result_ndim, result_shape, result_strides,
+        max_arr, result_size, result_ndim, result_shape, _strides, min_arr,
+        result_size, result_ndim, result_shape, _strides, NULL, NULL);
 
     DPCTLEvent_Wait(e1_ref);
     DPCTLEvent_Wait(e2_ref);
@@ -562,73 +539,64 @@ DPCTLSyclEventRef dpnp_ptp_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_ptp_c(void* result1_out,
+void dpnp_ptp_c(void *result1_out,
                 const size_t result_size,
                 const size_t result_ndim,
-                const shape_elem_type* result_shape,
-                const shape_elem_type* result_strides,
-                const void* input1_in,
+                const shape_elem_type *result_shape,
+                const shape_elem_type *result_strides,
+                const void *input1_in,
                 const size_t input_size,
                 const size_t input_ndim,
-                const shape_elem_type* input_shape,
-                const shape_elem_type* input_strides,
-                const shape_elem_type* axis,
+                const shape_elem_type *input_shape,
+                const shape_elem_type *input_strides,
+                const shape_elem_type *axis,
                 const size_t naxis)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_ptp_c<_DataType>(q_ref,
-                                                        result1_out,
-                                                        result_size,
-                                                        result_ndim,
-                                                        result_shape,
-                                                        result_strides,
-                                                        input1_in,
-                                                        input_size,
-                                                        input_ndim,
-                                                        input_shape,
-                                                        input_strides,
-                                                        axis,
-                                                        naxis,
-                                                        dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_ptp_c<_DataType>(
+        q_ref, result1_out, result_size, result_ndim, result_shape,
+        result_strides, input1_in, input_size, input_ndim, input_shape,
+        input_strides, axis, naxis, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_ptp_default_c)(void*,
+void (*dpnp_ptp_default_c)(void *,
                            const size_t,
                            const size_t,
-                           const shape_elem_type*,
-                           const shape_elem_type*,
-                           const void*,
+                           const shape_elem_type *,
+                           const shape_elem_type *,
+                           const void *,
                            const size_t,
                            const size_t,
-                           const shape_elem_type*,
-                           const shape_elem_type*,
-                           const shape_elem_type*,
+                           const shape_elem_type *,
+                           const shape_elem_type *,
+                           const shape_elem_type *,
                            const size_t) = dpnp_ptp_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_ptp_ext_c)(DPCTLSyclQueueRef,
-                                    void*,
+                                    void *,
                                     const size_t,
                                     const size_t,
-                                    const shape_elem_type*,
-                                    const shape_elem_type*,
-                                    const void*,
+                                    const shape_elem_type *,
+                                    const shape_elem_type *,
+                                    const void *,
                                     const size_t,
                                     const size_t,
-                                    const shape_elem_type*,
-                                    const shape_elem_type*,
-                                    const shape_elem_type*,
+                                    const shape_elem_type *,
+                                    const shape_elem_type *,
+                                    const shape_elem_type *,
                                     const size_t,
-                                    const DPCTLEventVectorRef) = dpnp_ptp_c<_DataType>;
+                                    const DPCTLEventVectorRef) =
+    dpnp_ptp_c<_DataType>;
 
 template <typename _DataType_input, typename _DataType_output>
 DPCTLSyclEventRef dpnp_vander_c(DPCTLSyclQueueRef q_ref,
-                                const void* array1_in,
-                                void* result1,
+                                const void *array1_in,
+                                void *result1,
                                 const size_t size_in,
                                 const size_t N,
                                 const int increasing,
@@ -642,51 +610,44 @@ DPCTLSyclEventRef dpnp_vander_c(DPCTLSyclQueueRef q_ref,
     if (!size_in || !N)
         return event_ref;
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     validate_type_for_device<_DataType_input>(q);
     validate_type_for_device<_DataType_output>(q);
 
-    DPNPC_ptr_adapter<_DataType_input> input1_ptr(q_ref,array1_in, size_in, true);
-    DPNPC_ptr_adapter<_DataType_output> result_ptr(q_ref,result1, size_in * N, true, true);
-    const _DataType_input* array_in = input1_ptr.get_ptr();
-    _DataType_output* result = result_ptr.get_ptr();
+    DPNPC_ptr_adapter<_DataType_input> input1_ptr(q_ref, array1_in, size_in,
+                                                  true);
+    DPNPC_ptr_adapter<_DataType_output> result_ptr(q_ref, result1, size_in * N,
+                                                   true, true);
+    const _DataType_input *array_in = input1_ptr.get_ptr();
+    _DataType_output *result        = result_ptr.get_ptr();
 
-    if (N == 1)
-    {
-        return dpnp_ones_c<_DataType_output>(q_ref, result, size_in, dep_event_vec_ref);
+    if (N == 1) {
+        return dpnp_ones_c<_DataType_output>(q_ref, result, size_in,
+                                             dep_event_vec_ref);
     }
 
-    if (increasing)
-    {
-        for (size_t i = 0; i < size_in; ++i)
-        {
+    if (increasing) {
+        for (size_t i = 0; i < size_in; ++i) {
             result[i * N] = 1;
         }
-        for (size_t i = 1; i < N; ++i)
-        {
-            for (size_t j = 0; j < size_in; ++j)
-            {
+        for (size_t i = 1; i < N; ++i) {
+            for (size_t j = 0; j < size_in; ++j) {
                 result[j * N + i] = result[j * N + i - 1] * array_in[j];
             }
         }
     }
-    else
-    {
-        for (size_t i = 0; i < size_in; ++i)
-        {
+    else {
+        for (size_t i = 0; i < size_in; ++i) {
             result[i * N + N - 1] = 1;
         }
-        for (size_t i = N - 2; i > 0; --i)
-        {
-            for (size_t j = 0; j < size_in; ++j)
-            {
+        for (size_t i = N - 2; i > 0; --i) {
+            for (size_t j = 0; j < size_in; ++j) {
                 result[j * N + i] = result[j * N + i + 1] * array_in[j];
             }
         }
 
-        for (size_t i = 0; i < size_in; ++i)
-        {
+        for (size_t i = 0; i < size_in; ++i) {
             result[i * N] = result[i * N + 1] * array_in[i];
         }
     }
@@ -695,45 +656,48 @@ DPCTLSyclEventRef dpnp_vander_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType_input, typename _DataType_output>
-void dpnp_vander_c(const void* array1_in, void* result1, const size_t size_in, const size_t N, const int increasing)
+void dpnp_vander_c(const void *array1_in,
+                   void *result1,
+                   const size_t size_in,
+                   const size_t N,
+                   const int increasing)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_vander_c<_DataType_input, _DataType_output>(q_ref,
-                                                                                   array1_in,
-                                                                                   result1,
-                                                                                   size_in,
-                                                                                   N,
-                                                                                   increasing,
-                                                                                   dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_vander_c<_DataType_input, _DataType_output>(
+            q_ref, array1_in, result1, size_in, N, increasing,
+            dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType_input, typename _DataType_output>
-void (*dpnp_vander_default_c)(const void*,
-                              void*,
+void (*dpnp_vander_default_c)(const void *,
+                              void *,
                               const size_t,
                               const size_t,
-                              const int) = dpnp_vander_c<_DataType_input, _DataType_output>;
+                              const int) =
+    dpnp_vander_c<_DataType_input, _DataType_output>;
 
 template <typename _DataType_input, typename _DataType_output>
 DPCTLSyclEventRef (*dpnp_vander_ext_c)(DPCTLSyclQueueRef,
-                                       const void*,
-                                       void*,
+                                       const void *,
+                                       void *,
                                        const size_t,
                                        const size_t,
                                        const int,
-                                       const DPCTLEventVectorRef) = dpnp_vander_c<_DataType_input, _DataType_output>;
+                                       const DPCTLEventVectorRef) =
+    dpnp_vander_c<_DataType_input, _DataType_output>;
 
 template <typename _DataType, typename _ResultType>
 class dpnp_trace_c_kernel;
 
 template <typename _DataType, typename _ResultType>
 DPCTLSyclEventRef dpnp_trace_c(DPCTLSyclQueueRef q_ref,
-                               const void* array1_in,
-                               void* result_in,
-                               const shape_elem_type* shape_,
+                               const void *array1_in,
+                               void *result_in,
+                               const shape_elem_type *shape_,
                                const size_t ndim,
                                const DPCTLEventVectorRef dep_event_vec_ref)
 {
@@ -742,84 +706,84 @@ DPCTLSyclEventRef dpnp_trace_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!array1_in || !result_in || !shape_ || !ndim)
-    {
+    if (!array1_in || !result_in || !shape_ || !ndim) {
         return event_ref;
     }
 
     const size_t last_dim = shape_[ndim - 1];
-    const size_t size = std::accumulate(shape_, shape_ + (ndim - 1), 1, std::multiplies<shape_elem_type>());
-    if (!size)
-    {
+    const size_t size     = std::accumulate(shape_, shape_ + (ndim - 1), 1,
+                                        std::multiplies<shape_elem_type>());
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     validate_type_for_device<_DataType>(q);
     validate_type_for_device<_ResultType>(q);
 
-    const _DataType* input = static_cast<const _DataType *>(array1_in);
-    _ResultType* result = static_cast<_ResultType *>(result_in);
+    const _DataType *input = static_cast<const _DataType *>(array1_in);
+    _ResultType *result    = static_cast<_ResultType *>(result_in);
 
     sycl::range<1> gws(size);
     auto kernel_parallel_for_func = [=](auto index) {
-        size_t i = index[0];
+        size_t i        = index[0];
         _ResultType acc = _ResultType(0);
 
-        for (size_t j = 0; j < last_dim; ++j)
-        {
+        for (size_t j = 0; j < last_dim; ++j) {
             acc += input[i * last_dim + j];
         }
 
         result[i] = acc;
     };
 
-    auto kernel_func = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class dpnp_trace_c_kernel<_DataType, _ResultType>>(gws, kernel_parallel_for_func);
+    auto kernel_func = [&](sycl::handler &cgh) {
+        cgh.parallel_for<class dpnp_trace_c_kernel<_DataType, _ResultType>>(
+            gws, kernel_parallel_for_func);
     };
 
     auto event = q.submit(kernel_func);
-    event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
+    event_ref  = reinterpret_cast<DPCTLSyclEventRef>(&event);
 
     return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType, typename _ResultType>
-void dpnp_trace_c(const void* array1_in, void* result_in, const shape_elem_type* shape_, const size_t ndim)
+void dpnp_trace_c(const void *array1_in,
+                  void *result_in,
+                  const shape_elem_type *shape_,
+                  const size_t ndim)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_trace_c<_DataType, _ResultType>(q_ref,
-                                                                       array1_in,
-                                                                       result_in,
-                                                                       shape_,
-                                                                       ndim,
-                                                                       dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref = dpnp_trace_c<_DataType, _ResultType>(
+        q_ref, array1_in, result_in, shape_, ndim, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType, typename _ResultType>
-void (*dpnp_trace_default_c)(const void*,
-                             void*,
-                             const shape_elem_type*,
-                             const size_t) = dpnp_trace_c<_DataType, _ResultType>;
+void (*dpnp_trace_default_c)(const void *,
+                             void *,
+                             const shape_elem_type *,
+                             const size_t) =
+    dpnp_trace_c<_DataType, _ResultType>;
 
 template <typename _DataType, typename _ResultType>
 DPCTLSyclEventRef (*dpnp_trace_ext_c)(DPCTLSyclQueueRef,
-                                      const void*,
-                                      void*,
-                                      const shape_elem_type*,
+                                      const void *,
+                                      void *,
+                                      const shape_elem_type *,
                                       const size_t,
-                                      const DPCTLEventVectorRef) = dpnp_trace_c<_DataType, _ResultType>;
+                                      const DPCTLEventVectorRef) =
+    dpnp_trace_c<_DataType, _ResultType>;
 
 template <typename _DataType>
 class dpnp_tri_c_kernel;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_tri_c(DPCTLSyclQueueRef q_ref,
-                             void* result1,
+                             void *result1,
                              const size_t N,
                              const size_t M,
                              const int k,
@@ -832,84 +796,77 @@ DPCTLSyclEventRef dpnp_tri_c(DPCTLSyclQueueRef q_ref,
 
     sycl::event event;
 
-    if (!result1 || !N || !M)
-    {
+    if (!result1 || !N || !M) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     validate_type_for_device<_DataType>(q);
 
-    _DataType* result = static_cast<_DataType *>(result1);
+    _DataType *result = static_cast<_DataType *>(result1);
 
     size_t idx = N * M;
     sycl::range<1> gws(idx);
     auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
         size_t ind = global_id[0];
-        size_t i = ind / M;
-        size_t j = ind % M;
+        size_t i   = ind / M;
+        size_t j   = ind % M;
 
-        int val = i + k + 1;
+        int val          = i + k + 1;
         size_t diag_idx_ = (val > 0) ? (size_t)val : 0;
-        size_t diag_idx = (M < diag_idx_) ? M : diag_idx_;
+        size_t diag_idx  = (M < diag_idx_) ? M : diag_idx_;
 
-        if (j < diag_idx)
-        {
+        if (j < diag_idx) {
             result[ind] = 1;
         }
-        else
-        {
+        else {
             result[ind] = 0;
         }
     };
 
-    auto kernel_func = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class dpnp_tri_c_kernel<_DataType>>(gws, kernel_parallel_for_func);
+    auto kernel_func = [&](sycl::handler &cgh) {
+        cgh.parallel_for<class dpnp_tri_c_kernel<_DataType>>(
+            gws, kernel_parallel_for_func);
     };
 
-    event = q.submit(kernel_func);
+    event     = q.submit(kernel_func);
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
 
     return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType>
-void dpnp_tri_c(void* result1, const size_t N, const size_t M, const int k)
+void dpnp_tri_c(void *result1, const size_t N, const size_t M, const int k)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_tri_c<_DataType>(q_ref,
-                                                        result1,
-                                                        N,
-                                                        M,
-                                                        k,
-                                                        dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_tri_c<_DataType>(q_ref, result1, N, M, k, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_tri_default_c)(void*,
-                           const size_t,
-                           const size_t,
-                           const int) = dpnp_tri_c<_DataType>;
+void (*dpnp_tri_default_c)(void *, const size_t, const size_t, const int) =
+    dpnp_tri_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_tri_ext_c)(DPCTLSyclQueueRef,
-                                    void*,
+                                    void *,
                                     const size_t,
                                     const size_t,
                                     const int,
-                                    const DPCTLEventVectorRef) = dpnp_tri_c<_DataType>;
+                                    const DPCTLEventVectorRef) =
+    dpnp_tri_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_tril_c(DPCTLSyclQueueRef q_ref,
-                              void* array_in,
-                              void* result1,
+                              void *array_in,
+                              void *result1,
                               const int k,
-                              shape_elem_type* shape,
-                              shape_elem_type* res_shape,
+                              shape_elem_type *shape,
+                              shape_elem_type *res_shape,
                               const size_t ndim,
                               const size_t res_ndim,
                               const DPCTLEventVectorRef dep_event_vec_ref)
@@ -919,102 +876,90 @@ DPCTLSyclEventRef dpnp_tril_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if ((array_in == nullptr) || (result1 == nullptr))
-    {
+    if ((array_in == nullptr) || (result1 == nullptr)) {
         return event_ref;
     }
 
-    if ((shape == nullptr) || (res_shape == nullptr))
-    {
+    if ((shape == nullptr) || (res_shape == nullptr)) {
         return event_ref;
     }
 
-    if ((ndim == 0) || (res_ndim == 0))
-    {
+    if ((ndim == 0) || (res_ndim == 0)) {
         return event_ref;
     }
 
-    const size_t res_size = std::accumulate(res_shape, res_shape + res_ndim, 1, std::multiplies<shape_elem_type>());
-    if (res_size == 0)
-    {
+    const size_t res_size = std::accumulate(res_shape, res_shape + res_ndim, 1,
+                                            std::multiplies<shape_elem_type>());
+    if (res_size == 0) {
         return event_ref;
     }
 
-    const size_t input_size = std::accumulate(shape, shape + ndim, 1, std::multiplies<shape_elem_type>());
-    if (input_size == 0)
-    {
+    const size_t input_size = std::accumulate(
+        shape, shape + ndim, 1, std::multiplies<shape_elem_type>());
+    if (input_size == 0) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     validate_type_for_device<_DataType>(q);
 
-    DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref,array_in, input_size, true);
-    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref,result1, res_size, true, true);
-    _DataType* array_m = input1_ptr.get_ptr();
-    _DataType* result = result_ptr.get_ptr();
+    DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array_in, input_size, true);
+    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, res_size, true,
+                                            true);
+    _DataType *array_m = input1_ptr.get_ptr();
+    _DataType *result  = result_ptr.get_ptr();
 
-    if (ndim == 1)
-    {
-        for (size_t i = 0; i < res_size; ++i)
-        {
-            size_t n = res_size;
+    if (ndim == 1) {
+        for (size_t i = 0; i < res_size; ++i) {
+            size_t n   = res_size;
             size_t val = i;
             int ids[res_ndim];
-            for (size_t j = 0; j < res_ndim; ++j)
-            {
+            for (size_t j = 0; j < res_ndim; ++j) {
                 n /= res_shape[j];
                 size_t p = val / n;
-                ids[j] = p;
-                if (p != 0)
-                {
+                ids[j]   = p;
+                if (p != 0) {
                     val = val - p * n;
                 }
             }
 
-            int diag_idx_ = (ids[res_ndim - 2] + k > -1) ? (ids[res_ndim - 2] + k) : -1;
-            int values = res_shape[res_ndim - 1];
+            int diag_idx_ =
+                (ids[res_ndim - 2] + k > -1) ? (ids[res_ndim - 2] + k) : -1;
+            int values   = res_shape[res_ndim - 1];
             int diag_idx = (values < diag_idx_) ? values : diag_idx_;
 
-            if (ids[res_ndim - 1] <= diag_idx)
-            {
+            if (ids[res_ndim - 1] <= diag_idx) {
                 result[i] = array_m[ids[res_ndim - 1]];
             }
-            else
-            {
+            else {
                 result[i] = 0;
             }
         }
     }
-    else
-    {
-        for (size_t i = 0; i < res_size; ++i)
-        {
-            size_t n = res_size;
+    else {
+        for (size_t i = 0; i < res_size; ++i) {
+            size_t n   = res_size;
             size_t val = i;
             int ids[res_ndim];
-            for (size_t j = 0; j < res_ndim; ++j)
-            {
+            for (size_t j = 0; j < res_ndim; ++j) {
                 n /= res_shape[j];
                 size_t p = val / n;
-                ids[j] = p;
-                if (p != 0)
-                {
+                ids[j]   = p;
+                if (p != 0) {
                     val = val - p * n;
                 }
             }
 
-            int diag_idx_ = (ids[res_ndim - 2] + k > -1) ? (ids[res_ndim - 2] + k) : -1;
-            int values = res_shape[res_ndim - 1];
+            int diag_idx_ =
+                (ids[res_ndim - 2] + k > -1) ? (ids[res_ndim - 2] + k) : -1;
+            int values   = res_shape[res_ndim - 1];
             int diag_idx = (values < diag_idx_) ? values : diag_idx_;
 
-            if (ids[res_ndim - 1] <= diag_idx)
-            {
+            if (ids[res_ndim - 1] <= diag_idx) {
                 result[i] = array_m[i];
             }
-            else
-            {
+            else {
                 result[i] = 0;
             }
         }
@@ -1023,45 +968,39 @@ DPCTLSyclEventRef dpnp_tril_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_tril_c(void* array_in,
-                 void* result1,
+void dpnp_tril_c(void *array_in,
+                 void *result1,
                  const int k,
-                 shape_elem_type* shape,
-                 shape_elem_type* res_shape,
+                 shape_elem_type *shape,
+                 shape_elem_type *res_shape,
                  const size_t ndim,
                  const size_t res_ndim)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_tril_c<_DataType>(q_ref,
-                                                         array_in,
-                                                         result1,
-                                                         k,
-                                                         shape,
-                                                         res_shape,
-                                                         ndim,
-                                                         res_ndim,
-                                                         dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_tril_c<_DataType>(q_ref, array_in, result1, k, shape, res_shape,
+                               ndim, res_ndim, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_tril_default_c)(void*,
-                            void*,
+void (*dpnp_tril_default_c)(void *,
+                            void *,
                             const int,
-                            shape_elem_type*,
-                            shape_elem_type*,
+                            shape_elem_type *,
+                            shape_elem_type *,
                             const size_t,
                             const size_t) = dpnp_tril_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_triu_c(DPCTLSyclQueueRef q_ref,
-                              void* array_in,
-                              void* result1,
+                              void *array_in,
+                              void *result1,
                               const int k,
-                              shape_elem_type* shape,
-                              shape_elem_type* res_shape,
+                              shape_elem_type *shape,
+                              shape_elem_type *res_shape,
                               const size_t ndim,
                               const size_t res_ndim,
                               const DPCTLEventVectorRef dep_event_vec_ref)
@@ -1071,102 +1010,90 @@ DPCTLSyclEventRef dpnp_triu_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if ((array_in == nullptr) || (result1 == nullptr))
-    {
+    if ((array_in == nullptr) || (result1 == nullptr)) {
         return event_ref;
     }
 
-    if ((shape == nullptr) || (res_shape == nullptr))
-    {
+    if ((shape == nullptr) || (res_shape == nullptr)) {
         return event_ref;
     }
 
-    if ((ndim == 0) || (res_ndim == 0))
-    {
+    if ((ndim == 0) || (res_ndim == 0)) {
         return event_ref;
     }
 
-    const size_t res_size = std::accumulate(res_shape, res_shape + res_ndim, 1, std::multiplies<shape_elem_type>());
-    if (res_size == 0)
-    {
+    const size_t res_size = std::accumulate(res_shape, res_shape + res_ndim, 1,
+                                            std::multiplies<shape_elem_type>());
+    if (res_size == 0) {
         return event_ref;
     }
 
-    const size_t input_size = std::accumulate(shape, shape + ndim, 1, std::multiplies<shape_elem_type>());
-    if (input_size == 0)
-    {
+    const size_t input_size = std::accumulate(
+        shape, shape + ndim, 1, std::multiplies<shape_elem_type>());
+    if (input_size == 0) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     validate_type_for_device<_DataType>(q);
 
-    DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref,array_in, input_size, true);
-    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref,result1, res_size, true, true);
-    _DataType* array_m = input1_ptr.get_ptr();
-    _DataType* result = result_ptr.get_ptr();
+    DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array_in, input_size, true);
+    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, res_size, true,
+                                            true);
+    _DataType *array_m = input1_ptr.get_ptr();
+    _DataType *result  = result_ptr.get_ptr();
 
-    if (ndim == 1)
-    {
-        for (size_t i = 0; i < res_size; ++i)
-        {
-            size_t n = res_size;
+    if (ndim == 1) {
+        for (size_t i = 0; i < res_size; ++i) {
+            size_t n   = res_size;
             size_t val = i;
             int ids[res_ndim];
-            for (size_t j = 0; j < res_ndim; ++j)
-            {
+            for (size_t j = 0; j < res_ndim; ++j) {
                 n /= res_shape[j];
                 size_t p = val / n;
-                ids[j] = p;
-                if (p != 0)
-                {
+                ids[j]   = p;
+                if (p != 0) {
                     val = val - p * n;
                 }
             }
 
-            int diag_idx_ = (ids[res_ndim - 2] + k > -1) ? (ids[res_ndim - 2] + k) : -1;
-            int values = res_shape[res_ndim - 1];
+            int diag_idx_ =
+                (ids[res_ndim - 2] + k > -1) ? (ids[res_ndim - 2] + k) : -1;
+            int values   = res_shape[res_ndim - 1];
             int diag_idx = (values < diag_idx_) ? values : diag_idx_;
 
-            if (ids[res_ndim - 1] >= diag_idx)
-            {
+            if (ids[res_ndim - 1] >= diag_idx) {
                 result[i] = array_m[ids[res_ndim - 1]];
             }
-            else
-            {
+            else {
                 result[i] = 0;
             }
         }
     }
-    else
-    {
-        for (size_t i = 0; i < res_size; ++i)
-        {
-            size_t n = res_size;
+    else {
+        for (size_t i = 0; i < res_size; ++i) {
+            size_t n   = res_size;
             size_t val = i;
             int ids[res_ndim];
-            for (size_t j = 0; j < res_ndim; ++j)
-            {
+            for (size_t j = 0; j < res_ndim; ++j) {
                 n /= res_shape[j];
                 size_t p = val / n;
-                ids[j] = p;
-                if (p != 0)
-                {
+                ids[j]   = p;
+                if (p != 0) {
                     val = val - p * n;
                 }
             }
 
-            int diag_idx_ = (ids[res_ndim - 2] + k > -1) ? (ids[res_ndim - 2] + k) : -1;
-            int values = res_shape[res_ndim - 1];
+            int diag_idx_ =
+                (ids[res_ndim - 2] + k > -1) ? (ids[res_ndim - 2] + k) : -1;
+            int values   = res_shape[res_ndim - 1];
             int diag_idx = (values < diag_idx_) ? values : diag_idx_;
 
-            if (ids[res_ndim - 1] >= diag_idx)
-            {
+            if (ids[res_ndim - 1] >= diag_idx) {
                 result[i] = array_m[i];
             }
-            else
-            {
+            else {
                 result[i] = 0;
             }
         }
@@ -1175,50 +1102,46 @@ DPCTLSyclEventRef dpnp_triu_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_triu_c(void* array_in,
-                 void* result1,
+void dpnp_triu_c(void *array_in,
+                 void *result1,
                  const int k,
-                 shape_elem_type* shape,
-                 shape_elem_type* res_shape,
+                 shape_elem_type *shape,
+                 shape_elem_type *res_shape,
                  const size_t ndim,
                  const size_t res_ndim)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_triu_c<_DataType>(q_ref,
-                                                         array_in,
-                                                         result1,
-                                                         k,
-                                                         shape,
-                                                         res_shape,
-                                                         ndim,
-                                                         res_ndim,
-                                                         dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_triu_c<_DataType>(q_ref, array_in, result1, k, shape, res_shape,
+                               ndim, res_ndim, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_triu_default_c)(void*,
-                            void*,
+void (*dpnp_triu_default_c)(void *,
+                            void *,
                             const int,
-                            shape_elem_type*,
-                            shape_elem_type*,
+                            shape_elem_type *,
+                            shape_elem_type *,
                             const size_t,
                             const size_t) = dpnp_triu_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_zeros_c(DPCTLSyclQueueRef q_ref,
-                               void* result,
+                               void *result,
                                size_t size,
                                const DPCTLEventVectorRef dep_event_vec_ref)
 {
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    _DataType* fill_value = reinterpret_cast<_DataType*>(sycl::malloc_shared(sizeof(_DataType), q));
+    _DataType *fill_value = reinterpret_cast<_DataType *>(
+        sycl::malloc_shared(sizeof(_DataType), q));
     fill_value[0] = 0;
 
-    DPCTLSyclEventRef event_ref = dpnp_initval_c<_DataType>(q_ref, result, fill_value, size, dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref = dpnp_initval_c<_DataType>(
+        q_ref, result, fill_value, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 
@@ -1228,24 +1151,22 @@ DPCTLSyclEventRef dpnp_zeros_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_zeros_c(void* result, size_t size)
+void dpnp_zeros_c(void *result, size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_zeros_c<_DataType>(q_ref,
-                                                          result,
-                                                          size,
-                                                          dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_zeros_c<_DataType>(q_ref, result, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_zeros_default_c)(void*, size_t) = dpnp_zeros_c<_DataType>;
+void (*dpnp_zeros_default_c)(void *, size_t) = dpnp_zeros_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_zeros_like_c(DPCTLSyclQueueRef q_ref,
-                                    void* result,
+                                    void *result,
                                     size_t size,
                                     const DPCTLEventVectorRef dep_event_vec_ref)
 {
@@ -1253,190 +1174,315 @@ DPCTLSyclEventRef dpnp_zeros_like_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_zeros_like_c(void* result, size_t size)
+void dpnp_zeros_like_c(void *result, size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_zeros_like_c<_DataType>(q_ref,
-                                                               result,
-                                                               size,
-                                                               dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_zeros_like_c<_DataType>(q_ref, result, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_zeros_like_default_c)(void*, size_t) = dpnp_zeros_like_c<_DataType>;
+void (*dpnp_zeros_like_default_c)(void *,
+                                  size_t) = dpnp_zeros_like_c<_DataType>;
 
-void func_map_init_arraycreation(func_map_t& fmap)
+void func_map_init_arraycreation(func_map_t &fmap)
 {
-    fmap[DPNPFuncName::DPNP_FN_ARANGE][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_arange_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARANGE][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_arange_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARANGE][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_arange_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_ARANGE][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_arange_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_ARANGE][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_arange_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARANGE][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_arange_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARANGE][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_arange_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_ARANGE][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_arange_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_DIAG][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_diag_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_DIAG][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_diag_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_DIAG][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_diag_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_DIAG][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_diag_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_DIAG][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_diag_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_DIAG][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_diag_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_DIAG][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_diag_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_DIAG][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_diag_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_DIAG_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_diag_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_DIAG_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_diag_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_DIAG_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_diag_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_DIAG_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_diag_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_DIAG_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_diag_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_DIAG_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_diag_ext_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_DIAG_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_diag_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_DIAG_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_diag_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_EYE][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_eye_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_EYE][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_eye_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_EYE][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_eye_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_EYE][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_eye_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_EYE][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_eye_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_EYE][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_eye_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_EYE][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_eye_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_EYE][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_eye_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_FULL][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_full_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_FULL][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_full_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_FULL][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_full_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_FULL][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_full_default_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_FULL][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_full_default_c<bool>};
-    fmap[DPNPFuncName::DPNP_FN_FULL][eft_C128][eft_C128] = {eft_C128,
-                                                            (void*)dpnp_full_default_c<std::complex<double>>};
+    fmap[DPNPFuncName::DPNP_FN_FULL][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_full_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_FULL][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_full_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_FULL][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_full_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_FULL][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_full_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_FULL][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_full_default_c<bool>};
+    fmap[DPNPFuncName::DPNP_FN_FULL][eft_C128][eft_C128] = {
+        eft_C128, (void *)dpnp_full_default_c<std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_FULL_LIKE][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_full_like_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_FULL_LIKE][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_full_like_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_FULL_LIKE][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_full_like_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_FULL_LIKE][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_full_like_default_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_FULL_LIKE][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_full_like_default_c<bool>};
+    fmap[DPNPFuncName::DPNP_FN_FULL_LIKE][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_full_like_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_FULL_LIKE][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_full_like_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_FULL_LIKE][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_full_like_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_FULL_LIKE][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_full_like_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_FULL_LIKE][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_full_like_default_c<bool>};
     fmap[DPNPFuncName::DPNP_FN_FULL_LIKE][eft_C128][eft_C128] = {
-        eft_C128, (void*)dpnp_full_like_default_c<std::complex<double>>};
+        eft_C128, (void *)dpnp_full_like_default_c<std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_IDENTITY][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_identity_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_IDENTITY][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_identity_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_IDENTITY][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_identity_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_IDENTITY][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_identity_default_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_IDENTITY][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_identity_default_c<bool>};
-    fmap[DPNPFuncName::DPNP_FN_IDENTITY][eft_C128][eft_C128] = {eft_C128,
-                                                                (void*)dpnp_identity_default_c<std::complex<double>>};
+    fmap[DPNPFuncName::DPNP_FN_IDENTITY][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_identity_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_IDENTITY][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_identity_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_IDENTITY][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_identity_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_IDENTITY][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_identity_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_IDENTITY][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_identity_default_c<bool>};
+    fmap[DPNPFuncName::DPNP_FN_IDENTITY][eft_C128][eft_C128] = {
+        eft_C128, (void *)dpnp_identity_default_c<std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_identity_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_identity_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_identity_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_identity_ext_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_identity_ext_c<bool>};
-    fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_C64][eft_C64] = {eft_C64,
-                                                                    (void*)dpnp_identity_ext_c<std::complex<float>>};
-    fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_C128][eft_C128] = {eft_C128,
-                                                                    (void*)dpnp_identity_ext_c<std::complex<double>>};
+    fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_identity_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_identity_ext_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_identity_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_identity_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_identity_ext_c<bool>};
+    fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_C64][eft_C64] = {
+        eft_C64, (void *)dpnp_identity_ext_c<std::complex<float>>};
+    fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_C128][eft_C128] = {
+        eft_C128, (void *)dpnp_identity_ext_c<std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_ONES][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_ones_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ONES][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_ones_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ONES][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_ones_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_ONES][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_ones_default_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_ONES][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_ones_default_c<bool>};
-    fmap[DPNPFuncName::DPNP_FN_ONES][eft_C128][eft_C128] = {eft_C128,
-                                                            (void*)dpnp_ones_default_c<std::complex<double>>};
+    fmap[DPNPFuncName::DPNP_FN_ONES][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_ones_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ONES][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_ones_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ONES][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_ones_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_ONES][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_ones_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_ONES][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_ones_default_c<bool>};
+    fmap[DPNPFuncName::DPNP_FN_ONES][eft_C128][eft_C128] = {
+        eft_C128, (void *)dpnp_ones_default_c<std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_ONES_LIKE][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_ones_like_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ONES_LIKE][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_ones_like_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ONES_LIKE][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_ones_like_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_ONES_LIKE][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_ones_like_default_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_ONES_LIKE][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_ones_like_default_c<bool>};
+    fmap[DPNPFuncName::DPNP_FN_ONES_LIKE][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_ones_like_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ONES_LIKE][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_ones_like_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ONES_LIKE][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_ones_like_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_ONES_LIKE][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_ones_like_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_ONES_LIKE][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_ones_like_default_c<bool>};
     fmap[DPNPFuncName::DPNP_FN_ONES_LIKE][eft_C128][eft_C128] = {
-        eft_C128, (void*)dpnp_ones_like_default_c<std::complex<double>>};
+        eft_C128, (void *)dpnp_ones_like_default_c<std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_PTP][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_ptp_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_PTP][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_ptp_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_PTP][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_ptp_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_PTP][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_ptp_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_PTP][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_ptp_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_PTP][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_ptp_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_PTP][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_ptp_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_PTP][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_ptp_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_PTP_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_ptp_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_PTP_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_ptp_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_PTP_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_ptp_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_PTP_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_ptp_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_PTP_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_ptp_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_PTP_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_ptp_ext_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_PTP_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_ptp_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_PTP_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_ptp_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_VANDER][eft_INT][eft_INT] = {eft_LNG, (void*)dpnp_vander_default_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_VANDER][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_vander_default_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_VANDER][eft_FLT][eft_FLT] = {eft_DBL, (void*)dpnp_vander_default_c<float, double>};
-    fmap[DPNPFuncName::DPNP_FN_VANDER][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_vander_default_c<double, double>};
-    fmap[DPNPFuncName::DPNP_FN_VANDER][eft_BLN][eft_BLN] = {eft_LNG, (void*)dpnp_vander_default_c<bool, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_VANDER][eft_INT][eft_INT] = {
+        eft_LNG, (void *)dpnp_vander_default_c<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_VANDER][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_vander_default_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_VANDER][eft_FLT][eft_FLT] = {
+        eft_DBL, (void *)dpnp_vander_default_c<float, double>};
+    fmap[DPNPFuncName::DPNP_FN_VANDER][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_vander_default_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_VANDER][eft_BLN][eft_BLN] = {
+        eft_LNG, (void *)dpnp_vander_default_c<bool, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_VANDER][eft_C128][eft_C128] = {
-        eft_C128, (void*)dpnp_vander_default_c<std::complex<double>, std::complex<double>>};
+        eft_C128,
+        (void *)
+            dpnp_vander_default_c<std::complex<double>, std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_INT][eft_INT] = {eft_LNG, (void*)dpnp_vander_ext_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_vander_ext_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_vander_ext_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_vander_ext_c<double, double>};
-    fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_BLN][eft_BLN] = {eft_LNG, (void*)dpnp_vander_ext_c<bool, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_INT][eft_INT] = {
+        eft_LNG, (void *)dpnp_vander_ext_c<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_vander_ext_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_vander_ext_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_vander_ext_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_BLN][eft_BLN] = {
+        eft_LNG, (void *)dpnp_vander_ext_c<bool, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_C64][eft_C64] = {
-        eft_C64, (void*)dpnp_vander_ext_c<std::complex<float>, std::complex<float>>};
+        eft_C64,
+        (void *)dpnp_vander_ext_c<std::complex<float>, std::complex<float>>};
     fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_C128][eft_C128] = {
-        eft_C128, (void*)dpnp_vander_ext_c<std::complex<double>, std::complex<double>>};
+        eft_C128,
+        (void *)dpnp_vander_ext_c<std::complex<double>, std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_trace_default_c<int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_LNG][eft_INT] = {eft_INT, (void*)dpnp_trace_default_c<int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_FLT][eft_INT] = {eft_INT, (void*)dpnp_trace_default_c<float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_DBL][eft_INT] = {eft_INT, (void*)dpnp_trace_default_c<double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_INT][eft_LNG] = {eft_LNG, (void*)dpnp_trace_default_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_trace_default_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_FLT][eft_LNG] = {eft_LNG, (void*)dpnp_trace_default_c<float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_DBL][eft_LNG] = {eft_LNG, (void*)dpnp_trace_default_c<double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_INT][eft_FLT] = {eft_FLT, (void*)dpnp_trace_default_c<int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_LNG][eft_FLT] = {eft_FLT, (void*)dpnp_trace_default_c<int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_trace_default_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_DBL][eft_FLT] = {eft_FLT, (void*)dpnp_trace_default_c<double, float>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_INT][eft_DBL] = {eft_DBL, (void*)dpnp_trace_default_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_LNG][eft_DBL] = {eft_DBL, (void*)dpnp_trace_default_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_FLT][eft_DBL] = {eft_DBL, (void*)dpnp_trace_default_c<float, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_trace_default_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_trace_default_c<int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_LNG][eft_INT] = {
+        eft_INT, (void *)dpnp_trace_default_c<int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_FLT][eft_INT] = {
+        eft_INT, (void *)dpnp_trace_default_c<float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_DBL][eft_INT] = {
+        eft_INT, (void *)dpnp_trace_default_c<double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_trace_default_c<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_trace_default_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_FLT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_trace_default_c<float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_DBL][eft_LNG] = {
+        eft_LNG, (void *)dpnp_trace_default_c<double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_INT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_trace_default_c<int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_LNG][eft_FLT] = {
+        eft_FLT, (void *)dpnp_trace_default_c<int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_trace_default_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_DBL][eft_FLT] = {
+        eft_FLT, (void *)dpnp_trace_default_c<double, float>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_trace_default_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_trace_default_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_trace_default_c<float, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_trace_default_c<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_trace_ext_c<int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_LNG][eft_INT] = {eft_INT, (void*)dpnp_trace_ext_c<int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_FLT][eft_INT] = {eft_INT, (void*)dpnp_trace_ext_c<float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_DBL][eft_INT] = {eft_INT, (void*)dpnp_trace_ext_c<double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_INT][eft_LNG] = {eft_LNG, (void*)dpnp_trace_ext_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_trace_ext_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_FLT][eft_LNG] = {eft_LNG, (void*)dpnp_trace_ext_c<float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_DBL][eft_LNG] = {eft_LNG, (void*)dpnp_trace_ext_c<double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_INT][eft_FLT] = {eft_FLT, (void*)dpnp_trace_ext_c<int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_LNG][eft_FLT] = {eft_FLT, (void*)dpnp_trace_ext_c<int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_trace_ext_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_DBL][eft_FLT] = {eft_FLT, (void*)dpnp_trace_ext_c<double, float>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_INT][eft_DBL] = {eft_DBL, (void*)dpnp_trace_ext_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_LNG][eft_DBL] = {eft_DBL, (void*)dpnp_trace_ext_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_FLT][eft_DBL] = {eft_DBL, (void*)dpnp_trace_ext_c<float, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_trace_ext_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_trace_ext_c<int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_LNG][eft_INT] = {
+        eft_INT, (void *)dpnp_trace_ext_c<int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_FLT][eft_INT] = {
+        eft_INT, (void *)dpnp_trace_ext_c<float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_DBL][eft_INT] = {
+        eft_INT, (void *)dpnp_trace_ext_c<double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_trace_ext_c<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_trace_ext_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_FLT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_trace_ext_c<float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_DBL][eft_LNG] = {
+        eft_LNG, (void *)dpnp_trace_ext_c<double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_INT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_trace_ext_c<int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_LNG][eft_FLT] = {
+        eft_FLT, (void *)dpnp_trace_ext_c<int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_trace_ext_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_DBL][eft_FLT] = {
+        eft_FLT, (void *)dpnp_trace_ext_c<double, float>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_trace_ext_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_trace_ext_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_trace_ext_c<float, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_trace_ext_c<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_TRI][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_tri_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRI][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_tri_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRI][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_tri_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_TRI][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_tri_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_TRI][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_tri_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRI][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_tri_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRI][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_tri_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_TRI][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_tri_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_TRI_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_tri_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRI_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_tri_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRI_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_tri_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_TRI_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_tri_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_TRI_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_tri_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRI_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_tri_ext_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRI_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_tri_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_TRI_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_tri_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_TRIL][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_tril_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRIL][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_tril_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRIL][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_tril_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_TRIL][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_tril_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_TRIL][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_tril_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRIL][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_tril_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRIL][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_tril_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_TRIL][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_tril_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_TRIU][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_triu_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRIU][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_triu_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRIU][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_triu_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_TRIU][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_triu_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_TRIU][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_triu_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRIU][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_triu_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRIU][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_triu_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_TRIU][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_triu_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_ZEROS][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_zeros_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_zeros_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_zeros_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_zeros_default_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_zeros_default_c<bool>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS][eft_C128][eft_C128] = {eft_C128,
-                                                             (void*)dpnp_zeros_default_c<std::complex<double>>};
+    fmap[DPNPFuncName::DPNP_FN_ZEROS][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_zeros_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ZEROS][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_zeros_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ZEROS][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_zeros_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_ZEROS][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_zeros_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_ZEROS][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_zeros_default_c<bool>};
+    fmap[DPNPFuncName::DPNP_FN_ZEROS][eft_C128][eft_C128] = {
+        eft_C128, (void *)dpnp_zeros_default_c<std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_zeros_like_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_zeros_like_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_zeros_like_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_zeros_like_default_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_zeros_like_default_c<bool>};
+    fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_zeros_like_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_zeros_like_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_zeros_like_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_zeros_like_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_zeros_like_default_c<bool>};
     fmap[DPNPFuncName::DPNP_FN_ZEROS_LIKE][eft_C128][eft_C128] = {
-        eft_C128, (void*)dpnp_zeros_like_default_c<std::complex<double>>};
+        eft_C128, (void *)dpnp_zeros_like_default_c<std::complex<double>>};
 
     return;
 }

--- a/dpnp/backend/kernels/dpnp_krnl_arraycreation.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_arraycreation.cpp
@@ -74,7 +74,7 @@ DPCTLSyclEventRef dpnp_arange_c(DPCTLSyclQueueRef q_ref,
             gws, kernel_parallel_for_func);
     };
 
-    event     = q.submit(kernel_func);
+    event = q.submit(kernel_func);
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
 
     return DPCTLEvent_Copy(event_ref);
@@ -85,7 +85,7 @@ void dpnp_arange_c(size_t start, size_t step, void *result1, size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_arange_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_arange_c<_DataType>(
         q_ref, start, step, result1, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
@@ -141,7 +141,7 @@ DPCTLSyclEventRef dpnp_diag_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     validate_type_for_device<_DataType>(q);
 
@@ -152,7 +152,7 @@ DPCTLSyclEventRef dpnp_diag_c(DPCTLSyclQueueRef q_ref,
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, v_in, input1_size, true);
     DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, result_size, true,
                                             true);
-    _DataType *v      = input1_ptr.get_ptr();
+    _DataType *v = input1_ptr.get_ptr();
     _DataType *result = result_ptr.get_ptr();
 
     size_t init0 = std::max(0, -k);
@@ -160,14 +160,14 @@ DPCTLSyclEventRef dpnp_diag_c(DPCTLSyclQueueRef q_ref,
 
     if (ndim == 1) {
         for (size_t i = 0; i < static_cast<size_t>(shape[0]); ++i) {
-            size_t ind  = (init0 + i) * res_shape[1] + init1 + i;
+            size_t ind = (init0 + i) * res_shape[1] + init1 + i;
             result[ind] = v[i];
         }
     }
     else {
         for (size_t i = 0; i < static_cast<size_t>(res_shape[0]); ++i) {
             size_t ind = (init0 + i) * shape[1] + init1 + i;
-            result[i]  = v[ind];
+            result[i] = v[ind];
         }
     }
     return event_ref;
@@ -296,7 +296,7 @@ void dpnp_full_c(void *array_in, void *result, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_full_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_full_c<_DataType>(
         q_ref, array_in, result, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
@@ -323,7 +323,7 @@ void dpnp_full_like_c(void *array_in, void *result, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_full_like_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_full_like_c<_DataType>(
         q_ref, array_in, result, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
@@ -361,8 +361,8 @@ DPCTLSyclEventRef dpnp_identity_c(DPCTLSyclQueueRef q_ref,
 
     sycl::range<2> gws(n, n);
     auto kernel_parallel_for_func = [=](sycl::id<2> global_id) {
-        size_t i          = global_id[0];
-        size_t j          = global_id[1];
+        size_t i = global_id[0];
+        size_t j = global_id[1];
         result[i * n + j] = i == j;
     };
 
@@ -371,7 +371,7 @@ DPCTLSyclEventRef dpnp_identity_c(DPCTLSyclQueueRef q_ref,
             gws, kernel_parallel_for_func);
     };
 
-    event     = q.submit(kernel_func);
+    event = q.submit(kernel_func);
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
 
     return DPCTLEvent_Copy(event_ref);
@@ -483,9 +483,9 @@ DPCTLSyclEventRef dpnp_ptp_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    DPCTLSyclEventRef e1_ref    = nullptr;
-    DPCTLSyclEventRef e2_ref    = nullptr;
-    DPCTLSyclEventRef e3_ref    = nullptr;
+    DPCTLSyclEventRef e1_ref = nullptr;
+    DPCTLSyclEventRef e2_ref = nullptr;
+    DPCTLSyclEventRef e3_ref = nullptr;
 
     if ((input1_in == nullptr) || (result1_out == nullptr)) {
         return event_ref;
@@ -502,7 +502,7 @@ DPCTLSyclEventRef dpnp_ptp_c(DPCTLSyclQueueRef q_ref,
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, input1_in, input_size, true);
     DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1_out, result_size,
                                             false, true);
-    _DataType *arr    = input1_ptr.get_ptr();
+    _DataType *arr = input1_ptr.get_ptr();
     _DataType *result = result_ptr.get_ptr();
 
     _DataType *min_arr = reinterpret_cast<_DataType *>(
@@ -554,7 +554,7 @@ void dpnp_ptp_c(void *result1_out,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_ptp_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_ptp_c<_DataType>(
         q_ref, result1_out, result_size, result_ndim, result_shape,
         result_strides, input1_in, input_size, input_ndim, input_shape,
         input_strides, axis, naxis, dep_event_vec_ref);
@@ -620,7 +620,7 @@ DPCTLSyclEventRef dpnp_vander_c(DPCTLSyclQueueRef q_ref,
     DPNPC_ptr_adapter<_DataType_output> result_ptr(q_ref, result1, size_in * N,
                                                    true, true);
     const _DataType_input *array_in = input1_ptr.get_ptr();
-    _DataType_output *result        = result_ptr.get_ptr();
+    _DataType_output *result = result_ptr.get_ptr();
 
     if (N == 1) {
         return dpnp_ones_c<_DataType_output>(q_ref, result, size_in,
@@ -711,7 +711,7 @@ DPCTLSyclEventRef dpnp_trace_c(DPCTLSyclQueueRef q_ref,
     }
 
     const size_t last_dim = shape_[ndim - 1];
-    const size_t size     = std::accumulate(shape_, shape_ + (ndim - 1), 1,
+    const size_t size = std::accumulate(shape_, shape_ + (ndim - 1), 1,
                                         std::multiplies<shape_elem_type>());
     if (!size) {
         return event_ref;
@@ -723,11 +723,11 @@ DPCTLSyclEventRef dpnp_trace_c(DPCTLSyclQueueRef q_ref,
     validate_type_for_device<_ResultType>(q);
 
     const _DataType *input = static_cast<const _DataType *>(array1_in);
-    _ResultType *result    = static_cast<_ResultType *>(result_in);
+    _ResultType *result = static_cast<_ResultType *>(result_in);
 
     sycl::range<1> gws(size);
     auto kernel_parallel_for_func = [=](auto index) {
-        size_t i        = index[0];
+        size_t i = index[0];
         _ResultType acc = _ResultType(0);
 
         for (size_t j = 0; j < last_dim; ++j) {
@@ -743,7 +743,7 @@ DPCTLSyclEventRef dpnp_trace_c(DPCTLSyclQueueRef q_ref,
     };
 
     auto event = q.submit(kernel_func);
-    event_ref  = reinterpret_cast<DPCTLSyclEventRef>(&event);
+    event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
 
     return DPCTLEvent_Copy(event_ref);
 }
@@ -810,12 +810,12 @@ DPCTLSyclEventRef dpnp_tri_c(DPCTLSyclQueueRef q_ref,
     sycl::range<1> gws(idx);
     auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
         size_t ind = global_id[0];
-        size_t i   = ind / M;
-        size_t j   = ind % M;
+        size_t i = ind / M;
+        size_t j = ind % M;
 
-        int val          = i + k + 1;
+        int val = i + k + 1;
         size_t diag_idx_ = (val > 0) ? (size_t)val : 0;
-        size_t diag_idx  = (M < diag_idx_) ? M : diag_idx_;
+        size_t diag_idx = (M < diag_idx_) ? M : diag_idx_;
 
         if (j < diag_idx) {
             result[ind] = 1;
@@ -830,7 +830,7 @@ DPCTLSyclEventRef dpnp_tri_c(DPCTLSyclQueueRef q_ref,
             gws, kernel_parallel_for_func);
     };
 
-    event     = q.submit(kernel_func);
+    event = q.submit(kernel_func);
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
 
     return DPCTLEvent_Copy(event_ref);
@@ -908,17 +908,17 @@ DPCTLSyclEventRef dpnp_tril_c(DPCTLSyclQueueRef q_ref,
     DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, res_size, true,
                                             true);
     _DataType *array_m = input1_ptr.get_ptr();
-    _DataType *result  = result_ptr.get_ptr();
+    _DataType *result = result_ptr.get_ptr();
 
     if (ndim == 1) {
         for (size_t i = 0; i < res_size; ++i) {
-            size_t n   = res_size;
+            size_t n = res_size;
             size_t val = i;
             int ids[res_ndim];
             for (size_t j = 0; j < res_ndim; ++j) {
                 n /= res_shape[j];
                 size_t p = val / n;
-                ids[j]   = p;
+                ids[j] = p;
                 if (p != 0) {
                     val = val - p * n;
                 }
@@ -926,7 +926,7 @@ DPCTLSyclEventRef dpnp_tril_c(DPCTLSyclQueueRef q_ref,
 
             int diag_idx_ =
                 (ids[res_ndim - 2] + k > -1) ? (ids[res_ndim - 2] + k) : -1;
-            int values   = res_shape[res_ndim - 1];
+            int values = res_shape[res_ndim - 1];
             int diag_idx = (values < diag_idx_) ? values : diag_idx_;
 
             if (ids[res_ndim - 1] <= diag_idx) {
@@ -939,13 +939,13 @@ DPCTLSyclEventRef dpnp_tril_c(DPCTLSyclQueueRef q_ref,
     }
     else {
         for (size_t i = 0; i < res_size; ++i) {
-            size_t n   = res_size;
+            size_t n = res_size;
             size_t val = i;
             int ids[res_ndim];
             for (size_t j = 0; j < res_ndim; ++j) {
                 n /= res_shape[j];
                 size_t p = val / n;
-                ids[j]   = p;
+                ids[j] = p;
                 if (p != 0) {
                     val = val - p * n;
                 }
@@ -953,7 +953,7 @@ DPCTLSyclEventRef dpnp_tril_c(DPCTLSyclQueueRef q_ref,
 
             int diag_idx_ =
                 (ids[res_ndim - 2] + k > -1) ? (ids[res_ndim - 2] + k) : -1;
-            int values   = res_shape[res_ndim - 1];
+            int values = res_shape[res_ndim - 1];
             int diag_idx = (values < diag_idx_) ? values : diag_idx_;
 
             if (ids[res_ndim - 1] <= diag_idx) {
@@ -1042,17 +1042,17 @@ DPCTLSyclEventRef dpnp_triu_c(DPCTLSyclQueueRef q_ref,
     DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, res_size, true,
                                             true);
     _DataType *array_m = input1_ptr.get_ptr();
-    _DataType *result  = result_ptr.get_ptr();
+    _DataType *result = result_ptr.get_ptr();
 
     if (ndim == 1) {
         for (size_t i = 0; i < res_size; ++i) {
-            size_t n   = res_size;
+            size_t n = res_size;
             size_t val = i;
             int ids[res_ndim];
             for (size_t j = 0; j < res_ndim; ++j) {
                 n /= res_shape[j];
                 size_t p = val / n;
-                ids[j]   = p;
+                ids[j] = p;
                 if (p != 0) {
                     val = val - p * n;
                 }
@@ -1060,7 +1060,7 @@ DPCTLSyclEventRef dpnp_triu_c(DPCTLSyclQueueRef q_ref,
 
             int diag_idx_ =
                 (ids[res_ndim - 2] + k > -1) ? (ids[res_ndim - 2] + k) : -1;
-            int values   = res_shape[res_ndim - 1];
+            int values = res_shape[res_ndim - 1];
             int diag_idx = (values < diag_idx_) ? values : diag_idx_;
 
             if (ids[res_ndim - 1] >= diag_idx) {
@@ -1073,13 +1073,13 @@ DPCTLSyclEventRef dpnp_triu_c(DPCTLSyclQueueRef q_ref,
     }
     else {
         for (size_t i = 0; i < res_size; ++i) {
-            size_t n   = res_size;
+            size_t n = res_size;
             size_t val = i;
             int ids[res_ndim];
             for (size_t j = 0; j < res_ndim; ++j) {
                 n /= res_shape[j];
                 size_t p = val / n;
-                ids[j]   = p;
+                ids[j] = p;
                 if (p != 0) {
                     val = val - p * n;
                 }
@@ -1087,7 +1087,7 @@ DPCTLSyclEventRef dpnp_triu_c(DPCTLSyclQueueRef q_ref,
 
             int diag_idx_ =
                 (ids[res_ndim - 2] + k > -1) ? (ids[res_ndim - 2] + k) : -1;
-            int values   = res_shape[res_ndim - 1];
+            int values = res_shape[res_ndim - 1];
             int diag_idx = (values < diag_idx_) ? values : diag_idx_;
 
             if (ids[res_ndim - 1] >= diag_idx) {

--- a/dpnp/backend/kernels/dpnp_krnl_bitwise.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_bitwise.cpp
@@ -51,9 +51,9 @@ DPCTLSyclEventRef dpnp_invert_c(DPCTLSyclQueueRef q_ref,
     sycl::event event;
 
     _DataType *input_data = static_cast<_DataType *>(array1_in);
-    _DataType *result     = static_cast<_DataType *>(result1);
+    _DataType *result = static_cast<_DataType *>(result1);
 
-    constexpr size_t lws          = 64;
+    constexpr size_t lws = 64;
     constexpr unsigned int vec_sz = 8;
 
     auto gws_range =
@@ -61,7 +61,7 @@ DPCTLSyclEventRef dpnp_invert_c(DPCTLSyclQueueRef q_ref,
     auto lws_range = sycl::range<1>(lws);
 
     auto kernel_parallel_for_func = [=](sycl::nd_item<1> nd_it) {
-        auto sg                = nd_it.get_sub_group();
+        auto sg = nd_it.get_sub_group();
         const auto max_sg_size = sg.get_max_local_range()[0];
         const size_t start =
             vec_sz * (nd_it.get_group(0) * nd_it.get_local_range(0) +
@@ -116,7 +116,7 @@ void dpnp_invert_c(void *array1_in, void *result1, size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_invert_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_invert_c<_DataType>(
         q_ref, array1_in, result1, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
@@ -154,260 +154,260 @@ static void func_map_init_bitwise_1arg_1type(func_map_t &fmap)
     return;
 }
 
-#define MACRO_2ARG_1TYPE_OP(__name__, __operation__)                                     \
-    template <typename _KernelNameSpecialization>                                        \
-    class __name__##_kernel;                                                             \
-                                                                                         \
-    template <typename _KernelNameSpecialization>                                        \
-    class __name__##_strides_kernel;                                                     \
-                                                                                         \
-    template <typename _KernelNameSpecialization>                                        \
-    class __name__##_broadcast_kernel;                                                   \
-                                                                                         \
-    template <typename _DataType>                                                        \
-    DPCTLSyclEventRef __name__(                                                          \
-        DPCTLSyclQueueRef q_ref, void *result_out, const size_t result_size,             \
-        const size_t result_ndim, const shape_elem_type *result_shape,                   \
-        const shape_elem_type *result_strides, const void *input1_in,                    \
-        const size_t input1_size, const size_t input1_ndim,                              \
-        const shape_elem_type *input1_shape,                                             \
-        const shape_elem_type *input1_strides, const void *input2_in,                    \
-        const size_t input2_size, const size_t input2_ndim,                              \
-        const shape_elem_type *input2_shape,                                             \
-        const shape_elem_type *input2_strides, const size_t *where,                      \
-        const DPCTLEventVectorRef dep_event_vec_ref)                                     \
-    {                                                                                    \
-        /* avoid warning unused variable*/                                               \
-        (void)result_shape;                                                              \
-        (void)where;                                                                     \
-        (void)dep_event_vec_ref;                                                         \
-                                                                                         \
-        DPCTLSyclEventRef event_ref = nullptr;                                           \
-                                                                                         \
-        if (!input1_size || !input2_size) {                                              \
-            return event_ref;                                                            \
-        }                                                                                \
-                                                                                         \
-        sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));                       \
-                                                                                         \
-        _DataType *input1_data =                                                         \
-            static_cast<_DataType *>(const_cast<void *>(input1_in));                     \
-        _DataType *input2_data =                                                         \
-            static_cast<_DataType *>(const_cast<void *>(input2_in));                     \
-        _DataType *result = static_cast<_DataType *>(result_out);                        \
-                                                                                         \
-        bool use_broadcasting = !array_equal(input1_shape, input1_ndim,                  \
-                                             input2_shape, input2_ndim);                 \
-                                                                                         \
-        shape_elem_type *input1_shape_offsets =                                          \
-            new shape_elem_type[input1_ndim];                                            \
-                                                                                         \
-        get_shape_offsets_inkernel(input1_shape, input1_ndim,                            \
-                                   input1_shape_offsets);                                \
-        bool use_strides = !array_equal(input1_strides, input1_ndim,                     \
-                                        input1_shape_offsets, input1_ndim);              \
-        delete[] input1_shape_offsets;                                                   \
-                                                                                         \
-        shape_elem_type *input2_shape_offsets =                                          \
-            new shape_elem_type[input2_ndim];                                            \
-                                                                                         \
-        get_shape_offsets_inkernel(input2_shape, input2_ndim,                            \
-                                   input2_shape_offsets);                                \
-        use_strides =                                                                    \
-            use_strides || !array_equal(input2_strides, input2_ndim,                     \
-                                        input2_shape_offsets, input2_ndim);              \
-        delete[] input2_shape_offsets;                                                   \
-                                                                                         \
-        sycl::event event;                                                               \
-        sycl::range<1> gws(result_size);                                                 \
-                                                                                         \
-        if (use_broadcasting) {                                                          \
-            DPNPC_id<_DataType> *input1_it;                                              \
-            const size_t input1_it_size_in_bytes =                                       \
-                sizeof(DPNPC_id<_DataType>);                                             \
-            input1_it = reinterpret_cast<DPNPC_id<_DataType> *>(                         \
-                dpnp_memory_alloc_c(q_ref, input1_it_size_in_bytes));                    \
-            new (input1_it)                                                              \
-                DPNPC_id<_DataType>(q_ref, input1_data, input1_shape,                    \
-                                    input1_strides, input1_ndim);                        \
-                                                                                         \
-            input1_it->broadcast_to_shape(result_shape, result_ndim);                    \
-                                                                                         \
-            DPNPC_id<_DataType> *input2_it;                                              \
-            const size_t input2_it_size_in_bytes =                                       \
-                sizeof(DPNPC_id<_DataType>);                                             \
-            input2_it = reinterpret_cast<DPNPC_id<_DataType> *>(                         \
-                dpnp_memory_alloc_c(q_ref, input2_it_size_in_bytes));                    \
-            new (input2_it)                                                              \
-                DPNPC_id<_DataType>(q_ref, input2_data, input2_shape,                    \
-                                    input2_strides, input2_ndim);                        \
-                                                                                         \
-            input2_it->broadcast_to_shape(result_shape, result_ndim);                    \
-                                                                                         \
-            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {                 \
-                const size_t i = global_id[0]; /* for (size_t i = 0; i <                 \
-                                                  result_size; ++i) */                   \
-                {                                                                        \
-                    const _DataType input1_elem = (*input1_it)[i];                       \
-                    const _DataType input2_elem = (*input2_it)[i];                       \
-                    result[i]                   = __operation__;                         \
-                }                                                                        \
-            };                                                                           \
-            auto kernel_func = [&](sycl::handler &cgh) {                                 \
-                cgh.parallel_for<                                                        \
-                    class __name__##_broadcast_kernel<_DataType>>(                       \
-                    gws, kernel_parallel_for_func);                                      \
-            };                                                                           \
-                                                                                         \
-            q.submit(kernel_func).wait();                                                \
-                                                                                         \
-            input1_it->~DPNPC_id();                                                      \
-            input2_it->~DPNPC_id();                                                      \
-                                                                                         \
-            return event_ref;                                                            \
-        }                                                                                \
-        else if (use_strides) {                                                          \
-            if ((result_ndim != input1_ndim) || (result_ndim != input2_ndim))            \
-            {                                                                            \
-                throw std::runtime_error(                                                \
-                    "Result ndim=" + std::to_string(result_ndim) +                       \
-                    " mismatches with either input1 ndim=" +                             \
-                    std::to_string(input1_ndim) +                                        \
-                    " or input2 ndim=" + std::to_string(input2_ndim));                   \
-            }                                                                            \
-                                                                                         \
-            /* memory transfer optimization, use USM-host for temporary speeds           \
-             * up tranfer to device */                                                   \
-            using usm_host_allocatorT =                                                  \
-                sycl::usm_allocator<shape_elem_type, sycl::usm::alloc::host>;            \
-                                                                                         \
-            size_t strides_size = 3 * result_ndim;                                       \
-            shape_elem_type *dev_strides_data =                                          \
-                sycl::malloc_device<shape_elem_type>(strides_size, q);                   \
-                                                                                         \
-            /* create host temporary for packed strides managed by shared                \
-             * pointer */                                                                \
-            auto strides_host_packed =                                                   \
-                std::vector<shape_elem_type, usm_host_allocatorT>(                       \
-                    strides_size, usm_host_allocatorT(q));                               \
-                                                                                         \
-            /* packed vector is concatenation of result_strides,                         \
-             * input1_strides and input2_strides */                                      \
-            std::copy(result_strides, result_strides + result_ndim,                      \
-                      strides_host_packed.begin());                                      \
-            std::copy(input1_strides, input1_strides + result_ndim,                      \
-                      strides_host_packed.begin() + result_ndim);                        \
-            std::copy(input2_strides, input2_strides + result_ndim,                      \
-                      strides_host_packed.begin() + 2 * result_ndim);                    \
-                                                                                         \
-            auto copy_strides_ev = q.copy<shape_elem_type>(                              \
-                strides_host_packed.data(), dev_strides_data,                            \
-                strides_host_packed.size());                                             \
-                                                                                         \
-            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {                 \
-                const size_t output_id =                                                 \
-                    global_id[0]; /* for (size_t i = 0; i < result_size; ++i)            \
-                                   */                                                    \
-                {                                                                        \
-                    const shape_elem_type *result_strides_data =                         \
-                        &dev_strides_data[0];                                            \
-                    const shape_elem_type *input1_strides_data =                         \
-                        &dev_strides_data[result_ndim];                                  \
-                    const shape_elem_type *input2_strides_data =                         \
-                        &dev_strides_data[2 * result_ndim];                              \
-                                                                                         \
-                    size_t input1_id = 0;                                                \
-                    size_t input2_id = 0;                                                \
-                                                                                         \
-                    for (size_t i = 0; i < result_ndim; ++i) {                           \
-                        const size_t output_xyz_id =                                     \
-                            get_xyz_id_by_id_inkernel(output_id,                         \
-                                                      result_strides_data,               \
-                                                      result_ndim, i);                   \
-                        input1_id += output_xyz_id * input1_strides_data[i];             \
-                        input2_id += output_xyz_id * input2_strides_data[i];             \
-                    }                                                                    \
-                                                                                         \
-                    const _DataType input1_elem =                                        \
-                        (input1_size == 1) ? input1_data[0]                              \
-                                           : input1_data[input1_id];                     \
-                    const _DataType input2_elem =                                        \
-                        (input2_size == 1) ? input2_data[0]                              \
-                                           : input2_data[input2_id];                     \
-                    result[output_id] = __operation__;                                   \
-                }                                                                        \
-            };                                                                           \
-            auto kernel_func = [&](sycl::handler &cgh) {                                 \
-                cgh.depends_on(copy_strides_ev);                                         \
-                cgh.parallel_for<class __name__##_strides_kernel<_DataType>>(            \
-                    gws, kernel_parallel_for_func);                                      \
-            };                                                                           \
-                                                                                         \
-            q.submit(kernel_func).wait();                                                \
-                                                                                         \
-            sycl::free(dev_strides_data, q);                                             \
-            return event_ref;                                                            \
-        }                                                                                \
-        else {                                                                           \
-            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {                 \
-                size_t i = global_id[0]; /* for (size_t i = 0; i <                       \
-                                            result_size; ++i) */                         \
-                const _DataType input1_elem =                                            \
-                    (input1_size == 1) ? input1_data[0] : input1_data[i];                \
-                const _DataType input2_elem =                                            \
-                    (input2_size == 1) ? input2_data[0] : input2_data[i];                \
-                result[i] = __operation__;                                               \
-            };                                                                           \
-            auto kernel_func = [&](sycl::handler &cgh) {                                 \
-                cgh.parallel_for<class __name__##_kernel<_DataType>>(                    \
-                    gws, kernel_parallel_for_func);                                      \
-            };                                                                           \
-            event = q.submit(kernel_func);                                               \
-        }                                                                                \
-                                                                                         \
-        event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);                         \
-        return DPCTLEvent_Copy(event_ref);                                               \
-    }                                                                                    \
-                                                                                         \
-    template <typename _DataType>                                                        \
-    void __name__(                                                                       \
-        void *result_out, const size_t result_size, const size_t result_ndim,            \
-        const shape_elem_type *result_shape,                                             \
-        const shape_elem_type *result_strides, const void *input1_in,                    \
-        const size_t input1_size, const size_t input1_ndim,                              \
-        const shape_elem_type *input1_shape,                                             \
-        const shape_elem_type *input1_strides, const void *input2_in,                    \
-        const size_t input2_size, const size_t input2_ndim,                              \
-        const shape_elem_type *input2_shape,                                             \
-        const shape_elem_type *input2_strides, const size_t *where)                      \
-    {                                                                                    \
-        DPCTLSyclQueueRef q_ref =                                                        \
-            reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);                            \
-        DPCTLEventVectorRef dep_event_vec_ref = nullptr;                                 \
-        DPCTLSyclEventRef event_ref           = __name__<_DataType>(                     \
+#define MACRO_2ARG_1TYPE_OP(__name__, __operation__)                           \
+    template <typename _KernelNameSpecialization>                              \
+    class __name__##_kernel;                                                   \
+                                                                               \
+    template <typename _KernelNameSpecialization>                              \
+    class __name__##_strides_kernel;                                           \
+                                                                               \
+    template <typename _KernelNameSpecialization>                              \
+    class __name__##_broadcast_kernel;                                         \
+                                                                               \
+    template <typename _DataType>                                              \
+    DPCTLSyclEventRef __name__(                                                \
+        DPCTLSyclQueueRef q_ref, void *result_out, const size_t result_size,   \
+        const size_t result_ndim, const shape_elem_type *result_shape,         \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const void *input2_in,          \
+        const size_t input2_size, const size_t input2_ndim,                    \
+        const shape_elem_type *input2_shape,                                   \
+        const shape_elem_type *input2_strides, const size_t *where,            \
+        const DPCTLEventVectorRef dep_event_vec_ref)                           \
+    {                                                                          \
+        /* avoid warning unused variable*/                                     \
+        (void)result_shape;                                                    \
+        (void)where;                                                           \
+        (void)dep_event_vec_ref;                                               \
+                                                                               \
+        DPCTLSyclEventRef event_ref = nullptr;                                 \
+                                                                               \
+        if (!input1_size || !input2_size) {                                    \
+            return event_ref;                                                  \
+        }                                                                      \
+                                                                               \
+        sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));             \
+                                                                               \
+        _DataType *input1_data =                                               \
+            static_cast<_DataType *>(const_cast<void *>(input1_in));           \
+        _DataType *input2_data =                                               \
+            static_cast<_DataType *>(const_cast<void *>(input2_in));           \
+        _DataType *result = static_cast<_DataType *>(result_out);              \
+                                                                               \
+        bool use_broadcasting = !array_equal(input1_shape, input1_ndim,        \
+                                             input2_shape, input2_ndim);       \
+                                                                               \
+        shape_elem_type *input1_shape_offsets =                                \
+            new shape_elem_type[input1_ndim];                                  \
+                                                                               \
+        get_shape_offsets_inkernel(input1_shape, input1_ndim,                  \
+                                   input1_shape_offsets);                      \
+        bool use_strides = !array_equal(input1_strides, input1_ndim,           \
+                                        input1_shape_offsets, input1_ndim);    \
+        delete[] input1_shape_offsets;                                         \
+                                                                               \
+        shape_elem_type *input2_shape_offsets =                                \
+            new shape_elem_type[input2_ndim];                                  \
+                                                                               \
+        get_shape_offsets_inkernel(input2_shape, input2_ndim,                  \
+                                   input2_shape_offsets);                      \
+        use_strides =                                                          \
+            use_strides || !array_equal(input2_strides, input2_ndim,           \
+                                        input2_shape_offsets, input2_ndim);    \
+        delete[] input2_shape_offsets;                                         \
+                                                                               \
+        sycl::event event;                                                     \
+        sycl::range<1> gws(result_size);                                       \
+                                                                               \
+        if (use_broadcasting) {                                                \
+            DPNPC_id<_DataType> *input1_it;                                    \
+            const size_t input1_it_size_in_bytes =                             \
+                sizeof(DPNPC_id<_DataType>);                                   \
+            input1_it = reinterpret_cast<DPNPC_id<_DataType> *>(               \
+                dpnp_memory_alloc_c(q_ref, input1_it_size_in_bytes));          \
+            new (input1_it)                                                    \
+                DPNPC_id<_DataType>(q_ref, input1_data, input1_shape,          \
+                                    input1_strides, input1_ndim);              \
+                                                                               \
+            input1_it->broadcast_to_shape(result_shape, result_ndim);          \
+                                                                               \
+            DPNPC_id<_DataType> *input2_it;                                    \
+            const size_t input2_it_size_in_bytes =                             \
+                sizeof(DPNPC_id<_DataType>);                                   \
+            input2_it = reinterpret_cast<DPNPC_id<_DataType> *>(               \
+                dpnp_memory_alloc_c(q_ref, input2_it_size_in_bytes));          \
+            new (input2_it)                                                    \
+                DPNPC_id<_DataType>(q_ref, input2_data, input2_shape,          \
+                                    input2_strides, input2_ndim);              \
+                                                                               \
+            input2_it->broadcast_to_shape(result_shape, result_ndim);          \
+                                                                               \
+            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {       \
+                const size_t i = global_id[0]; /* for (size_t i = 0; i <       \
+                                                  result_size; ++i) */         \
+                {                                                              \
+                    const _DataType input1_elem = (*input1_it)[i];             \
+                    const _DataType input2_elem = (*input2_it)[i];             \
+                    result[i] = __operation__;                                 \
+                }                                                              \
+            };                                                                 \
+            auto kernel_func = [&](sycl::handler &cgh) {                       \
+                cgh.parallel_for<                                              \
+                    class __name__##_broadcast_kernel<_DataType>>(             \
+                    gws, kernel_parallel_for_func);                            \
+            };                                                                 \
+                                                                               \
+            q.submit(kernel_func).wait();                                      \
+                                                                               \
+            input1_it->~DPNPC_id();                                            \
+            input2_it->~DPNPC_id();                                            \
+                                                                               \
+            return event_ref;                                                  \
+        }                                                                      \
+        else if (use_strides) {                                                \
+            if ((result_ndim != input1_ndim) || (result_ndim != input2_ndim))  \
+            {                                                                  \
+                throw std::runtime_error(                                      \
+                    "Result ndim=" + std::to_string(result_ndim) +             \
+                    " mismatches with either input1 ndim=" +                   \
+                    std::to_string(input1_ndim) +                              \
+                    " or input2 ndim=" + std::to_string(input2_ndim));         \
+            }                                                                  \
+                                                                               \
+            /* memory transfer optimization, use USM-host for temporary speeds \
+             * up tranfer to device */                                         \
+            using usm_host_allocatorT =                                        \
+                sycl::usm_allocator<shape_elem_type, sycl::usm::alloc::host>;  \
+                                                                               \
+            size_t strides_size = 3 * result_ndim;                             \
+            shape_elem_type *dev_strides_data =                                \
+                sycl::malloc_device<shape_elem_type>(strides_size, q);         \
+                                                                               \
+            /* create host temporary for packed strides managed by shared      \
+             * pointer */                                                      \
+            auto strides_host_packed =                                         \
+                std::vector<shape_elem_type, usm_host_allocatorT>(             \
+                    strides_size, usm_host_allocatorT(q));                     \
+                                                                               \
+            /* packed vector is concatenation of result_strides,               \
+             * input1_strides and input2_strides */                            \
+            std::copy(result_strides, result_strides + result_ndim,            \
+                      strides_host_packed.begin());                            \
+            std::copy(input1_strides, input1_strides + result_ndim,            \
+                      strides_host_packed.begin() + result_ndim);              \
+            std::copy(input2_strides, input2_strides + result_ndim,            \
+                      strides_host_packed.begin() + 2 * result_ndim);          \
+                                                                               \
+            auto copy_strides_ev = q.copy<shape_elem_type>(                    \
+                strides_host_packed.data(), dev_strides_data,                  \
+                strides_host_packed.size());                                   \
+                                                                               \
+            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {       \
+                const size_t output_id =                                       \
+                    global_id[0]; /* for (size_t i = 0; i < result_size; ++i)  \
+                                   */                                          \
+                {                                                              \
+                    const shape_elem_type *result_strides_data =               \
+                        &dev_strides_data[0];                                  \
+                    const shape_elem_type *input1_strides_data =               \
+                        &dev_strides_data[result_ndim];                        \
+                    const shape_elem_type *input2_strides_data =               \
+                        &dev_strides_data[2 * result_ndim];                    \
+                                                                               \
+                    size_t input1_id = 0;                                      \
+                    size_t input2_id = 0;                                      \
+                                                                               \
+                    for (size_t i = 0; i < result_ndim; ++i) {                 \
+                        const size_t output_xyz_id =                           \
+                            get_xyz_id_by_id_inkernel(output_id,               \
+                                                      result_strides_data,     \
+                                                      result_ndim, i);         \
+                        input1_id += output_xyz_id * input1_strides_data[i];   \
+                        input2_id += output_xyz_id * input2_strides_data[i];   \
+                    }                                                          \
+                                                                               \
+                    const _DataType input1_elem =                              \
+                        (input1_size == 1) ? input1_data[0]                    \
+                                           : input1_data[input1_id];           \
+                    const _DataType input2_elem =                              \
+                        (input2_size == 1) ? input2_data[0]                    \
+                                           : input2_data[input2_id];           \
+                    result[output_id] = __operation__;                         \
+                }                                                              \
+            };                                                                 \
+            auto kernel_func = [&](sycl::handler &cgh) {                       \
+                cgh.depends_on(copy_strides_ev);                               \
+                cgh.parallel_for<class __name__##_strides_kernel<_DataType>>(  \
+                    gws, kernel_parallel_for_func);                            \
+            };                                                                 \
+                                                                               \
+            q.submit(kernel_func).wait();                                      \
+                                                                               \
+            sycl::free(dev_strides_data, q);                                   \
+            return event_ref;                                                  \
+        }                                                                      \
+        else {                                                                 \
+            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {       \
+                size_t i = global_id[0]; /* for (size_t i = 0; i <             \
+                                            result_size; ++i) */               \
+                const _DataType input1_elem =                                  \
+                    (input1_size == 1) ? input1_data[0] : input1_data[i];      \
+                const _DataType input2_elem =                                  \
+                    (input2_size == 1) ? input2_data[0] : input2_data[i];      \
+                result[i] = __operation__;                                     \
+            };                                                                 \
+            auto kernel_func = [&](sycl::handler &cgh) {                       \
+                cgh.parallel_for<class __name__##_kernel<_DataType>>(          \
+                    gws, kernel_parallel_for_func);                            \
+            };                                                                 \
+            event = q.submit(kernel_func);                                     \
+        }                                                                      \
+                                                                               \
+        event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);               \
+        return DPCTLEvent_Copy(event_ref);                                     \
+    }                                                                          \
+                                                                               \
+    template <typename _DataType>                                              \
+    void __name__(                                                             \
+        void *result_out, const size_t result_size, const size_t result_ndim,  \
+        const shape_elem_type *result_shape,                                   \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const void *input2_in,          \
+        const size_t input2_size, const size_t input2_ndim,                    \
+        const shape_elem_type *input2_shape,                                   \
+        const shape_elem_type *input2_strides, const size_t *where)            \
+    {                                                                          \
+        DPCTLSyclQueueRef q_ref =                                              \
+            reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);                  \
+        DPCTLEventVectorRef dep_event_vec_ref = nullptr;                       \
+        DPCTLSyclEventRef event_ref = __name__<_DataType>(                     \
             q_ref, result_out, result_size, result_ndim, result_shape,         \
             result_strides, input1_in, input1_size, input1_ndim, input1_shape, \
             input1_strides, input2_in, input2_size, input2_ndim, input2_shape, \
             input2_strides, where, dep_event_vec_ref);                         \
-        DPCTLEvent_WaitAndThrow(event_ref);                                              \
-        DPCTLEvent_Delete(event_ref);                                                    \
-    }                                                                                    \
-                                                                                         \
-    template <typename _DataType>                                                        \
-    void (*__name__##_default)(                                                          \
-        void *, const size_t, const size_t, const shape_elem_type *,                     \
-        const shape_elem_type *, const void *, const size_t, const size_t,               \
-        const shape_elem_type *, const shape_elem_type *, const void *,                  \
-        const size_t, const size_t, const shape_elem_type *,                             \
-        const shape_elem_type *, const size_t *) = __name__<_DataType>;                  \
-                                                                                         \
-    template <typename _DataType>                                                        \
-    DPCTLSyclEventRef (*__name__##_ext)(                                                 \
-        DPCTLSyclQueueRef, void *, const size_t, const size_t,                           \
-        const shape_elem_type *, const shape_elem_type *, const void *,                  \
-        const size_t, const size_t, const shape_elem_type *,                             \
-        const shape_elem_type *, const void *, const size_t, const size_t,               \
-        const shape_elem_type *, const shape_elem_type *, const size_t *,                \
+        DPCTLEvent_WaitAndThrow(event_ref);                                    \
+        DPCTLEvent_Delete(event_ref);                                          \
+    }                                                                          \
+                                                                               \
+    template <typename _DataType>                                              \
+    void (*__name__##_default)(                                                \
+        void *, const size_t, const size_t, const shape_elem_type *,           \
+        const shape_elem_type *, const void *, const size_t, const size_t,     \
+        const shape_elem_type *, const shape_elem_type *, const void *,        \
+        const size_t, const size_t, const shape_elem_type *,                   \
+        const shape_elem_type *, const size_t *) = __name__<_DataType>;        \
+                                                                               \
+    template <typename _DataType>                                              \
+    DPCTLSyclEventRef (*__name__##_ext)(                                       \
+        DPCTLSyclQueueRef, void *, const size_t, const size_t,                 \
+        const shape_elem_type *, const shape_elem_type *, const void *,        \
+        const size_t, const size_t, const shape_elem_type *,                   \
+        const shape_elem_type *, const void *, const size_t, const size_t,     \
+        const shape_elem_type *, const shape_elem_type *, const size_t *,      \
         const DPCTLEventVectorRef) = __name__<_DataType>;
 
 #include <dpnp_gen_2arg_1type_tbl.hpp>

--- a/dpnp/backend/kernels/dpnp_krnl_bitwise.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_bitwise.cpp
@@ -37,8 +37,8 @@ class dpnp_invert_c_kernel;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_invert_c(DPCTLSyclQueueRef q_ref,
-                                void* array1_in,
-                                void* result1,
+                                void *array1_in,
+                                void *result1,
                                 size_t size,
                                 const DPCTLEventVectorRef dep_event_vec_ref)
 {
@@ -47,65 +47,63 @@ DPCTLSyclEventRef dpnp_invert_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
     sycl::event event;
 
-    _DataType* input_data = static_cast<_DataType*>(array1_in);
-    _DataType* result = static_cast<_DataType*>(result1);
+    _DataType *input_data = static_cast<_DataType *>(array1_in);
+    _DataType *result     = static_cast<_DataType *>(result1);
 
-    constexpr size_t lws = 64;
+    constexpr size_t lws          = 64;
     constexpr unsigned int vec_sz = 8;
 
-    auto gws_range = sycl::range<1>(((size + lws * vec_sz - 1) / (lws * vec_sz)) * lws);
+    auto gws_range =
+        sycl::range<1>(((size + lws * vec_sz - 1) / (lws * vec_sz)) * lws);
     auto lws_range = sycl::range<1>(lws);
 
     auto kernel_parallel_for_func = [=](sycl::nd_item<1> nd_it) {
-        auto sg = nd_it.get_sub_group();
+        auto sg                = nd_it.get_sub_group();
         const auto max_sg_size = sg.get_max_local_range()[0];
         const size_t start =
-            vec_sz * (nd_it.get_group(0) * nd_it.get_local_range(0) + sg.get_group_id()[0] * max_sg_size);
+            vec_sz * (nd_it.get_group(0) * nd_it.get_local_range(0) +
+                      sg.get_group_id()[0] * max_sg_size);
 
-        if (start + static_cast<size_t>(vec_sz) * max_sg_size < size)
-        {
-            using multi_ptrT = sycl::multi_ptr<_DataType, sycl::access::address_space::global_space>;
+        if (start + static_cast<size_t>(vec_sz) * max_sg_size < size) {
+            using multi_ptrT =
+                sycl::multi_ptr<_DataType,
+                                sycl::access::address_space::global_space>;
 
-            sycl::vec<_DataType, vec_sz> x = sg.load<vec_sz>(multi_ptrT(&input_data[start]));
+            sycl::vec<_DataType, vec_sz> x =
+                sg.load<vec_sz>(multi_ptrT(&input_data[start]));
             sycl::vec<_DataType, vec_sz> res_vec;
 
-            if constexpr (std::is_same_v<_DataType, bool>)
-            {
+            if constexpr (std::is_same_v<_DataType, bool>) {
 #pragma unroll
-                for (size_t k = 0; k < vec_sz; ++k)
-                {
+                for (size_t k = 0; k < vec_sz; ++k) {
                     res_vec[k] = !(x[k]);
                 }
             }
-            else
-            {
+            else {
                 res_vec = ~x;
             }
 
             sg.store<vec_sz>(multi_ptrT(&result[start]), res_vec);
         }
-        else
-        {
-            for (size_t k = start + sg.get_local_id()[0]; k < size; k += max_sg_size)
-            {
-                if constexpr (std::is_same_v<_DataType, bool>)
-                {
+        else {
+            for (size_t k = start + sg.get_local_id()[0]; k < size;
+                 k += max_sg_size) {
+                if constexpr (std::is_same_v<_DataType, bool>) {
                     result[k] = !(input_data[k]);
                 }
-                else
-                {
+                else {
                     result[k] = ~(input_data[k]);
                 }
             }
         }
     };
 
-    auto kernel_func = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class dpnp_invert_c_kernel<_DataType>>(sycl::nd_range<1>(gws_range, lws_range),
-                                                                kernel_parallel_for_func);
+    auto kernel_func = [&](sycl::handler &cgh) {
+        cgh.parallel_for<class dpnp_invert_c_kernel<_DataType>>(
+            sycl::nd_range<1>(gws_range, lws_range), kernel_parallel_for_func);
     };
     event = q.submit(kernel_func);
 
@@ -114,341 +112,368 @@ DPCTLSyclEventRef dpnp_invert_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_invert_c(void* array1_in, void* result1, size_t size)
+void dpnp_invert_c(void *array1_in, void *result1, size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_invert_c<_DataType>(q_ref,
-                                                           array1_in,
-                                                           result1,
-                                                           size,
-                                                           dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_invert_c<_DataType>(
+        q_ref, array1_in, result1, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_invert_default_c)(void*, void*, size_t) = dpnp_invert_c<_DataType>;
+void (*dpnp_invert_default_c)(void *,
+                              void *,
+                              size_t) = dpnp_invert_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_invert_ext_c)(DPCTLSyclQueueRef,
-                                       void*,
-                                       void*,
+                                       void *,
+                                       void *,
                                        size_t,
-                                       const DPCTLEventVectorRef) = dpnp_invert_c<_DataType>;
+                                       const DPCTLEventVectorRef) =
+    dpnp_invert_c<_DataType>;
 
-static void func_map_init_bitwise_1arg_1type(func_map_t& fmap)
+static void func_map_init_bitwise_1arg_1type(func_map_t &fmap)
 {
-    fmap[DPNPFuncName::DPNP_FN_INVERT][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_invert_default_c<bool>};
-    fmap[DPNPFuncName::DPNP_FN_INVERT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_invert_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_INVERT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_invert_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_INVERT][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_invert_default_c<bool>};
+    fmap[DPNPFuncName::DPNP_FN_INVERT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_invert_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_INVERT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_invert_default_c<int64_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_INVERT_EXT][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_invert_ext_c<bool>};
-    fmap[DPNPFuncName::DPNP_FN_INVERT_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_invert_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_INVERT_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_invert_ext_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_INVERT_EXT][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_invert_ext_c<bool>};
+    fmap[DPNPFuncName::DPNP_FN_INVERT_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_invert_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_INVERT_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_invert_ext_c<int64_t>};
 
     return;
 }
 
-#define MACRO_2ARG_1TYPE_OP(__name__, __operation__)                                                                   \
-    template <typename _KernelNameSpecialization>                                                                      \
-    class __name__##_kernel;                                                                                           \
-                                                                                                                       \
-    template <typename _KernelNameSpecialization>                                                                      \
-    class __name__##_strides_kernel;                                                                                   \
-                                                                                                                       \
-    template <typename _KernelNameSpecialization>                                                                      \
-    class __name__##_broadcast_kernel;                                                                                 \
-                                                                                                                       \
-    template <typename _DataType>                                                                                      \
-    DPCTLSyclEventRef __name__(DPCTLSyclQueueRef q_ref,                                                                \
-                               void* result_out,                                                                       \
-                               const size_t result_size,                                                               \
-                               const size_t result_ndim,                                                               \
-                               const shape_elem_type* result_shape,                                                    \
-                               const shape_elem_type* result_strides,                                                  \
-                               const void* input1_in,                                                                  \
-                               const size_t input1_size,                                                               \
-                               const size_t input1_ndim,                                                               \
-                               const shape_elem_type* input1_shape,                                                    \
-                               const shape_elem_type* input1_strides,                                                  \
-                               const void* input2_in,                                                                  \
-                               const size_t input2_size,                                                               \
-                               const size_t input2_ndim,                                                               \
-                               const shape_elem_type* input2_shape,                                                    \
-                               const shape_elem_type* input2_strides,                                                  \
-                               const size_t* where,                                                                    \
-                               const DPCTLEventVectorRef dep_event_vec_ref)                                            \
-    {                                                                                                                  \
-        /* avoid warning unused variable*/                                                                             \
-        (void)result_shape;                                                                                            \
-        (void)where;                                                                                                   \
-        (void)dep_event_vec_ref;                                                                                       \
-                                                                                                                       \
-        DPCTLSyclEventRef event_ref = nullptr;                                                                         \
-                                                                                                                       \
-        if (!input1_size || !input2_size)                                                                              \
-        {                                                                                                              \
-            return event_ref;                                                                                          \
-        }                                                                                                              \
-                                                                                                                       \
-        sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));                                                      \
-                                                                                                                       \
-        _DataType* input1_data = static_cast<_DataType*>(const_cast<void*>(input1_in));                                \
-        _DataType* input2_data = static_cast<_DataType*>(const_cast<void*>(input2_in));                                \
-        _DataType* result = static_cast<_DataType*>(result_out);                                                       \
-                                                                                                                       \
-        bool use_broadcasting = !array_equal(input1_shape, input1_ndim, input2_shape, input2_ndim);                    \
-                                                                                                                       \
-        shape_elem_type* input1_shape_offsets = new shape_elem_type[input1_ndim];                                      \
-                                                                                                                       \
-        get_shape_offsets_inkernel(input1_shape, input1_ndim, input1_shape_offsets);                                   \
-        bool use_strides = !array_equal(input1_strides, input1_ndim, input1_shape_offsets, input1_ndim);               \
-        delete[] input1_shape_offsets;                                                                                 \
-                                                                                                                       \
-        shape_elem_type* input2_shape_offsets = new shape_elem_type[input2_ndim];                                      \
-                                                                                                                       \
-        get_shape_offsets_inkernel(input2_shape, input2_ndim, input2_shape_offsets);                                   \
-        use_strides = use_strides || !array_equal(input2_strides, input2_ndim, input2_shape_offsets, input2_ndim);     \
-        delete[] input2_shape_offsets;                                                                                 \
-                                                                                                                       \
-        sycl::event event;                                                                                             \
-        sycl::range<1> gws(result_size);                                                                               \
-                                                                                                                       \
-        if (use_broadcasting)                                                                                          \
-        {                                                                                                              \
-            DPNPC_id<_DataType>* input1_it;                                                                            \
-            const size_t input1_it_size_in_bytes = sizeof(DPNPC_id<_DataType>);                                        \
-            input1_it = reinterpret_cast<DPNPC_id<_DataType>*>(dpnp_memory_alloc_c(q_ref, input1_it_size_in_bytes));   \
-            new (input1_it) DPNPC_id<_DataType>(q_ref, input1_data, input1_shape, input1_strides, input1_ndim);        \
-                                                                                                                       \
-            input1_it->broadcast_to_shape(result_shape, result_ndim);                                                  \
-                                                                                                                       \
-            DPNPC_id<_DataType>* input2_it;                                                                            \
-            const size_t input2_it_size_in_bytes = sizeof(DPNPC_id<_DataType>);                                        \
-            input2_it = reinterpret_cast<DPNPC_id<_DataType>*>(dpnp_memory_alloc_c(q_ref, input2_it_size_in_bytes));   \
-            new (input2_it) DPNPC_id<_DataType>(q_ref, input2_data, input2_shape, input2_strides, input2_ndim);        \
-                                                                                                                       \
-            input2_it->broadcast_to_shape(result_shape, result_ndim);                                                  \
-                                                                                                                       \
-            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {                                               \
-                const size_t i = global_id[0]; /* for (size_t i = 0; i < result_size; ++i) */                          \
-                {                                                                                                      \
-                    const _DataType input1_elem = (*input1_it)[i];                                                     \
-                    const _DataType input2_elem = (*input2_it)[i];                                                     \
-                    result[i] = __operation__;                                                                         \
-                }                                                                                                      \
-            };                                                                                                         \
-            auto kernel_func = [&](sycl::handler& cgh) {                                                               \
-                cgh.parallel_for<class __name__##_broadcast_kernel<_DataType>>(gws, kernel_parallel_for_func);         \
-            };                                                                                                         \
-                                                                                                                       \
-            q.submit(kernel_func).wait();                                                                              \
-                                                                                                                       \
-            input1_it->~DPNPC_id();                                                                                    \
-            input2_it->~DPNPC_id();                                                                                    \
-                                                                                                                       \
-            return event_ref;                                                                                          \
-        }                                                                                                              \
-        else if (use_strides)                                                                                          \
-        {                                                                                                              \
-            if ((result_ndim != input1_ndim) || (result_ndim != input2_ndim))                                          \
-            {                                                                                                          \
-                throw std::runtime_error("Result ndim=" + std::to_string(result_ndim) +                                \
-                                         " mismatches with either input1 ndim=" + std::to_string(input1_ndim) +        \
-                                         " or input2 ndim=" + std::to_string(input2_ndim));                            \
-            }                                                                                                          \
-                                                                                                                       \
-            /* memory transfer optimization, use USM-host for temporary speeds up tranfer to device */                 \
-            using usm_host_allocatorT = sycl::usm_allocator<shape_elem_type, sycl::usm::alloc::host>;                  \
-                                                                                                                       \
-            size_t strides_size = 3 * result_ndim;                                                                     \
-            shape_elem_type* dev_strides_data = sycl::malloc_device<shape_elem_type>(strides_size, q);                 \
-                                                                                                                       \
-            /* create host temporary for packed strides managed by shared pointer */                                   \
-            auto strides_host_packed =                                                                                 \
-                std::vector<shape_elem_type, usm_host_allocatorT>(strides_size, usm_host_allocatorT(q));               \
-                                                                                                                       \
-            /* packed vector is concatenation of result_strides, input1_strides and input2_strides */                  \
-            std::copy(result_strides, result_strides + result_ndim, strides_host_packed.begin());                      \
-            std::copy(input1_strides, input1_strides + result_ndim, strides_host_packed.begin() + result_ndim);        \
-            std::copy(input2_strides, input2_strides + result_ndim, strides_host_packed.begin() + 2 * result_ndim);    \
-                                                                                                                       \
-            auto copy_strides_ev =                                                                                     \
-                q.copy<shape_elem_type>(strides_host_packed.data(), dev_strides_data, strides_host_packed.size());     \
-                                                                                                                       \
-            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {                                               \
-                const size_t output_id = global_id[0]; /* for (size_t i = 0; i < result_size; ++i) */                  \
-                {                                                                                                      \
-                    const shape_elem_type* result_strides_data = &dev_strides_data[0];                                 \
-                    const shape_elem_type* input1_strides_data = &dev_strides_data[result_ndim];                       \
-                    const shape_elem_type* input2_strides_data = &dev_strides_data[2 * result_ndim];                   \
-                                                                                                                       \
-                    size_t input1_id = 0;                                                                              \
-                    size_t input2_id = 0;                                                                              \
-                                                                                                                       \
-                    for (size_t i = 0; i < result_ndim; ++i)                                                           \
-                    {                                                                                                  \
-                        const size_t output_xyz_id =                                                                   \
-                            get_xyz_id_by_id_inkernel(output_id, result_strides_data, result_ndim, i);                 \
-                        input1_id += output_xyz_id * input1_strides_data[i];                                           \
-                        input2_id += output_xyz_id * input2_strides_data[i];                                           \
-                    }                                                                                                  \
-                                                                                                                       \
-                    const _DataType input1_elem = (input1_size == 1) ? input1_data[0] : input1_data[input1_id];        \
-                    const _DataType input2_elem = (input2_size == 1) ? input2_data[0] : input2_data[input2_id];        \
-                    result[output_id] = __operation__;                                                                 \
-                }                                                                                                      \
-            };                                                                                                         \
-            auto kernel_func = [&](sycl::handler& cgh) {                                                               \
-                cgh.depends_on(copy_strides_ev);                                                                       \
-                cgh.parallel_for<class __name__##_strides_kernel<_DataType>>(gws, kernel_parallel_for_func);           \
-            };                                                                                                         \
-                                                                                                                       \
-            q.submit(kernel_func).wait();                                                                              \
-                                                                                                                       \
-            sycl::free(dev_strides_data, q);                                                                           \
-            return event_ref;                                                                                          \
-        }                                                                                                              \
-        else                                                                                                           \
-        {                                                                                                              \
-            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {                                               \
-                size_t i = global_id[0]; /* for (size_t i = 0; i < result_size; ++i) */                                \
-                const _DataType input1_elem = (input1_size == 1) ? input1_data[0] : input1_data[i];                    \
-                const _DataType input2_elem = (input2_size == 1) ? input2_data[0] : input2_data[i];                    \
-                result[i] = __operation__;                                                                             \
-            };                                                                                                         \
-            auto kernel_func = [&](sycl::handler& cgh) {                                                               \
-                cgh.parallel_for<class __name__##_kernel<_DataType>>(gws, kernel_parallel_for_func);                   \
-            };                                                                                                         \
-            event = q.submit(kernel_func);                                                                             \
-        }                                                                                                              \
-                                                                                                                       \
-        event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);                                                       \
-        return DPCTLEvent_Copy(event_ref);                                                                             \
-    }                                                                                                                  \
-                                                                                                                       \
-    template <typename _DataType>                                                                                      \
-    void __name__(void* result_out,                                                                                    \
-                  const size_t result_size,                                                                            \
-                  const size_t result_ndim,                                                                            \
-                  const shape_elem_type* result_shape,                                                                 \
-                  const shape_elem_type* result_strides,                                                               \
-                  const void* input1_in,                                                                               \
-                  const size_t input1_size,                                                                            \
-                  const size_t input1_ndim,                                                                            \
-                  const shape_elem_type* input1_shape,                                                                 \
-                  const shape_elem_type* input1_strides,                                                               \
-                  const void* input2_in,                                                                               \
-                  const size_t input2_size,                                                                            \
-                  const size_t input2_ndim,                                                                            \
-                  const shape_elem_type* input2_shape,                                                                 \
-                  const shape_elem_type* input2_strides,                                                               \
-                  const size_t* where)                                                                                 \
-    {                                                                                                                  \
-        DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);                                    \
-        DPCTLEventVectorRef dep_event_vec_ref = nullptr;                                                               \
-        DPCTLSyclEventRef event_ref = __name__<_DataType>(q_ref,                                                       \
-                                                          result_out,                                                  \
-                                                          result_size,                                                 \
-                                                          result_ndim,                                                 \
-                                                          result_shape,                                                \
-                                                          result_strides,                                              \
-                                                          input1_in,                                                   \
-                                                          input1_size,                                                 \
-                                                          input1_ndim,                                                 \
-                                                          input1_shape,                                                \
-                                                          input1_strides,                                              \
-                                                          input2_in,                                                   \
-                                                          input2_size,                                                 \
-                                                          input2_ndim,                                                 \
-                                                          input2_shape,                                                \
-                                                          input2_strides,                                              \
-                                                          where,                                                       \
-                                                          dep_event_vec_ref);                                          \
-        DPCTLEvent_WaitAndThrow(event_ref);                                                                            \
-        DPCTLEvent_Delete(event_ref);                                                                                  \
-    }                                                                                                                  \
-                                                                                                                       \
-    template <typename _DataType>                                                                                      \
-    void (*__name__##_default)(void*,                                                                                  \
-                               const size_t,                                                                           \
-                               const size_t,                                                                           \
-                               const shape_elem_type*,                                                                 \
-                               const shape_elem_type*,                                                                 \
-                               const void*,                                                                            \
-                               const size_t,                                                                           \
-                               const size_t,                                                                           \
-                               const shape_elem_type*,                                                                 \
-                               const shape_elem_type*,                                                                 \
-                               const void*,                                                                            \
-                               const size_t,                                                                           \
-                               const size_t,                                                                           \
-                               const shape_elem_type*,                                                                 \
-                               const shape_elem_type*,                                                                 \
-                               const size_t*) = __name__<_DataType>;                                                   \
-                                                                                                                       \
-    template <typename _DataType>                                                                                      \
-    DPCTLSyclEventRef (*__name__##_ext)(DPCTLSyclQueueRef,                                                             \
-                                        void*,                                                                         \
-                                        const size_t,                                                                  \
-                                        const size_t,                                                                  \
-                                        const shape_elem_type*,                                                        \
-                                        const shape_elem_type*,                                                        \
-                                        const void*,                                                                   \
-                                        const size_t,                                                                  \
-                                        const size_t,                                                                  \
-                                        const shape_elem_type*,                                                        \
-                                        const shape_elem_type*,                                                        \
-                                        const void*,                                                                   \
-                                        const size_t,                                                                  \
-                                        const size_t,                                                                  \
-                                        const shape_elem_type*,                                                        \
-                                        const shape_elem_type*,                                                        \
-                                        const size_t*,                                                                 \
-                                        const DPCTLEventVectorRef) = __name__<_DataType>;
+#define MACRO_2ARG_1TYPE_OP(__name__, __operation__)                                     \
+    template <typename _KernelNameSpecialization>                                        \
+    class __name__##_kernel;                                                             \
+                                                                                         \
+    template <typename _KernelNameSpecialization>                                        \
+    class __name__##_strides_kernel;                                                     \
+                                                                                         \
+    template <typename _KernelNameSpecialization>                                        \
+    class __name__##_broadcast_kernel;                                                   \
+                                                                                         \
+    template <typename _DataType>                                                        \
+    DPCTLSyclEventRef __name__(                                                          \
+        DPCTLSyclQueueRef q_ref, void *result_out, const size_t result_size,             \
+        const size_t result_ndim, const shape_elem_type *result_shape,                   \
+        const shape_elem_type *result_strides, const void *input1_in,                    \
+        const size_t input1_size, const size_t input1_ndim,                              \
+        const shape_elem_type *input1_shape,                                             \
+        const shape_elem_type *input1_strides, const void *input2_in,                    \
+        const size_t input2_size, const size_t input2_ndim,                              \
+        const shape_elem_type *input2_shape,                                             \
+        const shape_elem_type *input2_strides, const size_t *where,                      \
+        const DPCTLEventVectorRef dep_event_vec_ref)                                     \
+    {                                                                                    \
+        /* avoid warning unused variable*/                                               \
+        (void)result_shape;                                                              \
+        (void)where;                                                                     \
+        (void)dep_event_vec_ref;                                                         \
+                                                                                         \
+        DPCTLSyclEventRef event_ref = nullptr;                                           \
+                                                                                         \
+        if (!input1_size || !input2_size) {                                              \
+            return event_ref;                                                            \
+        }                                                                                \
+                                                                                         \
+        sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));                       \
+                                                                                         \
+        _DataType *input1_data =                                                         \
+            static_cast<_DataType *>(const_cast<void *>(input1_in));                     \
+        _DataType *input2_data =                                                         \
+            static_cast<_DataType *>(const_cast<void *>(input2_in));                     \
+        _DataType *result = static_cast<_DataType *>(result_out);                        \
+                                                                                         \
+        bool use_broadcasting = !array_equal(input1_shape, input1_ndim,                  \
+                                             input2_shape, input2_ndim);                 \
+                                                                                         \
+        shape_elem_type *input1_shape_offsets =                                          \
+            new shape_elem_type[input1_ndim];                                            \
+                                                                                         \
+        get_shape_offsets_inkernel(input1_shape, input1_ndim,                            \
+                                   input1_shape_offsets);                                \
+        bool use_strides = !array_equal(input1_strides, input1_ndim,                     \
+                                        input1_shape_offsets, input1_ndim);              \
+        delete[] input1_shape_offsets;                                                   \
+                                                                                         \
+        shape_elem_type *input2_shape_offsets =                                          \
+            new shape_elem_type[input2_ndim];                                            \
+                                                                                         \
+        get_shape_offsets_inkernel(input2_shape, input2_ndim,                            \
+                                   input2_shape_offsets);                                \
+        use_strides =                                                                    \
+            use_strides || !array_equal(input2_strides, input2_ndim,                     \
+                                        input2_shape_offsets, input2_ndim);              \
+        delete[] input2_shape_offsets;                                                   \
+                                                                                         \
+        sycl::event event;                                                               \
+        sycl::range<1> gws(result_size);                                                 \
+                                                                                         \
+        if (use_broadcasting) {                                                          \
+            DPNPC_id<_DataType> *input1_it;                                              \
+            const size_t input1_it_size_in_bytes =                                       \
+                sizeof(DPNPC_id<_DataType>);                                             \
+            input1_it = reinterpret_cast<DPNPC_id<_DataType> *>(                         \
+                dpnp_memory_alloc_c(q_ref, input1_it_size_in_bytes));                    \
+            new (input1_it)                                                              \
+                DPNPC_id<_DataType>(q_ref, input1_data, input1_shape,                    \
+                                    input1_strides, input1_ndim);                        \
+                                                                                         \
+            input1_it->broadcast_to_shape(result_shape, result_ndim);                    \
+                                                                                         \
+            DPNPC_id<_DataType> *input2_it;                                              \
+            const size_t input2_it_size_in_bytes =                                       \
+                sizeof(DPNPC_id<_DataType>);                                             \
+            input2_it = reinterpret_cast<DPNPC_id<_DataType> *>(                         \
+                dpnp_memory_alloc_c(q_ref, input2_it_size_in_bytes));                    \
+            new (input2_it)                                                              \
+                DPNPC_id<_DataType>(q_ref, input2_data, input2_shape,                    \
+                                    input2_strides, input2_ndim);                        \
+                                                                                         \
+            input2_it->broadcast_to_shape(result_shape, result_ndim);                    \
+                                                                                         \
+            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {                 \
+                const size_t i = global_id[0]; /* for (size_t i = 0; i <                 \
+                                                  result_size; ++i) */                   \
+                {                                                                        \
+                    const _DataType input1_elem = (*input1_it)[i];                       \
+                    const _DataType input2_elem = (*input2_it)[i];                       \
+                    result[i]                   = __operation__;                         \
+                }                                                                        \
+            };                                                                           \
+            auto kernel_func = [&](sycl::handler &cgh) {                                 \
+                cgh.parallel_for<                                                        \
+                    class __name__##_broadcast_kernel<_DataType>>(                       \
+                    gws, kernel_parallel_for_func);                                      \
+            };                                                                           \
+                                                                                         \
+            q.submit(kernel_func).wait();                                                \
+                                                                                         \
+            input1_it->~DPNPC_id();                                                      \
+            input2_it->~DPNPC_id();                                                      \
+                                                                                         \
+            return event_ref;                                                            \
+        }                                                                                \
+        else if (use_strides) {                                                          \
+            if ((result_ndim != input1_ndim) || (result_ndim != input2_ndim))            \
+            {                                                                            \
+                throw std::runtime_error(                                                \
+                    "Result ndim=" + std::to_string(result_ndim) +                       \
+                    " mismatches with either input1 ndim=" +                             \
+                    std::to_string(input1_ndim) +                                        \
+                    " or input2 ndim=" + std::to_string(input2_ndim));                   \
+            }                                                                            \
+                                                                                         \
+            /* memory transfer optimization, use USM-host for temporary speeds           \
+             * up tranfer to device */                                                   \
+            using usm_host_allocatorT =                                                  \
+                sycl::usm_allocator<shape_elem_type, sycl::usm::alloc::host>;            \
+                                                                                         \
+            size_t strides_size = 3 * result_ndim;                                       \
+            shape_elem_type *dev_strides_data =                                          \
+                sycl::malloc_device<shape_elem_type>(strides_size, q);                   \
+                                                                                         \
+            /* create host temporary for packed strides managed by shared                \
+             * pointer */                                                                \
+            auto strides_host_packed =                                                   \
+                std::vector<shape_elem_type, usm_host_allocatorT>(                       \
+                    strides_size, usm_host_allocatorT(q));                               \
+                                                                                         \
+            /* packed vector is concatenation of result_strides,                         \
+             * input1_strides and input2_strides */                                      \
+            std::copy(result_strides, result_strides + result_ndim,                      \
+                      strides_host_packed.begin());                                      \
+            std::copy(input1_strides, input1_strides + result_ndim,                      \
+                      strides_host_packed.begin() + result_ndim);                        \
+            std::copy(input2_strides, input2_strides + result_ndim,                      \
+                      strides_host_packed.begin() + 2 * result_ndim);                    \
+                                                                                         \
+            auto copy_strides_ev = q.copy<shape_elem_type>(                              \
+                strides_host_packed.data(), dev_strides_data,                            \
+                strides_host_packed.size());                                             \
+                                                                                         \
+            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {                 \
+                const size_t output_id =                                                 \
+                    global_id[0]; /* for (size_t i = 0; i < result_size; ++i)            \
+                                   */                                                    \
+                {                                                                        \
+                    const shape_elem_type *result_strides_data =                         \
+                        &dev_strides_data[0];                                            \
+                    const shape_elem_type *input1_strides_data =                         \
+                        &dev_strides_data[result_ndim];                                  \
+                    const shape_elem_type *input2_strides_data =                         \
+                        &dev_strides_data[2 * result_ndim];                              \
+                                                                                         \
+                    size_t input1_id = 0;                                                \
+                    size_t input2_id = 0;                                                \
+                                                                                         \
+                    for (size_t i = 0; i < result_ndim; ++i) {                           \
+                        const size_t output_xyz_id =                                     \
+                            get_xyz_id_by_id_inkernel(output_id,                         \
+                                                      result_strides_data,               \
+                                                      result_ndim, i);                   \
+                        input1_id += output_xyz_id * input1_strides_data[i];             \
+                        input2_id += output_xyz_id * input2_strides_data[i];             \
+                    }                                                                    \
+                                                                                         \
+                    const _DataType input1_elem =                                        \
+                        (input1_size == 1) ? input1_data[0]                              \
+                                           : input1_data[input1_id];                     \
+                    const _DataType input2_elem =                                        \
+                        (input2_size == 1) ? input2_data[0]                              \
+                                           : input2_data[input2_id];                     \
+                    result[output_id] = __operation__;                                   \
+                }                                                                        \
+            };                                                                           \
+            auto kernel_func = [&](sycl::handler &cgh) {                                 \
+                cgh.depends_on(copy_strides_ev);                                         \
+                cgh.parallel_for<class __name__##_strides_kernel<_DataType>>(            \
+                    gws, kernel_parallel_for_func);                                      \
+            };                                                                           \
+                                                                                         \
+            q.submit(kernel_func).wait();                                                \
+                                                                                         \
+            sycl::free(dev_strides_data, q);                                             \
+            return event_ref;                                                            \
+        }                                                                                \
+        else {                                                                           \
+            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {                 \
+                size_t i = global_id[0]; /* for (size_t i = 0; i <                       \
+                                            result_size; ++i) */                         \
+                const _DataType input1_elem =                                            \
+                    (input1_size == 1) ? input1_data[0] : input1_data[i];                \
+                const _DataType input2_elem =                                            \
+                    (input2_size == 1) ? input2_data[0] : input2_data[i];                \
+                result[i] = __operation__;                                               \
+            };                                                                           \
+            auto kernel_func = [&](sycl::handler &cgh) {                                 \
+                cgh.parallel_for<class __name__##_kernel<_DataType>>(                    \
+                    gws, kernel_parallel_for_func);                                      \
+            };                                                                           \
+            event = q.submit(kernel_func);                                               \
+        }                                                                                \
+                                                                                         \
+        event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);                         \
+        return DPCTLEvent_Copy(event_ref);                                               \
+    }                                                                                    \
+                                                                                         \
+    template <typename _DataType>                                                        \
+    void __name__(                                                                       \
+        void *result_out, const size_t result_size, const size_t result_ndim,            \
+        const shape_elem_type *result_shape,                                             \
+        const shape_elem_type *result_strides, const void *input1_in,                    \
+        const size_t input1_size, const size_t input1_ndim,                              \
+        const shape_elem_type *input1_shape,                                             \
+        const shape_elem_type *input1_strides, const void *input2_in,                    \
+        const size_t input2_size, const size_t input2_ndim,                              \
+        const shape_elem_type *input2_shape,                                             \
+        const shape_elem_type *input2_strides, const size_t *where)                      \
+    {                                                                                    \
+        DPCTLSyclQueueRef q_ref =                                                        \
+            reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);                            \
+        DPCTLEventVectorRef dep_event_vec_ref = nullptr;                                 \
+        DPCTLSyclEventRef event_ref           = __name__<_DataType>(                     \
+            q_ref, result_out, result_size, result_ndim, result_shape,         \
+            result_strides, input1_in, input1_size, input1_ndim, input1_shape, \
+            input1_strides, input2_in, input2_size, input2_ndim, input2_shape, \
+            input2_strides, where, dep_event_vec_ref);                         \
+        DPCTLEvent_WaitAndThrow(event_ref);                                              \
+        DPCTLEvent_Delete(event_ref);                                                    \
+    }                                                                                    \
+                                                                                         \
+    template <typename _DataType>                                                        \
+    void (*__name__##_default)(                                                          \
+        void *, const size_t, const size_t, const shape_elem_type *,                     \
+        const shape_elem_type *, const void *, const size_t, const size_t,               \
+        const shape_elem_type *, const shape_elem_type *, const void *,                  \
+        const size_t, const size_t, const shape_elem_type *,                             \
+        const shape_elem_type *, const size_t *) = __name__<_DataType>;                  \
+                                                                                         \
+    template <typename _DataType>                                                        \
+    DPCTLSyclEventRef (*__name__##_ext)(                                                 \
+        DPCTLSyclQueueRef, void *, const size_t, const size_t,                           \
+        const shape_elem_type *, const shape_elem_type *, const void *,                  \
+        const size_t, const size_t, const shape_elem_type *,                             \
+        const shape_elem_type *, const void *, const size_t, const size_t,               \
+        const shape_elem_type *, const shape_elem_type *, const size_t *,                \
+        const DPCTLEventVectorRef) = __name__<_DataType>;
 
 #include <dpnp_gen_2arg_1type_tbl.hpp>
 
-static void func_map_init_bitwise_2arg_1type(func_map_t& fmap)
+static void func_map_init_bitwise_2arg_1type(func_map_t &fmap)
 {
-    fmap[DPNPFuncName::DPNP_FN_BITWISE_AND][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_bitwise_and_c_default<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_BITWISE_AND][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_bitwise_and_c_default<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_BITWISE_AND][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_bitwise_and_c_default<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_BITWISE_AND][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_bitwise_and_c_default<int64_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_BITWISE_AND_EXT][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_bitwise_and_c_ext<bool>};
-    fmap[DPNPFuncName::DPNP_FN_BITWISE_AND_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_bitwise_and_c_ext<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_BITWISE_AND_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_bitwise_and_c_ext<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_BITWISE_AND_EXT][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_bitwise_and_c_ext<bool>};
+    fmap[DPNPFuncName::DPNP_FN_BITWISE_AND_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_bitwise_and_c_ext<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_BITWISE_AND_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_bitwise_and_c_ext<int64_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_BITWISE_OR][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_bitwise_or_c_default<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_BITWISE_OR][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_bitwise_or_c_default<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_BITWISE_OR][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_bitwise_or_c_default<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_BITWISE_OR][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_bitwise_or_c_default<int64_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_BITWISE_OR_EXT][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_bitwise_or_c_ext<bool>};
-    fmap[DPNPFuncName::DPNP_FN_BITWISE_OR_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_bitwise_or_c_ext<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_BITWISE_OR_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_bitwise_or_c_ext<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_BITWISE_OR_EXT][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_bitwise_or_c_ext<bool>};
+    fmap[DPNPFuncName::DPNP_FN_BITWISE_OR_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_bitwise_or_c_ext<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_BITWISE_OR_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_bitwise_or_c_ext<int64_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_BITWISE_XOR][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_bitwise_xor_c_default<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_BITWISE_XOR][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_bitwise_xor_c_default<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_BITWISE_XOR][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_bitwise_xor_c_default<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_BITWISE_XOR][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_bitwise_xor_c_default<int64_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_BITWISE_XOR_EXT][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_bitwise_xor_c_ext<bool>};
-    fmap[DPNPFuncName::DPNP_FN_BITWISE_XOR_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_bitwise_xor_c_ext<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_BITWISE_XOR_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_bitwise_xor_c_ext<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_BITWISE_XOR_EXT][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_bitwise_xor_c_ext<bool>};
+    fmap[DPNPFuncName::DPNP_FN_BITWISE_XOR_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_bitwise_xor_c_ext<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_BITWISE_XOR_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_bitwise_xor_c_ext<int64_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_LEFT_SHIFT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_left_shift_c_default<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_LEFT_SHIFT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_left_shift_c_default<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_LEFT_SHIFT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_left_shift_c_default<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_LEFT_SHIFT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_left_shift_c_default<int64_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_LEFT_SHIFT_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_left_shift_c_ext<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_LEFT_SHIFT_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_left_shift_c_ext<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_LEFT_SHIFT_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_left_shift_c_ext<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_LEFT_SHIFT_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_left_shift_c_ext<int64_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_RIGHT_SHIFT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_right_shift_c_default<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_RIGHT_SHIFT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_right_shift_c_default<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_RIGHT_SHIFT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_right_shift_c_default<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_RIGHT_SHIFT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_right_shift_c_default<int64_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_RIGHT_SHIFT_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_right_shift_c_ext<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_RIGHT_SHIFT_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_right_shift_c_ext<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_RIGHT_SHIFT_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_right_shift_c_ext<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_RIGHT_SHIFT_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_right_shift_c_ext<int64_t>};
 
     return;
 }
 
-void func_map_init_bitwise(func_map_t& fmap)
+void func_map_init_bitwise(func_map_t &fmap)
 {
     func_map_init_bitwise_1arg_1type(fmap);
     func_map_init_bitwise_2arg_1type(fmap);

--- a/dpnp/backend/kernels/dpnp_krnl_common.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_common.cpp
@@ -27,23 +27,23 @@
 #include <iostream>
 #include <type_traits>
 
-#include <dpnp_iface.hpp>
 #include "dpnp_fptr.hpp"
 #include "dpnp_utils.hpp"
 #include "dpnpc_memory_adapter.hpp"
 #include "queue_sycl.hpp"
+#include <dpnp_iface.hpp>
 
-namespace mkl_blas = oneapi::mkl::blas;
+namespace mkl_blas    = oneapi::mkl::blas;
 namespace mkl_blas_rm = oneapi::mkl::blas::row_major;
-namespace mkl_lapack = oneapi::mkl::lapack;
+namespace mkl_lapack  = oneapi::mkl::lapack;
 
 template <typename _DataType, typename _ResultType>
 class dpnp_astype_c_kernel;
 
 template <typename _DataType, typename _ResultType>
 DPCTLSyclEventRef dpnp_astype_c(DPCTLSyclQueueRef q_ref,
-                                const void* array1_in,
-                                void* result1,
+                                const void *array1_in,
+                                void *result1,
                                 const size_t size,
                                 const DPCTLEventVectorRef dep_event_vec_ref)
 {
@@ -52,31 +52,30 @@ DPCTLSyclEventRef dpnp_astype_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
     sycl::event event;
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, size);
-    const _DataType* array_in = input1_ptr.get_ptr();
-    _ResultType* result = reinterpret_cast<_ResultType*>(result1);
+    const _DataType *array_in = input1_ptr.get_ptr();
+    _ResultType *result       = reinterpret_cast<_ResultType *>(result1);
 
-    if ((array_in == nullptr) || (result == nullptr))
-    {
+    if ((array_in == nullptr) || (result == nullptr)) {
         return event_ref;
     }
 
-    if (size == 0)
-    {
+    if (size == 0) {
         return event_ref;
     }
 
     sycl::range<1> gws(size);
     auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
-        size_t i = global_id[0];
+        size_t i  = global_id[0];
         result[i] = array_in[i];
     };
 
-    auto kernel_func = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class dpnp_astype_c_kernel<_DataType, _ResultType>>(gws, kernel_parallel_for_func);
+    auto kernel_func = [&](sycl::handler &cgh) {
+        cgh.parallel_for<class dpnp_astype_c_kernel<_DataType, _ResultType>>(
+            gws, kernel_parallel_for_func);
     };
 
     event = q.submit(kernel_func);
@@ -87,89 +86,95 @@ DPCTLSyclEventRef dpnp_astype_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType, typename _ResultType>
-void dpnp_astype_c(const void* array1_in, void* result1, const size_t size)
+void dpnp_astype_c(const void *array1_in, void *result1, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_astype_c<_DataType, _ResultType>(q_ref,
-                                                                        array1_in,
-                                                                        result1,
-                                                                        size,
-                                                                        dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref = dpnp_astype_c<_DataType, _ResultType>(
+        q_ref, array1_in, result1, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType, typename _ResultType>
-void (*dpnp_astype_default_c)(const void*, void*, const size_t) = dpnp_astype_c<_DataType, _ResultType>;
+void (*dpnp_astype_default_c)(const void *, void *, const size_t) =
+    dpnp_astype_c<_DataType, _ResultType>;
 
 template <typename _DataType, typename _ResultType>
 DPCTLSyclEventRef (*dpnp_astype_ext_c)(DPCTLSyclQueueRef,
-                                       const void*,
-                                       void*,
+                                       const void *,
+                                       void *,
                                        const size_t,
-                                       const DPCTLEventVectorRef) = dpnp_astype_c<_DataType, _ResultType>;
+                                       const DPCTLEventVectorRef) =
+    dpnp_astype_c<_DataType, _ResultType>;
 
-template <typename _KernelNameSpecialization1, typename _KernelNameSpecialization2, typename _KernelNameSpecialization3>
+template <typename _KernelNameSpecialization1,
+          typename _KernelNameSpecialization2,
+          typename _KernelNameSpecialization3>
 class dpnp_dot_c_kernel;
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
-sycl::event dot(sycl::queue& queue,
-                _DataType_output* result_out,
-                _DataType_input1* input1_in,
-                _DataType_input2* input2_in,
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
+sycl::event dot(sycl::queue &queue,
+                _DataType_output *result_out,
+                _DataType_input1 *input1_in,
+                _DataType_input2 *input2_in,
                 size_t input1_strides,
                 size_t input2_strides,
                 size_t size,
-                const std::vector<sycl::event>& dependencies = {})
+                const std::vector<sycl::event> &dependencies = {})
 {
     (void)dependencies;
 
     sycl::event event;
 
-    if constexpr ((std::is_same<_DataType_input1, double>::value || std::is_same<_DataType_input1, float>::value) &&
+    if constexpr ((std::is_same<_DataType_input1, double>::value ||
+                   std::is_same<_DataType_input1, float>::value) &&
                   std::is_same<_DataType_input2, _DataType_input1>::value &&
                   std::is_same<_DataType_output, _DataType_input1>::value)
     {
-        event = oneapi::mkl::blas::dot(queue,
-                                       size,
-                                       input1_in,
+        event = oneapi::mkl::blas::dot(queue, size, input1_in,
                                        input1_strides, // input1 stride
                                        input2_in,
                                        input2_strides, // input2 stride
                                        result_out);
     }
-    else
-    {
+    else {
 #if LIBSYCL_VERSION_GREATER(5, 3, 0)
-        event = queue.submit([&](sycl::handler& cgh) {
-            cgh.parallel_for(sycl::range<1>{size},
-                             sycl::reduction(result_out,
-                                             std::plus<_DataType_output>(),
-                                             sycl::property::reduction::initialize_to_identity{}),
-                             [=](sycl::id<1> idx, auto& sum) {
-                                 sum += static_cast<_DataType_output>(input1_in[idx * input1_strides]) *
-                                        static_cast<_DataType_output>(input2_in[idx * input2_strides]);
-                             });
+        event = queue.submit([&](sycl::handler &cgh) {
+            cgh.parallel_for(
+                sycl::range<1>{size},
+                sycl::reduction(
+                    result_out, std::plus<_DataType_output>(),
+                    sycl::property::reduction::initialize_to_identity{}),
+                [=](sycl::id<1> idx, auto &sum) {
+                    sum += static_cast<_DataType_output>(
+                               input1_in[idx * input1_strides]) *
+                           static_cast<_DataType_output>(
+                               input2_in[idx * input2_strides]);
+                });
         });
         // for some reason few such kernels cannot work in parallel
         // looks like a bug in level0 because with opencl works fine
         // that is why we call wait here
         event.wait();
 #else
-        _DataType_output* local_mem =
-            reinterpret_cast<_DataType_output*>(sycl::malloc_shared(size * sizeof(_DataType_output), queue));
+        _DataType_output *local_mem = reinterpret_cast<_DataType_output *>(
+            sycl::malloc_shared(size * sizeof(_DataType_output), queue));
 
         // what about reduction??
         sycl::range<1> gws(size);
 
         auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
             const size_t index = global_id[0];
-            local_mem[index] = input1_in[index * input1_strides] * input2_in[index * input2_strides];
+            local_mem[index]   = input1_in[index * input1_strides] *
+                               input2_in[index * input2_strides];
         };
 
-        auto kernel_func = [&](sycl::handler& cgh) {
-            cgh.parallel_for<class dpnp_dot_c_kernel<_DataType_output, _DataType_input1, _DataType_input2>>(
+        auto kernel_func = [&](sycl::handler &cgh) {
+            cgh.parallel_for<class dpnp_dot_c_kernel<
+                _DataType_output, _DataType_input1, _DataType_input2>>(
                 gws, kernel_parallel_for_func);
         };
 
@@ -177,12 +182,14 @@ sycl::event dot(sycl::queue& queue,
 
         event.wait();
 
-        auto policy = oneapi::dpl::execution::make_device_policy<
-            class dpnp_dot_c_kernel<_DataType_output, _DataType_input1, _DataType_input2>>(queue);
+        auto policy =
+            oneapi::dpl::execution::make_device_policy<class dpnp_dot_c_kernel<
+                _DataType_output, _DataType_input1, _DataType_input2>>(queue);
 
         _DataType_output accumulator = 0;
         accumulator =
-            std::reduce(policy, local_mem, local_mem + size, _DataType_output(0), std::plus<_DataType_output>());
+            std::reduce(policy, local_mem, local_mem + size,
+                        _DataType_output(0), std::plus<_DataType_output>());
         policy.queue().wait();
 
         queue.memcpy(result_out, &accumulator, sizeof(_DataType_output)).wait();
@@ -193,131 +200,116 @@ sycl::event dot(sycl::queue& queue,
     return event;
 }
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
 DPCTLSyclEventRef dpnp_dot_c(DPCTLSyclQueueRef q_ref,
-                             void* result_out,
+                             void *result_out,
                              const size_t result_size,
                              const size_t result_ndim,
-                             const shape_elem_type* result_shape,
-                             const shape_elem_type* result_strides,
-                             const void* input1_in,
+                             const shape_elem_type *result_shape,
+                             const shape_elem_type *result_strides,
+                             const void *input1_in,
                              const size_t input1_size,
                              const size_t input1_ndim,
-                             const shape_elem_type* input1_shape,
-                             const shape_elem_type* input1_strides,
-                             const void* input2_in,
+                             const shape_elem_type *input1_shape,
+                             const shape_elem_type *input1_strides,
+                             const void *input2_in,
                              const size_t input2_size,
                              const size_t input2_ndim,
-                             const shape_elem_type* input2_shape,
-                             const shape_elem_type* input2_strides,
+                             const shape_elem_type *input2_shape,
+                             const shape_elem_type *input2_strides,
                              const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    DPNPC_ptr_adapter<_DataType_input1> input1_ptr(q_ref, input1_in, input1_size);
-    DPNPC_ptr_adapter<_DataType_input2> input2_ptr(q_ref, input2_in, input2_size);
-    _DataType_input1* input1 = input1_ptr.get_ptr();
-    _DataType_input2* input2 = input2_ptr.get_ptr();
-    _DataType_output* result = reinterpret_cast<_DataType_output*>(result_out);
+    DPNPC_ptr_adapter<_DataType_input1> input1_ptr(q_ref, input1_in,
+                                                   input1_size);
+    DPNPC_ptr_adapter<_DataType_input2> input2_ptr(q_ref, input2_in,
+                                                   input2_size);
+    _DataType_input1 *input1 = input1_ptr.get_ptr();
+    _DataType_input2 *input2 = input2_ptr.get_ptr();
+    _DataType_output *result = reinterpret_cast<_DataType_output *>(result_out);
 
-    if (!input1_size || !input2_size)
-    {
+    if (!input1_size || !input2_size) {
         _DataType_output val = _DataType_output(0);
         dpnp_initval_c<_DataType_output>(result, &val, result_size);
         return event_ref;
     }
 
     // scalar
-    if ((input1_ndim == 0) || (input2_ndim == 0))
-    {
+    if ((input1_ndim == 0) || (input2_ndim == 0)) {
         // there is no support of strides in multiply function
-        // so result can be wrong if input array has non-standard (c-contiguous) strides
-        dpnp_multiply_c<_DataType_output, _DataType_input1, _DataType_input2>(result,
-                                                                              result_size,
-                                                                              result_ndim,
-                                                                              result_shape,
-                                                                              result_strides,
-                                                                              input1_in,
-                                                                              input1_size,
-                                                                              input1_ndim,
-                                                                              input1_shape,
-                                                                              input1_strides,
-                                                                              input2_in,
-                                                                              input2_size,
-                                                                              input2_ndim,
-                                                                              input2_shape,
-                                                                              input2_strides,
-                                                                              NULL);
+        // so result can be wrong if input array has non-standard (c-contiguous)
+        // strides
+        dpnp_multiply_c<_DataType_output, _DataType_input1, _DataType_input2>(
+            result, result_size, result_ndim, result_shape, result_strides,
+            input1_in, input1_size, input1_ndim, input1_shape, input1_strides,
+            input2_in, input2_size, input2_ndim, input2_shape, input2_strides,
+            NULL);
         return event_ref;
     }
 
     // if both arrays are vectors
-    if ((input1_ndim == 1) && (input2_ndim == 1))
-    {
+    if ((input1_ndim == 1) && (input2_ndim == 1)) {
         assert(input1_size == input2_size);
-        sycl::event event = dot(q, result, input1, input2, input1_strides[0], input2_strides[0], input1_size);
+        sycl::event event = dot(q, result, input1, input2, input1_strides[0],
+                                input2_strides[0], input1_size);
         event.wait();
         return event_ref;
     }
 
     // 1D vector
-    size_t ext_input1_ndim = input1_ndim == 1 ? 2 : input1_ndim;
-    shape_elem_type* ext_input1_shape = new shape_elem_type[ext_input1_ndim];
-    shape_elem_type* ext_input1_strides = new shape_elem_type[ext_input1_ndim];
-    if (input1_ndim == 1)
-    {
-        ext_input1_shape[0] = 1;
-        ext_input1_shape[1] = input1_shape[0];
+    size_t ext_input1_ndim              = input1_ndim == 1 ? 2 : input1_ndim;
+    shape_elem_type *ext_input1_shape   = new shape_elem_type[ext_input1_ndim];
+    shape_elem_type *ext_input1_strides = new shape_elem_type[ext_input1_ndim];
+    if (input1_ndim == 1) {
+        ext_input1_shape[0]   = 1;
+        ext_input1_shape[1]   = input1_shape[0];
         ext_input1_strides[0] = 0;
         ext_input1_strides[1] = input1_strides[0];
     }
-    else
-    {
-        for (size_t i = 0; i < ext_input1_ndim; ++i)
-        {
-            ext_input1_shape[i] = input1_shape[i];
+    else {
+        for (size_t i = 0; i < ext_input1_ndim; ++i) {
+            ext_input1_shape[i]   = input1_shape[i];
             ext_input1_strides[i] = input1_strides[i];
         }
     }
-    size_t ext_input2_ndim = input2_ndim == 1 ? 2 : input2_ndim;
-    shape_elem_type* ext_input2_shape = new shape_elem_type[ext_input2_ndim];
-    shape_elem_type* ext_input2_strides = new shape_elem_type[ext_input2_ndim];
-    if (input2_ndim == 1)
-    {
-        ext_input2_shape[0] = input2_shape[0];
-        ext_input2_shape[1] = 1;
+    size_t ext_input2_ndim              = input2_ndim == 1 ? 2 : input2_ndim;
+    shape_elem_type *ext_input2_shape   = new shape_elem_type[ext_input2_ndim];
+    shape_elem_type *ext_input2_strides = new shape_elem_type[ext_input2_ndim];
+    if (input2_ndim == 1) {
+        ext_input2_shape[0]   = input2_shape[0];
+        ext_input2_shape[1]   = 1;
         ext_input2_strides[0] = input2_strides[0];
         ext_input2_strides[1] = 0;
     }
-    else
-    {
-        for (size_t i = 0; i < ext_input2_ndim; ++i)
-        {
-            ext_input2_shape[i] = input2_shape[i];
+    else {
+        for (size_t i = 0; i < ext_input2_ndim; ++i) {
+            ext_input2_shape[i]   = input2_shape[i];
             ext_input2_strides[i] = input2_strides[i];
         }
     }
-    size_t ext_result_ndim = ((input1_ndim == 1) || (input2_ndim == 1)) ? 2 : result_ndim;
-    shape_elem_type* ext_result_shape = new shape_elem_type[ext_result_ndim];
-    if ((input1_ndim == 1) || (input2_ndim == 1))
-    {
+    size_t ext_result_ndim =
+        ((input1_ndim == 1) || (input2_ndim == 1)) ? 2 : result_ndim;
+    shape_elem_type *ext_result_shape = new shape_elem_type[ext_result_ndim];
+    if ((input1_ndim == 1) || (input2_ndim == 1)) {
         ext_result_shape[0] = ext_input1_shape[0];
         ext_result_shape[1] = ext_input2_shape[1];
     }
-    else
-    {
-        for (size_t i = 0; i < ext_result_ndim; ++i)
-        {
+    else {
+        for (size_t i = 0; i < ext_result_ndim; ++i) {
             ext_result_shape[i] = result_shape[i];
         }
     }
 
     // check if GEMM can be executed (types)
-    if constexpr ((std::is_same<_DataType_input1, double>::value || std::is_same<_DataType_input1, float>::value) &&
+    if constexpr ((std::is_same<_DataType_input1, double>::value ||
+                   std::is_same<_DataType_input1, float>::value) &&
                   std::is_same<_DataType_input2, _DataType_input1>::value &&
                   std::is_same<_DataType_output, _DataType_input1>::value)
     {
@@ -325,107 +317,115 @@ DPCTLSyclEventRef dpnp_dot_c(DPCTLSyclQueueRef q_ref,
         // TODO: rewrite the condition in general case for ndims > 2
         // (looks like there are such another cases)
 
-        if (ext_input1_ndim == 2 && ext_input2_ndim == 2)
-        {
-// there is a difference of behavior with trans and sizes params in previous version of GEMM
-// only new version is supported, in case of old version computation goes in common way
+        if (ext_input1_ndim == 2 && ext_input2_ndim == 2) {
+// there is a difference of behavior with trans and sizes params in previous
+// version of GEMM only new version is supported, in case of old version
+// computation goes in common way
 #if INTEL_MKL_VERSION >= 20210004
-	    // is mat1 F-contiguous, C-contiguous
-            bool mat1_f_contig = (
-                ((ext_input1_shape[0] == 1) || (ext_input1_strides[0] == 1)) &&
-                ((ext_input1_shape[1] == 1) || (ext_input1_strides[1] == ext_input1_shape[0])));
-            bool mat1_c_contig = (
-                ((ext_input1_shape[1] == 1) || (ext_input1_strides[1] == 1)) &&
-                ((ext_input1_shape[0] == 1) || (ext_input1_strides[0] == ext_input1_shape[1])));
-	    // is mat2 F-contiguous, C-contiguous
-            bool mat2_f_contig = (
-                ((ext_input2_shape[0] == 1) || (ext_input2_strides[0] == 1)) &&
-                ((ext_input2_shape[1] == 1) || (ext_input2_strides[1] == ext_input2_shape[0])));
-            bool mat2_c_contig = (
-                ((ext_input2_shape[1] == 1) || (ext_input2_strides[1] == 1)) &&
-                ((ext_input2_shape[0] == 1) || (ext_input2_strides[0] == ext_input2_shape[1])));
+            // is mat1 F-contiguous, C-contiguous
+            bool mat1_f_contig =
+                (((ext_input1_shape[0] == 1) || (ext_input1_strides[0] == 1)) &&
+                 ((ext_input1_shape[1] == 1) ||
+                  (ext_input1_strides[1] == ext_input1_shape[0])));
+            bool mat1_c_contig =
+                (((ext_input1_shape[1] == 1) || (ext_input1_strides[1] == 1)) &&
+                 ((ext_input1_shape[0] == 1) ||
+                  (ext_input1_strides[0] == ext_input1_shape[1])));
+            // is mat2 F-contiguous, C-contiguous
+            bool mat2_f_contig =
+                (((ext_input2_shape[0] == 1) || (ext_input2_strides[0] == 1)) &&
+                 ((ext_input2_shape[1] == 1) ||
+                  (ext_input2_strides[1] == ext_input2_shape[0])));
+            bool mat2_c_contig =
+                (((ext_input2_shape[1] == 1) || (ext_input2_strides[1] == 1)) &&
+                 ((ext_input2_shape[0] == 1) ||
+                  (ext_input2_strides[0] == ext_input2_shape[1])));
 
-	    if ((mat1_f_contig || mat1_c_contig) && (mat2_f_contig || mat2_c_contig)) {
-		oneapi::mkl::transpose trans1 =
-		    (mat1_f_contig && !mat1_c_contig) ? oneapi::mkl::transpose::trans : oneapi::mkl::transpose::nontrans;
-		oneapi::mkl::transpose trans2 =
-		    (mat2_f_contig && !mat2_c_contig) ? oneapi::mkl::transpose::trans : oneapi::mkl::transpose::nontrans;
+            if ((mat1_f_contig || mat1_c_contig) &&
+                (mat2_f_contig || mat2_c_contig)) {
+                oneapi::mkl::transpose trans1 =
+                    (mat1_f_contig && !mat1_c_contig)
+                        ? oneapi::mkl::transpose::trans
+                        : oneapi::mkl::transpose::nontrans;
+                oneapi::mkl::transpose trans2 =
+                    (mat2_f_contig && !mat2_c_contig)
+                        ? oneapi::mkl::transpose::trans
+                        : oneapi::mkl::transpose::nontrans;
 
-		const size_t size_m = ext_input1_shape[0];
-		const size_t size_n = ext_input2_shape[1];
-		const size_t size_k = ext_input1_shape[1];
+                const size_t size_m = ext_input1_shape[0];
+                const size_t size_n = ext_input2_shape[1];
+                const size_t size_k = ext_input1_shape[1];
 
-		const std::int64_t lda =
-		    trans1 == oneapi::mkl::transpose::nontrans ? ext_input1_strides[0] : ext_input1_strides[1];
-		const std::int64_t ldb =
-		    trans2 == oneapi::mkl::transpose::nontrans ? ext_input2_strides[0] : ext_input2_strides[1];
+                const std::int64_t lda =
+                    trans1 == oneapi::mkl::transpose::nontrans
+                        ? ext_input1_strides[0]
+                        : ext_input1_strides[1];
+                const std::int64_t ldb =
+                    trans2 == oneapi::mkl::transpose::nontrans
+                        ? ext_input2_strides[0]
+                        : ext_input2_strides[1];
 
-		// definition of ldc will be another for result with non-standard (c-contiguous) strides
-		// const std::int64_t ldc = result_strides[0] == 1 ? result_strides[1] : result_strides[0];
-		const std::int64_t ldc = size_n;
+                // definition of ldc will be another for result with
+                // non-standard (c-contiguous) strides const std::int64_t ldc =
+                // result_strides[0] == 1 ? result_strides[1] :
+                // result_strides[0];
+                const std::int64_t ldc = size_n;
 
-		try {
-		    sycl::event event = mkl_blas_rm::gemm(q,
-							  trans1,
-							  trans2,
-							  size_m,
-							  size_n,
-							  size_k,
-							  _DataType_output(1), // alpha
-							  input1,
-							  lda,
-							  input2,
-							  ldb,
-							  _DataType_output(0), // beta
-							  result,
-							  ldc);
-		    event.wait();
-		    delete[] ext_input1_shape;
-		    delete[] ext_input1_strides;
-		    delete[] ext_input2_shape;
-		    delete[] ext_input2_strides;
-		    delete[] ext_result_shape;
+                try {
+                    sycl::event event = mkl_blas_rm::gemm(
+                        q, trans1, trans2, size_m, size_n, size_k,
+                        _DataType_output(1), // alpha
+                        input1, lda, input2, ldb,
+                        _DataType_output(0), // beta
+                        result, ldc);
+                    event.wait();
+                    delete[] ext_input1_shape;
+                    delete[] ext_input1_strides;
+                    delete[] ext_input2_shape;
+                    delete[] ext_input2_strides;
+                    delete[] ext_result_shape;
 
-		    return event_ref;
-		} catch (const std::exception &e) {
-		    // do nothing, proceed to general case
-		}
+                    return event_ref;
+                } catch (const std::exception &e) {
+                    // do nothing, proceed to general case
+                }
 #endif
-	    }
-	}
+            }
+        }
     }
 
     std::vector<sycl::event> dot_events;
     dot_events.reserve(result_size);
 
-    size_t dot_st1 = ext_input1_strides[ext_input1_ndim - 1];
-    size_t dot_st2 = ext_input2_strides[ext_input2_ndim - 2];
+    size_t dot_st1  = ext_input1_strides[ext_input1_ndim - 1];
+    size_t dot_st2  = ext_input2_strides[ext_input2_ndim - 2];
     size_t dot_size = ext_input1_shape[ext_input1_ndim - 1];
 
-    shape_elem_type* res_coords = new shape_elem_type[ext_result_ndim];
-    shape_elem_type* result_offsets = new shape_elem_type[ext_result_ndim];
-    get_shape_offsets_inkernel(ext_result_shape, ext_result_ndim, result_offsets);
+    shape_elem_type *res_coords     = new shape_elem_type[ext_result_ndim];
+    shape_elem_type *result_offsets = new shape_elem_type[ext_result_ndim];
+    get_shape_offsets_inkernel(ext_result_shape, ext_result_ndim,
+                               result_offsets);
 
-    for (size_t i = 0; i < result_size; ++i)
-    {
+    for (size_t i = 0; i < result_size; ++i) {
         get_xyz_by_id(i, ext_result_ndim, result_offsets, res_coords);
 
-        _DataType_output* dot_res = result + i;
+        _DataType_output *dot_res = result + i;
 
-        _DataType_input1* dot_in1 = input1;
-        for (size_t j = 0; j < ext_input1_ndim - 1; ++j)
-        {
+        _DataType_input1 *dot_in1 = input1;
+        for (size_t j = 0; j < ext_input1_ndim - 1; ++j) {
             dot_in1 = dot_in1 + res_coords[j] * ext_input1_strides[j];
         }
 
-        _DataType_input2* dot_in2 = input2;
-        for (size_t j = 0; j < ext_input2_ndim - 2; ++j)
-        {
-            dot_in2 = dot_in2 + res_coords[ext_input1_ndim - 1 + j] * ext_input2_strides[j];
+        _DataType_input2 *dot_in2 = input2;
+        for (size_t j = 0; j < ext_input2_ndim - 2; ++j) {
+            dot_in2 = dot_in2 + res_coords[ext_input1_ndim - 1 + j] *
+                                    ext_input2_strides[j];
         }
-        dot_in2 = dot_in2 + res_coords[ext_input1_ndim + ext_input2_ndim - 3] * ext_input2_strides[ext_input2_ndim - 1];
+        dot_in2 = dot_in2 + res_coords[ext_input1_ndim + ext_input2_ndim - 3] *
+                                ext_input2_strides[ext_input2_ndim - 1];
 
-        dot_events.push_back(dot(q, dot_res, dot_in1, dot_in2, dot_st1, dot_st2, dot_size));
+        dot_events.push_back(
+            dot(q, dot_res, dot_in1, dot_in2, dot_st1, dot_st2, dot_size));
     }
 
     sycl::event::wait(dot_events);
@@ -441,158 +441,162 @@ DPCTLSyclEventRef dpnp_dot_c(DPCTLSyclQueueRef q_ref,
     return event_ref;
 }
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
-void dpnp_dot_c(void* result_out,
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
+void dpnp_dot_c(void *result_out,
                 const size_t result_size,
                 const size_t result_ndim,
-                const shape_elem_type* result_shape,
-                const shape_elem_type* result_strides,
-                const void* input1_in,
+                const shape_elem_type *result_shape,
+                const shape_elem_type *result_strides,
+                const void *input1_in,
                 const size_t input1_size,
                 const size_t input1_ndim,
-                const shape_elem_type* input1_shape,
-                const shape_elem_type* input1_strides,
-                const void* input2_in,
+                const shape_elem_type *input1_shape,
+                const shape_elem_type *input1_strides,
+                const void *input2_in,
                 const size_t input2_size,
                 const size_t input2_ndim,
-                const shape_elem_type* input2_shape,
-                const shape_elem_type* input2_strides)
+                const shape_elem_type *input2_shape,
+                const shape_elem_type *input2_strides)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_dot_c<_DataType_output, _DataType_input1, _DataType_input2>(q_ref,
-                                                                                                   result_out,
-                                                                                                   result_size,
-                                                                                                   result_ndim,
-                                                                                                   result_shape,
-                                                                                                   result_strides,
-                                                                                                   input1_in,
-                                                                                                   input1_size,
-                                                                                                   input1_ndim,
-                                                                                                   input1_shape,
-                                                                                                   input1_strides,
-                                                                                                   input2_in,
-                                                                                                   input2_size,
-                                                                                                   input2_ndim,
-                                                                                                   input2_shape,
-                                                                                                   input2_strides,
-                                                                                                   dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_dot_c<_DataType_output, _DataType_input1, _DataType_input2>(
+            q_ref, result_out, result_size, result_ndim, result_shape,
+            result_strides, input1_in, input1_size, input1_ndim, input1_shape,
+            input1_strides, input2_in, input2_size, input2_ndim, input2_shape,
+            input2_strides, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
-void (*dpnp_dot_default_c)(void*,
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
+void (*dpnp_dot_default_c)(void *,
                            const size_t,
                            const size_t,
-                           const shape_elem_type*,
-                           const shape_elem_type*,
-                           const void*,
+                           const shape_elem_type *,
+                           const shape_elem_type *,
+                           const void *,
                            const size_t,
                            const size_t,
-                           const shape_elem_type*,
-                           const shape_elem_type*,
-                           const void*,
+                           const shape_elem_type *,
+                           const shape_elem_type *,
+                           const void *,
                            const size_t,
                            const size_t,
-                           const shape_elem_type*,
-                           const shape_elem_type*) = dpnp_dot_c<_DataType_output, _DataType_input1, _DataType_input2>;
+                           const shape_elem_type *,
+                           const shape_elem_type *) =
+    dpnp_dot_c<_DataType_output, _DataType_input1, _DataType_input2>;
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
 DPCTLSyclEventRef (*dpnp_dot_ext_c)(DPCTLSyclQueueRef,
-                                    void*,
+                                    void *,
                                     const size_t,
                                     const size_t,
-                                    const shape_elem_type*,
-                                    const shape_elem_type*,
-                                    const void*,
+                                    const shape_elem_type *,
+                                    const shape_elem_type *,
+                                    const void *,
                                     const size_t,
                                     const size_t,
-                                    const shape_elem_type*,
-                                    const shape_elem_type*,
-                                    const void*,
+                                    const shape_elem_type *,
+                                    const shape_elem_type *,
+                                    const void *,
                                     const size_t,
                                     const size_t,
-                                    const shape_elem_type*,
-                                    const shape_elem_type*,
-                                    const DPCTLEventVectorRef) = dpnp_dot_c<_DataType_output, _DataType_input1, _DataType_input2>;
+                                    const shape_elem_type *,
+                                    const shape_elem_type *,
+                                    const DPCTLEventVectorRef) =
+    dpnp_dot_c<_DataType_output, _DataType_input1, _DataType_input2>;
 
 template <typename _DataType, typename _ResultType>
 DPCTLSyclEventRef dpnp_eig_c(DPCTLSyclQueueRef q_ref,
-                             const void* array_in,
-                             void* result1,
-                             void* result2,
+                             const void *array_in,
+                             void *result1,
+                             void *result2,
                              size_t size,
                              const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // TODO this kernel works with square 2-D array only
 
     // Kernel Type for calculation is double type
-    // because interface requires float type but calculations are expected in double type
+    // because interface requires float type but calculations are expected in
+    // double type
 
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
     sycl::event event;
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array_in, size * size, true);
-    DPNPC_ptr_adapter<_ResultType> result1_ptr(q_ref, result1, size, true, true);
-    DPNPC_ptr_adapter<_ResultType> result2_ptr(q_ref, result2, size * size, true, true);
-    const _DataType* array = input1_ptr.get_ptr();
-    _ResultType* result_val = result1_ptr.get_ptr();
-    _ResultType* result_vec = result2_ptr.get_ptr();
+    DPNPC_ptr_adapter<_ResultType> result1_ptr(q_ref, result1, size, true,
+                                               true);
+    DPNPC_ptr_adapter<_ResultType> result2_ptr(q_ref, result2, size * size,
+                                               true, true);
+    const _DataType *array  = input1_ptr.get_ptr();
+    _ResultType *result_val = result1_ptr.get_ptr();
+    _ResultType *result_vec = result2_ptr.get_ptr();
 
-    double* result_val_kern = reinterpret_cast<double*>(sycl::malloc_shared(size * sizeof(double), q));
-    double* result_vec_kern = reinterpret_cast<double*>(sycl::malloc_shared(size * size * sizeof(double), q));
+    double *result_val_kern = reinterpret_cast<double *>(
+        sycl::malloc_shared(size * sizeof(double), q));
+    double *result_vec_kern = reinterpret_cast<double *>(
+        sycl::malloc_shared(size * size * sizeof(double), q));
 
     // type conversion. Also, math library requires copy memory because override
-    for (size_t it = 0; it < (size * size); ++it)
-    {
-        result_vec_kern[it] = array[it]; // TODO use memcpy_c or input1_ptr(array_in, size, true)
+    for (size_t it = 0; it < (size * size); ++it) {
+        result_vec_kern[it] =
+            array[it]; // TODO use memcpy_c or input1_ptr(array_in, size, true)
     }
 
     const std::int64_t lda = std::max<size_t>(1UL, size);
 
-    const std::int64_t scratchpad_size = mkl_lapack::syevd_scratchpad_size<double>(
-        q, oneapi::mkl::job::vec, oneapi::mkl::uplo::upper, size, lda);
+    const std::int64_t scratchpad_size =
+        mkl_lapack::syevd_scratchpad_size<double>(
+            q, oneapi::mkl::job::vec, oneapi::mkl::uplo::upper, size, lda);
 
     // https://github.com/IntelPython/dpnp/issues/1005
-    // Test tests/test_linalg.py::test_eig_arange raises 2 issues in dpnp_eig_c on CPU
-    // 1. Call of mkl_lapack::syevd_scratchpad_size<double> returns wrong value that causes out of memory issue.
+    // Test tests/test_linalg.py::test_eig_arange raises 2 issues in dpnp_eig_c
+    // on CPU
+    // 1. Call of mkl_lapack::syevd_scratchpad_size<double> returns wrong value
+    // that causes out of memory issue.
     // 2. Call of the function oneapi::mkl::lapack::syevd causes segfault.
     // Example of the command to reproduce the issues:
-    // SYCL_DEVICE_FILTER=cpu pytest tests/test_linalg.py::test_eig_arange[2-float64]
-    // High-level reason of the issues is numpy is imported before dpnp in third party tests.
-    // Low-level reason of the issues could be related to MKL runtime library loaded during numpy import.
+    // SYCL_DEVICE_FILTER=cpu pytest
+    // tests/test_linalg.py::test_eig_arange[2-float64] High-level reason of the
+    // issues is numpy is imported before dpnp in third party tests. Low-level
+    // reason of the issues could be related to MKL runtime library loaded
+    // during numpy import.
 
-    double* scratchpad = reinterpret_cast<double*>(sycl::malloc_shared(scratchpad_size * sizeof(double), q));
+    double *scratchpad = reinterpret_cast<double *>(
+        sycl::malloc_shared(scratchpad_size * sizeof(double), q));
 
-    event = mkl_lapack::syevd(q,                        // queue
-                              oneapi::mkl::job::vec,    // jobz
-                              oneapi::mkl::uplo::upper, // uplo
-                              size,                     // The order of the matrix A (0 <= n)
-                              result_vec_kern,          // will be overwritten with eigenvectors
-                              lda,
-                              result_val_kern,
-                              scratchpad,
-                              scratchpad_size);
+    event = mkl_lapack::syevd(
+        q,                        // queue
+        oneapi::mkl::job::vec,    // jobz
+        oneapi::mkl::uplo::upper, // uplo
+        size,                     // The order of the matrix A (0 <= n)
+        result_vec_kern,          // will be overwritten with eigenvectors
+        lda, result_val_kern, scratchpad, scratchpad_size);
     event.wait();
 
     sycl::free(scratchpad, q);
 
-    for (size_t it1 = 0; it1 < size; ++it1)
-    {
-        result_val[it1] = result_val_kern[it1]; // TODO use memcpy_c or dpnpc_transpose_c
-        for (size_t it2 = 0; it2 < size; ++it2)
-        {
+    for (size_t it1 = 0; it1 < size; ++it1) {
+        result_val[it1] =
+            result_val_kern[it1]; // TODO use memcpy_c or dpnpc_transpose_c
+        for (size_t it2 = 0; it2 < size; ++it2) {
             // copy + transpose
             result_vec[it2 * size + it1] = result_vec_kern[it1 * size + it2];
         }
@@ -605,92 +609,90 @@ DPCTLSyclEventRef dpnp_eig_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType, typename _ResultType>
-void dpnp_eig_c(const void* array_in, void* result1, void* result2, size_t size)
+void dpnp_eig_c(const void *array_in, void *result1, void *result2, size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_eig_c<_DataType, _ResultType>(q_ref,
-                                                                     array_in,
-                                                                     result1,
-                                                                     result2,
-                                                                     size,
-                                                                     dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_eig_c<_DataType, _ResultType>(
+        q_ref, array_in, result1, result2, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType, typename _ResultType>
-void (*dpnp_eig_default_c)(const void*, void*, void*, size_t) = dpnp_eig_c<_DataType, _ResultType>;
+void (*dpnp_eig_default_c)(const void *, void *, void *, size_t) =
+    dpnp_eig_c<_DataType, _ResultType>;
 
 template <typename _DataType, typename _ResultType>
 DPCTLSyclEventRef (*dpnp_eig_ext_c)(DPCTLSyclQueueRef,
-                                    const void*,
-                                    void*,
-                                    void*,
+                                    const void *,
+                                    void *,
+                                    void *,
                                     size_t,
-                                    const DPCTLEventVectorRef) = dpnp_eig_c<_DataType, _ResultType>;
+                                    const DPCTLEventVectorRef) =
+    dpnp_eig_c<_DataType, _ResultType>;
 
 template <typename _DataType, typename _ResultType>
 DPCTLSyclEventRef dpnp_eigvals_c(DPCTLSyclQueueRef q_ref,
-                                 const void* array_in,
-                                 void* result1,
+                                 const void *array_in,
+                                 void *result1,
                                  size_t size,
                                  const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // TODO this kernel works with square 2-D array only
 
     // Kernel Type for calculation is double type
-    // because interface requires float type but calculations are expected in double type
+    // because interface requires float type but calculations are expected in
+    // double type
 
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
     sycl::event event;
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array_in, size * size, true);
-    DPNPC_ptr_adapter<_ResultType> result1_ptr(q_ref, result1, size, true, true);
-    const _DataType* array = input1_ptr.get_ptr();
-    _ResultType* result_val = result1_ptr.get_ptr();
+    DPNPC_ptr_adapter<_ResultType> result1_ptr(q_ref, result1, size, true,
+                                               true);
+    const _DataType *array  = input1_ptr.get_ptr();
+    _ResultType *result_val = result1_ptr.get_ptr();
 
-    double* result_val_kern = reinterpret_cast<double*>(sycl::malloc_shared(size * sizeof(double), q));
-    double* result_vec_kern = reinterpret_cast<double*>(sycl::malloc_shared(size * size * sizeof(double), q));
+    double *result_val_kern = reinterpret_cast<double *>(
+        sycl::malloc_shared(size * sizeof(double), q));
+    double *result_vec_kern = reinterpret_cast<double *>(
+        sycl::malloc_shared(size * size * sizeof(double), q));
 
     // type conversion. Also, math library requires copy memory because override
-    for (size_t it = 0; it < (size * size); ++it)
-    {
+    for (size_t it = 0; it < (size * size); ++it) {
         result_vec_kern[it] = array[it]; // TODO same as previous kernel
     }
 
     const std::int64_t lda = std::max<size_t>(1UL, size);
 
-    const std::int64_t scratchpad_size = mkl_lapack::syevd_scratchpad_size<double>(
-        q, oneapi::mkl::job::vec, oneapi::mkl::uplo::upper, size, lda);
+    const std::int64_t scratchpad_size =
+        mkl_lapack::syevd_scratchpad_size<double>(
+            q, oneapi::mkl::job::vec, oneapi::mkl::uplo::upper, size, lda);
 
-    double* scratchpad = reinterpret_cast<double*>(sycl::malloc_shared(scratchpad_size * sizeof(double), q));
+    double *scratchpad = reinterpret_cast<double *>(
+        sycl::malloc_shared(scratchpad_size * sizeof(double), q));
 
     event = mkl_lapack::syevd(q,                        // queue
                               oneapi::mkl::job::vec,    // jobz
                               oneapi::mkl::uplo::upper, // uplo
-                              size,                     // The order of the matrix A (0 <= n)
-                              result_vec_kern,
-                              lda,
-                              result_val_kern,
-                              scratchpad,
+                              size, // The order of the matrix A (0 <= n)
+                              result_vec_kern, lda, result_val_kern, scratchpad,
                               scratchpad_size);
     event.wait();
 
     sycl::free(scratchpad, q);
 
-    for (size_t it1 = 0; it1 < size; ++it1)
-    {
+    for (size_t it1 = 0; it1 < size; ++it1) {
         result_val[it1] = result_val_kern[it1];
     }
 
@@ -700,36 +702,36 @@ DPCTLSyclEventRef dpnp_eigvals_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType, typename _ResultType>
-void dpnp_eigvals_c(const void* array_in, void* result1, size_t size)
+void dpnp_eigvals_c(const void *array_in, void *result1, size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_eigvals_c<_DataType, _ResultType>(q_ref,
-                                                                         array_in,
-                                                                         result1,
-                                                                         size,
-                                                                         dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref = dpnp_eigvals_c<_DataType, _ResultType>(
+        q_ref, array_in, result1, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType, typename _ResultType>
-void (*dpnp_eigvals_default_c)(const void*, void*, size_t) = dpnp_eigvals_c<_DataType, _ResultType>;
+void (*dpnp_eigvals_default_c)(const void *,
+                               void *,
+                               size_t) = dpnp_eigvals_c<_DataType, _ResultType>;
 
 template <typename _DataType, typename _ResultType>
 DPCTLSyclEventRef (*dpnp_eigvals_ext_c)(DPCTLSyclQueueRef,
-                                        const void*,
-                                        void*,
+                                        const void *,
+                                        void *,
                                         size_t,
-                                        const DPCTLEventVectorRef) = dpnp_eigvals_c<_DataType, _ResultType>;
+                                        const DPCTLEventVectorRef) =
+    dpnp_eigvals_c<_DataType, _ResultType>;
 
 template <typename _DataType>
 class dpnp_initval_c_kernel;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_initval_c(DPCTLSyclQueueRef q_ref,
-                                 void* result,
-                                 void* value,
+                                 void *result,
+                                 void *value,
                                  size_t size,
                                  const DPCTLEventVectorRef dep_event_vec_ref)
 {
@@ -738,66 +740,65 @@ DPCTLSyclEventRef dpnp_initval_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
     _DataType val = *(static_cast<_DataType *>(value));
 
     validate_type_for_device<_DataType>(q);
 
     auto event = q.fill<_DataType>(result, val, size);
-    event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
+    event_ref  = reinterpret_cast<DPCTLSyclEventRef>(&event);
 
     return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType>
-void dpnp_initval_c(void* result1, void* value, size_t size)
+void dpnp_initval_c(void *result1, void *value, size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_initval_c<_DataType>(q_ref,
-                                                            result1,
-                                                            value,
-                                                            size,
-                                                            dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_initval_c<_DataType>(
+        q_ref, result1, value, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_initval_default_c)(void*, void*, size_t) = dpnp_initval_c<_DataType>;
+void (*dpnp_initval_default_c)(void *,
+                               void *,
+                               size_t) = dpnp_initval_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_initval_ext_c)(DPCTLSyclQueueRef,
-                                        void*,
-                                        void*,
+                                        void *,
+                                        void *,
                                         size_t,
-                                        const DPCTLEventVectorRef) = dpnp_initval_c<_DataType>;
+                                        const DPCTLEventVectorRef) =
+    dpnp_initval_c<_DataType>;
 
 template <typename _KernelNameSpecialization>
 class dpnp_matmul_c_kernel;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_matmul_c(DPCTLSyclQueueRef q_ref,
-                                void* result_out,
+                                void *result_out,
                                 const size_t result_size,
                                 const size_t result_ndim,
-                                const shape_elem_type* result_shape,
-                                const shape_elem_type* result_strides,
-                                const void* input1_in,
+                                const shape_elem_type *result_shape,
+                                const shape_elem_type *result_strides,
+                                const void *input1_in,
                                 const size_t input1_size,
                                 const size_t input1_ndim,
-                                const shape_elem_type* input1_shape,
-                                const shape_elem_type* input1_strides,
-                                const void* input2_in,
+                                const shape_elem_type *input1_shape,
+                                const shape_elem_type *input1_strides,
+                                const void *input2_in,
                                 const size_t input2_size,
                                 const size_t input2_ndim,
-                                const shape_elem_type* input2_shape,
-                                const shape_elem_type* input2_strides,
+                                const shape_elem_type *input2_shape,
+                                const shape_elem_type *input2_strides,
                                 const DPCTLEventVectorRef dep_event_vec_ref)
 {
     (void)result_size;
@@ -817,74 +818,70 @@ DPCTLSyclEventRef dpnp_matmul_c(DPCTLSyclQueueRef q_ref,
     size_t size_n = input2_shape[1];
     size_t size_k = input1_shape[1];
 
-    if (!size_m || !size_n || !size_k)
-    {
+    if (!size_m || !size_n || !size_k) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
     std::vector<sycl::event> dep_events = cast_event_vector(dep_event_vec_ref);
     sycl::event event;
 
-    _DataType* array_1 = reinterpret_cast<_DataType*>(const_cast<void*>(input1_in));
-    _DataType* array_2 = reinterpret_cast<_DataType*>(const_cast<void*>(input2_in));
-    _DataType* result = reinterpret_cast<_DataType*>(result_out);
+    _DataType *array_1 =
+        reinterpret_cast<_DataType *>(const_cast<void *>(input1_in));
+    _DataType *array_2 =
+        reinterpret_cast<_DataType *>(const_cast<void *>(input2_in));
+    _DataType *result = reinterpret_cast<_DataType *>(result_out);
 
-    if constexpr (std::is_same<_DataType, double>::value || std::is_same<_DataType, float>::value)
+    if constexpr (std::is_same<_DataType, double>::value ||
+                  std::is_same<_DataType, float>::value)
     {
         // using std::max for these ldx variables is required by math library
-        const std::int64_t lda = std::max<size_t>(1UL, size_k); // First dimensions of array_1
-        const std::int64_t ldb = std::max<size_t>(1UL, size_n); // First dimensions of array_2
-        const std::int64_t ldc = std::max<size_t>(1UL, size_n); // Fast dimensions of result
+        const std::int64_t lda =
+            std::max<size_t>(1UL, size_k); // First dimensions of array_1
+        const std::int64_t ldb =
+            std::max<size_t>(1UL, size_n); // First dimensions of array_2
+        const std::int64_t ldc =
+            std::max<size_t>(1UL, size_n); // Fast dimensions of result
 
-        event = mkl_blas::gemm(q,
-                               oneapi::mkl::transpose::nontrans,
-                               oneapi::mkl::transpose::nontrans,
-                               size_n,
-                               size_m,
-                               size_k,
-                               _DataType(1),
-                               array_2,
-                               ldb,
-                               array_1,
-                               lda,
-                               _DataType(0),
-                               result,
-                               ldc,
-                               dep_events);
+        event = mkl_blas::gemm(q, oneapi::mkl::transpose::nontrans,
+                               oneapi::mkl::transpose::nontrans, size_n, size_m,
+                               size_k, _DataType(1), array_2, ldb, array_1, lda,
+                               _DataType(0), result, ldc, dep_events);
     }
-    else
-    {
+    else {
         // input1: M x K
         // input2: K x N
         // result: M x N
-        const size_t dim_m = size_m; // shape1.front(); // First dimensions of array1
-        const size_t dim_n = size_n; // shape2.back();  // Last dimensions of array2
-        const size_t dim_k = size_k; // shape1.back(); // First dimensions of array2
+        const size_t dim_m =
+            size_m; // shape1.front(); // First dimensions of array1
+        const size_t dim_n =
+            size_n; // shape2.back();  // Last dimensions of array2
+        const size_t dim_k =
+            size_k; // shape1.back(); // First dimensions of array2
 
         sycl::range<2> gws(dim_m, dim_n); // dimensions are: "i" and "j"
 
         auto kernel_parallel_for_func = [=](sycl::id<2> global_id) {
-            size_t i = global_id[0]; //for (size_t i = 0; i < size; ++i)
+            size_t i = global_id[0]; // for (size_t i = 0; i < size; ++i)
             {
-                size_t j = global_id[1]; //for (size_t j = 0; j < size; ++j)
+                size_t j = global_id[1]; // for (size_t j = 0; j < size; ++j)
                 {
                     _DataType acc = _DataType(0);
-                    for (size_t k = 0; k < dim_k; ++k)
-                    {
+                    for (size_t k = 0; k < dim_k; ++k) {
                         const size_t index_1 = i * dim_k + k;
                         const size_t index_2 = k * dim_n + j;
                         acc += array_1[index_1] * array_2[index_2];
                     }
                     const size_t index_result = i * dim_n + j;
-                    result[index_result] = acc;
+                    result[index_result]      = acc;
                 }
             }
         };
 
-        auto kernel_func = [&](sycl::handler& cgh) {
+        auto kernel_func = [&](sycl::handler &cgh) {
             cgh.depends_on(dep_events);
-            cgh.parallel_for<class dpnp_matmul_c_kernel<_DataType>>(gws, kernel_parallel_for_func);
+            cgh.parallel_for<class dpnp_matmul_c_kernel<_DataType>>(
+                gws, kernel_parallel_for_func);
         };
 
         event = q.submit(kernel_func);
@@ -896,260 +893,336 @@ DPCTLSyclEventRef dpnp_matmul_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_matmul_c(void* result_out,
+void dpnp_matmul_c(void *result_out,
                    const size_t result_size,
                    const size_t result_ndim,
-                   const shape_elem_type* result_shape,
-                   const shape_elem_type* result_strides,
-                   const void* input1_in,
+                   const shape_elem_type *result_shape,
+                   const shape_elem_type *result_strides,
+                   const void *input1_in,
                    const size_t input1_size,
                    const size_t input1_ndim,
-                   const shape_elem_type* input1_shape,
-                   const shape_elem_type* input1_strides,
-                   const void* input2_in,
+                   const shape_elem_type *input1_shape,
+                   const shape_elem_type *input1_strides,
+                   const void *input2_in,
                    const size_t input2_size,
                    const size_t input2_ndim,
-                   const shape_elem_type* input2_shape,
-                   const shape_elem_type* input2_strides)
+                   const shape_elem_type *input2_shape,
+                   const shape_elem_type *input2_strides)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_matmul_c<_DataType>(q_ref,
-                                                           result_out,
-                                                           result_size,
-                                                           result_ndim,
-                                                           result_shape,
-                                                           result_strides,
-                                                           input1_in,
-                                                           input1_size,
-                                                           input1_ndim,
-                                                           input1_shape,
-                                                           input1_strides,
-                                                           input2_in,
-                                                           input2_size,
-                                                           input2_ndim,
-                                                           input2_shape,
-                                                           input2_strides,
-                                                           dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_matmul_c<_DataType>(
+        q_ref, result_out, result_size, result_ndim, result_shape,
+        result_strides, input1_in, input1_size, input1_ndim, input1_shape,
+        input1_strides, input2_in, input2_size, input2_ndim, input2_shape,
+        input2_strides, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_matmul_default_c)(void*,
+void (*dpnp_matmul_default_c)(void *,
                               const size_t,
                               const size_t,
-                              const shape_elem_type*,
-                              const shape_elem_type*,
-                              const void*,
+                              const shape_elem_type *,
+                              const shape_elem_type *,
+                              const void *,
                               const size_t,
                               const size_t,
-                              const shape_elem_type*,
-                              const shape_elem_type*,
-                              const void*,
+                              const shape_elem_type *,
+                              const shape_elem_type *,
+                              const void *,
                               const size_t,
                               const size_t,
-                              const shape_elem_type*,
-                              const shape_elem_type*) = dpnp_matmul_c<_DataType>;
+                              const shape_elem_type *,
+                              const shape_elem_type *) =
+    dpnp_matmul_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_matmul_ext_c)(DPCTLSyclQueueRef,
-                                       void*,
+                                       void *,
                                        const size_t,
                                        const size_t,
-                                       const shape_elem_type*,
-                                       const shape_elem_type*,
-                                       const void*,
+                                       const shape_elem_type *,
+                                       const shape_elem_type *,
+                                       const void *,
                                        const size_t,
                                        const size_t,
-                                       const shape_elem_type*,
-                                       const shape_elem_type*,
-                                       const void*,
+                                       const shape_elem_type *,
+                                       const shape_elem_type *,
+                                       const void *,
                                        const size_t,
                                        const size_t,
-                                       const shape_elem_type*,
-                                       const shape_elem_type*,
-                                       const DPCTLEventVectorRef) = dpnp_matmul_c<_DataType>;
+                                       const shape_elem_type *,
+                                       const shape_elem_type *,
+                                       const DPCTLEventVectorRef) =
+    dpnp_matmul_c<_DataType>;
 
-void func_map_init_linalg(func_map_t& fmap)
+void func_map_init_linalg(func_map_t &fmap)
 {
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_astype_default_c<bool, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_BLN][eft_INT] = {eft_INT, (void*)dpnp_astype_default_c<bool, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_BLN][eft_LNG] = {eft_LNG, (void*)dpnp_astype_default_c<bool, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_BLN][eft_FLT] = {eft_FLT, (void*)dpnp_astype_default_c<bool, float>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_BLN][eft_DBL] = {eft_DBL, (void*)dpnp_astype_default_c<bool, double>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_INT][eft_BLN] = {eft_BLN, (void*)dpnp_astype_default_c<int32_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_astype_default_c<int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_INT][eft_LNG] = {eft_LNG, (void*)dpnp_astype_default_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_INT][eft_FLT] = {eft_FLT, (void*)dpnp_astype_default_c<int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_INT][eft_DBL] = {eft_DBL, (void*)dpnp_astype_default_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_LNG][eft_BLN] = {eft_BLN, (void*)dpnp_astype_default_c<int64_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_LNG][eft_INT] = {eft_INT, (void*)dpnp_astype_default_c<int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_astype_default_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_LNG][eft_FLT] = {eft_FLT, (void*)dpnp_astype_default_c<int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_LNG][eft_DBL] = {eft_DBL, (void*)dpnp_astype_default_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_FLT][eft_BLN] = {eft_BLN, (void*)dpnp_astype_default_c<float, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_FLT][eft_INT] = {eft_INT, (void*)dpnp_astype_default_c<float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_FLT][eft_LNG] = {eft_LNG, (void*)dpnp_astype_default_c<float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_astype_default_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_FLT][eft_DBL] = {eft_DBL, (void*)dpnp_astype_default_c<float, double>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_DBL][eft_BLN] = {eft_BLN, (void*)dpnp_astype_default_c<double, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_DBL][eft_INT] = {eft_INT, (void*)dpnp_astype_default_c<double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_DBL][eft_LNG] = {eft_LNG, (void*)dpnp_astype_default_c<double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_DBL][eft_FLT] = {eft_FLT, (void*)dpnp_astype_default_c<double, float>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_astype_default_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_astype_default_c<bool, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_BLN][eft_INT] = {
+        eft_INT, (void *)dpnp_astype_default_c<bool, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_BLN][eft_LNG] = {
+        eft_LNG, (void *)dpnp_astype_default_c<bool, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_BLN][eft_FLT] = {
+        eft_FLT, (void *)dpnp_astype_default_c<bool, float>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_BLN][eft_DBL] = {
+        eft_DBL, (void *)dpnp_astype_default_c<bool, double>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_INT][eft_BLN] = {
+        eft_BLN, (void *)dpnp_astype_default_c<int32_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_astype_default_c<int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_astype_default_c<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_INT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_astype_default_c<int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_astype_default_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_LNG][eft_BLN] = {
+        eft_BLN, (void *)dpnp_astype_default_c<int64_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_LNG][eft_INT] = {
+        eft_INT, (void *)dpnp_astype_default_c<int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_astype_default_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_LNG][eft_FLT] = {
+        eft_FLT, (void *)dpnp_astype_default_c<int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_astype_default_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_FLT][eft_BLN] = {
+        eft_BLN, (void *)dpnp_astype_default_c<float, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_FLT][eft_INT] = {
+        eft_INT, (void *)dpnp_astype_default_c<float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_FLT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_astype_default_c<float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_astype_default_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_astype_default_c<float, double>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_DBL][eft_BLN] = {
+        eft_BLN, (void *)dpnp_astype_default_c<double, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_DBL][eft_INT] = {
+        eft_INT, (void *)dpnp_astype_default_c<double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_DBL][eft_LNG] = {
+        eft_LNG, (void *)dpnp_astype_default_c<double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_DBL][eft_FLT] = {
+        eft_FLT, (void *)dpnp_astype_default_c<double, float>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_astype_default_c<double, double>};
     fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_C64][eft_C64] = {
-        eft_C64, (void*)dpnp_astype_default_c<std::complex<float>, std::complex<float>>};
+        eft_C64,
+        (void *)
+            dpnp_astype_default_c<std::complex<float>, std::complex<float>>};
     fmap[DPNPFuncName::DPNP_FN_ASTYPE][eft_C128][eft_C128] = {
-        eft_C128, (void*)dpnp_astype_default_c<std::complex<double>, std::complex<double>>};
+        eft_C128,
+        (void *)
+            dpnp_astype_default_c<std::complex<double>, std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_astype_ext_c<bool, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_BLN][eft_INT] = {eft_INT, (void*)dpnp_astype_ext_c<bool, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_BLN][eft_LNG] = {eft_LNG, (void*)dpnp_astype_ext_c<bool, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_BLN][eft_FLT] = {eft_FLT, (void*)dpnp_astype_ext_c<bool, float>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_BLN][eft_DBL] = {eft_DBL, (void*)dpnp_astype_ext_c<bool, double>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_INT][eft_BLN] = {eft_BLN, (void*)dpnp_astype_ext_c<int32_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_astype_ext_c<int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_INT][eft_LNG] = {eft_LNG, (void*)dpnp_astype_ext_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_INT][eft_FLT] = {eft_FLT, (void*)dpnp_astype_ext_c<int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_INT][eft_DBL] = {eft_DBL, (void*)dpnp_astype_ext_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_LNG][eft_BLN] = {eft_BLN, (void*)dpnp_astype_ext_c<int64_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_LNG][eft_INT] = {eft_INT, (void*)dpnp_astype_ext_c<int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_astype_ext_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_LNG][eft_FLT] = {eft_FLT, (void*)dpnp_astype_ext_c<int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_LNG][eft_DBL] = {eft_DBL, (void*)dpnp_astype_ext_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_FLT][eft_BLN] = {eft_BLN, (void*)dpnp_astype_ext_c<float, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_FLT][eft_INT] = {eft_INT, (void*)dpnp_astype_ext_c<float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_FLT][eft_LNG] = {eft_LNG, (void*)dpnp_astype_ext_c<float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_astype_ext_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_FLT][eft_DBL] = {eft_DBL, (void*)dpnp_astype_ext_c<float, double>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_DBL][eft_BLN] = {eft_BLN, (void*)dpnp_astype_ext_c<double, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_DBL][eft_INT] = {eft_INT, (void*)dpnp_astype_ext_c<double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_DBL][eft_LNG] = {eft_LNG, (void*)dpnp_astype_ext_c<double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_DBL][eft_FLT] = {eft_FLT, (void*)dpnp_astype_ext_c<double, float>};
-    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_astype_ext_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_astype_ext_c<bool, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_BLN][eft_INT] = {
+        eft_INT, (void *)dpnp_astype_ext_c<bool, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_BLN][eft_LNG] = {
+        eft_LNG, (void *)dpnp_astype_ext_c<bool, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_BLN][eft_FLT] = {
+        eft_FLT, (void *)dpnp_astype_ext_c<bool, float>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_BLN][eft_DBL] = {
+        eft_DBL, (void *)dpnp_astype_ext_c<bool, double>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_INT][eft_BLN] = {
+        eft_BLN, (void *)dpnp_astype_ext_c<int32_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_astype_ext_c<int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_astype_ext_c<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_INT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_astype_ext_c<int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_astype_ext_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_LNG][eft_BLN] = {
+        eft_BLN, (void *)dpnp_astype_ext_c<int64_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_LNG][eft_INT] = {
+        eft_INT, (void *)dpnp_astype_ext_c<int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_astype_ext_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_LNG][eft_FLT] = {
+        eft_FLT, (void *)dpnp_astype_ext_c<int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_astype_ext_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_FLT][eft_BLN] = {
+        eft_BLN, (void *)dpnp_astype_ext_c<float, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_FLT][eft_INT] = {
+        eft_INT, (void *)dpnp_astype_ext_c<float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_FLT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_astype_ext_c<float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_astype_ext_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_astype_ext_c<float, double>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_DBL][eft_BLN] = {
+        eft_BLN, (void *)dpnp_astype_ext_c<double, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_DBL][eft_INT] = {
+        eft_INT, (void *)dpnp_astype_ext_c<double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_DBL][eft_LNG] = {
+        eft_LNG, (void *)dpnp_astype_ext_c<double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_DBL][eft_FLT] = {
+        eft_FLT, (void *)dpnp_astype_ext_c<double, float>};
+    fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_astype_ext_c<double, double>};
     fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_C64][eft_C64] = {
-        eft_C64, (void*)dpnp_astype_ext_c<std::complex<float>, std::complex<float>>};
+        eft_C64,
+        (void *)dpnp_astype_ext_c<std::complex<float>, std::complex<float>>};
     fmap[DPNPFuncName::DPNP_FN_ASTYPE_EXT][eft_C128][eft_C128] = {
-        eft_C128, (void*)dpnp_astype_ext_c<std::complex<double>, std::complex<double>>};
+        eft_C128,
+        (void *)dpnp_astype_ext_c<std::complex<double>, std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_DOT][eft_INT][eft_INT] = {eft_INT,
-                                                         (void*)dpnp_dot_default_c<int32_t, int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_DOT][eft_INT][eft_LNG] = {eft_LNG,
-                                                         (void*)dpnp_dot_default_c<int64_t, int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_DOT][eft_INT][eft_FLT] = {eft_DBL,
-                                                         (void*)dpnp_dot_default_c<double, int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_DOT][eft_INT][eft_DBL] = {eft_DBL,
-                                                         (void*)dpnp_dot_default_c<double, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_DOT][eft_LNG][eft_INT] = {eft_LNG,
-                                                         (void*)dpnp_dot_default_c<int64_t, int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_DOT][eft_LNG][eft_LNG] = {eft_LNG,
-                                                         (void*)dpnp_dot_default_c<int64_t, int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_DOT][eft_LNG][eft_FLT] = {eft_DBL,
-                                                         (void*)dpnp_dot_default_c<double, int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_DOT][eft_LNG][eft_DBL] = {eft_DBL,
-                                                         (void*)dpnp_dot_default_c<double, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_DOT][eft_FLT][eft_INT] = {eft_DBL,
-                                                         (void*)dpnp_dot_default_c<double, float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_DOT][eft_FLT][eft_LNG] = {eft_DBL,
-                                                         (void*)dpnp_dot_default_c<double, float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_DOT][eft_FLT][eft_FLT] = {eft_FLT,
-                                                         (void*)dpnp_dot_default_c<float, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_DOT][eft_FLT][eft_DBL] = {eft_DBL,
-                                                         (void*)dpnp_dot_default_c<double, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_DOT][eft_DBL][eft_INT] = {eft_DBL,
-                                                         (void*)dpnp_dot_default_c<double, double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_DOT][eft_DBL][eft_LNG] = {eft_DBL,
-                                                         (void*)dpnp_dot_default_c<double, double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_DOT][eft_DBL][eft_FLT] = {eft_DBL,
-                                                         (void*)dpnp_dot_default_c<double, double, float>};
-    fmap[DPNPFuncName::DPNP_FN_DOT][eft_DBL][eft_DBL] = {eft_DBL,
-                                                         (void*)dpnp_dot_default_c<double, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_DOT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_dot_default_c<int32_t, int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_DOT][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_dot_default_c<int64_t, int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_DOT][eft_INT][eft_FLT] = {
+        eft_DBL, (void *)dpnp_dot_default_c<double, int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_DOT][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_dot_default_c<double, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_DOT][eft_LNG][eft_INT] = {
+        eft_LNG, (void *)dpnp_dot_default_c<int64_t, int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_DOT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_dot_default_c<int64_t, int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_DOT][eft_LNG][eft_FLT] = {
+        eft_DBL, (void *)dpnp_dot_default_c<double, int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_DOT][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_dot_default_c<double, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_DOT][eft_FLT][eft_INT] = {
+        eft_DBL, (void *)dpnp_dot_default_c<double, float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_DOT][eft_FLT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_dot_default_c<double, float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_DOT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_dot_default_c<float, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_DOT][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_dot_default_c<double, float, double>};
+    fmap[DPNPFuncName::DPNP_FN_DOT][eft_DBL][eft_INT] = {
+        eft_DBL, (void *)dpnp_dot_default_c<double, double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_DOT][eft_DBL][eft_LNG] = {
+        eft_DBL, (void *)dpnp_dot_default_c<double, double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_DOT][eft_DBL][eft_FLT] = {
+        eft_DBL, (void *)dpnp_dot_default_c<double, double, float>};
+    fmap[DPNPFuncName::DPNP_FN_DOT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_dot_default_c<double, double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_INT][eft_INT] = {eft_INT,
-                                                             (void*)dpnp_dot_ext_c<int32_t, int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_INT][eft_LNG] = {eft_LNG,
-                                                             (void*)dpnp_dot_ext_c<int64_t, int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_INT][eft_FLT] = {eft_DBL,
-                                                             (void*)dpnp_dot_ext_c<double, int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_INT][eft_DBL] = {eft_DBL,
-                                                             (void*)dpnp_dot_ext_c<double, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_LNG][eft_INT] = {eft_LNG,
-                                                             (void*)dpnp_dot_ext_c<int64_t, int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_LNG][eft_LNG] = {eft_LNG,
-                                                             (void*)dpnp_dot_ext_c<int64_t, int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_LNG][eft_FLT] = {eft_DBL,
-                                                             (void*)dpnp_dot_ext_c<double, int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_LNG][eft_DBL] = {eft_DBL,
-                                                             (void*)dpnp_dot_ext_c<double, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_FLT][eft_INT] = {eft_DBL,
-                                                             (void*)dpnp_dot_ext_c<double, float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_FLT][eft_LNG] = {eft_DBL,
-                                                             (void*)dpnp_dot_ext_c<double, float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_FLT][eft_FLT] = {eft_FLT,
-                                                             (void*)dpnp_dot_ext_c<float, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_FLT][eft_DBL] = {eft_DBL,
-                                                             (void*)dpnp_dot_ext_c<double, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_DBL][eft_INT] = {eft_DBL,
-                                                             (void*)dpnp_dot_ext_c<double, double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_DBL][eft_LNG] = {eft_DBL,
-                                                             (void*)dpnp_dot_ext_c<double, double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_DBL][eft_FLT] = {eft_DBL,
-                                                             (void*)dpnp_dot_ext_c<double, double, float>};
-    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_DBL][eft_DBL] = {eft_DBL,
-                                                             (void*)dpnp_dot_ext_c<double, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_dot_ext_c<int32_t, int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_dot_ext_c<int64_t, int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_INT][eft_FLT] = {
+        eft_DBL, (void *)dpnp_dot_ext_c<double, int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_dot_ext_c<double, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_LNG][eft_INT] = {
+        eft_LNG, (void *)dpnp_dot_ext_c<int64_t, int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_dot_ext_c<int64_t, int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_LNG][eft_FLT] = {
+        eft_DBL, (void *)dpnp_dot_ext_c<double, int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_dot_ext_c<double, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_FLT][eft_INT] = {
+        eft_DBL, (void *)dpnp_dot_ext_c<double, float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_FLT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_dot_ext_c<double, float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_dot_ext_c<float, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_dot_ext_c<double, float, double>};
+    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_DBL][eft_INT] = {
+        eft_DBL, (void *)dpnp_dot_ext_c<double, double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_DBL][eft_LNG] = {
+        eft_DBL, (void *)dpnp_dot_ext_c<double, double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_DBL][eft_FLT] = {
+        eft_DBL, (void *)dpnp_dot_ext_c<double, double, float>};
+    fmap[DPNPFuncName::DPNP_FN_DOT_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_dot_ext_c<double, double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_EIG][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_eig_default_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_EIG][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_eig_default_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_EIG][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_eig_default_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_EIG][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_eig_default_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_EIG][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_eig_default_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_EIG][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_eig_default_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_EIG][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_eig_default_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_EIG][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_eig_default_c<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_EIG_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_eig_ext_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_EIG_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_eig_ext_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_EIG_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_eig_ext_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_EIG_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_eig_ext_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_EIG_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_eig_ext_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_EIG_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_eig_ext_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_EIG_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_eig_ext_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_EIG_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_eig_ext_c<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_EIGVALS][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_eigvals_default_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_EIGVALS][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_eigvals_default_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_EIGVALS][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_eigvals_default_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_EIGVALS][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_eigvals_default_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_EIGVALS][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_eigvals_default_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_EIGVALS][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_eigvals_default_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_EIGVALS][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_eigvals_default_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_EIGVALS][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_eigvals_default_c<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_EIGVALS_EXT][eft_INT][eft_INT] = {eft_DBL,
-                                                                 (void*)dpnp_eigvals_ext_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_EIGVALS_EXT][eft_LNG][eft_LNG] = {eft_DBL,
-                                                                 (void*)dpnp_eigvals_ext_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_EIGVALS_EXT][eft_FLT][eft_FLT] = {eft_FLT,
-                                                                 (void*)dpnp_eigvals_ext_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_EIGVALS_EXT][eft_DBL][eft_DBL] = {eft_DBL,
-                                                                 (void*)dpnp_eigvals_ext_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_EIGVALS_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_eigvals_ext_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_EIGVALS_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_eigvals_ext_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_EIGVALS_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_eigvals_ext_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_EIGVALS_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_eigvals_ext_c<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_INITVAL][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_initval_default_c<bool>};
-    fmap[DPNPFuncName::DPNP_FN_INITVAL][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_initval_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_INITVAL][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_initval_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_INITVAL][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_initval_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_INITVAL][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_initval_default_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_INITVAL][eft_C128][eft_C128] = {eft_C128,
-                                                               (void*)dpnp_initval_default_c<std::complex<double>>};
+    fmap[DPNPFuncName::DPNP_FN_INITVAL][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_initval_default_c<bool>};
+    fmap[DPNPFuncName::DPNP_FN_INITVAL][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_initval_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_INITVAL][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_initval_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_INITVAL][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_initval_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_INITVAL][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_initval_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_INITVAL][eft_C128][eft_C128] = {
+        eft_C128, (void *)dpnp_initval_default_c<std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_INITVAL_EXT][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_initval_ext_c<bool>};
-    fmap[DPNPFuncName::DPNP_FN_INITVAL_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_initval_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_INITVAL_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_initval_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_INITVAL_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_initval_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_INITVAL_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_initval_ext_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_INITVAL_EXT][eft_C64][eft_C64] = {eft_C64,
-                                                                 (void*)dpnp_initval_ext_c<std::complex<float>>};
-    fmap[DPNPFuncName::DPNP_FN_INITVAL_EXT][eft_C128][eft_C128] = {eft_C128,
-                                                                   (void*)dpnp_initval_ext_c<std::complex<double>>};
+    fmap[DPNPFuncName::DPNP_FN_INITVAL_EXT][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_initval_ext_c<bool>};
+    fmap[DPNPFuncName::DPNP_FN_INITVAL_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_initval_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_INITVAL_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_initval_ext_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_INITVAL_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_initval_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_INITVAL_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_initval_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_INITVAL_EXT][eft_C64][eft_C64] = {
+        eft_C64, (void *)dpnp_initval_ext_c<std::complex<float>>};
+    fmap[DPNPFuncName::DPNP_FN_INITVAL_EXT][eft_C128][eft_C128] = {
+        eft_C128, (void *)dpnp_initval_ext_c<std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_MATMUL][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_matmul_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MATMUL][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_matmul_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MATMUL][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_matmul_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_MATMUL][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_matmul_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_MATMUL][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_matmul_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_MATMUL][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_matmul_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_MATMUL][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_matmul_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_MATMUL][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_matmul_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_MATMUL_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_matmul_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MATMUL_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_matmul_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MATMUL_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_matmul_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_MATMUL_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_matmul_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_MATMUL_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_matmul_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_MATMUL_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_matmul_ext_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_MATMUL_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_matmul_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_MATMUL_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_matmul_ext_c<double>};
 
     return;
 }

--- a/dpnp/backend/kernels/dpnp_krnl_common.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_common.cpp
@@ -33,9 +33,9 @@
 #include "queue_sycl.hpp"
 #include <dpnp_iface.hpp>
 
-namespace mkl_blas    = oneapi::mkl::blas;
+namespace mkl_blas = oneapi::mkl::blas;
 namespace mkl_blas_rm = oneapi::mkl::blas::row_major;
-namespace mkl_lapack  = oneapi::mkl::lapack;
+namespace mkl_lapack = oneapi::mkl::lapack;
 
 template <typename _DataType, typename _ResultType>
 class dpnp_astype_c_kernel;
@@ -57,7 +57,7 @@ DPCTLSyclEventRef dpnp_astype_c(DPCTLSyclQueueRef q_ref,
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, size);
     const _DataType *array_in = input1_ptr.get_ptr();
-    _ResultType *result       = reinterpret_cast<_ResultType *>(result1);
+    _ResultType *result = reinterpret_cast<_ResultType *>(result1);
 
     if ((array_in == nullptr) || (result == nullptr)) {
         return event_ref;
@@ -69,7 +69,7 @@ DPCTLSyclEventRef dpnp_astype_c(DPCTLSyclQueueRef q_ref,
 
     sycl::range<1> gws(size);
     auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
-        size_t i  = global_id[0];
+        size_t i = global_id[0];
         result[i] = array_in[i];
     };
 
@@ -168,7 +168,7 @@ sycl::event dot(sycl::queue &queue,
 
         auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
             const size_t index = global_id[0];
-            local_mem[index]   = input1_in[index * input1_strides] *
+            local_mem[index] = input1_in[index * input1_strides] *
                                input2_in[index * input2_strides];
         };
 
@@ -225,7 +225,7 @@ DPCTLSyclEventRef dpnp_dot_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_DataType_input1> input1_ptr(q_ref, input1_in,
                                                    input1_size);
@@ -264,33 +264,33 @@ DPCTLSyclEventRef dpnp_dot_c(DPCTLSyclQueueRef q_ref,
     }
 
     // 1D vector
-    size_t ext_input1_ndim              = input1_ndim == 1 ? 2 : input1_ndim;
-    shape_elem_type *ext_input1_shape   = new shape_elem_type[ext_input1_ndim];
+    size_t ext_input1_ndim = input1_ndim == 1 ? 2 : input1_ndim;
+    shape_elem_type *ext_input1_shape = new shape_elem_type[ext_input1_ndim];
     shape_elem_type *ext_input1_strides = new shape_elem_type[ext_input1_ndim];
     if (input1_ndim == 1) {
-        ext_input1_shape[0]   = 1;
-        ext_input1_shape[1]   = input1_shape[0];
+        ext_input1_shape[0] = 1;
+        ext_input1_shape[1] = input1_shape[0];
         ext_input1_strides[0] = 0;
         ext_input1_strides[1] = input1_strides[0];
     }
     else {
         for (size_t i = 0; i < ext_input1_ndim; ++i) {
-            ext_input1_shape[i]   = input1_shape[i];
+            ext_input1_shape[i] = input1_shape[i];
             ext_input1_strides[i] = input1_strides[i];
         }
     }
-    size_t ext_input2_ndim              = input2_ndim == 1 ? 2 : input2_ndim;
-    shape_elem_type *ext_input2_shape   = new shape_elem_type[ext_input2_ndim];
+    size_t ext_input2_ndim = input2_ndim == 1 ? 2 : input2_ndim;
+    shape_elem_type *ext_input2_shape = new shape_elem_type[ext_input2_ndim];
     shape_elem_type *ext_input2_strides = new shape_elem_type[ext_input2_ndim];
     if (input2_ndim == 1) {
-        ext_input2_shape[0]   = input2_shape[0];
-        ext_input2_shape[1]   = 1;
+        ext_input2_shape[0] = input2_shape[0];
+        ext_input2_shape[1] = 1;
         ext_input2_strides[0] = input2_strides[0];
         ext_input2_strides[1] = 0;
     }
     else {
         for (size_t i = 0; i < ext_input2_ndim; ++i) {
-            ext_input2_shape[i]   = input2_shape[i];
+            ext_input2_shape[i] = input2_shape[i];
             ext_input2_strides[i] = input2_strides[i];
         }
     }
@@ -397,11 +397,11 @@ DPCTLSyclEventRef dpnp_dot_c(DPCTLSyclQueueRef q_ref,
     std::vector<sycl::event> dot_events;
     dot_events.reserve(result_size);
 
-    size_t dot_st1  = ext_input1_strides[ext_input1_ndim - 1];
-    size_t dot_st2  = ext_input2_strides[ext_input2_ndim - 2];
+    size_t dot_st1 = ext_input1_strides[ext_input1_ndim - 1];
+    size_t dot_st2 = ext_input2_strides[ext_input2_ndim - 2];
     size_t dot_size = ext_input1_shape[ext_input1_ndim - 1];
 
-    shape_elem_type *res_coords     = new shape_elem_type[ext_result_ndim];
+    shape_elem_type *res_coords = new shape_elem_type[ext_result_ndim];
     shape_elem_type *result_offsets = new shape_elem_type[ext_result_ndim];
     get_shape_offsets_inkernel(ext_result_shape, ext_result_ndim,
                                result_offsets);
@@ -545,7 +545,7 @@ DPCTLSyclEventRef dpnp_eig_c(DPCTLSyclQueueRef q_ref,
                                                true);
     DPNPC_ptr_adapter<_ResultType> result2_ptr(q_ref, result2, size * size,
                                                true, true);
-    const _DataType *array  = input1_ptr.get_ptr();
+    const _DataType *array = input1_ptr.get_ptr();
     _ResultType *result_val = result1_ptr.get_ptr();
     _ResultType *result_vec = result2_ptr.get_ptr();
 
@@ -613,7 +613,7 @@ void dpnp_eig_c(const void *array_in, void *result1, void *result2, size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_eig_c<_DataType, _ResultType>(
+    DPCTLSyclEventRef event_ref = dpnp_eig_c<_DataType, _ResultType>(
         q_ref, array_in, result1, result2, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
@@ -660,7 +660,7 @@ DPCTLSyclEventRef dpnp_eigvals_c(DPCTLSyclQueueRef q_ref,
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array_in, size * size, true);
     DPNPC_ptr_adapter<_ResultType> result1_ptr(q_ref, result1, size, true,
                                                true);
-    const _DataType *array  = input1_ptr.get_ptr();
+    const _DataType *array = input1_ptr.get_ptr();
     _ResultType *result_val = result1_ptr.get_ptr();
 
     double *result_val_kern = reinterpret_cast<double *>(
@@ -750,7 +750,7 @@ DPCTLSyclEventRef dpnp_initval_c(DPCTLSyclQueueRef q_ref,
     validate_type_for_device<_DataType>(q);
 
     auto event = q.fill<_DataType>(result, val, size);
-    event_ref  = reinterpret_cast<DPCTLSyclEventRef>(&event);
+    event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
 
     return DPCTLEvent_Copy(event_ref);
 }
@@ -760,7 +760,7 @@ void dpnp_initval_c(void *result1, void *value, size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_initval_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_initval_c<_DataType>(
         q_ref, result1, value, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
@@ -873,7 +873,7 @@ DPCTLSyclEventRef dpnp_matmul_c(DPCTLSyclQueueRef q_ref,
                         acc += array_1[index_1] * array_2[index_2];
                     }
                     const size_t index_result = i * dim_n + j;
-                    result[index_result]      = acc;
+                    result[index_result] = acc;
                 }
             }
         };
@@ -911,7 +911,7 @@ void dpnp_matmul_c(void *result_out,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_matmul_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_matmul_c<_DataType>(
         q_ref, result_out, result_size, result_ndim, result_shape,
         result_strides, input1_in, input1_size, input1_ndim, input1_shape,
         input1_strides, input2_in, input2_size, input2_ndim, input2_shape,

--- a/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
@@ -34,527 +34,790 @@
 #include "dpnpc_memory_adapter.hpp"
 #include "queue_sycl.hpp"
 
-#define MACRO_1ARG_2TYPES_OP(__name__, __operation1__, __operation2__)                                                 \
-    template <typename _KernelNameSpecialization1, typename _KernelNameSpecialization2>                                \
-    class __name__##_kernel;                                                                                           \
-                                                                                                                       \
-    template <typename _KernelNameSpecialization1, typename _KernelNameSpecialization2>                                \
-    class __name__##_strides_kernel;                                                                                   \
-                                                                                                                       \
-    template <typename _DataType_input, typename _DataType_output>                                                     \
-    DPCTLSyclEventRef __name__(DPCTLSyclQueueRef q_ref,                                                                \
-                               void* result_out,                                                                       \
-                               const size_t result_size,                                                               \
-                               const size_t result_ndim,                                                               \
-                               const shape_elem_type* result_shape,                                                    \
-                               const shape_elem_type* result_strides,                                                  \
-                               const void* input1_in,                                                                  \
-                               const size_t input1_size,                                                               \
-                               const size_t input1_ndim,                                                               \
-                               const shape_elem_type* input1_shape,                                                    \
-                               const shape_elem_type* input1_strides,                                                  \
-                               const size_t* where,                                                                    \
-                               const DPCTLEventVectorRef dep_event_vec_ref)                                            \
-    {                                                                                                                  \
-        /* avoid warning unused variable*/                                                                             \
-        (void)result_shape;                                                                                            \
-        (void)where;                                                                                                   \
-        (void)dep_event_vec_ref;                                                                                       \
-                                                                                                                       \
-        DPCTLSyclEventRef event_ref = nullptr;                                                                         \
-                                                                                                                       \
-        if (!input1_size)                                                                                              \
-        {                                                                                                              \
-            return event_ref;                                                                                          \
-        }                                                                                                              \
-                                                                                                                       \
-        sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));                                                      \
-                                                                                                                       \
-        _DataType_input* input1_data = static_cast<_DataType_input*>(const_cast<void*>(input1_in));                    \
-        _DataType_output* result = static_cast<_DataType_output*>(result_out);                                         \
-                                                                                                                       \
-        shape_elem_type* input1_shape_offsets = new shape_elem_type[input1_ndim];                                      \
-                                                                                                                       \
-        get_shape_offsets_inkernel(input1_shape, input1_ndim, input1_shape_offsets);                                   \
-        bool use_strides = !array_equal(input1_strides, input1_ndim, input1_shape_offsets, input1_ndim);               \
-        delete[] input1_shape_offsets;                                                                                 \
-                                                                                                                       \
-        sycl::event event;                                                                                             \
-        sycl::range<1> gws(result_size);                                                                               \
-                                                                                                                       \
-        if (use_strides)                                                                                               \
-        {                                                                                                              \
-            if (result_ndim != input1_ndim)                                                                            \
-            {                                                                                                          \
-                throw std::runtime_error("Result ndim=" + std::to_string(result_ndim) +                                \
-                                         " mismatches with input1 ndim=" + std::to_string(input1_ndim));               \
-            }                                                                                                          \
-                                                                                                                       \
-            /* memory transfer optimization, use USM-host for temporary speeds up tranfer to device */                 \
-            using usm_host_allocatorT = sycl::usm_allocator<shape_elem_type, sycl::usm::alloc::host>;                  \
-                                                                                                                       \
-            size_t strides_size = 2 * result_ndim;                                                                     \
-            shape_elem_type* dev_strides_data = sycl::malloc_device<shape_elem_type>(strides_size, q);                 \
-                                                                                                                       \
-            /* create host temporary for packed strides managed by shared pointer */                                   \
-            auto strides_host_packed =                                                                                 \
-                std::vector<shape_elem_type, usm_host_allocatorT>(strides_size, usm_host_allocatorT(q));               \
-                                                                                                                       \
-            /* packed vector is concatenation of result_strides, input1_strides and input2_strides */                  \
-            std::copy(result_strides, result_strides + result_ndim, strides_host_packed.begin());                      \
-            std::copy(input1_strides, input1_strides + result_ndim, strides_host_packed.begin() + result_ndim);        \
-                                                                                                                       \
-            auto copy_strides_ev =                                                                                     \
-                q.copy<shape_elem_type>(strides_host_packed.data(), dev_strides_data, strides_host_packed.size());     \
-                                                                                                                       \
-            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {                                               \
-                size_t output_id = global_id[0]; /* for (size_t i = 0; i < result_size; ++i) */                        \
-                {                                                                                                      \
-                    const shape_elem_type* result_strides_data = &dev_strides_data[0];                                 \
-                    const shape_elem_type* input1_strides_data = &dev_strides_data[result_ndim];                       \
-                                                                                                                       \
-                    size_t input_id = 0;                                                                               \
-                    for (size_t i = 0; i < input1_ndim; ++i)                                                           \
-                    {                                                                                                  \
-                        const size_t output_xyz_id =                                                                   \
-                            get_xyz_id_by_id_inkernel(output_id, result_strides_data, result_ndim, i);                 \
-                        input_id += output_xyz_id * input1_strides_data[i];                                            \
-                    }                                                                                                  \
-                                                                                                                       \
-                    const _DataType_output input_elem = input1_data[input_id];                                         \
-                    result[output_id] = __operation1__;                                                                \
-                }                                                                                                      \
-            };                                                                                                         \
-            auto kernel_func = [&](sycl::handler& cgh) {                                                               \
-                cgh.parallel_for<class __name__##_strides_kernel<_DataType_input, _DataType_output>>(                  \
-                    gws, kernel_parallel_for_func);                                                                    \
-            };                                                                                                         \
-                                                                                                                       \
-            q.submit(kernel_func).wait();                                                                              \
-                                                                                                                       \
-            sycl::free(dev_strides_data, q);                                                                           \
-            return event_ref;                                                                                          \
-        }                                                                                                              \
-        else                                                                                                           \
-        {                                                                                                              \
-            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {                                               \
-                size_t output_id = global_id[0]; /* for (size_t i = 0; i < result_size; ++i) */                        \
-                {                                                                                                      \
-                    const _DataType_output input_elem = input1_data[output_id];                                        \
-                    result[output_id] = __operation1__;                                                                \
-                }                                                                                                      \
-            };                                                                                                         \
-            auto kernel_func = [&](sycl::handler& cgh) {                                                               \
-                cgh.parallel_for<class __name__##_kernel<_DataType_input, _DataType_output>>(                          \
-                    gws, kernel_parallel_for_func);                                                                    \
-            };                                                                                                         \
-                                                                                                                       \
-            if constexpr (both_types_are_same<_DataType_input, _DataType_output, float, double>)                       \
-            {                                                                                                          \
-                if (q.get_device().has(sycl::aspect::fp64))                                                            \
-                {                                                                                                      \
-                    event = __operation2__;                                                                            \
-                                                                                                                       \
-                    event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);                                           \
-                    return DPCTLEvent_Copy(event_ref);                                                                 \
-                }                                                                                                      \
-            }                                                                                                          \
-            event = q.submit(kernel_func);                                                                             \
-        }                                                                                                              \
-                                                                                                                       \
-        event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);                                                       \
-        return DPCTLEvent_Copy(event_ref);                                                                             \
-    }                                                                                                                  \
-                                                                                                                       \
-    template <typename _DataType_input, typename _DataType_output>                                                     \
-    void __name__(void* result_out,                                                                                    \
-                  const size_t result_size,                                                                            \
-                  const size_t result_ndim,                                                                            \
-                  const shape_elem_type* result_shape,                                                                 \
-                  const shape_elem_type* result_strides,                                                               \
-                  const void* input1_in,                                                                               \
-                  const size_t input1_size,                                                                            \
-                  const size_t input1_ndim,                                                                            \
-                  const shape_elem_type* input1_shape,                                                                 \
-                  const shape_elem_type* input1_strides,                                                               \
-                  const size_t* where)                                                                                 \
-    {                                                                                                                  \
-        DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);                                    \
-        DPCTLEventVectorRef dep_event_vec_ref = nullptr;                                                               \
-        DPCTLSyclEventRef event_ref = __name__<_DataType_input, _DataType_output>(q_ref,                               \
-                                                                                  result_out,                          \
-                                                                                  result_size,                         \
-                                                                                  result_ndim,                         \
-                                                                                  result_shape,                        \
-                                                                                  result_strides,                      \
-                                                                                  input1_in,                           \
-                                                                                  input1_size,                         \
-                                                                                  input1_ndim,                         \
-                                                                                  input1_shape,                        \
-                                                                                  input1_strides,                      \
-                                                                                  where,                               \
-                                                                                  dep_event_vec_ref);                  \
-        DPCTLEvent_WaitAndThrow(event_ref);                                                                            \
-        DPCTLEvent_Delete(event_ref);                                                                                  \
-    }                                                                                                                  \
-                                                                                                                       \
-    template <typename _DataType_input, typename _DataType_output>                                                     \
-    void (*__name__##_default)(void*,                                                                                  \
-                               const size_t,                                                                           \
-                               const size_t,                                                                           \
-                               const shape_elem_type*,                                                                 \
-                               const shape_elem_type*,                                                                 \
-                               const void*,                                                                            \
-                               const size_t,                                                                           \
-                               const size_t,                                                                           \
-                               const shape_elem_type*,                                                                 \
-                               const shape_elem_type*,                                                                 \
-                               const size_t*) = __name__<_DataType_input, _DataType_output>;                           \
-                                                                                                                       \
-    template <typename _DataType_input, typename _DataType_output>                                                     \
-    DPCTLSyclEventRef (*__name__##_ext)(DPCTLSyclQueueRef,                                                             \
-                                        void*,                                                                         \
-                                        const size_t,                                                                  \
-                                        const size_t,                                                                  \
-                                        const shape_elem_type*,                                                        \
-                                        const shape_elem_type*,                                                        \
-                                        const void*,                                                                   \
-                                        const size_t,                                                                  \
-                                        const size_t,                                                                  \
-                                        const shape_elem_type*,                                                        \
-                                        const shape_elem_type*,                                                        \
-                                        const size_t*,                                                                 \
-                                        const DPCTLEventVectorRef) = __name__<_DataType_input, _DataType_output>;
+#define MACRO_1ARG_2TYPES_OP(__name__, __operation1__, __operation2__)         \
+    template <typename _KernelNameSpecialization1,                             \
+              typename _KernelNameSpecialization2>                             \
+    class __name__##_kernel;                                                   \
+                                                                               \
+    template <typename _KernelNameSpecialization1,                             \
+              typename _KernelNameSpecialization2>                             \
+    class __name__##_strides_kernel;                                           \
+                                                                               \
+    template <typename _DataType_input, typename _DataType_output>             \
+    DPCTLSyclEventRef __name__(                                                \
+        DPCTLSyclQueueRef q_ref, void *result_out, const size_t result_size,   \
+        const size_t result_ndim, const shape_elem_type *result_shape,         \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const size_t *where,            \
+        const DPCTLEventVectorRef dep_event_vec_ref)                           \
+    {                                                                          \
+        /* avoid warning unused variable*/                                     \
+        (void)result_shape;                                                    \
+        (void)where;                                                           \
+        (void)dep_event_vec_ref;                                               \
+                                                                               \
+        DPCTLSyclEventRef event_ref = nullptr;                                 \
+                                                                               \
+        if (!input1_size) {                                                    \
+            return event_ref;                                                  \
+        }                                                                      \
+                                                                               \
+        sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));             \
+                                                                               \
+        _DataType_input *input1_data =                                         \
+            static_cast<_DataType_input *>(const_cast<void *>(input1_in));     \
+        _DataType_output *result =                                             \
+            static_cast<_DataType_output *>(result_out);                       \
+                                                                               \
+        shape_elem_type *input1_shape_offsets =                                \
+            new shape_elem_type[input1_ndim];                                  \
+                                                                               \
+        get_shape_offsets_inkernel(input1_shape, input1_ndim,                  \
+                                   input1_shape_offsets);                      \
+        bool use_strides = !array_equal(input1_strides, input1_ndim,           \
+                                        input1_shape_offsets, input1_ndim);    \
+        delete[] input1_shape_offsets;                                         \
+                                                                               \
+        sycl::event event;                                                     \
+        sycl::range<1> gws(result_size);                                       \
+                                                                               \
+        if (use_strides) {                                                     \
+            if (result_ndim != input1_ndim) {                                  \
+                throw std::runtime_error(                                      \
+                    "Result ndim=" + std::to_string(result_ndim) +             \
+                    " mismatches with input1 ndim=" +                          \
+                    std::to_string(input1_ndim));                              \
+            }                                                                  \
+                                                                               \
+            /* memory transfer optimization, use USM-host for temporary speeds \
+             * up tranfer to device */                                         \
+            using usm_host_allocatorT =                                        \
+                sycl::usm_allocator<shape_elem_type, sycl::usm::alloc::host>;  \
+                                                                               \
+            size_t strides_size = 2 * result_ndim;                             \
+            shape_elem_type *dev_strides_data =                                \
+                sycl::malloc_device<shape_elem_type>(strides_size, q);         \
+                                                                               \
+            /* create host temporary for packed strides managed by shared      \
+             * pointer */                                                      \
+            auto strides_host_packed =                                         \
+                std::vector<shape_elem_type, usm_host_allocatorT>(             \
+                    strides_size, usm_host_allocatorT(q));                     \
+                                                                               \
+            /* packed vector is concatenation of result_strides,               \
+             * input1_strides and input2_strides */                            \
+            std::copy(result_strides, result_strides + result_ndim,            \
+                      strides_host_packed.begin());                            \
+            std::copy(input1_strides, input1_strides + result_ndim,            \
+                      strides_host_packed.begin() + result_ndim);              \
+                                                                               \
+            auto copy_strides_ev = q.copy<shape_elem_type>(                    \
+                strides_host_packed.data(), dev_strides_data,                  \
+                strides_host_packed.size());                                   \
+                                                                               \
+            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {       \
+                size_t output_id = global_id[0]; /* for (size_t i = 0; i <     \
+                                                    result_size; ++i) */       \
+                {                                                              \
+                    const shape_elem_type *result_strides_data =               \
+                        &dev_strides_data[0];                                  \
+                    const shape_elem_type *input1_strides_data =               \
+                        &dev_strides_data[result_ndim];                        \
+                                                                               \
+                    size_t input_id = 0;                                       \
+                    for (size_t i = 0; i < input1_ndim; ++i) {                 \
+                        const size_t output_xyz_id =                           \
+                            get_xyz_id_by_id_inkernel(output_id,               \
+                                                      result_strides_data,     \
+                                                      result_ndim, i);         \
+                        input_id += output_xyz_id * input1_strides_data[i];    \
+                    }                                                          \
+                                                                               \
+                    const _DataType_output input_elem = input1_data[input_id]; \
+                    result[output_id]                 = __operation1__;        \
+                }                                                              \
+            };                                                                 \
+            auto kernel_func = [&](sycl::handler &cgh) {                       \
+                cgh.parallel_for<class __name__##_strides_kernel<              \
+                    _DataType_input, _DataType_output>>(                       \
+                    gws, kernel_parallel_for_func);                            \
+            };                                                                 \
+                                                                               \
+            q.submit(kernel_func).wait();                                      \
+                                                                               \
+            sycl::free(dev_strides_data, q);                                   \
+            return event_ref;                                                  \
+        }                                                                      \
+        else {                                                                 \
+            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {       \
+                size_t output_id = global_id[0]; /* for (size_t i = 0; i <     \
+                                                    result_size; ++i) */       \
+                {                                                              \
+                    const _DataType_output input_elem =                        \
+                        input1_data[output_id];                                \
+                    result[output_id] = __operation1__;                        \
+                }                                                              \
+            };                                                                 \
+            auto kernel_func = [&](sycl::handler &cgh) {                       \
+                cgh.parallel_for<class __name__##_kernel<_DataType_input,      \
+                                                         _DataType_output>>(   \
+                    gws, kernel_parallel_for_func);                            \
+            };                                                                 \
+                                                                               \
+            if constexpr (both_types_are_same<_DataType_input,                 \
+                                              _DataType_output, float,         \
+                                              double>)                         \
+            {                                                                  \
+                if (q.get_device().has(sycl::aspect::fp64)) {                  \
+                    event = __operation2__;                                    \
+                                                                               \
+                    event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);   \
+                    return DPCTLEvent_Copy(event_ref);                         \
+                }                                                              \
+            }                                                                  \
+            event = q.submit(kernel_func);                                     \
+        }                                                                      \
+                                                                               \
+        event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);               \
+        return DPCTLEvent_Copy(event_ref);                                     \
+    }                                                                          \
+                                                                               \
+    template <typename _DataType_input, typename _DataType_output>             \
+    void __name__(                                                             \
+        void *result_out, const size_t result_size, const size_t result_ndim,  \
+        const shape_elem_type *result_shape,                                   \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const size_t *where)            \
+    {                                                                          \
+        DPCTLSyclQueueRef q_ref =                                              \
+            reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);                  \
+        DPCTLEventVectorRef dep_event_vec_ref = nullptr;                       \
+        DPCTLSyclEventRef event_ref =                                          \
+            __name__<_DataType_input, _DataType_output>(                       \
+                q_ref, result_out, result_size, result_ndim, result_shape,     \
+                result_strides, input1_in, input1_size, input1_ndim,           \
+                input1_shape, input1_strides, where, dep_event_vec_ref);       \
+        DPCTLEvent_WaitAndThrow(event_ref);                                    \
+        DPCTLEvent_Delete(event_ref);                                          \
+    }                                                                          \
+                                                                               \
+    template <typename _DataType_input, typename _DataType_output>             \
+    void (*__name__##_default)(                                                \
+        void *, const size_t, const size_t, const shape_elem_type *,           \
+        const shape_elem_type *, const void *, const size_t, const size_t,     \
+        const shape_elem_type *, const shape_elem_type *, const size_t *) =    \
+        __name__<_DataType_input, _DataType_output>;                           \
+                                                                               \
+    template <typename _DataType_input, typename _DataType_output>             \
+    DPCTLSyclEventRef (*__name__##_ext)(                                       \
+        DPCTLSyclQueueRef, void *, const size_t, const size_t,                 \
+        const shape_elem_type *, const shape_elem_type *, const void *,        \
+        const size_t, const size_t, const shape_elem_type *,                   \
+        const shape_elem_type *, const size_t *, const DPCTLEventVectorRef) =  \
+        __name__<_DataType_input, _DataType_output>;
 
 #include <dpnp_gen_1arg_2type_tbl.hpp>
 
-static void func_map_init_elemwise_1arg_2type(func_map_t& fmap)
+static void func_map_init_elemwise_1arg_2type(func_map_t &fmap)
 {
-    fmap[DPNPFuncName::DPNP_FN_ARCCOS][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_acos_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCCOS][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_acos_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCCOS][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_acos_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_ARCCOS][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_acos_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCCOS][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_acos_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCCOS][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_acos_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCCOS][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_acos_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCCOS][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_acos_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_ARCCOS_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_acos_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCCOS_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_acos_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCCOS_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_acos_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_ARCCOS_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_acos_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCCOS_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_acos_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCCOS_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_acos_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCCOS_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_acos_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCCOS_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_acos_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_ARCCOSH][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_acosh_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCCOSH][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_acosh_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCCOSH][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_acosh_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_ARCCOSH][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_acosh_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCCOSH][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_acosh_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCCOSH][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_acosh_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCCOSH][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_acosh_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCCOSH][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_acosh_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_ARCCOSH_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_acosh_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCCOSH_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_acosh_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCCOSH_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_acosh_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_ARCCOSH_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_acosh_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCCOSH_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_acosh_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCCOSH_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_acosh_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCCOSH_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_acosh_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCCOSH_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_acosh_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_ARCSIN][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_asin_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCSIN][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_asin_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCSIN][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_asin_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_ARCSIN][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_asin_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCSIN][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_asin_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCSIN][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_asin_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCSIN][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_asin_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCSIN][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_asin_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_ARCSIN_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_asin_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCSIN_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_asin_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCSIN_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_asin_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_ARCSIN_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_asin_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCSIN_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_asin_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCSIN_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_asin_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCSIN_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_asin_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCSIN_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_asin_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_ARCSINH][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_asinh_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCSINH][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_asinh_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCSINH][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_asinh_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_ARCSINH][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_asinh_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCSINH][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_asinh_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCSINH][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_asinh_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCSINH][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_asinh_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCSINH][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_asinh_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_ARCSINH_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_asinh_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCSINH_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_asinh_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCSINH_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_asinh_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_ARCSINH_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_asinh_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCSINH_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_asinh_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCSINH_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_asinh_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCSINH_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_asinh_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCSINH_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_asinh_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_atan_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_atan_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_atan_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_atan_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_atan_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_atan_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_atan_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_atan_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_atan_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_atan_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_atan_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_atan_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_atan_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_atan_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_atan_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_atan_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_ARCTANH][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_atanh_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTANH][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_atanh_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTANH][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_atanh_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTANH][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_atanh_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTANH][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_atanh_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTANH][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_atanh_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTANH][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_atanh_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTANH][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_atanh_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_ARCTANH_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_atanh_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTANH_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_atanh_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTANH_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_atanh_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTANH_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_atanh_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTANH_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_atanh_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTANH_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_atanh_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTANH_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_atanh_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTANH_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_atanh_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_CBRT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_cbrt_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_CBRT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_cbrt_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_CBRT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_cbrt_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_CBRT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_cbrt_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_CBRT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_cbrt_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_CBRT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_cbrt_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_CBRT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_cbrt_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_CBRT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_cbrt_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_CBRT_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_cbrt_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_CBRT_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_cbrt_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_CBRT_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_cbrt_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_CBRT_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_cbrt_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_CBRT_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_cbrt_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_CBRT_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_cbrt_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_CBRT_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_cbrt_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_CBRT_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_cbrt_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_CEIL][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_ceil_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_CEIL][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_ceil_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_CEIL][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_ceil_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_CEIL][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_ceil_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_CEIL][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_ceil_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_CEIL][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_ceil_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_CEIL][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_ceil_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_CEIL][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_ceil_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_CEIL_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_ceil_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_CEIL_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_ceil_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_CEIL_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_ceil_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_CEIL_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_ceil_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_CEIL_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_ceil_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_CEIL_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_ceil_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_CEIL_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_ceil_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_CEIL_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_ceil_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_copyto_c_default<bool, bool>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_BLN][eft_INT] = {eft_INT, (void*)dpnp_copyto_c_default<bool, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_BLN][eft_LNG] = {eft_LNG, (void*)dpnp_copyto_c_default<bool, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_BLN][eft_FLT] = {eft_FLT, (void*)dpnp_copyto_c_default<bool, float>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_BLN][eft_DBL] = {eft_DBL, (void*)dpnp_copyto_c_default<bool, double>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_INT][eft_BLN] = {eft_BLN, (void*)dpnp_copyto_c_default<int32_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_copyto_c_default<int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_INT][eft_LNG] = {eft_LNG, (void*)dpnp_copyto_c_default<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_INT][eft_FLT] = {eft_FLT, (void*)dpnp_copyto_c_default<int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_INT][eft_DBL] = {eft_DBL, (void*)dpnp_copyto_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_LNG][eft_BLN] = {eft_BLN, (void*)dpnp_copyto_c_default<int64_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_LNG][eft_INT] = {eft_INT, (void*)dpnp_copyto_c_default<int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_copyto_c_default<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_LNG][eft_FLT] = {eft_FLT, (void*)dpnp_copyto_c_default<int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_LNG][eft_DBL] = {eft_DBL, (void*)dpnp_copyto_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_FLT][eft_BLN] = {eft_BLN, (void*)dpnp_copyto_c_default<float, bool>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_FLT][eft_INT] = {eft_INT, (void*)dpnp_copyto_c_default<float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_FLT][eft_LNG] = {eft_LNG, (void*)dpnp_copyto_c_default<float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_copyto_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_FLT][eft_DBL] = {eft_DBL, (void*)dpnp_copyto_c_default<float, double>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_DBL][eft_BLN] = {eft_BLN, (void*)dpnp_copyto_c_default<double, bool>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_DBL][eft_INT] = {eft_INT, (void*)dpnp_copyto_c_default<double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_DBL][eft_LNG] = {eft_LNG, (void*)dpnp_copyto_c_default<double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_DBL][eft_FLT] = {eft_FLT, (void*)dpnp_copyto_c_default<double, float>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_copyto_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_copyto_c_default<bool, bool>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_BLN][eft_INT] = {
+        eft_INT, (void *)dpnp_copyto_c_default<bool, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_BLN][eft_LNG] = {
+        eft_LNG, (void *)dpnp_copyto_c_default<bool, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_BLN][eft_FLT] = {
+        eft_FLT, (void *)dpnp_copyto_c_default<bool, float>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_BLN][eft_DBL] = {
+        eft_DBL, (void *)dpnp_copyto_c_default<bool, double>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_INT][eft_BLN] = {
+        eft_BLN, (void *)dpnp_copyto_c_default<int32_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_copyto_c_default<int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_copyto_c_default<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_INT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_copyto_c_default<int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_copyto_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_LNG][eft_BLN] = {
+        eft_BLN, (void *)dpnp_copyto_c_default<int64_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_LNG][eft_INT] = {
+        eft_INT, (void *)dpnp_copyto_c_default<int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_copyto_c_default<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_LNG][eft_FLT] = {
+        eft_FLT, (void *)dpnp_copyto_c_default<int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_copyto_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_FLT][eft_BLN] = {
+        eft_BLN, (void *)dpnp_copyto_c_default<float, bool>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_FLT][eft_INT] = {
+        eft_INT, (void *)dpnp_copyto_c_default<float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_FLT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_copyto_c_default<float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_copyto_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_copyto_c_default<float, double>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_DBL][eft_BLN] = {
+        eft_BLN, (void *)dpnp_copyto_c_default<double, bool>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_DBL][eft_INT] = {
+        eft_INT, (void *)dpnp_copyto_c_default<double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_DBL][eft_LNG] = {
+        eft_LNG, (void *)dpnp_copyto_c_default<double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_DBL][eft_FLT] = {
+        eft_FLT, (void *)dpnp_copyto_c_default<double, float>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_copyto_c_default<double, double>};
     fmap[DPNPFuncName::DPNP_FN_COPYTO][eft_C128][eft_C128] = {
-        eft_C128, (void*)dpnp_copyto_c_default<std::complex<double>, std::complex<double>>};
+        eft_C128,
+        (void *)
+            dpnp_copyto_c_default<std::complex<double>, std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_copyto_c_ext<bool, bool>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_BLN][eft_INT] = {eft_INT, (void*)dpnp_copyto_c_ext<bool, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_BLN][eft_LNG] = {eft_LNG, (void*)dpnp_copyto_c_ext<bool, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_BLN][eft_FLT] = {eft_FLT, (void*)dpnp_copyto_c_ext<bool, float>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_BLN][eft_DBL] = {eft_DBL, (void*)dpnp_copyto_c_ext<bool, double>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_INT][eft_BLN] = {eft_BLN, (void*)dpnp_copyto_c_ext<int32_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_copyto_c_ext<int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_INT][eft_LNG] = {eft_LNG, (void*)dpnp_copyto_c_ext<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_INT][eft_FLT] = {eft_FLT, (void*)dpnp_copyto_c_ext<int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_INT][eft_DBL] = {eft_DBL, (void*)dpnp_copyto_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_LNG][eft_BLN] = {eft_BLN, (void*)dpnp_copyto_c_ext<int64_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_LNG][eft_INT] = {eft_INT, (void*)dpnp_copyto_c_ext<int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_copyto_c_ext<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_LNG][eft_FLT] = {eft_FLT, (void*)dpnp_copyto_c_ext<int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_LNG][eft_DBL] = {eft_DBL, (void*)dpnp_copyto_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_FLT][eft_BLN] = {eft_BLN, (void*)dpnp_copyto_c_ext<float, bool>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_FLT][eft_INT] = {eft_INT, (void*)dpnp_copyto_c_ext<float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_FLT][eft_LNG] = {eft_LNG, (void*)dpnp_copyto_c_ext<float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_copyto_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_FLT][eft_DBL] = {eft_DBL, (void*)dpnp_copyto_c_ext<float, double>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_DBL][eft_BLN] = {eft_BLN, (void*)dpnp_copyto_c_ext<double, bool>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_DBL][eft_INT] = {eft_INT, (void*)dpnp_copyto_c_ext<double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_DBL][eft_LNG] = {eft_LNG, (void*)dpnp_copyto_c_ext<double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_DBL][eft_FLT] = {eft_FLT, (void*)dpnp_copyto_c_ext<double, float>};
-    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_copyto_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_copyto_c_ext<bool, bool>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_BLN][eft_INT] = {
+        eft_INT, (void *)dpnp_copyto_c_ext<bool, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_BLN][eft_LNG] = {
+        eft_LNG, (void *)dpnp_copyto_c_ext<bool, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_BLN][eft_FLT] = {
+        eft_FLT, (void *)dpnp_copyto_c_ext<bool, float>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_BLN][eft_DBL] = {
+        eft_DBL, (void *)dpnp_copyto_c_ext<bool, double>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_INT][eft_BLN] = {
+        eft_BLN, (void *)dpnp_copyto_c_ext<int32_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_copyto_c_ext<int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_copyto_c_ext<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_INT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_copyto_c_ext<int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_copyto_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_LNG][eft_BLN] = {
+        eft_BLN, (void *)dpnp_copyto_c_ext<int64_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_LNG][eft_INT] = {
+        eft_INT, (void *)dpnp_copyto_c_ext<int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_copyto_c_ext<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_LNG][eft_FLT] = {
+        eft_FLT, (void *)dpnp_copyto_c_ext<int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_copyto_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_FLT][eft_BLN] = {
+        eft_BLN, (void *)dpnp_copyto_c_ext<float, bool>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_FLT][eft_INT] = {
+        eft_INT, (void *)dpnp_copyto_c_ext<float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_FLT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_copyto_c_ext<float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_copyto_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_copyto_c_ext<float, double>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_DBL][eft_BLN] = {
+        eft_BLN, (void *)dpnp_copyto_c_ext<double, bool>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_DBL][eft_INT] = {
+        eft_INT, (void *)dpnp_copyto_c_ext<double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_DBL][eft_LNG] = {
+        eft_LNG, (void *)dpnp_copyto_c_ext<double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_DBL][eft_FLT] = {
+        eft_FLT, (void *)dpnp_copyto_c_ext<double, float>};
+    fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_copyto_c_ext<double, double>};
     fmap[DPNPFuncName::DPNP_FN_COPYTO_EXT][eft_C128][eft_C128] = {
-        eft_C128, (void*)dpnp_copyto_c_ext<std::complex<double>, std::complex<double>>};
+        eft_C128,
+        (void *)dpnp_copyto_c_ext<std::complex<double>, std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_COS][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_cos_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_COS][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_cos_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_COS][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_cos_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_COS][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_cos_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_COS][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_cos_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_COS][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_cos_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_COS][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_cos_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_COS][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_cos_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_COS_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_cos_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_COS_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_cos_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_COS_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_cos_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_COS_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_cos_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_COS_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_cos_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_COS_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_cos_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_COS_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_cos_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_COS_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_cos_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_COSH][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_cosh_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_COSH][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_cosh_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_COSH][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_cosh_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_COSH][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_cosh_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_COSH][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_cosh_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_COSH][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_cosh_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_COSH][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_cosh_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_COSH][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_cosh_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_COSH_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_cosh_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_COSH_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_cosh_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_COSH_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_cosh_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_COSH_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_cosh_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_COSH_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_cosh_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_COSH_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_cosh_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_COSH_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_cosh_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_COSH_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_cosh_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_DEGREES][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_degrees_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_DEGREES][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_degrees_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_DEGREES][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_degrees_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_DEGREES][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_degrees_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_DEGREES][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_degrees_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_DEGREES][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_degrees_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_DEGREES][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_degrees_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_DEGREES][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_degrees_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_DEGREES_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_degrees_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_DEGREES_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_degrees_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_DEGREES_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_degrees_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_DEGREES_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_degrees_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_DEGREES_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_degrees_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_DEGREES_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_degrees_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_DEGREES_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_degrees_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_DEGREES_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_degrees_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_EXP2][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_exp2_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_EXP2][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_exp2_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_EXP2][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_exp2_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_EXP2][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_exp2_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_EXP2][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_exp2_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_EXP2][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_exp2_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_EXP2][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_exp2_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_EXP2][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_exp2_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_EXP2_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_exp2_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_EXP2_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_exp2_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_EXP2_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_exp2_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_EXP2_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_exp2_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_EXP2_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_exp2_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_EXP2_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_exp2_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_EXP2_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_exp2_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_EXP2_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_exp2_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_EXP][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_exp_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_EXP][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_exp_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_EXP][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_exp_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_EXP][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_exp_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_EXP][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_exp_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_EXP][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_exp_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_EXP][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_exp_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_EXP][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_exp_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_EXP_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_exp_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_EXP_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_exp_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_EXP_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_exp_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_EXP_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_exp_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_EXP_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_exp_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_EXP_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_exp_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_EXP_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_exp_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_EXP_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_exp_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_EXPM1][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_expm1_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_EXPM1][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_expm1_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_EXPM1][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_expm1_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_EXPM1][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_expm1_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_EXPM1][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_expm1_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_EXPM1][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_expm1_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_EXPM1][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_expm1_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_EXPM1][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_expm1_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_EXPM1_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_expm1_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_EXPM1_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_expm1_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_EXPM1_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_expm1_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_EXPM1_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_expm1_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_EXPM1_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_expm1_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_EXPM1_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_expm1_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_EXPM1_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_expm1_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_EXPM1_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_expm1_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_FABS][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_fabs_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_FABS][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_fabs_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_FABS][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_fabs_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_FABS][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_fabs_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_FABS][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_fabs_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_FABS][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_fabs_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_FABS][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_fabs_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_FABS][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_fabs_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_FABS_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_fabs_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_FABS_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_fabs_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_FABS_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_fabs_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_FABS_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_fabs_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_FABS_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_fabs_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_FABS_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_fabs_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_FABS_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_fabs_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_FABS_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_fabs_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_FLOOR][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_floor_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_FLOOR][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_floor_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_FLOOR][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_floor_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_FLOOR][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_floor_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_FLOOR][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_floor_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_FLOOR][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_floor_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_FLOOR][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_floor_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_FLOOR][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_floor_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_FLOOR_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_floor_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_FLOOR_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_floor_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_FLOOR_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_floor_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_FLOOR_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_floor_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_FLOOR_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_floor_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_FLOOR_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_floor_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_FLOOR_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_floor_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_FLOOR_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_floor_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_LOG10][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_log10_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_LOG10][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_log10_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_LOG10][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_log10_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_LOG10][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_log10_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG10][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_log10_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG10][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_log10_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG10][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_log10_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_LOG10][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_log10_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_LOG10_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_log10_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_LOG10_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_log10_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_LOG10_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_log10_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_LOG10_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_log10_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG10_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_log10_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG10_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_log10_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG10_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_log10_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_LOG10_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_log10_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_LOG1P][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_log1p_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_LOG1P][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_log1p_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_LOG1P][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_log1p_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_LOG1P][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_log1p_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG1P][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_log1p_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG1P][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_log1p_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG1P][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_log1p_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_LOG1P][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_log1p_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_LOG1P_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_log1p_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_LOG1P_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_log1p_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_LOG1P_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_log1p_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_LOG1P_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_log1p_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG1P_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_log1p_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG1P_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_log1p_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG1P_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_log1p_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_LOG1P_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_log1p_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_LOG2][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_log2_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_LOG2][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_log2_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_LOG2][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_log2_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_LOG2][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_log2_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG2][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_log2_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG2][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_log2_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG2][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_log2_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_LOG2][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_log2_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_LOG2_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_log2_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_LOG2_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_log2_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_LOG2_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_log2_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_LOG2_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_log2_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG2_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_log2_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG2_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_log2_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG2_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_log2_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_LOG2_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_log2_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_LOG][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_log_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_LOG][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_log_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_LOG][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_log_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_LOG][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_log_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_log_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_log_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_log_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_LOG][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_log_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_LOG_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_log_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_LOG_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_log_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_LOG_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_log_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_LOG_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_log_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_log_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_log_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_LOG_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_log_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_LOG_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_log_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RADIANS][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_radians_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_RADIANS][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_radians_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_RADIANS][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_radians_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_RADIANS][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_radians_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_RADIANS][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_radians_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_RADIANS][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_radians_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_RADIANS][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_radians_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_RADIANS][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_radians_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RADIANS_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_radians_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_RADIANS_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_radians_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_RADIANS_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_radians_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_RADIANS_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_radians_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_RADIANS_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_radians_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_RADIANS_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_radians_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_RADIANS_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_radians_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_RADIANS_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_radians_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_SIN][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_sin_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_SIN][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_sin_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_SIN][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_sin_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_SIN][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_sin_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_SIN][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_sin_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_SIN][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_sin_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_SIN][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_sin_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_SIN][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_sin_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_SIN_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_sin_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_SIN_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_sin_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_SIN_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_sin_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_SIN_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_sin_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_SIN_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_sin_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_SIN_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_sin_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_SIN_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_sin_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_SIN_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_sin_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_SINH][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_sinh_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_SINH][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_sinh_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_SINH][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_sinh_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_SINH][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_sinh_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_SINH][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_sinh_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_SINH][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_sinh_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_SINH][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_sinh_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_SINH][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_sinh_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_SINH_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_sinh_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_SINH_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_sinh_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_SINH_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_sinh_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_SINH_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_sinh_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_SINH_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_sinh_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_SINH_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_sinh_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_SINH_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_sinh_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_SINH_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_sinh_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_SQRT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_sqrt_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_SQRT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_sqrt_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_SQRT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_sqrt_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_SQRT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_sqrt_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_SQRT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_sqrt_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_SQRT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_sqrt_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_SQRT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_sqrt_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_SQRT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_sqrt_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_SQRT_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_sqrt_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_SQRT_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_sqrt_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_SQRT_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_sqrt_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_SQRT_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_sqrt_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_SQRT_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_sqrt_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_SQRT_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_sqrt_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_SQRT_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_sqrt_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_SQRT_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_sqrt_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_TAN][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_tan_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TAN][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_tan_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TAN][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_tan_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_TAN][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_tan_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_TAN][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_tan_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TAN][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_tan_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TAN][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_tan_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_TAN][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_tan_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_TAN_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_tan_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TAN_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_tan_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TAN_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_tan_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_TAN_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_tan_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_TAN_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_tan_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TAN_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_tan_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TAN_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_tan_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_TAN_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_tan_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_TANH][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_tanh_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TANH][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_tanh_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TANH][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_tanh_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_TANH][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_tanh_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_TANH][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_tanh_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TANH][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_tanh_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TANH][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_tanh_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_TANH][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_tanh_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_TANH_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_tanh_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TANH_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_tanh_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TANH_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_tanh_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_TANH_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_tanh_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_TANH_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_tanh_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TANH_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_tanh_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TANH_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_tanh_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_TANH_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_tanh_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_TRUNC][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_trunc_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRUNC][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_trunc_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRUNC][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_trunc_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_TRUNC][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_trunc_c_default<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRUNC][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_trunc_c_default<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRUNC][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_trunc_c_default<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRUNC][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_trunc_c_default<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_TRUNC][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_trunc_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_TRUNC_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_trunc_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRUNC_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_trunc_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRUNC_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_trunc_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_TRUNC_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_trunc_c_ext<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRUNC_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_trunc_c_ext<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRUNC_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_trunc_c_ext<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRUNC_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_trunc_c_ext<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_TRUNC_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_trunc_c_ext<double, double>};
 
     return;
 }
@@ -562,13 +825,11 @@ static void func_map_init_elemwise_1arg_2type(func_map_t& fmap)
 template <typename T>
 constexpr T dispatch_erf_op(T elem)
 {
-    if constexpr (is_any_v<T, std::int32_t, std::int64_t>)
-    {
+    if constexpr (is_any_v<T, std::int32_t, std::int64_t>) {
         // TODO: need to convert to double when possible
         return sycl::erf((float)elem);
     }
-    else
-    {
+    else {
         return sycl::erf(elem);
     }
 }
@@ -576,1394 +837,1497 @@ constexpr T dispatch_erf_op(T elem)
 template <typename T>
 constexpr T dispatch_sign_op(T elem)
 {
-    if constexpr (is_any_v<T, std::int32_t, std::int64_t>)
-    {
+    if constexpr (is_any_v<T, std::int32_t, std::int64_t>) {
         if (elem > 0)
             return T(1);
         if (elem < 0)
             return T(-1);
         return elem; // elem is 0
     }
-    else
-    {
+    else {
         return sycl::sign(elem);
     }
 }
 
-#define MACRO_1ARG_1TYPE_OP(__name__, __operation1__, __operation2__)                                                  \
-    template <typename _KernelNameSpecialization>                                                                      \
-    class __name__##_kernel;                                                                                           \
-                                                                                                                       \
-    template <typename _KernelNameSpecialization>                                                                      \
-    class __name__##_strides_kernel;                                                                                   \
-                                                                                                                       \
-    template <typename _DataType>                                                                                      \
-    DPCTLSyclEventRef __name__(DPCTLSyclQueueRef q_ref,                                                                \
-                               void* result_out,                                                                       \
-                               const size_t result_size,                                                               \
-                               const size_t result_ndim,                                                               \
-                               const shape_elem_type* result_shape,                                                    \
-                               const shape_elem_type* result_strides,                                                  \
-                               const void* input1_in,                                                                  \
-                               const size_t input1_size,                                                               \
-                               const size_t input1_ndim,                                                               \
-                               const shape_elem_type* input1_shape,                                                    \
-                               const shape_elem_type* input1_strides,                                                  \
-                               const size_t* where,                                                                    \
-                               const DPCTLEventVectorRef dep_event_vec_ref)                                            \
-    {                                                                                                                  \
-        /* avoid warning unused variable*/                                                                             \
-        (void)result_shape;                                                                                            \
-        (void)where;                                                                                                   \
-        (void)dep_event_vec_ref;                                                                                       \
-                                                                                                                       \
-        DPCTLSyclEventRef event_ref = nullptr;                                                                         \
-                                                                                                                       \
-        if (!input1_size)                                                                                              \
-        {                                                                                                              \
-            return event_ref;                                                                                          \
-        }                                                                                                              \
-                                                                                                                       \
-        sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));                                                      \
-                                                                                                                       \
-        _DataType* input1_data = static_cast<_DataType*>(const_cast<void*>(input1_in));                                \
-        _DataType* result = static_cast<_DataType*>(result_out);                                                       \
-                                                                                                                       \
-        shape_elem_type* input1_shape_offsets = new shape_elem_type[input1_ndim];                                      \
-                                                                                                                       \
-        get_shape_offsets_inkernel(input1_shape, input1_ndim, input1_shape_offsets);                                   \
-        bool use_strides = !array_equal(input1_strides, input1_ndim, input1_shape_offsets, input1_ndim);               \
-        delete[] input1_shape_offsets;                                                                                 \
-                                                                                                                       \
-        sycl::event event;                                                                                             \
-        sycl::range<1> gws(result_size);                                                                               \
-                                                                                                                       \
-        if (use_strides)                                                                                               \
-        {                                                                                                              \
-            if (result_ndim != input1_ndim)                                                                            \
-            {                                                                                                          \
-                throw std::runtime_error("Result ndim=" + std::to_string(result_ndim) +                                \
-                                         " mismatches with input1 ndim=" + std::to_string(input1_ndim));               \
-            }                                                                                                          \
-                                                                                                                       \
-            /* memory transfer optimization, use USM-host for temporary speeds up tranfer to device */                 \
-            using usm_host_allocatorT = sycl::usm_allocator<shape_elem_type, sycl::usm::alloc::host>;                  \
-                                                                                                                       \
-            size_t strides_size = 2 * result_ndim;                                                                     \
-            shape_elem_type* dev_strides_data = sycl::malloc_device<shape_elem_type>(strides_size, q);                 \
-                                                                                                                       \
-            /* create host temporary for packed strides managed by shared pointer */                                   \
-            auto strides_host_packed =                                                                                 \
-                std::vector<shape_elem_type, usm_host_allocatorT>(strides_size, usm_host_allocatorT(q));               \
-                                                                                                                       \
-            /* packed vector is concatenation of result_strides, input1_strides and input2_strides */                  \
-            std::copy(result_strides, result_strides + result_ndim, strides_host_packed.begin());                      \
-            std::copy(input1_strides, input1_strides + result_ndim, strides_host_packed.begin() + result_ndim);        \
-                                                                                                                       \
-            auto copy_strides_ev =                                                                                     \
-                q.copy<shape_elem_type>(strides_host_packed.data(), dev_strides_data, strides_host_packed.size());     \
-                                                                                                                       \
-            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {                                               \
-                size_t output_id = global_id[0]; /* for (size_t i = 0; i < result_size; ++i) */                        \
-                {                                                                                                      \
-                    const shape_elem_type* result_strides_data = &dev_strides_data[0];                                 \
-                    const shape_elem_type* input1_strides_data = &dev_strides_data[result_ndim];                       \
-                                                                                                                       \
-                    size_t input_id = 0;                                                                               \
-                    for (size_t i = 0; i < input1_ndim; ++i)                                                           \
-                    {                                                                                                  \
-                        const size_t output_xyz_id =                                                                   \
-                            get_xyz_id_by_id_inkernel(output_id, result_strides_data, result_ndim, i);                 \
-                        input_id += output_xyz_id * input1_strides_data[i];                                            \
-                    }                                                                                                  \
-                                                                                                                       \
-                    const _DataType input_elem = input1_data[input_id];                                                \
-                    result[output_id] = __operation1__;                                                                \
-                }                                                                                                      \
-            };                                                                                                         \
-            auto kernel_func = [&](sycl::handler& cgh) {                                                               \
-                cgh.parallel_for<class __name__##_strides_kernel<_DataType>>(gws, kernel_parallel_for_func);           \
-            };                                                                                                         \
-                                                                                                                       \
-            q.submit(kernel_func).wait();                                                                              \
-                                                                                                                       \
-            sycl::free(dev_strides_data, q);                                                                           \
-            return event_ref;                                                                                          \
-        }                                                                                                              \
-        else                                                                                                           \
-        {                                                                                                              \
-            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {                                               \
-                size_t i = global_id[0]; /* for (size_t i = 0; i < result_size; ++i) */                                \
-                {                                                                                                      \
-                    const _DataType input_elem = input1_data[i];                                                       \
-                    result[i] = __operation1__;                                                                        \
-                }                                                                                                      \
-            };                                                                                                         \
-            auto kernel_func = [&](sycl::handler& cgh) {                                                               \
-                cgh.parallel_for<class __name__##_kernel<_DataType>>(gws, kernel_parallel_for_func);                   \
-            };                                                                                                         \
-                                                                                                                       \
-            if constexpr (is_any_v<_DataType, float, double>)                                                          \
-            {                                                                                                          \
-                if (q.get_device().has(sycl::aspect::fp64))                                                            \
-                {                                                                                                      \
-                    event = __operation2__;                                                                            \
-                                                                                                                       \
-                    event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);                                           \
-                    return DPCTLEvent_Copy(event_ref);                                                                 \
-                }                                                                                                      \
-            }                                                                                                          \
-            event = q.submit(kernel_func);                                                                             \
-        }                                                                                                              \
-                                                                                                                       \
-        event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);                                                       \
-        return DPCTLEvent_Copy(event_ref);                                                                             \
-    }                                                                                                                  \
-                                                                                                                       \
-    template <typename _DataType>                                                                                      \
-    void __name__(void* result_out,                                                                                    \
-                  const size_t result_size,                                                                            \
-                  const size_t result_ndim,                                                                            \
-                  const shape_elem_type* result_shape,                                                                 \
-                  const shape_elem_type* result_strides,                                                               \
-                  const void* input1_in,                                                                               \
-                  const size_t input1_size,                                                                            \
-                  const size_t input1_ndim,                                                                            \
-                  const shape_elem_type* input1_shape,                                                                 \
-                  const shape_elem_type* input1_strides,                                                               \
-                  const size_t* where)                                                                                 \
-    {                                                                                                                  \
-        DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);                                    \
-        DPCTLEventVectorRef dep_event_vec_ref = nullptr;                                                               \
-        DPCTLSyclEventRef event_ref = __name__<_DataType>(q_ref,                                                       \
-                                                          result_out,                                                  \
-                                                          result_size,                                                 \
-                                                          result_ndim,                                                 \
-                                                          result_shape,                                                \
-                                                          result_strides,                                              \
-                                                          input1_in,                                                   \
-                                                          input1_size,                                                 \
-                                                          input1_ndim,                                                 \
-                                                          input1_shape,                                                \
-                                                          input1_strides,                                              \
-                                                          where,                                                       \
-                                                          dep_event_vec_ref);                                          \
-        DPCTLEvent_WaitAndThrow(event_ref);                                                                            \
-        DPCTLEvent_Delete(event_ref);                                                                                  \
-    }                                                                                                                  \
-                                                                                                                       \
-    template <typename _DataType>                                                                                      \
-    void (*__name__##_default)(void*,                                                                                  \
-                               const size_t,                                                                           \
-                               const size_t,                                                                           \
-                               const shape_elem_type*,                                                                 \
-                               const shape_elem_type*,                                                                 \
-                               const void*,                                                                            \
-                               const size_t,                                                                           \
-                               const size_t,                                                                           \
-                               const shape_elem_type*,                                                                 \
-                               const shape_elem_type*,                                                                 \
-                               const size_t*) = __name__<_DataType>;                                                   \
-                                                                                                                       \
-    template <typename _DataType>                                                                                      \
-    DPCTLSyclEventRef (*__name__##_ext)(DPCTLSyclQueueRef,                                                             \
-                                        void*,                                                                         \
-                                        const size_t,                                                                  \
-                                        const size_t,                                                                  \
-                                        const shape_elem_type*,                                                        \
-                                        const shape_elem_type*,                                                        \
-                                        const void*,                                                                   \
-                                        const size_t,                                                                  \
-                                        const size_t,                                                                  \
-                                        const shape_elem_type*,                                                        \
-                                        const shape_elem_type*,                                                        \
-                                        const size_t*,                                                                 \
-                                        const DPCTLEventVectorRef) = __name__<_DataType>;
+#define MACRO_1ARG_1TYPE_OP(__name__, __operation1__, __operation2__)                    \
+    template <typename _KernelNameSpecialization>                                        \
+    class __name__##_kernel;                                                             \
+                                                                                         \
+    template <typename _KernelNameSpecialization>                                        \
+    class __name__##_strides_kernel;                                                     \
+                                                                                         \
+    template <typename _DataType>                                                        \
+    DPCTLSyclEventRef __name__(                                                          \
+        DPCTLSyclQueueRef q_ref, void *result_out, const size_t result_size,             \
+        const size_t result_ndim, const shape_elem_type *result_shape,                   \
+        const shape_elem_type *result_strides, const void *input1_in,                    \
+        const size_t input1_size, const size_t input1_ndim,                              \
+        const shape_elem_type *input1_shape,                                             \
+        const shape_elem_type *input1_strides, const size_t *where,                      \
+        const DPCTLEventVectorRef dep_event_vec_ref)                                     \
+    {                                                                                    \
+        /* avoid warning unused variable*/                                               \
+        (void)result_shape;                                                              \
+        (void)where;                                                                     \
+        (void)dep_event_vec_ref;                                                         \
+                                                                                         \
+        DPCTLSyclEventRef event_ref = nullptr;                                           \
+                                                                                         \
+        if (!input1_size) {                                                              \
+            return event_ref;                                                            \
+        }                                                                                \
+                                                                                         \
+        sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));                       \
+                                                                                         \
+        _DataType *input1_data =                                                         \
+            static_cast<_DataType *>(const_cast<void *>(input1_in));                     \
+        _DataType *result = static_cast<_DataType *>(result_out);                        \
+                                                                                         \
+        shape_elem_type *input1_shape_offsets =                                          \
+            new shape_elem_type[input1_ndim];                                            \
+                                                                                         \
+        get_shape_offsets_inkernel(input1_shape, input1_ndim,                            \
+                                   input1_shape_offsets);                                \
+        bool use_strides = !array_equal(input1_strides, input1_ndim,                     \
+                                        input1_shape_offsets, input1_ndim);              \
+        delete[] input1_shape_offsets;                                                   \
+                                                                                         \
+        sycl::event event;                                                               \
+        sycl::range<1> gws(result_size);                                                 \
+                                                                                         \
+        if (use_strides) {                                                               \
+            if (result_ndim != input1_ndim) {                                            \
+                throw std::runtime_error(                                                \
+                    "Result ndim=" + std::to_string(result_ndim) +                       \
+                    " mismatches with input1 ndim=" +                                    \
+                    std::to_string(input1_ndim));                                        \
+            }                                                                            \
+                                                                                         \
+            /* memory transfer optimization, use USM-host for temporary speeds           \
+             * up tranfer to device */                                                   \
+            using usm_host_allocatorT =                                                  \
+                sycl::usm_allocator<shape_elem_type, sycl::usm::alloc::host>;            \
+                                                                                         \
+            size_t strides_size = 2 * result_ndim;                                       \
+            shape_elem_type *dev_strides_data =                                          \
+                sycl::malloc_device<shape_elem_type>(strides_size, q);                   \
+                                                                                         \
+            /* create host temporary for packed strides managed by shared                \
+             * pointer */                                                                \
+            auto strides_host_packed =                                                   \
+                std::vector<shape_elem_type, usm_host_allocatorT>(                       \
+                    strides_size, usm_host_allocatorT(q));                               \
+                                                                                         \
+            /* packed vector is concatenation of result_strides,                         \
+             * input1_strides and input2_strides */                                      \
+            std::copy(result_strides, result_strides + result_ndim,                      \
+                      strides_host_packed.begin());                                      \
+            std::copy(input1_strides, input1_strides + result_ndim,                      \
+                      strides_host_packed.begin() + result_ndim);                        \
+                                                                                         \
+            auto copy_strides_ev = q.copy<shape_elem_type>(                              \
+                strides_host_packed.data(), dev_strides_data,                            \
+                strides_host_packed.size());                                             \
+                                                                                         \
+            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {                 \
+                size_t output_id = global_id[0]; /* for (size_t i = 0; i <               \
+                                                    result_size; ++i) */                 \
+                {                                                                        \
+                    const shape_elem_type *result_strides_data =                         \
+                        &dev_strides_data[0];                                            \
+                    const shape_elem_type *input1_strides_data =                         \
+                        &dev_strides_data[result_ndim];                                  \
+                                                                                         \
+                    size_t input_id = 0;                                                 \
+                    for (size_t i = 0; i < input1_ndim; ++i) {                           \
+                        const size_t output_xyz_id =                                     \
+                            get_xyz_id_by_id_inkernel(output_id,                         \
+                                                      result_strides_data,               \
+                                                      result_ndim, i);                   \
+                        input_id += output_xyz_id * input1_strides_data[i];              \
+                    }                                                                    \
+                                                                                         \
+                    const _DataType input_elem = input1_data[input_id];                  \
+                    result[output_id]          = __operation1__;                         \
+                }                                                                        \
+            };                                                                           \
+            auto kernel_func = [&](sycl::handler &cgh) {                                 \
+                cgh.parallel_for<class __name__##_strides_kernel<_DataType>>(            \
+                    gws, kernel_parallel_for_func);                                      \
+            };                                                                           \
+                                                                                         \
+            q.submit(kernel_func).wait();                                                \
+                                                                                         \
+            sycl::free(dev_strides_data, q);                                             \
+            return event_ref;                                                            \
+        }                                                                                \
+        else {                                                                           \
+            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {                 \
+                size_t i = global_id[0]; /* for (size_t i = 0; i <                       \
+                                            result_size; ++i) */                         \
+                {                                                                        \
+                    const _DataType input_elem = input1_data[i];                         \
+                    result[i]                  = __operation1__;                         \
+                }                                                                        \
+            };                                                                           \
+            auto kernel_func = [&](sycl::handler &cgh) {                                 \
+                cgh.parallel_for<class __name__##_kernel<_DataType>>(                    \
+                    gws, kernel_parallel_for_func);                                      \
+            };                                                                           \
+                                                                                         \
+            if constexpr (is_any_v<_DataType, float, double>) {                          \
+                if (q.get_device().has(sycl::aspect::fp64)) {                            \
+                    event = __operation2__;                                              \
+                                                                                         \
+                    event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);             \
+                    return DPCTLEvent_Copy(event_ref);                                   \
+                }                                                                        \
+            }                                                                            \
+            event = q.submit(kernel_func);                                               \
+        }                                                                                \
+                                                                                         \
+        event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);                         \
+        return DPCTLEvent_Copy(event_ref);                                               \
+    }                                                                                    \
+                                                                                         \
+    template <typename _DataType>                                                        \
+    void __name__(                                                                       \
+        void *result_out, const size_t result_size, const size_t result_ndim,            \
+        const shape_elem_type *result_shape,                                             \
+        const shape_elem_type *result_strides, const void *input1_in,                    \
+        const size_t input1_size, const size_t input1_ndim,                              \
+        const shape_elem_type *input1_shape,                                             \
+        const shape_elem_type *input1_strides, const size_t *where)                      \
+    {                                                                                    \
+        DPCTLSyclQueueRef q_ref =                                                        \
+            reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);                            \
+        DPCTLEventVectorRef dep_event_vec_ref = nullptr;                                 \
+        DPCTLSyclEventRef event_ref           = __name__<_DataType>(                     \
+            q_ref, result_out, result_size, result_ndim, result_shape,         \
+            result_strides, input1_in, input1_size, input1_ndim, input1_shape, \
+            input1_strides, where, dep_event_vec_ref);                         \
+        DPCTLEvent_WaitAndThrow(event_ref);                                              \
+        DPCTLEvent_Delete(event_ref);                                                    \
+    }                                                                                    \
+                                                                                         \
+    template <typename _DataType>                                                        \
+    void (*__name__##_default)(                                                          \
+        void *, const size_t, const size_t, const shape_elem_type *,                     \
+        const shape_elem_type *, const void *, const size_t, const size_t,               \
+        const shape_elem_type *, const shape_elem_type *, const size_t *) =              \
+        __name__<_DataType>;                                                             \
+                                                                                         \
+    template <typename _DataType>                                                        \
+    DPCTLSyclEventRef (*__name__##_ext)(                                                 \
+        DPCTLSyclQueueRef, void *, const size_t, const size_t,                           \
+        const shape_elem_type *, const shape_elem_type *, const void *,                  \
+        const size_t, const size_t, const shape_elem_type *,                             \
+        const shape_elem_type *, const size_t *, const DPCTLEventVectorRef) =            \
+        __name__<_DataType>;
 
 #include <dpnp_gen_1arg_1type_tbl.hpp>
 
-static void func_map_init_elemwise_1arg_1type(func_map_t& fmap)
+static void func_map_init_elemwise_1arg_1type(func_map_t &fmap)
 {
-    fmap[DPNPFuncName::DPNP_FN_CONJIGUATE][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_copy_c_default<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_CONJIGUATE][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_copy_c_default<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_CONJIGUATE][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_copy_c_default<float>};
-    fmap[DPNPFuncName::DPNP_FN_CONJIGUATE][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_copy_c_default<double>};
+    fmap[DPNPFuncName::DPNP_FN_CONJIGUATE][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_copy_c_default<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_CONJIGUATE][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_copy_c_default<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_CONJIGUATE][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_copy_c_default<float>};
+    fmap[DPNPFuncName::DPNP_FN_CONJIGUATE][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_copy_c_default<double>};
     fmap[DPNPFuncName::DPNP_FN_CONJIGUATE][eft_C128][eft_C128] = {
-        eft_C128, (void*)dpnp_conjugate_c_default<std::complex<double>>};
+        eft_C128, (void *)dpnp_conjugate_c_default<std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_CONJIGUATE_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_copy_c_ext<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_CONJIGUATE_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_copy_c_ext<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_CONJIGUATE_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_copy_c_ext<float>};
-    fmap[DPNPFuncName::DPNP_FN_CONJIGUATE_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_copy_c_ext<double>};
+    fmap[DPNPFuncName::DPNP_FN_CONJIGUATE_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_copy_c_ext<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_CONJIGUATE_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_copy_c_ext<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_CONJIGUATE_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_copy_c_ext<float>};
+    fmap[DPNPFuncName::DPNP_FN_CONJIGUATE_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_copy_c_ext<double>};
     fmap[DPNPFuncName::DPNP_FN_CONJIGUATE_EXT][eft_C128][eft_C128] = {
-        eft_C128, (void*)dpnp_conjugate_c_ext<std::complex<double>>};
+        eft_C128, (void *)dpnp_conjugate_c_ext<std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_COPY][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_copy_c_default<bool>};
-    fmap[DPNPFuncName::DPNP_FN_COPY][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_copy_c_default<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_COPY][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_copy_c_default<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_COPY][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_copy_c_default<float>};
-    fmap[DPNPFuncName::DPNP_FN_COPY][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_copy_c_default<double>};
-    fmap[DPNPFuncName::DPNP_FN_COPY][eft_C128][eft_C128] = {eft_C128,
-                                                            (void*)dpnp_copy_c_default<std::complex<double>>};
+    fmap[DPNPFuncName::DPNP_FN_COPY][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_copy_c_default<bool>};
+    fmap[DPNPFuncName::DPNP_FN_COPY][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_copy_c_default<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_COPY][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_copy_c_default<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_COPY][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_copy_c_default<float>};
+    fmap[DPNPFuncName::DPNP_FN_COPY][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_copy_c_default<double>};
+    fmap[DPNPFuncName::DPNP_FN_COPY][eft_C128][eft_C128] = {
+        eft_C128, (void *)dpnp_copy_c_default<std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_COPY_EXT][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_copy_c_ext<bool>};
-    fmap[DPNPFuncName::DPNP_FN_COPY_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_copy_c_ext<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_COPY_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_copy_c_ext<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_COPY_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_copy_c_ext<float>};
-    fmap[DPNPFuncName::DPNP_FN_COPY_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_copy_c_ext<double>};
-    fmap[DPNPFuncName::DPNP_FN_COPY_EXT][eft_C64][eft_C64] = {eft_C64, (void*)dpnp_copy_c_ext<std::complex<float>>};
-    fmap[DPNPFuncName::DPNP_FN_COPY_EXT][eft_C128][eft_C128] = {eft_C128, (void*)dpnp_copy_c_ext<std::complex<double>>};
+    fmap[DPNPFuncName::DPNP_FN_COPY_EXT][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_copy_c_ext<bool>};
+    fmap[DPNPFuncName::DPNP_FN_COPY_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_copy_c_ext<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_COPY_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_copy_c_ext<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_COPY_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_copy_c_ext<float>};
+    fmap[DPNPFuncName::DPNP_FN_COPY_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_copy_c_ext<double>};
+    fmap[DPNPFuncName::DPNP_FN_COPY_EXT][eft_C64][eft_C64] = {
+        eft_C64, (void *)dpnp_copy_c_ext<std::complex<float>>};
+    fmap[DPNPFuncName::DPNP_FN_COPY_EXT][eft_C128][eft_C128] = {
+        eft_C128, (void *)dpnp_copy_c_ext<std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_ERF][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_erf_c_default<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ERF][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_erf_c_default<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ERF][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_erf_c_default<float>};
-    fmap[DPNPFuncName::DPNP_FN_ERF][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_erf_c_default<double>};
+    fmap[DPNPFuncName::DPNP_FN_ERF][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_erf_c_default<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ERF][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_erf_c_default<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ERF][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_erf_c_default<float>};
+    fmap[DPNPFuncName::DPNP_FN_ERF][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_erf_c_default<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_ERF_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_erf_c_ext<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ERF_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_erf_c_ext<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ERF_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_erf_c_ext<float>};
-    fmap[DPNPFuncName::DPNP_FN_ERF_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_erf_c_ext<double>};
+    fmap[DPNPFuncName::DPNP_FN_ERF_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_erf_c_ext<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ERF_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_erf_c_ext<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ERF_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_erf_c_ext<float>};
+    fmap[DPNPFuncName::DPNP_FN_ERF_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_erf_c_ext<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_FLATTEN][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_copy_c_default<bool>};
-    fmap[DPNPFuncName::DPNP_FN_FLATTEN][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_copy_c_default<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_FLATTEN][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_copy_c_default<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_FLATTEN][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_copy_c_default<float>};
-    fmap[DPNPFuncName::DPNP_FN_FLATTEN][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_copy_c_default<double>};
-    fmap[DPNPFuncName::DPNP_FN_FLATTEN][eft_C128][eft_C128] = {eft_C128,
-                                                               (void*)dpnp_copy_c_default<std::complex<double>>};
+    fmap[DPNPFuncName::DPNP_FN_FLATTEN][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_copy_c_default<bool>};
+    fmap[DPNPFuncName::DPNP_FN_FLATTEN][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_copy_c_default<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_FLATTEN][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_copy_c_default<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_FLATTEN][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_copy_c_default<float>};
+    fmap[DPNPFuncName::DPNP_FN_FLATTEN][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_copy_c_default<double>};
+    fmap[DPNPFuncName::DPNP_FN_FLATTEN][eft_C128][eft_C128] = {
+        eft_C128, (void *)dpnp_copy_c_default<std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_FLATTEN_EXT][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_copy_c_ext<bool>};
-    fmap[DPNPFuncName::DPNP_FN_FLATTEN_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_copy_c_ext<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_FLATTEN_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_copy_c_ext<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_FLATTEN_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_copy_c_ext<float>};
-    fmap[DPNPFuncName::DPNP_FN_FLATTEN_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_copy_c_ext<double>};
-    fmap[DPNPFuncName::DPNP_FN_FLATTEN_EXT][eft_C128][eft_C128] = {eft_C128,
-                                                                   (void*)dpnp_copy_c_ext<std::complex<double>>};
+    fmap[DPNPFuncName::DPNP_FN_FLATTEN_EXT][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_copy_c_ext<bool>};
+    fmap[DPNPFuncName::DPNP_FN_FLATTEN_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_copy_c_ext<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_FLATTEN_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_copy_c_ext<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_FLATTEN_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_copy_c_ext<float>};
+    fmap[DPNPFuncName::DPNP_FN_FLATTEN_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_copy_c_ext<double>};
+    fmap[DPNPFuncName::DPNP_FN_FLATTEN_EXT][eft_C128][eft_C128] = {
+        eft_C128, (void *)dpnp_copy_c_ext<std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_NEGATIVE][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_negative_c_default<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_NEGATIVE][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_negative_c_default<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_NEGATIVE][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_negative_c_default<float>};
-    fmap[DPNPFuncName::DPNP_FN_NEGATIVE][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_negative_c_default<double>};
+    fmap[DPNPFuncName::DPNP_FN_NEGATIVE][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_negative_c_default<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_NEGATIVE][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_negative_c_default<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_NEGATIVE][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_negative_c_default<float>};
+    fmap[DPNPFuncName::DPNP_FN_NEGATIVE][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_negative_c_default<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_NEGATIVE_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_negative_c_ext<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_NEGATIVE_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_negative_c_ext<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_NEGATIVE_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_negative_c_ext<float>};
-    fmap[DPNPFuncName::DPNP_FN_NEGATIVE_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_negative_c_ext<double>};
+    fmap[DPNPFuncName::DPNP_FN_NEGATIVE_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_negative_c_ext<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_NEGATIVE_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_negative_c_ext<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_NEGATIVE_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_negative_c_ext<float>};
+    fmap[DPNPFuncName::DPNP_FN_NEGATIVE_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_negative_c_ext<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RECIP][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_recip_c_default<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_RECIP][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_recip_c_default<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_RECIP][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_recip_c_default<float>};
-    fmap[DPNPFuncName::DPNP_FN_RECIP][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_recip_c_default<double>};
+    fmap[DPNPFuncName::DPNP_FN_RECIP][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_recip_c_default<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_RECIP][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_recip_c_default<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_RECIP][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_recip_c_default<float>};
+    fmap[DPNPFuncName::DPNP_FN_RECIP][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_recip_c_default<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RECIP_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_recip_c_ext<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_RECIP_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_recip_c_ext<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_RECIP_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_recip_c_ext<float>};
-    fmap[DPNPFuncName::DPNP_FN_RECIP_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_recip_c_ext<double>};
+    fmap[DPNPFuncName::DPNP_FN_RECIP_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_recip_c_ext<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_RECIP_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_recip_c_ext<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_RECIP_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_recip_c_ext<float>};
+    fmap[DPNPFuncName::DPNP_FN_RECIP_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_recip_c_ext<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_SIGN][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_sign_c_default<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_SIGN][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_sign_c_default<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_SIGN][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_sign_c_default<float>};
-    fmap[DPNPFuncName::DPNP_FN_SIGN][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_sign_c_default<double>};
+    fmap[DPNPFuncName::DPNP_FN_SIGN][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_sign_c_default<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_SIGN][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_sign_c_default<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_SIGN][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_sign_c_default<float>};
+    fmap[DPNPFuncName::DPNP_FN_SIGN][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_sign_c_default<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_SIGN_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_sign_c_ext<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_SIGN_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_sign_c_ext<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_SIGN_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_sign_c_ext<float>};
-    fmap[DPNPFuncName::DPNP_FN_SIGN_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_sign_c_ext<double>};
+    fmap[DPNPFuncName::DPNP_FN_SIGN_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_sign_c_ext<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_SIGN_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_sign_c_ext<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_SIGN_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_sign_c_ext<float>};
+    fmap[DPNPFuncName::DPNP_FN_SIGN_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_sign_c_ext<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_SQUARE][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_square_c_default<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_SQUARE][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_square_c_default<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_SQUARE][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_square_c_default<float>};
-    fmap[DPNPFuncName::DPNP_FN_SQUARE][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_square_c_default<double>};
+    fmap[DPNPFuncName::DPNP_FN_SQUARE][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_square_c_default<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_SQUARE][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_square_c_default<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_SQUARE][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_square_c_default<float>};
+    fmap[DPNPFuncName::DPNP_FN_SQUARE][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_square_c_default<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_SQUARE_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_square_c_ext<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_SQUARE_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_square_c_ext<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_SQUARE_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_square_c_ext<float>};
-    fmap[DPNPFuncName::DPNP_FN_SQUARE_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_square_c_ext<double>};
+    fmap[DPNPFuncName::DPNP_FN_SQUARE_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_square_c_ext<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_SQUARE_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_square_c_ext<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_SQUARE_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_square_c_ext<float>};
+    fmap[DPNPFuncName::DPNP_FN_SQUARE_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_square_c_ext<double>};
 
     return;
 }
 
-#define MACRO_2ARG_3TYPES_OP(                                                                                          \
-    __name__, __operation__, __vec_operation__, __vec_types__, __mkl_operation__, __mkl_types__)                       \
-    template <typename _KernelNameSpecialization1,                                                                     \
-              typename _KernelNameSpecialization2,                                                                     \
-              typename _KernelNameSpecialization3>                                                                     \
-    class __name__##_kernel;                                                                                           \
-                                                                                                                       \
-    template <typename _KernelNameSpecialization1,                                                                     \
-              typename _KernelNameSpecialization2,                                                                     \
-              typename _KernelNameSpecialization3>                                                                     \
-    class __name__##_sg_kernel;                                                                                        \
-                                                                                                                       \
-    template <typename _KernelNameSpecialization1,                                                                     \
-              typename _KernelNameSpecialization2,                                                                     \
-              typename _KernelNameSpecialization3>                                                                     \
-    class __name__##_broadcast_kernel;                                                                                 \
-                                                                                                                       \
-    template <typename _KernelNameSpecialization1,                                                                     \
-              typename _KernelNameSpecialization2,                                                                     \
-              typename _KernelNameSpecialization3>                                                                     \
-    class __name__##_strides_kernel;                                                                                   \
-                                                                                                                       \
-    template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>                         \
-    DPCTLSyclEventRef __name__(DPCTLSyclQueueRef q_ref,                                                                \
-                               void* result_out,                                                                       \
-                               const size_t result_size,                                                               \
-                               const size_t result_ndim,                                                               \
-                               const shape_elem_type* result_shape,                                                    \
-                               const shape_elem_type* result_strides,                                                  \
-                               const void* input1_in,                                                                  \
-                               const size_t input1_size,                                                               \
-                               const size_t input1_ndim,                                                               \
-                               const shape_elem_type* input1_shape,                                                    \
-                               const shape_elem_type* input1_strides,                                                  \
-                               const void* input2_in,                                                                  \
-                               const size_t input2_size,                                                               \
-                               const size_t input2_ndim,                                                               \
-                               const shape_elem_type* input2_shape,                                                    \
-                               const shape_elem_type* input2_strides,                                                  \
-                               const size_t* where,                                                                    \
-                               const DPCTLEventVectorRef dep_event_vec_ref)                                            \
-    {                                                                                                                  \
-        /* avoid warning unused variable*/                                                                             \
-        (void)where;                                                                                                   \
-        (void)dep_event_vec_ref;                                                                                       \
-                                                                                                                       \
-        DPCTLSyclEventRef event_ref = nullptr;                                                                         \
-                                                                                                                       \
-        if (!input1_size || !input2_size)                                                                              \
-        {                                                                                                              \
-            return event_ref;                                                                                          \
-        }                                                                                                              \
-                                                                                                                       \
-        sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));                                                      \
-                                                                                                                       \
-        _DataType_input1* input1_data = static_cast<_DataType_input1*>(const_cast<void*>(input1_in));                  \
-        _DataType_input2* input2_data = static_cast<_DataType_input2*>(const_cast<void*>(input2_in));                  \
-        _DataType_output* result = static_cast<_DataType_output*>(result_out);                                         \
-                                                                                                                       \
-        bool use_broadcasting = !array_equal(input1_shape, input1_ndim, input2_shape, input2_ndim);                    \
-                                                                                                                       \
-        shape_elem_type* input1_shape_offsets = new shape_elem_type[input1_ndim];                                      \
-                                                                                                                       \
-        get_shape_offsets_inkernel(input1_shape, input1_ndim, input1_shape_offsets);                                   \
-        bool use_strides = !array_equal(input1_strides, input1_ndim, input1_shape_offsets, input1_ndim);               \
-        delete[] input1_shape_offsets;                                                                                 \
-                                                                                                                       \
-        shape_elem_type* input2_shape_offsets = new shape_elem_type[input2_ndim];                                      \
-                                                                                                                       \
-        get_shape_offsets_inkernel(input2_shape, input2_ndim, input2_shape_offsets);                                   \
-        use_strides = use_strides || !array_equal(input2_strides, input2_ndim, input2_shape_offsets, input2_ndim);     \
-        delete[] input2_shape_offsets;                                                                                 \
-                                                                                                                       \
-        sycl::event event;                                                                                             \
-        sycl::range<1> gws(result_size);                                                                               \
-                                                                                                                       \
-        if (use_broadcasting)                                                                                          \
-        {                                                                                                              \
-            DPNPC_id<_DataType_input1>* input1_it;                                                                     \
-            const size_t input1_it_size_in_bytes = sizeof(DPNPC_id<_DataType_input1>);                                 \
-            input1_it =                                                                                                \
-                reinterpret_cast<DPNPC_id<_DataType_input1>*>(dpnp_memory_alloc_c(q_ref, input1_it_size_in_bytes));    \
-            new (input1_it) DPNPC_id<_DataType_input1>(q_ref, input1_data, input1_shape, input1_strides, input1_ndim); \
-                                                                                                                       \
-            input1_it->broadcast_to_shape(result_shape, result_ndim);                                                  \
-                                                                                                                       \
-            DPNPC_id<_DataType_input2>* input2_it;                                                                     \
-            const size_t input2_it_size_in_bytes = sizeof(DPNPC_id<_DataType_input2>);                                 \
-            input2_it =                                                                                                \
-                reinterpret_cast<DPNPC_id<_DataType_input2>*>(dpnp_memory_alloc_c(q_ref, input2_it_size_in_bytes));    \
-            new (input2_it) DPNPC_id<_DataType_input2>(q_ref, input2_data, input2_shape, input2_strides, input2_ndim); \
-                                                                                                                       \
-            input2_it->broadcast_to_shape(result_shape, result_ndim);                                                  \
-                                                                                                                       \
-            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {                                               \
-                const size_t i = global_id[0]; /* for (size_t i = 0; i < result_size; ++i) */                          \
-                {                                                                                                      \
-                    const _DataType_output input1_elem = (*input1_it)[i];                                              \
-                    const _DataType_output input2_elem = (*input2_it)[i];                                              \
-                    result[i] = __operation__;                                                                         \
-                }                                                                                                      \
-            };                                                                                                         \
-            auto kernel_func = [&](sycl::handler& cgh) {                                                               \
-                cgh.parallel_for<                                                                                      \
-                    class __name__##_broadcast_kernel<_DataType_output, _DataType_input1, _DataType_input2>>(          \
-                    gws, kernel_parallel_for_func);                                                                    \
-            };                                                                                                         \
-                                                                                                                       \
-            q.submit(kernel_func).wait();                                                                              \
-                                                                                                                       \
-            input1_it->~DPNPC_id();                                                                                    \
-            input2_it->~DPNPC_id();                                                                                    \
-                                                                                                                       \
-            return event_ref;                                                                                          \
-        }                                                                                                              \
-        else if (use_strides)                                                                                          \
-        {                                                                                                              \
-            if ((result_ndim != input1_ndim) || (result_ndim != input2_ndim))                                          \
-            {                                                                                                          \
-                throw std::runtime_error("Result ndim=" + std::to_string(result_ndim) +                                \
-                                         " mismatches with either input1 ndim=" + std::to_string(input1_ndim) +        \
-                                         " or input2 ndim=" + std::to_string(input2_ndim));                            \
-            }                                                                                                          \
-                                                                                                                       \
-            /* memory transfer optimization, use USM-host for temporary speeds up tranfer to device */                 \
-            using usm_host_allocatorT = sycl::usm_allocator<shape_elem_type, sycl::usm::alloc::host>;                  \
-                                                                                                                       \
-            size_t strides_size = 3 * result_ndim;                                                                     \
-            shape_elem_type* dev_strides_data = sycl::malloc_device<shape_elem_type>(strides_size, q);                 \
-                                                                                                                       \
-            /* create host temporary for packed strides managed by shared pointer */                                   \
-            auto strides_host_packed =                                                                                 \
-                std::vector<shape_elem_type, usm_host_allocatorT>(strides_size, usm_host_allocatorT(q));               \
-                                                                                                                       \
-            /* packed vector is concatenation of result_strides, input1_strides and input2_strides */                  \
-            std::copy(result_strides, result_strides + result_ndim, strides_host_packed.begin());                      \
-            std::copy(input1_strides, input1_strides + result_ndim, strides_host_packed.begin() + result_ndim);        \
-            std::copy(input2_strides, input2_strides + result_ndim, strides_host_packed.begin() + 2 * result_ndim);    \
-                                                                                                                       \
-            auto copy_strides_ev =                                                                                     \
-                q.copy<shape_elem_type>(strides_host_packed.data(), dev_strides_data, strides_host_packed.size());     \
-                                                                                                                       \
-            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {                                               \
-                const size_t output_id = global_id[0]; /* for (size_t i = 0; i < result_size; ++i) */                  \
-                {                                                                                                      \
-                    const shape_elem_type* result_strides_data = &dev_strides_data[0];                                 \
-                    const shape_elem_type* input1_strides_data = &dev_strides_data[result_ndim];                       \
-                    const shape_elem_type* input2_strides_data = &dev_strides_data[2 * result_ndim];                   \
-                                                                                                                       \
-                    size_t input1_id = 0;                                                                              \
-                    size_t input2_id = 0;                                                                              \
-                                                                                                                       \
-                    for (size_t i = 0; i < result_ndim; ++i)                                                           \
-                    {                                                                                                  \
-                        const size_t output_xyz_id =                                                                   \
-                            get_xyz_id_by_id_inkernel(output_id, result_strides_data, result_ndim, i);                 \
-                        input1_id += output_xyz_id * input1_strides_data[i];                                           \
-                        input2_id += output_xyz_id * input2_strides_data[i];                                           \
-                    }                                                                                                  \
-                                                                                                                       \
-                    const _DataType_output input1_elem = input1_data[input1_id];                                       \
-                    const _DataType_output input2_elem = input2_data[input2_id];                                       \
-                    result[output_id] = __operation__;                                                                 \
-                }                                                                                                      \
-            };                                                                                                         \
-            auto kernel_func = [&](sycl::handler& cgh) {                                                               \
-                cgh.depends_on(copy_strides_ev);                                                                       \
-                cgh.parallel_for<                                                                                      \
-                    class __name__##_strides_kernel<_DataType_output, _DataType_input1, _DataType_input2>>(            \
-                    gws, kernel_parallel_for_func);                                                                    \
-            };                                                                                                         \
-                                                                                                                       \
-            q.submit(kernel_func).wait();                                                                              \
-                                                                                                                       \
-            sycl::free(dev_strides_data, q);                                                                           \
-            return event_ref;                                                                                          \
-        }                                                                                                              \
-        else                                                                                                           \
-        {                                                                                                              \
-            if constexpr (both_types_are_same<_DataType_input1, _DataType_input2, __mkl_types__>)                      \
-            {                                                                                                          \
-                if (q.get_device().has(sycl::aspect::fp64))                                                            \
-                {                                                                                                      \
-                    event = __mkl_operation__(q, result_size, input1_data, input2_data, result);                       \
-                                                                                                                       \
-                    event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);                                           \
-                    return DPCTLEvent_Copy(event_ref);                                                                 \
-                }                                                                                                      \
-            }                                                                                                          \
-                                                                                                                       \
-            if constexpr (none_of_both_types<_DataType_input1,                                                         \
-                                             _DataType_input2,                                                         \
-                                             std::complex<float>,                                                      \
-                                             std::complex<double>>)                                                    \
-            {                                                                                                          \
-                constexpr size_t lws = 64;                                                                             \
-                constexpr unsigned int vec_sz = 8;                                                                     \
-                constexpr sycl::access::address_space global_space = sycl::access::address_space::global_space;        \
-                                                                                                                       \
-                auto gws_range = sycl::range<1>(((result_size + lws * vec_sz - 1) / (lws * vec_sz)) * lws);            \
-                auto lws_range = sycl::range<1>(lws);                                                                  \
-                                                                                                                       \
-                auto kernel_parallel_for_func = [=](sycl::nd_item<1> nd_it) {                                          \
-                    auto sg = nd_it.get_sub_group();                                                                   \
-                    const auto max_sg_size = sg.get_max_local_range()[0];                                              \
-                    const size_t start =                                                                               \
-                        vec_sz * (nd_it.get_group(0) * nd_it.get_local_range(0) + sg.get_group_id()[0] * max_sg_size); \
-                                                                                                                       \
-                    if (start + static_cast<size_t>(vec_sz) * max_sg_size < result_size)                               \
-                    {                                                                                                  \
-                        using input1_ptrT = sycl::multi_ptr<_DataType_input1, global_space>;                           \
-                        using input2_ptrT = sycl::multi_ptr<_DataType_input2, global_space>;                           \
-                        using result_ptrT = sycl::multi_ptr<_DataType_output, global_space>;                           \
-                                                                                                                       \
-                        sycl::vec<_DataType_output, vec_sz> res_vec;                                                   \
-                                                                                                                       \
-                        if constexpr (both_types_are_any_of<_DataType_input1, _DataType_input2, __vec_types__>)        \
-                        {                                                                                              \
-                            if constexpr (both_types_are_same<_DataType_input1, _DataType_input2, _DataType_output>)   \
-                            {                                                                                          \
-                                sycl::vec<_DataType_input1, vec_sz> x1 =                                               \
-                                    sg.load<vec_sz>(input1_ptrT(&input1_data[start]));                                 \
-                                sycl::vec<_DataType_input2, vec_sz> x2 =                                               \
-                                    sg.load<vec_sz>(input2_ptrT(&input2_data[start]));                                 \
-                                                                                                                       \
-                                res_vec = __vec_operation__;                                                           \
-                            }                                                                                          \
-                            else /* input types don't match result type, so explicit casting is required */            \
-                            {                                                                                          \
-                                sycl::vec<_DataType_output, vec_sz> x1 =                                               \
-                                    dpnp_vec_cast<_DataType_output, _DataType_input1, vec_sz>(                         \
-                                        sg.load<vec_sz>(input1_ptrT(&input1_data[start])));                            \
-                                sycl::vec<_DataType_output, vec_sz> x2 =                                               \
-                                    dpnp_vec_cast<_DataType_output, _DataType_input2, vec_sz>(                         \
-                                        sg.load<vec_sz>(input2_ptrT(&input2_data[start])));                            \
-                                                                                                                       \
-                                res_vec = __vec_operation__;                                                           \
-                            }                                                                                          \
-                        }                                                                                              \
-                        else                                                                                           \
-                        {                                                                                              \
-                            sycl::vec<_DataType_input1, vec_sz> x1 =                                                   \
-                                sg.load<vec_sz>(input1_ptrT(&input1_data[start]));                                     \
-                            sycl::vec<_DataType_input2, vec_sz> x2 =                                                   \
-                                sg.load<vec_sz>(input2_ptrT(&input2_data[start]));                                     \
-                                                                                                                       \
-                            for (size_t k = 0; k < vec_sz; ++k)                                                        \
-                            {                                                                                          \
-                                const _DataType_output input1_elem = x1[k];                                            \
-                                const _DataType_output input2_elem = x2[k];                                            \
-                                res_vec[k] = __operation__;                                                            \
-                            }                                                                                          \
-                        }                                                                                              \
-                        sg.store<vec_sz>(result_ptrT(&result[start]), res_vec);                                        \
-                    }                                                                                                  \
-                    else                                                                                               \
-                    {                                                                                                  \
-                        for (size_t k = start + sg.get_local_id()[0]; k < result_size; k += max_sg_size)               \
-                        {                                                                                              \
-                            const _DataType_output input1_elem = input1_data[k];                                       \
-                            const _DataType_output input2_elem = input2_data[k];                                       \
-                            result[k] = __operation__;                                                                 \
-                        }                                                                                              \
-                    }                                                                                                  \
-                };                                                                                                     \
-                                                                                                                       \
-                auto kernel_func = [&](sycl::handler& cgh) {                                                           \
-                    cgh.parallel_for<                                                                                  \
-                        class __name__##_sg_kernel<_DataType_output, _DataType_input1, _DataType_input2>>(             \
-                        sycl::nd_range<1>(gws_range, lws_range), kernel_parallel_for_func);                            \
-                };                                                                                                     \
-                event = q.submit(kernel_func);                                                                         \
-            }                                                                                                          \
-            else /* either input1 or input2 has complex type */                                                        \
-            {                                                                                                          \
-                auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {                                           \
-                    const size_t i = global_id[0]; /* for (size_t i = 0; i < result_size; ++i) */                      \
-                                                                                                                       \
-                    const _DataType_output input1_elem = input1_data[i];                                               \
-                    const _DataType_output input2_elem = input2_data[i];                                               \
-                    result[i] = __operation__;                                                                         \
-                };                                                                                                     \
-                auto kernel_func = [&](sycl::handler& cgh) {                                                           \
-                    cgh.parallel_for<class __name__##_kernel<_DataType_output, _DataType_input1, _DataType_input2>>(   \
-                        gws, kernel_parallel_for_func);                                                                \
-                };                                                                                                     \
-                event = q.submit(kernel_func);                                                                         \
-            }                                                                                                          \
-        }                                                                                                              \
-                                                                                                                       \
-        event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);                                                       \
-        return DPCTLEvent_Copy(event_ref);                                                                             \
-    }                                                                                                                  \
-                                                                                                                       \
-    template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>                         \
-    void __name__(void* result_out,                                                                                    \
-                  const size_t result_size,                                                                            \
-                  const size_t result_ndim,                                                                            \
-                  const shape_elem_type* result_shape,                                                                 \
-                  const shape_elem_type* result_strides,                                                               \
-                  const void* input1_in,                                                                               \
-                  const size_t input1_size,                                                                            \
-                  const size_t input1_ndim,                                                                            \
-                  const shape_elem_type* input1_shape,                                                                 \
-                  const shape_elem_type* input1_strides,                                                               \
-                  const void* input2_in,                                                                               \
-                  const size_t input2_size,                                                                            \
-                  const size_t input2_ndim,                                                                            \
-                  const shape_elem_type* input2_shape,                                                                 \
-                  const shape_elem_type* input2_strides,                                                               \
-                  const size_t* where)                                                                                 \
-    {                                                                                                                  \
-        DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);                                    \
-        DPCTLEventVectorRef dep_event_vec_ref = nullptr;                                                               \
-        DPCTLSyclEventRef event_ref =                                                                                  \
-            __name__<_DataType_output, _DataType_input1, _DataType_input2>(q_ref,                                      \
-                                                                           result_out,                                 \
-                                                                           result_size,                                \
-                                                                           result_ndim,                                \
-                                                                           result_shape,                               \
-                                                                           result_strides,                             \
-                                                                           input1_in,                                  \
-                                                                           input1_size,                                \
-                                                                           input1_ndim,                                \
-                                                                           input1_shape,                               \
-                                                                           input1_strides,                             \
-                                                                           input2_in,                                  \
-                                                                           input2_size,                                \
-                                                                           input2_ndim,                                \
-                                                                           input2_shape,                               \
-                                                                           input2_strides,                             \
-                                                                           where,                                      \
-                                                                           dep_event_vec_ref);                         \
-        DPCTLEvent_WaitAndThrow(event_ref);                                                                            \
-        DPCTLEvent_Delete(event_ref);                                                                                  \
-    }                                                                                                                  \
-                                                                                                                       \
-    template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>                         \
-    void (*__name__##_default)(void*,                                                                                  \
-                               const size_t,                                                                           \
-                               const size_t,                                                                           \
-                               const shape_elem_type*,                                                                 \
-                               const shape_elem_type*,                                                                 \
-                               const void*,                                                                            \
-                               const size_t,                                                                           \
-                               const size_t,                                                                           \
-                               const shape_elem_type*,                                                                 \
-                               const shape_elem_type*,                                                                 \
-                               const void*,                                                                            \
-                               const size_t,                                                                           \
-                               const size_t,                                                                           \
-                               const shape_elem_type*,                                                                 \
-                               const shape_elem_type*,                                                                 \
-                               const size_t*) = __name__<_DataType_output, _DataType_input1, _DataType_input2>;        \
-                                                                                                                       \
-    template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>                         \
-    DPCTLSyclEventRef (*__name__##_ext)(DPCTLSyclQueueRef,                                                             \
-                                        void*,                                                                         \
-                                        const size_t,                                                                  \
-                                        const size_t,                                                                  \
-                                        const shape_elem_type*,                                                        \
-                                        const shape_elem_type*,                                                        \
-                                        const void*,                                                                   \
-                                        const size_t,                                                                  \
-                                        const size_t,                                                                  \
-                                        const shape_elem_type*,                                                        \
-                                        const shape_elem_type*,                                                        \
-                                        const void*,                                                                   \
-                                        const size_t,                                                                  \
-                                        const size_t,                                                                  \
-                                        const shape_elem_type*,                                                        \
-                                        const shape_elem_type*,                                                        \
-                                        const size_t*,                                                                 \
-                                        const DPCTLEventVectorRef) =                                                   \
+#define MACRO_2ARG_3TYPES_OP(__name__, __operation__, __vec_operation__,       \
+                             __vec_types__, __mkl_operation__, __mkl_types__)  \
+    template <typename _KernelNameSpecialization1,                             \
+              typename _KernelNameSpecialization2,                             \
+              typename _KernelNameSpecialization3>                             \
+    class __name__##_kernel;                                                   \
+                                                                               \
+    template <typename _KernelNameSpecialization1,                             \
+              typename _KernelNameSpecialization2,                             \
+              typename _KernelNameSpecialization3>                             \
+    class __name__##_sg_kernel;                                                \
+                                                                               \
+    template <typename _KernelNameSpecialization1,                             \
+              typename _KernelNameSpecialization2,                             \
+              typename _KernelNameSpecialization3>                             \
+    class __name__##_broadcast_kernel;                                         \
+                                                                               \
+    template <typename _KernelNameSpecialization1,                             \
+              typename _KernelNameSpecialization2,                             \
+              typename _KernelNameSpecialization3>                             \
+    class __name__##_strides_kernel;                                           \
+                                                                               \
+    template <typename _DataType_output, typename _DataType_input1,            \
+              typename _DataType_input2>                                       \
+    DPCTLSyclEventRef __name__(                                                \
+        DPCTLSyclQueueRef q_ref, void *result_out, const size_t result_size,   \
+        const size_t result_ndim, const shape_elem_type *result_shape,         \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const void *input2_in,          \
+        const size_t input2_size, const size_t input2_ndim,                    \
+        const shape_elem_type *input2_shape,                                   \
+        const shape_elem_type *input2_strides, const size_t *where,            \
+        const DPCTLEventVectorRef dep_event_vec_ref)                           \
+    {                                                                          \
+        /* avoid warning unused variable*/                                     \
+        (void)where;                                                           \
+        (void)dep_event_vec_ref;                                               \
+                                                                               \
+        DPCTLSyclEventRef event_ref = nullptr;                                 \
+                                                                               \
+        if (!input1_size || !input2_size) {                                    \
+            return event_ref;                                                  \
+        }                                                                      \
+                                                                               \
+        sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));             \
+                                                                               \
+        _DataType_input1 *input1_data =                                        \
+            static_cast<_DataType_input1 *>(const_cast<void *>(input1_in));    \
+        _DataType_input2 *input2_data =                                        \
+            static_cast<_DataType_input2 *>(const_cast<void *>(input2_in));    \
+        _DataType_output *result =                                             \
+            static_cast<_DataType_output *>(result_out);                       \
+                                                                               \
+        bool use_broadcasting = !array_equal(input1_shape, input1_ndim,        \
+                                             input2_shape, input2_ndim);       \
+                                                                               \
+        shape_elem_type *input1_shape_offsets =                                \
+            new shape_elem_type[input1_ndim];                                  \
+                                                                               \
+        get_shape_offsets_inkernel(input1_shape, input1_ndim,                  \
+                                   input1_shape_offsets);                      \
+        bool use_strides = !array_equal(input1_strides, input1_ndim,           \
+                                        input1_shape_offsets, input1_ndim);    \
+        delete[] input1_shape_offsets;                                         \
+                                                                               \
+        shape_elem_type *input2_shape_offsets =                                \
+            new shape_elem_type[input2_ndim];                                  \
+                                                                               \
+        get_shape_offsets_inkernel(input2_shape, input2_ndim,                  \
+                                   input2_shape_offsets);                      \
+        use_strides =                                                          \
+            use_strides || !array_equal(input2_strides, input2_ndim,           \
+                                        input2_shape_offsets, input2_ndim);    \
+        delete[] input2_shape_offsets;                                         \
+                                                                               \
+        sycl::event event;                                                     \
+        sycl::range<1> gws(result_size);                                       \
+                                                                               \
+        if (use_broadcasting) {                                                \
+            DPNPC_id<_DataType_input1> *input1_it;                             \
+            const size_t input1_it_size_in_bytes =                             \
+                sizeof(DPNPC_id<_DataType_input1>);                            \
+            input1_it = reinterpret_cast<DPNPC_id<_DataType_input1> *>(        \
+                dpnp_memory_alloc_c(q_ref, input1_it_size_in_bytes));          \
+            new (input1_it)                                                    \
+                DPNPC_id<_DataType_input1>(q_ref, input1_data, input1_shape,   \
+                                           input1_strides, input1_ndim);       \
+                                                                               \
+            input1_it->broadcast_to_shape(result_shape, result_ndim);          \
+                                                                               \
+            DPNPC_id<_DataType_input2> *input2_it;                             \
+            const size_t input2_it_size_in_bytes =                             \
+                sizeof(DPNPC_id<_DataType_input2>);                            \
+            input2_it = reinterpret_cast<DPNPC_id<_DataType_input2> *>(        \
+                dpnp_memory_alloc_c(q_ref, input2_it_size_in_bytes));          \
+            new (input2_it)                                                    \
+                DPNPC_id<_DataType_input2>(q_ref, input2_data, input2_shape,   \
+                                           input2_strides, input2_ndim);       \
+                                                                               \
+            input2_it->broadcast_to_shape(result_shape, result_ndim);          \
+                                                                               \
+            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {       \
+                const size_t i = global_id[0]; /* for (size_t i = 0; i <       \
+                                                  result_size; ++i) */         \
+                {                                                              \
+                    const _DataType_output input1_elem = (*input1_it)[i];      \
+                    const _DataType_output input2_elem = (*input2_it)[i];      \
+                    result[i]                          = __operation__;        \
+                }                                                              \
+            };                                                                 \
+            auto kernel_func = [&](sycl::handler &cgh) {                       \
+                cgh.parallel_for<class __name__##_broadcast_kernel<            \
+                    _DataType_output, _DataType_input1, _DataType_input2>>(    \
+                    gws, kernel_parallel_for_func);                            \
+            };                                                                 \
+                                                                               \
+            q.submit(kernel_func).wait();                                      \
+                                                                               \
+            input1_it->~DPNPC_id();                                            \
+            input2_it->~DPNPC_id();                                            \
+                                                                               \
+            return event_ref;                                                  \
+        }                                                                      \
+        else if (use_strides) {                                                \
+            if ((result_ndim != input1_ndim) || (result_ndim != input2_ndim))  \
+            {                                                                  \
+                throw std::runtime_error(                                      \
+                    "Result ndim=" + std::to_string(result_ndim) +             \
+                    " mismatches with either input1 ndim=" +                   \
+                    std::to_string(input1_ndim) +                              \
+                    " or input2 ndim=" + std::to_string(input2_ndim));         \
+            }                                                                  \
+                                                                               \
+            /* memory transfer optimization, use USM-host for temporary speeds \
+             * up tranfer to device */                                         \
+            using usm_host_allocatorT =                                        \
+                sycl::usm_allocator<shape_elem_type, sycl::usm::alloc::host>;  \
+                                                                               \
+            size_t strides_size = 3 * result_ndim;                             \
+            shape_elem_type *dev_strides_data =                                \
+                sycl::malloc_device<shape_elem_type>(strides_size, q);         \
+                                                                               \
+            /* create host temporary for packed strides managed by shared      \
+             * pointer */                                                      \
+            auto strides_host_packed =                                         \
+                std::vector<shape_elem_type, usm_host_allocatorT>(             \
+                    strides_size, usm_host_allocatorT(q));                     \
+                                                                               \
+            /* packed vector is concatenation of result_strides,               \
+             * input1_strides and input2_strides */                            \
+            std::copy(result_strides, result_strides + result_ndim,            \
+                      strides_host_packed.begin());                            \
+            std::copy(input1_strides, input1_strides + result_ndim,            \
+                      strides_host_packed.begin() + result_ndim);              \
+            std::copy(input2_strides, input2_strides + result_ndim,            \
+                      strides_host_packed.begin() + 2 * result_ndim);          \
+                                                                               \
+            auto copy_strides_ev = q.copy<shape_elem_type>(                    \
+                strides_host_packed.data(), dev_strides_data,                  \
+                strides_host_packed.size());                                   \
+                                                                               \
+            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {       \
+                const size_t output_id =                                       \
+                    global_id[0]; /* for (size_t i = 0; i < result_size; ++i)  \
+                                   */                                          \
+                {                                                              \
+                    const shape_elem_type *result_strides_data =               \
+                        &dev_strides_data[0];                                  \
+                    const shape_elem_type *input1_strides_data =               \
+                        &dev_strides_data[result_ndim];                        \
+                    const shape_elem_type *input2_strides_data =               \
+                        &dev_strides_data[2 * result_ndim];                    \
+                                                                               \
+                    size_t input1_id = 0;                                      \
+                    size_t input2_id = 0;                                      \
+                                                                               \
+                    for (size_t i = 0; i < result_ndim; ++i) {                 \
+                        const size_t output_xyz_id =                           \
+                            get_xyz_id_by_id_inkernel(output_id,               \
+                                                      result_strides_data,     \
+                                                      result_ndim, i);         \
+                        input1_id += output_xyz_id * input1_strides_data[i];   \
+                        input2_id += output_xyz_id * input2_strides_data[i];   \
+                    }                                                          \
+                                                                               \
+                    const _DataType_output input1_elem =                       \
+                        input1_data[input1_id];                                \
+                    const _DataType_output input2_elem =                       \
+                        input2_data[input2_id];                                \
+                    result[output_id] = __operation__;                         \
+                }                                                              \
+            };                                                                 \
+            auto kernel_func = [&](sycl::handler &cgh) {                       \
+                cgh.depends_on(copy_strides_ev);                               \
+                cgh.parallel_for<class __name__##_strides_kernel<              \
+                    _DataType_output, _DataType_input1, _DataType_input2>>(    \
+                    gws, kernel_parallel_for_func);                            \
+            };                                                                 \
+                                                                               \
+            q.submit(kernel_func).wait();                                      \
+                                                                               \
+            sycl::free(dev_strides_data, q);                                   \
+            return event_ref;                                                  \
+        }                                                                      \
+        else {                                                                 \
+            if constexpr (both_types_are_same<_DataType_input1,                \
+                                              _DataType_input2,                \
+                                              __mkl_types__>)                  \
+            {                                                                  \
+                if (q.get_device().has(sycl::aspect::fp64)) {                  \
+                    event = __mkl_operation__(q, result_size, input1_data,     \
+                                              input2_data, result);            \
+                                                                               \
+                    event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);   \
+                    return DPCTLEvent_Copy(event_ref);                         \
+                }                                                              \
+            }                                                                  \
+                                                                               \
+            if constexpr (none_of_both_types<                                  \
+                              _DataType_input1, _DataType_input2,              \
+                              std::complex<float>, std::complex<double>>)      \
+            {                                                                  \
+                constexpr size_t lws          = 64;                            \
+                constexpr unsigned int vec_sz = 8;                             \
+                constexpr sycl::access::address_space global_space =           \
+                    sycl::access::address_space::global_space;                 \
+                                                                               \
+                auto gws_range = sycl::range<1>(                               \
+                    ((result_size + lws * vec_sz - 1) / (lws * vec_sz)) *      \
+                    lws);                                                      \
+                auto lws_range = sycl::range<1>(lws);                          \
+                                                                               \
+                auto kernel_parallel_for_func = [=](sycl::nd_item<1> nd_it) {  \
+                    auto sg                = nd_it.get_sub_group();            \
+                    const auto max_sg_size = sg.get_max_local_range()[0];      \
+                    const size_t start =                                       \
+                        vec_sz *                                               \
+                        (nd_it.get_group(0) * nd_it.get_local_range(0) +       \
+                         sg.get_group_id()[0] * max_sg_size);                  \
+                                                                               \
+                    if (start + static_cast<size_t>(vec_sz) * max_sg_size <    \
+                        result_size) {                                         \
+                        using input1_ptrT =                                    \
+                            sycl::multi_ptr<_DataType_input1, global_space>;   \
+                        using input2_ptrT =                                    \
+                            sycl::multi_ptr<_DataType_input2, global_space>;   \
+                        using result_ptrT =                                    \
+                            sycl::multi_ptr<_DataType_output, global_space>;   \
+                                                                               \
+                        sycl::vec<_DataType_output, vec_sz> res_vec;           \
+                                                                               \
+                        if constexpr (both_types_are_any_of<_DataType_input1,  \
+                                                            _DataType_input2,  \
+                                                            __vec_types__>)    \
+                        {                                                      \
+                            if constexpr (both_types_are_same<                 \
+                                              _DataType_input1,                \
+                                              _DataType_input2,                \
+                                              _DataType_output>)               \
+                            {                                                  \
+                                sycl::vec<_DataType_input1, vec_sz> x1 =       \
+                                    sg.load<vec_sz>(                           \
+                                        input1_ptrT(&input1_data[start]));     \
+                                sycl::vec<_DataType_input2, vec_sz> x2 =       \
+                                    sg.load<vec_sz>(                           \
+                                        input2_ptrT(&input2_data[start]));     \
+                                                                               \
+                                res_vec = __vec_operation__;                   \
+                            }                                                  \
+                            else /* input types don't match result type, so    \
+                                    explicit casting is required */            \
+                            {                                                  \
+                                sycl::vec<_DataType_output, vec_sz> x1 =       \
+                                    dpnp_vec_cast<_DataType_output,            \
+                                                  _DataType_input1, vec_sz>(   \
+                                        sg.load<vec_sz>(input1_ptrT(           \
+                                            &input1_data[start])));            \
+                                sycl::vec<_DataType_output, vec_sz> x2 =       \
+                                    dpnp_vec_cast<_DataType_output,            \
+                                                  _DataType_input2, vec_sz>(   \
+                                        sg.load<vec_sz>(input2_ptrT(           \
+                                            &input2_data[start])));            \
+                                                                               \
+                                res_vec = __vec_operation__;                   \
+                            }                                                  \
+                        }                                                      \
+                        else {                                                 \
+                            sycl::vec<_DataType_input1, vec_sz> x1 =           \
+                                sg.load<vec_sz>(                               \
+                                    input1_ptrT(&input1_data[start]));         \
+                            sycl::vec<_DataType_input2, vec_sz> x2 =           \
+                                sg.load<vec_sz>(                               \
+                                    input2_ptrT(&input2_data[start]));         \
+                                                                               \
+                            for (size_t k = 0; k < vec_sz; ++k) {              \
+                                const _DataType_output input1_elem = x1[k];    \
+                                const _DataType_output input2_elem = x2[k];    \
+                                res_vec[k] = __operation__;                    \
+                            }                                                  \
+                        }                                                      \
+                        sg.store<vec_sz>(result_ptrT(&result[start]),          \
+                                         res_vec);                             \
+                    }                                                          \
+                    else {                                                     \
+                        for (size_t k = start + sg.get_local_id()[0];          \
+                             k < result_size; k += max_sg_size) {              \
+                            const _DataType_output input1_elem =               \
+                                input1_data[k];                                \
+                            const _DataType_output input2_elem =               \
+                                input2_data[k];                                \
+                            result[k] = __operation__;                         \
+                        }                                                      \
+                    }                                                          \
+                };                                                             \
+                                                                               \
+                auto kernel_func = [&](sycl::handler &cgh) {                   \
+                    cgh.parallel_for<class __name__##_sg_kernel<               \
+                        _DataType_output, _DataType_input1,                    \
+                        _DataType_input2>>(                                    \
+                        sycl::nd_range<1>(gws_range, lws_range),               \
+                        kernel_parallel_for_func);                             \
+                };                                                             \
+                event = q.submit(kernel_func);                                 \
+            }                                                                  \
+            else /* either input1 or input2 has complex type */ {              \
+                auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {   \
+                    const size_t i = global_id[0]; /* for (size_t i = 0; i <   \
+                                                      result_size; ++i) */     \
+                                                                               \
+                    const _DataType_output input1_elem = input1_data[i];       \
+                    const _DataType_output input2_elem = input2_data[i];       \
+                    result[i]                          = __operation__;        \
+                };                                                             \
+                auto kernel_func = [&](sycl::handler &cgh) {                   \
+                    cgh.parallel_for<class __name__##_kernel<                  \
+                        _DataType_output, _DataType_input1,                    \
+                        _DataType_input2>>(gws, kernel_parallel_for_func);     \
+                };                                                             \
+                event = q.submit(kernel_func);                                 \
+            }                                                                  \
+        }                                                                      \
+                                                                               \
+        event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);               \
+        return DPCTLEvent_Copy(event_ref);                                     \
+    }                                                                          \
+                                                                               \
+    template <typename _DataType_output, typename _DataType_input1,            \
+              typename _DataType_input2>                                       \
+    void __name__(                                                             \
+        void *result_out, const size_t result_size, const size_t result_ndim,  \
+        const shape_elem_type *result_shape,                                   \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const void *input2_in,          \
+        const size_t input2_size, const size_t input2_ndim,                    \
+        const shape_elem_type *input2_shape,                                   \
+        const shape_elem_type *input2_strides, const size_t *where)            \
+    {                                                                          \
+        DPCTLSyclQueueRef q_ref =                                              \
+            reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);                  \
+        DPCTLEventVectorRef dep_event_vec_ref = nullptr;                       \
+        DPCTLSyclEventRef event_ref =                                          \
+            __name__<_DataType_output, _DataType_input1, _DataType_input2>(    \
+                q_ref, result_out, result_size, result_ndim, result_shape,     \
+                result_strides, input1_in, input1_size, input1_ndim,           \
+                input1_shape, input1_strides, input2_in, input2_size,          \
+                input2_ndim, input2_shape, input2_strides, where,              \
+                dep_event_vec_ref);                                            \
+        DPCTLEvent_WaitAndThrow(event_ref);                                    \
+        DPCTLEvent_Delete(event_ref);                                          \
+    }                                                                          \
+                                                                               \
+    template <typename _DataType_output, typename _DataType_input1,            \
+              typename _DataType_input2>                                       \
+    void (*__name__##_default)(                                                \
+        void *, const size_t, const size_t, const shape_elem_type *,           \
+        const shape_elem_type *, const void *, const size_t, const size_t,     \
+        const shape_elem_type *, const shape_elem_type *, const void *,        \
+        const size_t, const size_t, const shape_elem_type *,                   \
+        const shape_elem_type *, const size_t *) =                             \
+        __name__<_DataType_output, _DataType_input1, _DataType_input2>;        \
+                                                                               \
+    template <typename _DataType_output, typename _DataType_input1,            \
+              typename _DataType_input2>                                       \
+    DPCTLSyclEventRef (*__name__##_ext)(                                       \
+        DPCTLSyclQueueRef, void *, const size_t, const size_t,                 \
+        const shape_elem_type *, const shape_elem_type *, const void *,        \
+        const size_t, const size_t, const shape_elem_type *,                   \
+        const shape_elem_type *, const void *, const size_t, const size_t,     \
+        const shape_elem_type *, const shape_elem_type *, const size_t *,      \
+        const DPCTLEventVectorRef) =                                           \
         __name__<_DataType_output, _DataType_input1, _DataType_input2>;
 
 #include <dpnp_gen_2arg_3type_tbl.hpp>
 
-template <DPNPFuncType FT1, DPNPFuncType FT2, typename has_fp64 = std::true_type>
+template <DPNPFuncType FT1,
+          DPNPFuncType FT2,
+          typename has_fp64 = std::true_type>
 static constexpr DPNPFuncType get_divide_res_type()
 {
-    constexpr auto widest_type = populate_func_types<FT1, FT2>();
+    constexpr auto widest_type  = populate_func_types<FT1, FT2>();
     constexpr auto shortes_type = (widest_type == FT1) ? FT2 : FT1;
 
-    if constexpr (widest_type == DPNPFuncType::DPNP_FT_CMPLX128 || widest_type == DPNPFuncType::DPNP_FT_DOUBLE)
+    if constexpr (widest_type == DPNPFuncType::DPNP_FT_CMPLX128 ||
+                  widest_type == DPNPFuncType::DPNP_FT_DOUBLE)
     {
         return widest_type;
     }
-    else if constexpr (widest_type == DPNPFuncType::DPNP_FT_CMPLX64)
-    {
-        if constexpr (shortes_type == DPNPFuncType::DPNP_FT_DOUBLE)
-        {
+    else if constexpr (widest_type == DPNPFuncType::DPNP_FT_CMPLX64) {
+        if constexpr (shortes_type == DPNPFuncType::DPNP_FT_DOUBLE) {
             return DPNPFuncType::DPNP_FT_CMPLX128;
         }
         else if constexpr (has_fp64::value &&
-                           (shortes_type == DPNPFuncType::DPNP_FT_INT || shortes_type == DPNPFuncType::DPNP_FT_LONG))
+                           (shortes_type == DPNPFuncType::DPNP_FT_INT ||
+                            shortes_type == DPNPFuncType::DPNP_FT_LONG))
         {
             return DPNPFuncType::DPNP_FT_CMPLX128;
         }
     }
-    else if constexpr (widest_type == DPNPFuncType::DPNP_FT_FLOAT)
-    {
+    else if constexpr (widest_type == DPNPFuncType::DPNP_FT_FLOAT) {
         if constexpr (has_fp64::value &&
-                      (shortes_type == DPNPFuncType::DPNP_FT_INT || shortes_type == DPNPFuncType::DPNP_FT_LONG))
+                      (shortes_type == DPNPFuncType::DPNP_FT_INT ||
+                       shortes_type == DPNPFuncType::DPNP_FT_LONG))
         {
             return DPNPFuncType::DPNP_FT_DOUBLE;
         }
     }
-    else if constexpr (has_fp64::value)
-    {
+    else if constexpr (has_fp64::value) {
         return DPNPFuncType::DPNP_FT_DOUBLE;
     }
-    else
-    {
+    else {
         return DPNPFuncType::DPNP_FT_FLOAT;
     }
     return widest_type;
 }
 
 template <DPNPFuncType FT1, DPNPFuncType... FTs>
-static void func_map_elemwise_2arg_3type_core(func_map_t& fmap)
+static void func_map_elemwise_2arg_3type_core(func_map_t &fmap)
 {
     ((fmap[DPNPFuncName::DPNP_FN_ADD_EXT][FT1][FTs] =
           {populate_func_types<FT1, FTs>(),
-           (void*)dpnp_add_c_ext<func_type_map_t::find_type<populate_func_types<FT1, FTs>()>,
-                                 func_type_map_t::find_type<FT1>,
-                                 func_type_map_t::find_type<FTs>>}),
+           (void *)dpnp_add_c_ext<
+               func_type_map_t::find_type<populate_func_types<FT1, FTs>()>,
+               func_type_map_t::find_type<FT1>,
+               func_type_map_t::find_type<FTs>>}),
      ...);
     ((fmap[DPNPFuncName::DPNP_FN_DIVIDE_EXT][FT1][FTs] =
           {get_divide_res_type<FT1, FTs>(),
-           (void*)dpnp_divide_c_ext<func_type_map_t::find_type<get_divide_res_type<FT1, FTs>()>,
-                                    func_type_map_t::find_type<FT1>,
-                                    func_type_map_t::find_type<FTs>>,
+           (void *)dpnp_divide_c_ext<
+               func_type_map_t::find_type<get_divide_res_type<FT1, FTs>()>,
+               func_type_map_t::find_type<FT1>,
+               func_type_map_t::find_type<FTs>>,
            get_divide_res_type<FT1, FTs, std::false_type>(),
-           (void*)dpnp_divide_c_ext<func_type_map_t::find_type<get_divide_res_type<FT1, FTs, std::false_type>()>,
-                                    func_type_map_t::find_type<FT1>,
-                                    func_type_map_t::find_type<FTs>>}),
+           (void *)
+               dpnp_divide_c_ext<func_type_map_t::find_type<get_divide_res_type<
+                                     FT1, FTs, std::false_type>()>,
+                                 func_type_map_t::find_type<FT1>,
+                                 func_type_map_t::find_type<FTs>>}),
      ...);
     ((fmap[DPNPFuncName::DPNP_FN_MULTIPLY_EXT][FT1][FTs] =
           {populate_func_types<FT1, FTs>(),
-           (void*)dpnp_multiply_c_ext<func_type_map_t::find_type<populate_func_types<FT1, FTs>()>,
-                                      func_type_map_t::find_type<FT1>,
-                                      func_type_map_t::find_type<FTs>>}),
+           (void *)dpnp_multiply_c_ext<
+               func_type_map_t::find_type<populate_func_types<FT1, FTs>()>,
+               func_type_map_t::find_type<FT1>,
+               func_type_map_t::find_type<FTs>>}),
      ...);
     ((fmap[DPNPFuncName::DPNP_FN_POWER_EXT][FT1][FTs] =
           {populate_func_types<FT1, FTs>(),
-           (void*)dpnp_power_c_ext<func_type_map_t::find_type<populate_func_types<FT1, FTs>()>,
-                                   func_type_map_t::find_type<FT1>,
-                                   func_type_map_t::find_type<FTs>>}),
+           (void *)dpnp_power_c_ext<
+               func_type_map_t::find_type<populate_func_types<FT1, FTs>()>,
+               func_type_map_t::find_type<FT1>,
+               func_type_map_t::find_type<FTs>>}),
      ...);
     ((fmap[DPNPFuncName::DPNP_FN_SUBTRACT_EXT][FT1][FTs] =
           {populate_func_types<FT1, FTs>(),
-           (void*)dpnp_subtract_c_ext<func_type_map_t::find_type<populate_func_types<FT1, FTs>()>,
-                                      func_type_map_t::find_type<FT1>,
-                                      func_type_map_t::find_type<FTs>>}),
+           (void *)dpnp_subtract_c_ext<
+               func_type_map_t::find_type<populate_func_types<FT1, FTs>()>,
+               func_type_map_t::find_type<FT1>,
+               func_type_map_t::find_type<FTs>>}),
      ...);
 }
 
 template <DPNPFuncType... FTs>
-static void func_map_elemwise_2arg_3type_helper(func_map_t& fmap)
+static void func_map_elemwise_2arg_3type_helper(func_map_t &fmap)
 {
     ((func_map_elemwise_2arg_3type_core<FTs, FTs...>(fmap)), ...);
 }
 
-static void func_map_init_elemwise_2arg_3type(func_map_t& fmap)
+static void func_map_init_elemwise_2arg_3type(func_map_t &fmap)
 {
-    fmap[DPNPFuncName::DPNP_FN_ADD][eft_INT][eft_INT] = {eft_INT,
-                                                         (void*)dpnp_add_c_default<int32_t, int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ADD][eft_INT][eft_LNG] = {eft_LNG,
-                                                         (void*)dpnp_add_c_default<int64_t, int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ADD][eft_INT][eft_FLT] = {eft_DBL,
-                                                         (void*)dpnp_add_c_default<double, int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_ADD][eft_INT][eft_DBL] = {eft_DBL,
-                                                         (void*)dpnp_add_c_default<double, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ADD][eft_LNG][eft_INT] = {eft_LNG,
-                                                         (void*)dpnp_add_c_default<int64_t, int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ADD][eft_LNG][eft_LNG] = {eft_LNG,
-                                                         (void*)dpnp_add_c_default<int64_t, int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ADD][eft_LNG][eft_FLT] = {eft_DBL,
-                                                         (void*)dpnp_add_c_default<double, int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_ADD][eft_LNG][eft_DBL] = {eft_DBL,
-                                                         (void*)dpnp_add_c_default<double, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ADD][eft_FLT][eft_INT] = {eft_DBL,
-                                                         (void*)dpnp_add_c_default<double, float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ADD][eft_FLT][eft_LNG] = {eft_DBL,
-                                                         (void*)dpnp_add_c_default<double, float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ADD][eft_FLT][eft_FLT] = {eft_FLT,
-                                                         (void*)dpnp_add_c_default<float, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_ADD][eft_FLT][eft_DBL] = {eft_DBL,
-                                                         (void*)dpnp_add_c_default<double, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_ADD][eft_DBL][eft_INT] = {eft_DBL,
-                                                         (void*)dpnp_add_c_default<double, double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ADD][eft_DBL][eft_LNG] = {eft_DBL,
-                                                         (void*)dpnp_add_c_default<double, double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ADD][eft_DBL][eft_FLT] = {eft_DBL,
-                                                         (void*)dpnp_add_c_default<double, double, float>};
-    fmap[DPNPFuncName::DPNP_FN_ADD][eft_DBL][eft_DBL] = {eft_DBL,
-                                                         (void*)dpnp_add_c_default<double, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_ADD][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_add_c_default<int32_t, int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ADD][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_add_c_default<int64_t, int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ADD][eft_INT][eft_FLT] = {
+        eft_DBL, (void *)dpnp_add_c_default<double, int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_ADD][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_add_c_default<double, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ADD][eft_LNG][eft_INT] = {
+        eft_LNG, (void *)dpnp_add_c_default<int64_t, int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ADD][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_add_c_default<int64_t, int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ADD][eft_LNG][eft_FLT] = {
+        eft_DBL, (void *)dpnp_add_c_default<double, int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_ADD][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_add_c_default<double, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ADD][eft_FLT][eft_INT] = {
+        eft_DBL, (void *)dpnp_add_c_default<double, float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ADD][eft_FLT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_add_c_default<double, float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ADD][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_add_c_default<float, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_ADD][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_add_c_default<double, float, double>};
+    fmap[DPNPFuncName::DPNP_FN_ADD][eft_DBL][eft_INT] = {
+        eft_DBL, (void *)dpnp_add_c_default<double, double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ADD][eft_DBL][eft_LNG] = {
+        eft_DBL, (void *)dpnp_add_c_default<double, double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ADD][eft_DBL][eft_FLT] = {
+        eft_DBL, (void *)dpnp_add_c_default<double, double, float>};
+    fmap[DPNPFuncName::DPNP_FN_ADD][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_add_c_default<double, double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_INT][eft_INT] = {eft_DBL,
-                                                             (void*)dpnp_arctan2_c_default<double, int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_INT][eft_LNG] = {eft_DBL,
-                                                             (void*)dpnp_arctan2_c_default<double, int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_INT][eft_FLT] = {eft_DBL,
-                                                             (void*)dpnp_arctan2_c_default<double, int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_INT][eft_DBL] = {eft_DBL,
-                                                             (void*)dpnp_arctan2_c_default<double, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_LNG][eft_INT] = {eft_DBL,
-                                                             (void*)dpnp_arctan2_c_default<double, int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_LNG][eft_LNG] = {eft_DBL,
-                                                             (void*)dpnp_arctan2_c_default<double, int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_LNG][eft_FLT] = {eft_DBL,
-                                                             (void*)dpnp_arctan2_c_default<double, int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_LNG][eft_DBL] = {eft_DBL,
-                                                             (void*)dpnp_arctan2_c_default<double, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_FLT][eft_INT] = {eft_DBL,
-                                                             (void*)dpnp_arctan2_c_default<double, float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_FLT][eft_LNG] = {eft_DBL,
-                                                             (void*)dpnp_arctan2_c_default<double, float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_FLT][eft_FLT] = {eft_FLT,
-                                                             (void*)dpnp_arctan2_c_default<float, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_FLT][eft_DBL] = {eft_DBL,
-                                                             (void*)dpnp_arctan2_c_default<double, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_DBL][eft_INT] = {eft_DBL,
-                                                             (void*)dpnp_arctan2_c_default<double, double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_DBL][eft_LNG] = {eft_DBL,
-                                                             (void*)dpnp_arctan2_c_default<double, double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_DBL][eft_FLT] = {eft_DBL,
-                                                             (void*)dpnp_arctan2_c_default<double, double, float>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_DBL][eft_DBL] = {eft_DBL,
-                                                             (void*)dpnp_arctan2_c_default<double, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_arctan2_c_default<double, int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_INT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_arctan2_c_default<double, int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_INT][eft_FLT] = {
+        eft_DBL, (void *)dpnp_arctan2_c_default<double, int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_arctan2_c_default<double, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_LNG][eft_INT] = {
+        eft_DBL, (void *)dpnp_arctan2_c_default<double, int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_arctan2_c_default<double, int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_LNG][eft_FLT] = {
+        eft_DBL, (void *)dpnp_arctan2_c_default<double, int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_arctan2_c_default<double, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_FLT][eft_INT] = {
+        eft_DBL, (void *)dpnp_arctan2_c_default<double, float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_FLT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_arctan2_c_default<double, float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_arctan2_c_default<float, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_arctan2_c_default<double, float, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_DBL][eft_INT] = {
+        eft_DBL, (void *)dpnp_arctan2_c_default<double, double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_DBL][eft_LNG] = {
+        eft_DBL, (void *)dpnp_arctan2_c_default<double, double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_DBL][eft_FLT] = {
+        eft_DBL, (void *)dpnp_arctan2_c_default<double, double, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_arctan2_c_default<double, double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_INT][eft_INT] = {eft_DBL,
-                                                                 (void*)dpnp_arctan2_c_ext<double, int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_INT][eft_LNG] = {eft_DBL,
-                                                                 (void*)dpnp_arctan2_c_ext<double, int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_INT][eft_FLT] = {eft_DBL,
-                                                                 (void*)dpnp_arctan2_c_ext<double, int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_INT][eft_DBL] = {eft_DBL,
-                                                                 (void*)dpnp_arctan2_c_ext<double, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_LNG][eft_INT] = {eft_DBL,
-                                                                 (void*)dpnp_arctan2_c_ext<double, int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_LNG][eft_LNG] = {eft_DBL,
-                                                                 (void*)dpnp_arctan2_c_ext<double, int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_LNG][eft_FLT] = {eft_DBL,
-                                                                 (void*)dpnp_arctan2_c_ext<double, int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_LNG][eft_DBL] = {eft_DBL,
-                                                                 (void*)dpnp_arctan2_c_ext<double, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_FLT][eft_INT] = {eft_DBL,
-                                                                 (void*)dpnp_arctan2_c_ext<double, float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_FLT][eft_LNG] = {eft_DBL,
-                                                                 (void*)dpnp_arctan2_c_ext<double, float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_FLT][eft_FLT] = {eft_FLT,
-                                                                 (void*)dpnp_arctan2_c_ext<float, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_FLT][eft_DBL] = {eft_DBL,
-                                                                 (void*)dpnp_arctan2_c_ext<double, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_DBL][eft_INT] = {eft_DBL,
-                                                                 (void*)dpnp_arctan2_c_ext<double, double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_DBL][eft_LNG] = {eft_DBL,
-                                                                 (void*)dpnp_arctan2_c_ext<double, double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_DBL][eft_FLT] = {eft_DBL,
-                                                                 (void*)dpnp_arctan2_c_ext<double, double, float>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_DBL][eft_DBL] = {eft_DBL,
-                                                                 (void*)dpnp_arctan2_c_ext<double, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_arctan2_c_ext<double, int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_INT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_arctan2_c_ext<double, int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_INT][eft_FLT] = {
+        eft_DBL, (void *)dpnp_arctan2_c_ext<double, int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_arctan2_c_ext<double, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_LNG][eft_INT] = {
+        eft_DBL, (void *)dpnp_arctan2_c_ext<double, int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_arctan2_c_ext<double, int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_LNG][eft_FLT] = {
+        eft_DBL, (void *)dpnp_arctan2_c_ext<double, int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_arctan2_c_ext<double, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_FLT][eft_INT] = {
+        eft_DBL, (void *)dpnp_arctan2_c_ext<double, float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_FLT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_arctan2_c_ext<double, float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_arctan2_c_ext<float, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_arctan2_c_ext<double, float, double>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_DBL][eft_INT] = {
+        eft_DBL, (void *)dpnp_arctan2_c_ext<double, double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_DBL][eft_LNG] = {
+        eft_DBL, (void *)dpnp_arctan2_c_ext<double, double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_DBL][eft_FLT] = {
+        eft_DBL, (void *)dpnp_arctan2_c_ext<double, double, float>};
+    fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_arctan2_c_ext<double, double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN][eft_INT][eft_INT] = {
-        eft_DBL, (void*)dpnp_copysign_c_default<double, int32_t, int32_t>};
+        eft_DBL, (void *)dpnp_copysign_c_default<double, int32_t, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN][eft_INT][eft_LNG] = {
-        eft_DBL, (void*)dpnp_copysign_c_default<double, int32_t, int64_t>};
+        eft_DBL, (void *)dpnp_copysign_c_default<double, int32_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN][eft_INT][eft_FLT] = {
-        eft_DBL, (void*)dpnp_copysign_c_default<double, int32_t, float>};
+        eft_DBL, (void *)dpnp_copysign_c_default<double, int32_t, float>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN][eft_INT][eft_DBL] = {
-        eft_DBL, (void*)dpnp_copysign_c_default<double, int32_t, double>};
+        eft_DBL, (void *)dpnp_copysign_c_default<double, int32_t, double>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN][eft_LNG][eft_INT] = {
-        eft_DBL, (void*)dpnp_copysign_c_default<double, int64_t, int32_t>};
+        eft_DBL, (void *)dpnp_copysign_c_default<double, int64_t, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN][eft_LNG][eft_LNG] = {
-        eft_DBL, (void*)dpnp_copysign_c_default<double, int64_t, int64_t>};
+        eft_DBL, (void *)dpnp_copysign_c_default<double, int64_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN][eft_LNG][eft_FLT] = {
-        eft_DBL, (void*)dpnp_copysign_c_default<double, int64_t, float>};
+        eft_DBL, (void *)dpnp_copysign_c_default<double, int64_t, float>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN][eft_LNG][eft_DBL] = {
-        eft_DBL, (void*)dpnp_copysign_c_default<double, int64_t, double>};
+        eft_DBL, (void *)dpnp_copysign_c_default<double, int64_t, double>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN][eft_FLT][eft_INT] = {
-        eft_DBL, (void*)dpnp_copysign_c_default<double, float, int32_t>};
+        eft_DBL, (void *)dpnp_copysign_c_default<double, float, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN][eft_FLT][eft_LNG] = {
-        eft_DBL,  (void*)dpnp_copysign_c_default<double, float, int64_t>};
+        eft_DBL, (void *)dpnp_copysign_c_default<double, float, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN][eft_FLT][eft_FLT] = {
-        eft_FLT, (void*)dpnp_copysign_c_default<float, float, float>};
+        eft_FLT, (void *)dpnp_copysign_c_default<float, float, float>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN][eft_FLT][eft_DBL] = {
-        eft_DBL, (void*)dpnp_copysign_c_default<double, float, double>};
+        eft_DBL, (void *)dpnp_copysign_c_default<double, float, double>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN][eft_DBL][eft_INT] = {
-        eft_DBL, (void*)dpnp_copysign_c_default<double, double, int32_t>};
+        eft_DBL, (void *)dpnp_copysign_c_default<double, double, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN][eft_DBL][eft_LNG] = {
-        eft_DBL, (void*)dpnp_copysign_c_default<double, double, int64_t>};
+        eft_DBL, (void *)dpnp_copysign_c_default<double, double, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN][eft_DBL][eft_FLT] = {
-        eft_DBL, (void*)dpnp_copysign_c_default<double, double, float>};
+        eft_DBL, (void *)dpnp_copysign_c_default<double, double, float>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN][eft_DBL][eft_DBL] = {
-        eft_DBL, (void*)dpnp_copysign_c_default<double, double, double>};
+        eft_DBL, (void *)dpnp_copysign_c_default<double, double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN_EXT][eft_INT][eft_INT] = {
-        eft_DBL, (void*)dpnp_copysign_c_ext<double, int32_t, int32_t>};
+        eft_DBL, (void *)dpnp_copysign_c_ext<double, int32_t, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN_EXT][eft_INT][eft_LNG] = {
-        eft_DBL, (void*)dpnp_copysign_c_ext<double, int32_t, int64_t>};
+        eft_DBL, (void *)dpnp_copysign_c_ext<double, int32_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN_EXT][eft_INT][eft_FLT] = {
-        eft_DBL, (void*)dpnp_copysign_c_ext<double, int32_t, float>};
+        eft_DBL, (void *)dpnp_copysign_c_ext<double, int32_t, float>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN_EXT][eft_INT][eft_DBL] = {
-        eft_DBL, (void*)dpnp_copysign_c_ext<double, int32_t, double>};
+        eft_DBL, (void *)dpnp_copysign_c_ext<double, int32_t, double>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN_EXT][eft_LNG][eft_INT] = {
-        eft_DBL, (void*)dpnp_copysign_c_ext<double, int64_t, int32_t>};
+        eft_DBL, (void *)dpnp_copysign_c_ext<double, int64_t, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN_EXT][eft_LNG][eft_LNG] = {
-        eft_DBL, (void*)dpnp_copysign_c_ext<double, int64_t, int64_t>};
+        eft_DBL, (void *)dpnp_copysign_c_ext<double, int64_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN_EXT][eft_LNG][eft_FLT] = {
-        eft_DBL, (void*)dpnp_copysign_c_ext<double, int64_t, float>};
+        eft_DBL, (void *)dpnp_copysign_c_ext<double, int64_t, float>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN_EXT][eft_LNG][eft_DBL] = {
-        eft_DBL, (void*)dpnp_copysign_c_ext<double, int64_t, double>};
+        eft_DBL, (void *)dpnp_copysign_c_ext<double, int64_t, double>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN_EXT][eft_FLT][eft_INT] = {
-        eft_DBL, (void*)dpnp_copysign_c_ext<double, float, int32_t>};
+        eft_DBL, (void *)dpnp_copysign_c_ext<double, float, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN_EXT][eft_FLT][eft_LNG] = {
-        eft_DBL,  (void*)dpnp_copysign_c_ext<double, float, int64_t>};
+        eft_DBL, (void *)dpnp_copysign_c_ext<double, float, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN_EXT][eft_FLT][eft_FLT] = {
-        eft_FLT, (void*)dpnp_copysign_c_ext<float, float, float>};
+        eft_FLT, (void *)dpnp_copysign_c_ext<float, float, float>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN_EXT][eft_FLT][eft_DBL] = {
-        eft_DBL, (void*)dpnp_copysign_c_ext<double, float, double>};
+        eft_DBL, (void *)dpnp_copysign_c_ext<double, float, double>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN_EXT][eft_DBL][eft_INT] = {
-        eft_DBL, (void*)dpnp_copysign_c_ext<double, double, int32_t>};
+        eft_DBL, (void *)dpnp_copysign_c_ext<double, double, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN_EXT][eft_DBL][eft_LNG] = {
-        eft_DBL, (void*)dpnp_copysign_c_ext<double, double, int64_t>};
+        eft_DBL, (void *)dpnp_copysign_c_ext<double, double, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN_EXT][eft_DBL][eft_FLT] = {
-        eft_DBL, (void*)dpnp_copysign_c_ext<double, double, float>};
+        eft_DBL, (void *)dpnp_copysign_c_ext<double, double, float>};
     fmap[DPNPFuncName::DPNP_FN_COPYSIGN_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void*)dpnp_copysign_c_ext<double, double, double>};
+        eft_DBL, (void *)dpnp_copysign_c_ext<double, double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_INT][eft_INT] = {eft_DBL,
-                                                            (void*)dpnp_divide_c_default<double, int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_INT][eft_LNG] = {eft_DBL,
-                                                            (void*)dpnp_divide_c_default<double, int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_INT][eft_FLT] = {eft_DBL,
-                                                            (void*)dpnp_divide_c_default<double, int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_INT][eft_DBL] = {eft_DBL,
-                                                            (void*)dpnp_divide_c_default<double, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_LNG][eft_INT] = {eft_DBL,
-                                                            (void*)dpnp_divide_c_default<double, int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_LNG][eft_LNG] = {eft_DBL,
-                                                            (void*)dpnp_divide_c_default<double, int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_LNG][eft_FLT] = {eft_DBL,
-                                                            (void*)dpnp_divide_c_default<double, int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_LNG][eft_DBL] = {eft_DBL,
-                                                            (void*)dpnp_divide_c_default<double, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_FLT][eft_INT] = {eft_DBL,
-                                                            (void*)dpnp_divide_c_default<double, float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_FLT][eft_LNG] = {eft_DBL,
-                                                            (void*)dpnp_divide_c_default<double, float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_FLT][eft_FLT] = {eft_FLT,
-                                                            (void*)dpnp_divide_c_default<float, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_FLT][eft_DBL] = {eft_DBL,
-                                                            (void*)dpnp_divide_c_default<double, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_DBL][eft_INT] = {eft_DBL,
-                                                            (void*)dpnp_divide_c_default<double, double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_DBL][eft_LNG] = {eft_DBL,
-                                                            (void*)dpnp_divide_c_default<double, double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_DBL][eft_FLT] = {eft_DBL,
-                                                            (void*)dpnp_divide_c_default<double, double, float>};
-    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_DBL][eft_DBL] = {eft_DBL,
-                                                            (void*)dpnp_divide_c_default<double, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_divide_c_default<double, int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_INT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_divide_c_default<double, int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_INT][eft_FLT] = {
+        eft_DBL, (void *)dpnp_divide_c_default<double, int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_divide_c_default<double, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_LNG][eft_INT] = {
+        eft_DBL, (void *)dpnp_divide_c_default<double, int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_divide_c_default<double, int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_LNG][eft_FLT] = {
+        eft_DBL, (void *)dpnp_divide_c_default<double, int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_divide_c_default<double, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_FLT][eft_INT] = {
+        eft_DBL, (void *)dpnp_divide_c_default<double, float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_FLT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_divide_c_default<double, float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_divide_c_default<float, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_divide_c_default<double, float, double>};
+    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_DBL][eft_INT] = {
+        eft_DBL, (void *)dpnp_divide_c_default<double, double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_DBL][eft_LNG] = {
+        eft_DBL, (void *)dpnp_divide_c_default<double, double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_DBL][eft_FLT] = {
+        eft_DBL, (void *)dpnp_divide_c_default<double, double, float>};
+    fmap[DPNPFuncName::DPNP_FN_DIVIDE][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_divide_c_default<double, double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_INT][eft_INT] = {eft_INT,
-                                                          (void*)dpnp_fmod_c_default<int32_t, int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_INT][eft_LNG] = {eft_LNG,
-                                                          (void*)dpnp_fmod_c_default<int64_t, int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_INT][eft_FLT] = {eft_DBL,
-                                                          (void*)dpnp_fmod_c_default<double, int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_INT][eft_DBL] = {eft_DBL,
-                                                          (void*)dpnp_fmod_c_default<double, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_LNG][eft_INT] = {eft_LNG,
-                                                          (void*)dpnp_fmod_c_default<int64_t, int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_LNG][eft_LNG] = {eft_LNG,
-                                                          (void*)dpnp_fmod_c_default<int64_t, int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_LNG][eft_FLT] = {eft_DBL,
-                                                          (void*)dpnp_fmod_c_default<double, int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_LNG][eft_DBL] = {eft_DBL,
-                                                          (void*)dpnp_fmod_c_default<double, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_FLT][eft_INT] = {eft_DBL,
-                                                          (void*)dpnp_fmod_c_default<double, float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_FLT][eft_LNG] = {eft_DBL,
-                                                          (void*)dpnp_fmod_c_default<double, float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_FLT][eft_FLT] = {eft_FLT,
-                                                          (void*)dpnp_fmod_c_default<float, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_FLT][eft_DBL] = {eft_DBL,
-                                                          (void*)dpnp_fmod_c_default<double, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_DBL][eft_INT] = {eft_DBL,
-                                                          (void*)dpnp_fmod_c_default<double, double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_DBL][eft_LNG] = {eft_DBL,
-                                                          (void*)dpnp_fmod_c_default<double, double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_DBL][eft_FLT] = {eft_DBL,
-                                                          (void*)dpnp_fmod_c_default<double, double, float>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_DBL][eft_DBL] = {eft_DBL,
-                                                          (void*)dpnp_fmod_c_default<double, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_fmod_c_default<int32_t, int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_fmod_c_default<int64_t, int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_INT][eft_FLT] = {
+        eft_DBL, (void *)dpnp_fmod_c_default<double, int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_fmod_c_default<double, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_LNG][eft_INT] = {
+        eft_LNG, (void *)dpnp_fmod_c_default<int64_t, int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_fmod_c_default<int64_t, int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_LNG][eft_FLT] = {
+        eft_DBL, (void *)dpnp_fmod_c_default<double, int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_fmod_c_default<double, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_FLT][eft_INT] = {
+        eft_DBL, (void *)dpnp_fmod_c_default<double, float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_FLT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_fmod_c_default<double, float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_fmod_c_default<float, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_fmod_c_default<double, float, double>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_DBL][eft_INT] = {
+        eft_DBL, (void *)dpnp_fmod_c_default<double, double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_DBL][eft_LNG] = {
+        eft_DBL, (void *)dpnp_fmod_c_default<double, double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_DBL][eft_FLT] = {
+        eft_DBL, (void *)dpnp_fmod_c_default<double, double, float>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_fmod_c_default<double, double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_INT][eft_INT] = {eft_INT,
-                                                              (void*)dpnp_fmod_c_ext<int32_t, int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_INT][eft_LNG] = {eft_LNG,
-                                                              (void*)dpnp_fmod_c_ext<int64_t, int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_INT][eft_FLT] = {eft_DBL,
-                                                              (void*)dpnp_fmod_c_ext<double, int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_INT][eft_DBL] = {eft_DBL,
-                                                              (void*)dpnp_fmod_c_ext<double, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_LNG][eft_INT] = {eft_LNG,
-                                                              (void*)dpnp_fmod_c_ext<int64_t, int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_LNG][eft_LNG] = {eft_LNG,
-                                                              (void*)dpnp_fmod_c_ext<int64_t, int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_LNG][eft_FLT] = {eft_DBL,
-                                                              (void*)dpnp_fmod_c_ext<double, int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_LNG][eft_DBL] = {eft_DBL,
-                                                              (void*)dpnp_fmod_c_ext<double, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_FLT][eft_INT] = {eft_DBL,
-                                                              (void*)dpnp_fmod_c_ext<double, float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_FLT][eft_LNG] = {eft_DBL,
-                                                              (void*)dpnp_fmod_c_ext<double, float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_FLT][eft_FLT] = {eft_FLT,
-                                                              (void*)dpnp_fmod_c_ext<float, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_FLT][eft_DBL] = {eft_DBL,
-                                                              (void*)dpnp_fmod_c_ext<double, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_DBL][eft_INT] = {eft_DBL,
-                                                              (void*)dpnp_fmod_c_ext<double, double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_DBL][eft_LNG] = {eft_DBL,
-                                                              (void*)dpnp_fmod_c_ext<double, double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_DBL][eft_FLT] = {eft_DBL,
-                                                              (void*)dpnp_fmod_c_ext<double, double, float>};
-    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_DBL][eft_DBL] = {eft_DBL,
-                                                              (void*)dpnp_fmod_c_ext<double, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_fmod_c_ext<int32_t, int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_fmod_c_ext<int64_t, int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_INT][eft_FLT] = {
+        eft_DBL, (void *)dpnp_fmod_c_ext<double, int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_fmod_c_ext<double, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_LNG][eft_INT] = {
+        eft_LNG, (void *)dpnp_fmod_c_ext<int64_t, int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_fmod_c_ext<int64_t, int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_LNG][eft_FLT] = {
+        eft_DBL, (void *)dpnp_fmod_c_ext<double, int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_fmod_c_ext<double, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_FLT][eft_INT] = {
+        eft_DBL, (void *)dpnp_fmod_c_ext<double, float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_FLT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_fmod_c_ext<double, float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_fmod_c_ext<float, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_fmod_c_ext<double, float, double>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_DBL][eft_INT] = {
+        eft_DBL, (void *)dpnp_fmod_c_ext<double, double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_DBL][eft_LNG] = {
+        eft_DBL, (void *)dpnp_fmod_c_ext<double, double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_DBL][eft_FLT] = {
+        eft_DBL, (void *)dpnp_fmod_c_ext<double, double, float>};
+    fmap[DPNPFuncName::DPNP_FN_FMOD_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_fmod_c_ext<double, double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_INT][eft_INT] = {eft_DBL,
-                                                           (void*)dpnp_hypot_c_default<double, int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_INT][eft_LNG] = {eft_DBL,
-                                                           (void*)dpnp_hypot_c_default<double, int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_INT][eft_FLT] = {eft_DBL,
-                                                           (void*)dpnp_hypot_c_default<double, int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_INT][eft_DBL] = {eft_DBL,
-                                                           (void*)dpnp_hypot_c_default<double, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_LNG][eft_INT] = {eft_DBL,
-                                                           (void*)dpnp_hypot_c_default<double, int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_LNG][eft_LNG] = {eft_DBL,
-                                                           (void*)dpnp_hypot_c_default<double, int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_LNG][eft_FLT] = {eft_DBL,
-                                                           (void*)dpnp_hypot_c_default<double, int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_LNG][eft_DBL] = {eft_DBL,
-                                                           (void*)dpnp_hypot_c_default<double, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_FLT][eft_INT] = {eft_DBL,
-                                                           (void*)dpnp_hypot_c_default<double, float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_FLT][eft_LNG] = {eft_DBL,
-                                                           (void*)dpnp_hypot_c_default<double, float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_FLT][eft_FLT] = {eft_FLT,
-                                                           (void*)dpnp_hypot_c_default<float, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_FLT][eft_DBL] = {eft_DBL,
-                                                           (void*)dpnp_hypot_c_default<double, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_DBL][eft_INT] = {eft_DBL,
-                                                           (void*)dpnp_hypot_c_default<double, double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_DBL][eft_LNG] = {eft_DBL,
-                                                           (void*)dpnp_hypot_c_default<double, double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_DBL][eft_FLT] = {eft_DBL,
-                                                           (void*)dpnp_hypot_c_default<double, double, float>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_DBL][eft_DBL] = {eft_DBL,
-                                                           (void*)dpnp_hypot_c_default<double, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_hypot_c_default<double, int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_INT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_hypot_c_default<double, int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_INT][eft_FLT] = {
+        eft_DBL, (void *)dpnp_hypot_c_default<double, int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_hypot_c_default<double, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_LNG][eft_INT] = {
+        eft_DBL, (void *)dpnp_hypot_c_default<double, int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_hypot_c_default<double, int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_LNG][eft_FLT] = {
+        eft_DBL, (void *)dpnp_hypot_c_default<double, int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_hypot_c_default<double, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_FLT][eft_INT] = {
+        eft_DBL, (void *)dpnp_hypot_c_default<double, float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_FLT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_hypot_c_default<double, float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_hypot_c_default<float, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_hypot_c_default<double, float, double>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_DBL][eft_INT] = {
+        eft_DBL, (void *)dpnp_hypot_c_default<double, double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_DBL][eft_LNG] = {
+        eft_DBL, (void *)dpnp_hypot_c_default<double, double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_DBL][eft_FLT] = {
+        eft_DBL, (void *)dpnp_hypot_c_default<double, double, float>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_hypot_c_default<double, double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_INT][eft_INT] = {eft_DBL,
-                                                               (void*)dpnp_hypot_c_ext<double, int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_INT][eft_LNG] = {eft_DBL,
-                                                               (void*)dpnp_hypot_c_ext<double, int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_INT][eft_FLT] = {eft_DBL,
-                                                               (void*)dpnp_hypot_c_ext<double, int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_INT][eft_DBL] = {eft_DBL,
-                                                               (void*)dpnp_hypot_c_ext<double, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_LNG][eft_INT] = {eft_DBL,
-                                                               (void*)dpnp_hypot_c_ext<double, int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_LNG][eft_LNG] = {eft_DBL,
-                                                               (void*)dpnp_hypot_c_ext<double, int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_LNG][eft_FLT] = {eft_DBL,
-                                                               (void*)dpnp_hypot_c_ext<double, int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_LNG][eft_DBL] = {eft_DBL,
-                                                               (void*)dpnp_hypot_c_ext<double, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_FLT][eft_INT] = {eft_DBL,
-                                                               (void*)dpnp_hypot_c_ext<double, float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_FLT][eft_LNG] = {eft_DBL,
-                                                               (void*)dpnp_hypot_c_ext<double, float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_FLT][eft_FLT] = {eft_FLT,
-                                                               (void*)dpnp_hypot_c_ext<float, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_FLT][eft_DBL] = {eft_DBL,
-                                                               (void*)dpnp_hypot_c_ext<double, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_DBL][eft_INT] = {eft_DBL,
-                                                               (void*)dpnp_hypot_c_ext<double, double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_DBL][eft_LNG] = {eft_DBL,
-                                                               (void*)dpnp_hypot_c_ext<double, double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_DBL][eft_FLT] = {eft_DBL,
-                                                               (void*)dpnp_hypot_c_ext<double, double, float>};
-    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_DBL][eft_DBL] = {eft_DBL,
-                                                               (void*)dpnp_hypot_c_ext<double, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_hypot_c_ext<double, int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_INT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_hypot_c_ext<double, int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_INT][eft_FLT] = {
+        eft_DBL, (void *)dpnp_hypot_c_ext<double, int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_hypot_c_ext<double, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_LNG][eft_INT] = {
+        eft_DBL, (void *)dpnp_hypot_c_ext<double, int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_hypot_c_ext<double, int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_LNG][eft_FLT] = {
+        eft_DBL, (void *)dpnp_hypot_c_ext<double, int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_hypot_c_ext<double, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_FLT][eft_INT] = {
+        eft_DBL, (void *)dpnp_hypot_c_ext<double, float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_FLT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_hypot_c_ext<double, float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_hypot_c_ext<float, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_hypot_c_ext<double, float, double>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_DBL][eft_INT] = {
+        eft_DBL, (void *)dpnp_hypot_c_ext<double, double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_DBL][eft_LNG] = {
+        eft_DBL, (void *)dpnp_hypot_c_ext<double, double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_DBL][eft_FLT] = {
+        eft_DBL, (void *)dpnp_hypot_c_ext<double, double, float>};
+    fmap[DPNPFuncName::DPNP_FN_HYPOT_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_hypot_c_ext<double, double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_INT][eft_INT] = {eft_INT,
-                                                             (void*)dpnp_maximum_c_default<int32_t, int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_INT][eft_LNG] = {eft_LNG,
-                                                             (void*)dpnp_maximum_c_default<int64_t, int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_INT][eft_FLT] = {eft_DBL,
-                                                             (void*)dpnp_maximum_c_default<double, int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_INT][eft_DBL] = {eft_DBL,
-                                                             (void*)dpnp_maximum_c_default<double, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_LNG][eft_INT] = {eft_LNG,
-                                                             (void*)dpnp_maximum_c_default<int64_t, int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_LNG][eft_LNG] = {eft_LNG,
-                                                             (void*)dpnp_maximum_c_default<int64_t, int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_LNG][eft_FLT] = {eft_DBL,
-                                                             (void*)dpnp_maximum_c_default<double, int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_LNG][eft_DBL] = {eft_DBL,
-                                                             (void*)dpnp_maximum_c_default<double, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_FLT][eft_INT] = {eft_DBL,
-                                                             (void*)dpnp_maximum_c_default<double, float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_FLT][eft_LNG] = {eft_DBL,
-                                                             (void*)dpnp_maximum_c_default<double, float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_FLT][eft_FLT] = {eft_FLT,
-                                                             (void*)dpnp_maximum_c_default<float, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_FLT][eft_DBL] = {eft_DBL,
-                                                             (void*)dpnp_maximum_c_default<double, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_DBL][eft_INT] = {eft_DBL,
-                                                             (void*)dpnp_maximum_c_default<double, double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_DBL][eft_LNG] = {eft_DBL,
-                                                             (void*)dpnp_maximum_c_default<double, double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_DBL][eft_FLT] = {eft_DBL,
-                                                             (void*)dpnp_maximum_c_default<double, double, float>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_DBL][eft_DBL] = {eft_DBL,
-                                                             (void*)dpnp_maximum_c_default<double, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_maximum_c_default<int32_t, int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_maximum_c_default<int64_t, int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_INT][eft_FLT] = {
+        eft_DBL, (void *)dpnp_maximum_c_default<double, int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_maximum_c_default<double, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_LNG][eft_INT] = {
+        eft_LNG, (void *)dpnp_maximum_c_default<int64_t, int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_maximum_c_default<int64_t, int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_LNG][eft_FLT] = {
+        eft_DBL, (void *)dpnp_maximum_c_default<double, int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_maximum_c_default<double, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_FLT][eft_INT] = {
+        eft_DBL, (void *)dpnp_maximum_c_default<double, float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_FLT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_maximum_c_default<double, float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_maximum_c_default<float, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_maximum_c_default<double, float, double>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_DBL][eft_INT] = {
+        eft_DBL, (void *)dpnp_maximum_c_default<double, double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_DBL][eft_LNG] = {
+        eft_DBL, (void *)dpnp_maximum_c_default<double, double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_DBL][eft_FLT] = {
+        eft_DBL, (void *)dpnp_maximum_c_default<double, double, float>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_maximum_c_default<double, double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_INT][eft_INT] = {eft_INT,
-                                                                 (void*)dpnp_maximum_c_ext<int32_t, int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_INT][eft_LNG] = {eft_LNG,
-                                                                 (void*)dpnp_maximum_c_ext<int64_t, int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_INT][eft_FLT] = {eft_DBL,
-                                                                 (void*)dpnp_maximum_c_ext<double, int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_INT][eft_DBL] = {eft_DBL,
-                                                                 (void*)dpnp_maximum_c_ext<double, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_LNG][eft_INT] = {eft_LNG,
-                                                                 (void*)dpnp_maximum_c_ext<int64_t, int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_LNG][eft_LNG] = {eft_LNG,
-                                                                 (void*)dpnp_maximum_c_ext<int64_t, int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_LNG][eft_FLT] = {eft_DBL,
-                                                                 (void*)dpnp_maximum_c_ext<double, int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_LNG][eft_DBL] = {eft_DBL,
-                                                                 (void*)dpnp_maximum_c_ext<double, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_FLT][eft_INT] = {eft_DBL,
-                                                                 (void*)dpnp_maximum_c_ext<double, float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_FLT][eft_LNG] = {eft_DBL,
-                                                                 (void*)dpnp_maximum_c_ext<double, float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_FLT][eft_FLT] = {eft_FLT,
-                                                                 (void*)dpnp_maximum_c_ext<float, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_FLT][eft_DBL] = {eft_DBL,
-                                                                 (void*)dpnp_maximum_c_ext<double, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_DBL][eft_INT] = {eft_DBL,
-                                                                 (void*)dpnp_maximum_c_ext<double, double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_DBL][eft_LNG] = {eft_DBL,
-                                                                 (void*)dpnp_maximum_c_ext<double, double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_DBL][eft_FLT] = {eft_DBL,
-                                                                 (void*)dpnp_maximum_c_ext<double, double, float>};
-    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_DBL][eft_DBL] = {eft_DBL,
-                                                                 (void*)dpnp_maximum_c_ext<double, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_maximum_c_ext<int32_t, int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_maximum_c_ext<int64_t, int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_INT][eft_FLT] = {
+        eft_DBL, (void *)dpnp_maximum_c_ext<double, int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_maximum_c_ext<double, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_LNG][eft_INT] = {
+        eft_LNG, (void *)dpnp_maximum_c_ext<int64_t, int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_maximum_c_ext<int64_t, int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_LNG][eft_FLT] = {
+        eft_DBL, (void *)dpnp_maximum_c_ext<double, int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_maximum_c_ext<double, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_FLT][eft_INT] = {
+        eft_DBL, (void *)dpnp_maximum_c_ext<double, float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_FLT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_maximum_c_ext<double, float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_maximum_c_ext<float, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_maximum_c_ext<double, float, double>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_DBL][eft_INT] = {
+        eft_DBL, (void *)dpnp_maximum_c_ext<double, double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_DBL][eft_LNG] = {
+        eft_DBL, (void *)dpnp_maximum_c_ext<double, double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_DBL][eft_FLT] = {
+        eft_DBL, (void *)dpnp_maximum_c_ext<double, double, float>};
+    fmap[DPNPFuncName::DPNP_FN_MAXIMUM_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_maximum_c_ext<double, double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_INT][eft_INT] = {eft_INT,
-                                                             (void*)dpnp_minimum_c_default<int32_t, int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_INT][eft_LNG] = {eft_LNG,
-                                                             (void*)dpnp_minimum_c_default<int64_t, int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_INT][eft_FLT] = {eft_DBL,
-                                                             (void*)dpnp_minimum_c_default<double, int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_INT][eft_DBL] = {eft_DBL,
-                                                             (void*)dpnp_minimum_c_default<double, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_LNG][eft_INT] = {eft_LNG,
-                                                             (void*)dpnp_minimum_c_default<int64_t, int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_LNG][eft_LNG] = {eft_LNG,
-                                                             (void*)dpnp_minimum_c_default<int64_t, int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_LNG][eft_FLT] = {eft_DBL,
-                                                             (void*)dpnp_minimum_c_default<double, int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_LNG][eft_DBL] = {eft_DBL,
-                                                             (void*)dpnp_minimum_c_default<double, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_FLT][eft_INT] = {eft_DBL,
-                                                             (void*)dpnp_minimum_c_default<double, float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_FLT][eft_LNG] = {eft_DBL,
-                                                             (void*)dpnp_minimum_c_default<double, float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_FLT][eft_FLT] = {eft_FLT,
-                                                             (void*)dpnp_minimum_c_default<float, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_FLT][eft_DBL] = {eft_DBL,
-                                                             (void*)dpnp_minimum_c_default<double, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_DBL][eft_INT] = {eft_DBL,
-                                                             (void*)dpnp_minimum_c_default<double, double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_DBL][eft_LNG] = {eft_DBL,
-                                                             (void*)dpnp_minimum_c_default<double, double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_DBL][eft_FLT] = {eft_DBL,
-                                                             (void*)dpnp_minimum_c_default<double, double, float>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_DBL][eft_DBL] = {eft_DBL,
-                                                             (void*)dpnp_minimum_c_default<double, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_minimum_c_default<int32_t, int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_minimum_c_default<int64_t, int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_INT][eft_FLT] = {
+        eft_DBL, (void *)dpnp_minimum_c_default<double, int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_minimum_c_default<double, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_LNG][eft_INT] = {
+        eft_LNG, (void *)dpnp_minimum_c_default<int64_t, int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_minimum_c_default<int64_t, int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_LNG][eft_FLT] = {
+        eft_DBL, (void *)dpnp_minimum_c_default<double, int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_minimum_c_default<double, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_FLT][eft_INT] = {
+        eft_DBL, (void *)dpnp_minimum_c_default<double, float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_FLT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_minimum_c_default<double, float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_minimum_c_default<float, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_minimum_c_default<double, float, double>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_DBL][eft_INT] = {
+        eft_DBL, (void *)dpnp_minimum_c_default<double, double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_DBL][eft_LNG] = {
+        eft_DBL, (void *)dpnp_minimum_c_default<double, double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_DBL][eft_FLT] = {
+        eft_DBL, (void *)dpnp_minimum_c_default<double, double, float>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_minimum_c_default<double, double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_INT][eft_INT] = {eft_INT,
-                                                                 (void*)dpnp_minimum_c_ext<int32_t, int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_INT][eft_LNG] = {eft_LNG,
-                                                                 (void*)dpnp_minimum_c_ext<int64_t, int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_INT][eft_FLT] = {eft_DBL,
-                                                                 (void*)dpnp_minimum_c_ext<double, int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_INT][eft_DBL] = {eft_DBL,
-                                                                 (void*)dpnp_minimum_c_ext<double, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_LNG][eft_INT] = {eft_LNG,
-                                                                 (void*)dpnp_minimum_c_ext<int64_t, int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_LNG][eft_LNG] = {eft_LNG,
-                                                                 (void*)dpnp_minimum_c_ext<int64_t, int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_LNG][eft_FLT] = {eft_DBL,
-                                                                 (void*)dpnp_minimum_c_ext<double, int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_LNG][eft_DBL] = {eft_DBL,
-                                                                 (void*)dpnp_minimum_c_ext<double, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_FLT][eft_INT] = {eft_DBL,
-                                                                 (void*)dpnp_minimum_c_ext<double, float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_FLT][eft_LNG] = {eft_DBL,
-                                                                 (void*)dpnp_minimum_c_ext<double, float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_FLT][eft_FLT] = {eft_FLT,
-                                                                 (void*)dpnp_minimum_c_ext<float, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_FLT][eft_DBL] = {eft_DBL,
-                                                                 (void*)dpnp_minimum_c_ext<double, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_DBL][eft_INT] = {eft_DBL,
-                                                                 (void*)dpnp_minimum_c_ext<double, double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_DBL][eft_LNG] = {eft_DBL,
-                                                                 (void*)dpnp_minimum_c_ext<double, double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_DBL][eft_FLT] = {eft_DBL,
-                                                                 (void*)dpnp_minimum_c_ext<double, double, float>};
-    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_DBL][eft_DBL] = {eft_DBL,
-                                                                 (void*)dpnp_minimum_c_ext<double, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_minimum_c_ext<int32_t, int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_minimum_c_ext<int64_t, int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_INT][eft_FLT] = {
+        eft_DBL, (void *)dpnp_minimum_c_ext<double, int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_minimum_c_ext<double, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_LNG][eft_INT] = {
+        eft_LNG, (void *)dpnp_minimum_c_ext<int64_t, int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_minimum_c_ext<int64_t, int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_LNG][eft_FLT] = {
+        eft_DBL, (void *)dpnp_minimum_c_ext<double, int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_minimum_c_ext<double, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_FLT][eft_INT] = {
+        eft_DBL, (void *)dpnp_minimum_c_ext<double, float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_FLT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_minimum_c_ext<double, float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_minimum_c_ext<float, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_minimum_c_ext<double, float, double>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_DBL][eft_INT] = {
+        eft_DBL, (void *)dpnp_minimum_c_ext<double, double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_DBL][eft_LNG] = {
+        eft_DBL, (void *)dpnp_minimum_c_ext<double, double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_DBL][eft_FLT] = {
+        eft_DBL, (void *)dpnp_minimum_c_ext<double, double, float>};
+    fmap[DPNPFuncName::DPNP_FN_MINIMUM_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_minimum_c_ext<double, double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_BLN][eft_BLN] = {
-        eft_BLN, (void*)dpnp_multiply_c_default<bool, bool, bool>};
+        eft_BLN, (void *)dpnp_multiply_c_default<bool, bool, bool>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_BLN][eft_INT] = {
-        eft_INT, (void*)dpnp_multiply_c_default<int32_t, bool, int32_t>};
+        eft_INT, (void *)dpnp_multiply_c_default<int32_t, bool, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_BLN][eft_LNG] = {
-        eft_LNG, (void*)dpnp_multiply_c_default<int64_t, bool, int64_t>};
+        eft_LNG, (void *)dpnp_multiply_c_default<int64_t, bool, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_BLN][eft_FLT] = {
-        eft_FLT, (void*)dpnp_multiply_c_default<float, bool, float>};
+        eft_FLT, (void *)dpnp_multiply_c_default<float, bool, float>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_BLN][eft_DBL] = {
-        eft_DBL,  (void*)dpnp_multiply_c_default<double, bool, double>};
+        eft_DBL, (void *)dpnp_multiply_c_default<double, bool, double>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_INT][eft_BLN] = {
-        eft_INT, (void*)dpnp_multiply_c_default<int32_t, int32_t, bool>};
+        eft_INT, (void *)dpnp_multiply_c_default<int32_t, int32_t, bool>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_INT][eft_INT] = {
-        eft_INT, (void*)dpnp_multiply_c_default<int32_t, int32_t, int32_t>};
+        eft_INT, (void *)dpnp_multiply_c_default<int32_t, int32_t, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_INT][eft_LNG] = {
-        eft_LNG, (void*)dpnp_multiply_c_default<int64_t, int32_t, int64_t>};
+        eft_LNG, (void *)dpnp_multiply_c_default<int64_t, int32_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_INT][eft_FLT] = {
-        eft_DBL, (void*)dpnp_multiply_c_default<double, int32_t, float>};
+        eft_DBL, (void *)dpnp_multiply_c_default<double, int32_t, float>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_INT][eft_DBL] = {
-        eft_DBL, (void*)dpnp_multiply_c_default<double, int32_t, double>};
+        eft_DBL, (void *)dpnp_multiply_c_default<double, int32_t, double>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_LNG][eft_BLN] = {
-        eft_LNG, (void*)dpnp_multiply_c_default<int64_t, int64_t, bool>};
+        eft_LNG, (void *)dpnp_multiply_c_default<int64_t, int64_t, bool>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_LNG][eft_INT] = {
-        eft_LNG, (void*)dpnp_multiply_c_default<int64_t, int64_t, int32_t>};
+        eft_LNG, (void *)dpnp_multiply_c_default<int64_t, int64_t, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_LNG][eft_LNG] = {
-        eft_LNG, (void*)dpnp_multiply_c_default<int64_t, int64_t, int64_t>};
+        eft_LNG, (void *)dpnp_multiply_c_default<int64_t, int64_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_LNG][eft_FLT] = {
-        eft_DBL, (void*)dpnp_multiply_c_default<double, int64_t, float>};
+        eft_DBL, (void *)dpnp_multiply_c_default<double, int64_t, float>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_LNG][eft_DBL] = {
-        eft_DBL, (void*)dpnp_multiply_c_default<double, int64_t, double>};
+        eft_DBL, (void *)dpnp_multiply_c_default<double, int64_t, double>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_FLT][eft_BLN] = {
-        eft_FLT, (void*)dpnp_multiply_c_default<float, float, bool>};
+        eft_FLT, (void *)dpnp_multiply_c_default<float, float, bool>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_FLT][eft_INT] = {
-        eft_DBL, (void*)dpnp_multiply_c_default<double, float, int32_t>};
+        eft_DBL, (void *)dpnp_multiply_c_default<double, float, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_FLT][eft_LNG] = {
-        eft_DBL, (void*)dpnp_multiply_c_default<double, float, int64_t>};
+        eft_DBL, (void *)dpnp_multiply_c_default<double, float, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_FLT][eft_FLT] = {
-        eft_FLT, (void*)dpnp_multiply_c_default<float, float, float>};
+        eft_FLT, (void *)dpnp_multiply_c_default<float, float, float>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_FLT][eft_DBL] = {
-        eft_DBL, (void*)dpnp_multiply_c_default<double, float, double>};
+        eft_DBL, (void *)dpnp_multiply_c_default<double, float, double>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_DBL][eft_BLN] = {
-        eft_DBL, (void*)dpnp_multiply_c_default<double, double, bool>};
+        eft_DBL, (void *)dpnp_multiply_c_default<double, double, bool>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_DBL][eft_INT] = {
-        eft_DBL, (void*)dpnp_multiply_c_default<double, double, int32_t>};
+        eft_DBL, (void *)dpnp_multiply_c_default<double, double, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_DBL][eft_LNG] = {
-        eft_DBL, (void*)dpnp_multiply_c_default<double, double, int64_t>};
+        eft_DBL, (void *)dpnp_multiply_c_default<double, double, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_DBL][eft_FLT] = {
-        eft_DBL, (void*)dpnp_multiply_c_default<double, double, float>};
+        eft_DBL, (void *)dpnp_multiply_c_default<double, double, float>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_DBL][eft_DBL] = {
-        eft_DBL, (void*)dpnp_multiply_c_default<double, double, double>};
+        eft_DBL, (void *)dpnp_multiply_c_default<double, double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_C64][eft_BLN] = {
-        eft_C64, (void*)dpnp_multiply_c_default<std::complex<float>, std::complex<float>, bool>};
+        eft_C64, (void *)dpnp_multiply_c_default<std::complex<float>,
+                                                 std::complex<float>, bool>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_C64][eft_INT] = {
-        eft_C64, (void*)dpnp_multiply_c_default<std::complex<float>, std::complex<float>, int32_t>};
+        eft_C64, (void *)dpnp_multiply_c_default<std::complex<float>,
+                                                 std::complex<float>, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_C64][eft_LNG] = {
-        eft_C64, (void*)dpnp_multiply_c_default<std::complex<float>, std::complex<float>, int64_t>};
+        eft_C64, (void *)dpnp_multiply_c_default<std::complex<float>,
+                                                 std::complex<float>, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_C64][eft_FLT] = {
-        eft_C64, (void*)dpnp_multiply_c_default<std::complex<float>, std::complex<float>, float>};
+        eft_C64, (void *)dpnp_multiply_c_default<std::complex<float>,
+                                                 std::complex<float>, float>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_C64][eft_DBL] = {
-        eft_C128, (void*)dpnp_multiply_c_default<std::complex<double>, std::complex<float>, double>};
+        eft_C128, (void *)dpnp_multiply_c_default<std::complex<double>,
+                                                  std::complex<float>, double>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_C64][eft_C64] = {
-        eft_C64, (void*)dpnp_multiply_c_default<std::complex<float>, std::complex<float>, std::complex<float>>};
+        eft_C64,
+        (void *)dpnp_multiply_c_default<
+            std::complex<float>, std::complex<float>, std::complex<float>>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_C64][eft_C128] = {
-        eft_C128, (void*)dpnp_multiply_c_default<std::complex<double>, std::complex<float>, std::complex<double>>};
+        eft_C128,
+        (void *)dpnp_multiply_c_default<
+            std::complex<double>, std::complex<float>, std::complex<double>>};
 
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_C128][eft_BLN] = {
-        eft_C128, (void*)dpnp_multiply_c_default<std::complex<double>, std::complex<double>, bool>};
+        eft_C128, (void *)dpnp_multiply_c_default<std::complex<double>,
+                                                  std::complex<double>, bool>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_C128][eft_INT] = {
-        eft_C128, (void*)dpnp_multiply_c_default<std::complex<double>, std::complex<double>, int32_t>};
+        eft_C128,
+        (void *)dpnp_multiply_c_default<std::complex<double>,
+                                        std::complex<double>, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_C128][eft_LNG] = {
-        eft_C128, (void*)dpnp_multiply_c_default<std::complex<double>, std::complex<double>, int64_t>};
+        eft_C128,
+        (void *)dpnp_multiply_c_default<std::complex<double>,
+                                        std::complex<double>, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_C128][eft_FLT] = {
-        eft_C128, (void*)dpnp_multiply_c_default<std::complex<double>, std::complex<double>, float>};
+        eft_C128, (void *)dpnp_multiply_c_default<std::complex<double>,
+                                                  std::complex<double>, float>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_C128][eft_DBL] = {
-        eft_C128, (void*)dpnp_multiply_c_default<std::complex<double>, std::complex<double>, double>};
+        eft_C128,
+        (void *)dpnp_multiply_c_default<std::complex<double>,
+                                        std::complex<double>, double>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_C128][eft_C64] = {
-        eft_C128, (void*)dpnp_multiply_c_default<std::complex<double>, std::complex<double>, std::complex<float>>};
+        eft_C128,
+        (void *)dpnp_multiply_c_default<
+            std::complex<double>, std::complex<double>, std::complex<float>>};
     fmap[DPNPFuncName::DPNP_FN_MULTIPLY][eft_C128][eft_C128] = {
-        eft_C128, (void*)dpnp_multiply_c_default<std::complex<double>, std::complex<double>, std::complex<double>>};
+        eft_C128,
+        (void *)dpnp_multiply_c_default<
+            std::complex<double>, std::complex<double>, std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_POWER][eft_INT][eft_INT] = {eft_INT,
-                                                           (void*)dpnp_power_c_default<int32_t, int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_POWER][eft_INT][eft_LNG] = {eft_LNG,
-                                                           (void*)dpnp_power_c_default<int64_t, int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_POWER][eft_INT][eft_FLT] = {eft_DBL,
-                                                           (void*)dpnp_power_c_default<double, int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_POWER][eft_INT][eft_DBL] = {eft_DBL,
-                                                           (void*)dpnp_power_c_default<double, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_POWER][eft_LNG][eft_INT] = {eft_LNG,
-                                                           (void*)dpnp_power_c_default<int64_t, int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_POWER][eft_LNG][eft_LNG] = {eft_LNG,
-                                                           (void*)dpnp_power_c_default<int64_t, int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_POWER][eft_LNG][eft_FLT] = {eft_DBL,
-                                                           (void*)dpnp_power_c_default<double, int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_POWER][eft_LNG][eft_DBL] = {eft_DBL,
-                                                           (void*)dpnp_power_c_default<double, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_POWER][eft_FLT][eft_INT] = {eft_DBL,
-                                                           (void*)dpnp_power_c_default<double, float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_POWER][eft_FLT][eft_LNG] = {eft_DBL,
-                                                           (void*)dpnp_power_c_default<double, float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_POWER][eft_FLT][eft_FLT] = {eft_FLT,
-                                                           (void*)dpnp_power_c_default<float, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_POWER][eft_FLT][eft_DBL] = {eft_DBL,
-                                                           (void*)dpnp_power_c_default<double, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_POWER][eft_DBL][eft_INT] = {eft_DBL,
-                                                           (void*)dpnp_power_c_default<double, double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_POWER][eft_DBL][eft_LNG] = {eft_DBL,
-                                                           (void*)dpnp_power_c_default<double, double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_POWER][eft_DBL][eft_FLT] = {eft_DBL,
-                                                           (void*)dpnp_power_c_default<double, double, float>};
-    fmap[DPNPFuncName::DPNP_FN_POWER][eft_DBL][eft_DBL] = {eft_DBL,
-                                                           (void*)dpnp_power_c_default<double, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_POWER][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_power_c_default<int32_t, int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_POWER][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_power_c_default<int64_t, int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_POWER][eft_INT][eft_FLT] = {
+        eft_DBL, (void *)dpnp_power_c_default<double, int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_POWER][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_power_c_default<double, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_POWER][eft_LNG][eft_INT] = {
+        eft_LNG, (void *)dpnp_power_c_default<int64_t, int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_POWER][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_power_c_default<int64_t, int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_POWER][eft_LNG][eft_FLT] = {
+        eft_DBL, (void *)dpnp_power_c_default<double, int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_POWER][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_power_c_default<double, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_POWER][eft_FLT][eft_INT] = {
+        eft_DBL, (void *)dpnp_power_c_default<double, float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_POWER][eft_FLT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_power_c_default<double, float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_POWER][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_power_c_default<float, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_POWER][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_power_c_default<double, float, double>};
+    fmap[DPNPFuncName::DPNP_FN_POWER][eft_DBL][eft_INT] = {
+        eft_DBL, (void *)dpnp_power_c_default<double, double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_POWER][eft_DBL][eft_LNG] = {
+        eft_DBL, (void *)dpnp_power_c_default<double, double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_POWER][eft_DBL][eft_FLT] = {
+        eft_DBL, (void *)dpnp_power_c_default<double, double, float>};
+    fmap[DPNPFuncName::DPNP_FN_POWER][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_power_c_default<double, double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_SUBTRACT][eft_INT][eft_INT] = {
-        eft_INT, (void*)dpnp_subtract_c_default<int32_t, int32_t, int32_t>};
+        eft_INT, (void *)dpnp_subtract_c_default<int32_t, int32_t, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_SUBTRACT][eft_INT][eft_LNG] = {
-        eft_LNG, (void*)dpnp_subtract_c_default<int64_t, int32_t, int64_t>};
+        eft_LNG, (void *)dpnp_subtract_c_default<int64_t, int32_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_SUBTRACT][eft_INT][eft_FLT] = {
-        eft_DBL, (void*)dpnp_subtract_c_default<double, int32_t, float>};
+        eft_DBL, (void *)dpnp_subtract_c_default<double, int32_t, float>};
     fmap[DPNPFuncName::DPNP_FN_SUBTRACT][eft_INT][eft_DBL] = {
-        eft_DBL, (void*)dpnp_subtract_c_default<double, int32_t, double>};
+        eft_DBL, (void *)dpnp_subtract_c_default<double, int32_t, double>};
     fmap[DPNPFuncName::DPNP_FN_SUBTRACT][eft_LNG][eft_INT] = {
-        eft_LNG, (void*)dpnp_subtract_c_default<int64_t, int64_t, int32_t>};
+        eft_LNG, (void *)dpnp_subtract_c_default<int64_t, int64_t, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_SUBTRACT][eft_LNG][eft_LNG] = {
-        eft_LNG, (void*)dpnp_subtract_c_default<int64_t, int64_t, int64_t>};
+        eft_LNG, (void *)dpnp_subtract_c_default<int64_t, int64_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_SUBTRACT][eft_LNG][eft_FLT] = {
-        eft_DBL, (void*)dpnp_subtract_c_default<double, int64_t, float>};
+        eft_DBL, (void *)dpnp_subtract_c_default<double, int64_t, float>};
     fmap[DPNPFuncName::DPNP_FN_SUBTRACT][eft_LNG][eft_DBL] = {
-        eft_DBL, (void*)dpnp_subtract_c_default<double, int64_t, double>};
+        eft_DBL, (void *)dpnp_subtract_c_default<double, int64_t, double>};
     fmap[DPNPFuncName::DPNP_FN_SUBTRACT][eft_FLT][eft_INT] = {
-        eft_DBL, (void*)dpnp_subtract_c_default<double, float, int32_t>};
+        eft_DBL, (void *)dpnp_subtract_c_default<double, float, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_SUBTRACT][eft_FLT][eft_LNG] = {
-        eft_DBL, (void*)dpnp_subtract_c_default<double, float, int64_t>};
+        eft_DBL, (void *)dpnp_subtract_c_default<double, float, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_SUBTRACT][eft_FLT][eft_FLT] = {
-        eft_FLT, (void*)dpnp_subtract_c_default<float, float, float>};
+        eft_FLT, (void *)dpnp_subtract_c_default<float, float, float>};
     fmap[DPNPFuncName::DPNP_FN_SUBTRACT][eft_FLT][eft_DBL] = {
-        eft_DBL, (void*)dpnp_subtract_c_default<double, float, double>};
+        eft_DBL, (void *)dpnp_subtract_c_default<double, float, double>};
     fmap[DPNPFuncName::DPNP_FN_SUBTRACT][eft_DBL][eft_INT] = {
-        eft_DBL, (void*)dpnp_subtract_c_default<double, double, int32_t>};
+        eft_DBL, (void *)dpnp_subtract_c_default<double, double, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_SUBTRACT][eft_DBL][eft_LNG] = {
-        eft_DBL, (void*)dpnp_subtract_c_default<double, double, int64_t>};
+        eft_DBL, (void *)dpnp_subtract_c_default<double, double, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_SUBTRACT][eft_DBL][eft_FLT] = {
-        eft_DBL, (void*)dpnp_subtract_c_default<double, double, float>};
+        eft_DBL, (void *)dpnp_subtract_c_default<double, double, float>};
     fmap[DPNPFuncName::DPNP_FN_SUBTRACT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void*)dpnp_subtract_c_default<double, double, double>};
+        eft_DBL, (void *)dpnp_subtract_c_default<double, double, double>};
 
-    func_map_elemwise_2arg_3type_helper<eft_BLN, eft_INT, eft_LNG, eft_FLT, eft_DBL, eft_C64, eft_C128>(fmap);
+    func_map_elemwise_2arg_3type_helper<eft_BLN, eft_INT, eft_LNG, eft_FLT,
+                                        eft_DBL, eft_C64, eft_C128>(fmap);
 
     return;
 }
 
-void func_map_init_elemwise(func_map_t& fmap)
+void func_map_init_elemwise(func_map_t &fmap)
 {
     func_map_init_elemwise_1arg_1type(fmap);
     func_map_init_elemwise_1arg_2type(fmap);

--- a/dpnp/backend/kernels/dpnp_krnl_fft.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_fft.cpp
@@ -25,18 +25,24 @@
 
 #include <iostream>
 
-#include <dpnp_iface.hpp>
 #include "dpnp_fptr.hpp"
 #include "dpnp_utils.hpp"
 #include "dpnpc_memory_adapter.hpp"
 #include "queue_sycl.hpp"
+#include <dpnp_iface.hpp>
 
 namespace mkl_dft = oneapi::mkl::dft;
 
-typedef mkl_dft::descriptor<mkl_dft::precision::DOUBLE, mkl_dft::domain::COMPLEX> desc_dp_cmplx_t;
-typedef mkl_dft::descriptor<mkl_dft::precision::SINGLE, mkl_dft::domain::COMPLEX> desc_sp_cmplx_t;
-typedef mkl_dft::descriptor<mkl_dft::precision::DOUBLE, mkl_dft::domain::REAL> desc_dp_real_t;
-typedef mkl_dft::descriptor<mkl_dft::precision::SINGLE, mkl_dft::domain::REAL> desc_sp_real_t;
+typedef mkl_dft::descriptor<mkl_dft::precision::DOUBLE,
+                            mkl_dft::domain::COMPLEX>
+    desc_dp_cmplx_t;
+typedef mkl_dft::descriptor<mkl_dft::precision::SINGLE,
+                            mkl_dft::domain::COMPLEX>
+    desc_sp_cmplx_t;
+typedef mkl_dft::descriptor<mkl_dft::precision::DOUBLE, mkl_dft::domain::REAL>
+    desc_dp_real_t;
+typedef mkl_dft::descriptor<mkl_dft::precision::SINGLE, mkl_dft::domain::REAL>
+    desc_sp_real_t;
 
 #ifdef _WIN32
 #ifndef M_PI // Windows compatibility
@@ -44,15 +50,16 @@ typedef mkl_dft::descriptor<mkl_dft::precision::SINGLE, mkl_dft::domain::REAL> d
 #endif
 #endif
 
-template <typename _KernelNameSpecialization1, typename _KernelNameSpecialization2>
+template <typename _KernelNameSpecialization1,
+          typename _KernelNameSpecialization2>
 class dpnp_fft_fft_c_kernel;
 
 template <typename _DataType_input, typename _DataType_output>
 static void dpnp_fft_fft_sycl_c(DPCTLSyclQueueRef q_ref,
-                                const void* array1_in,
-                                void* result_out,
-                                const shape_elem_type* input_shape,
-                                const shape_elem_type* output_shape,
+                                const void *array1_in,
+                                void *result_out,
+                                const shape_elem_type *input_shape,
+                                const shape_elem_type *output_shape,
                                 size_t shape_size,
                                 const size_t result_size,
                                 const size_t input_size,
@@ -60,8 +67,7 @@ static void dpnp_fft_fft_sycl_c(DPCTLSyclQueueRef q_ref,
                                 long input_boundarie,
                                 size_t inverse)
 {
-    if (!(input_size && result_size && shape_size))
-    {
+    if (!(input_size && result_size && shape_size)) {
         return;
     }
 
@@ -69,20 +75,21 @@ static void dpnp_fft_fft_sycl_c(DPCTLSyclQueueRef q_ref,
 
     const double kernel_pi = inverse ? -M_PI : M_PI;
 
-    sycl::queue queue = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue queue = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    _DataType_input* array_1 = static_cast<_DataType_input *>(const_cast<void *>(array1_in));
-    _DataType_output* result = static_cast<_DataType_output *>(result_out);
+    _DataType_input *array_1 =
+        static_cast<_DataType_input *>(const_cast<void *>(array1_in));
+    _DataType_output *result = static_cast<_DataType_output *>(result_out);
 
     // kernel specific temporal data
-    shape_elem_type* output_shape_offsets =
-        reinterpret_cast<shape_elem_type*>(sycl::malloc_shared(shape_size * sizeof(shape_elem_type), queue));
-    shape_elem_type* input_shape_offsets =
-        reinterpret_cast<shape_elem_type*>(sycl::malloc_shared(shape_size * sizeof(shape_elem_type), queue));
+    shape_elem_type *output_shape_offsets = reinterpret_cast<shape_elem_type *>(
+        sycl::malloc_shared(shape_size * sizeof(shape_elem_type), queue));
+    shape_elem_type *input_shape_offsets = reinterpret_cast<shape_elem_type *>(
+        sycl::malloc_shared(shape_size * sizeof(shape_elem_type), queue));
     // must be a thread local storage.
-    shape_elem_type* axis_iterator =
-        reinterpret_cast<shape_elem_type*>(sycl::malloc_shared(result_size * shape_size * sizeof(shape_elem_type),
-                                                               queue));
+    shape_elem_type *axis_iterator =
+        reinterpret_cast<shape_elem_type *>(sycl::malloc_shared(
+            result_size * shape_size * sizeof(shape_elem_type), queue));
 
     get_shape_offsets_inkernel(output_shape, shape_size, output_shape_offsets);
     get_shape_offsets_inkernel(input_shape, shape_size, input_shape_offsets);
@@ -94,50 +101,53 @@ static void dpnp_fft_fft_sycl_c(DPCTLSyclQueueRef q_ref,
         double sum_real = 0.0;
         double sum_imag = 0.0;
         // need to replace this array by thread local storage
-        shape_elem_type* axis_iterator_thread = axis_iterator + (output_id * shape_size);
+        shape_elem_type *axis_iterator_thread =
+            axis_iterator + (output_id * shape_size);
 
         size_t xyz_id;
-        for (size_t i = 0; i < shape_size; ++i)
-        {
-            xyz_id = get_xyz_id_by_id_inkernel(output_id, output_shape_offsets, shape_size, i);
+        for (size_t i = 0; i < shape_size; ++i) {
+            xyz_id = get_xyz_id_by_id_inkernel(output_id, output_shape_offsets,
+                                               shape_size, i);
             axis_iterator_thread[i] = xyz_id;
         }
 
         const long axis_length = input_boundarie;
-        for (long it = 0; it < axis_length; ++it)
-        {
+        for (long it = 0; it < axis_length; ++it) {
             double in_real = 0.0;
             double in_imag = 0.0;
 
             axis_iterator_thread[axis] = it;
 
-            const size_t input_it = get_id_by_xyz_inkernel(axis_iterator_thread, shape_size, input_shape_offsets);
+            const size_t input_it = get_id_by_xyz_inkernel(
+                axis_iterator_thread, shape_size, input_shape_offsets);
 
-            if (it < input_shape[axis])
-            {
-                if constexpr (std::is_same<_DataType_input, std::complex<double>>::value)
-                {
-                    const _DataType_input* cmplx_ptr = array_1 + input_it;
-                    const double* dbl_ptr = reinterpret_cast<const double*>(cmplx_ptr);
+            if (it < input_shape[axis]) {
+                if constexpr (std::is_same<_DataType_input,
+                                           std::complex<double>>::value) {
+                    const _DataType_input *cmplx_ptr = array_1 + input_it;
+                    const double *dbl_ptr =
+                        reinterpret_cast<const double *>(cmplx_ptr);
                     in_real = *dbl_ptr;
                     in_imag = *(dbl_ptr + 1);
                 }
-                else if constexpr (std::is_same<_DataType_input, std::complex<float>>::value)
-                {
-                    const _DataType_input* cmplx_ptr = array_1 + input_it;
-                    const float* dbl_ptr = reinterpret_cast<const float*>(cmplx_ptr);
+                else if constexpr (std::is_same<_DataType_input,
+                                                std::complex<float>>::value) {
+                    const _DataType_input *cmplx_ptr = array_1 + input_it;
+                    const float *dbl_ptr =
+                        reinterpret_cast<const float *>(cmplx_ptr);
                     in_real = *dbl_ptr;
                     in_imag = *(dbl_ptr + 1);
                 }
-                else
-                {
+                else {
                     in_real = array_1[input_it];
                 }
             }
 
-            xyz_id = get_xyz_id_by_id_inkernel(output_id, output_shape_offsets, shape_size, axis);
+            xyz_id = get_xyz_id_by_id_inkernel(output_id, output_shape_offsets,
+                                               shape_size, axis);
             const size_t output_local_id = xyz_id;
-            const double angle = 2.0 * kernel_pi * it * output_local_id / axis_length;
+            const double angle =
+                2.0 * kernel_pi * it * output_local_id / axis_length;
 
             const double angle_cos = sycl::cos(angle);
             const double angle_sin = sycl::sin(angle);
@@ -146,8 +156,7 @@ static void dpnp_fft_fft_sycl_c(DPCTLSyclQueueRef q_ref,
             sum_imag += -in_real * angle_sin + in_imag * angle_cos;
         }
 
-        if (inverse)
-        {
+        if (inverse) {
             sum_real = sum_real / input_boundarie;
             sum_imag = sum_imag / input_boundarie;
         }
@@ -155,8 +164,10 @@ static void dpnp_fft_fft_sycl_c(DPCTLSyclQueueRef q_ref,
         result[output_id] = _DataType_output(sum_real, sum_imag);
     };
 
-    auto kernel_func = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class dpnp_fft_fft_c_kernel<_DataType_input, _DataType_output>>(gws, kernel_parallel_for_func);
+    auto kernel_func = [&](sycl::handler &cgh) {
+        cgh.parallel_for<
+            class dpnp_fft_fft_c_kernel<_DataType_input, _DataType_output>>(
+            gws, kernel_parallel_for_func);
     };
 
     event = queue.submit(kernel_func);
@@ -169,40 +180,44 @@ static void dpnp_fft_fft_sycl_c(DPCTLSyclQueueRef q_ref,
     return;
 }
 
-template <typename _DataType_input, typename _DataType_output, typename _Descriptor_type>
-static void dpnp_fft_fft_mathlib_cmplx_to_cmplx_c(DPCTLSyclQueueRef q_ref,
-                                                  const void* array1_in,
-                                                  void* result_out,
-                                                  const shape_elem_type* input_shape,
-                                                  const shape_elem_type* result_shape,
-                                                  const size_t shape_size,
-                                                  const size_t input_size,
-                                                  const size_t result_size,
-                                                  size_t inverse,
-                                                  const size_t norm)
+template <typename _DataType_input,
+          typename _DataType_output,
+          typename _Descriptor_type>
+static void
+    dpnp_fft_fft_mathlib_cmplx_to_cmplx_c(DPCTLSyclQueueRef q_ref,
+                                          const void *array1_in,
+                                          void *result_out,
+                                          const shape_elem_type *input_shape,
+                                          const shape_elem_type *result_shape,
+                                          const size_t shape_size,
+                                          const size_t input_size,
+                                          const size_t result_size,
+                                          size_t inverse,
+                                          const size_t norm)
 {
     // avoid warning unused variable
     (void)result_shape;
     (void)input_size;
     (void)result_size;
 
-    if (!shape_size)
-    {
+    if (!shape_size) {
         return;
     }
 
-    sycl::queue queue = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue queue = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    _DataType_input* array_1 = static_cast<_DataType_input*>(const_cast<void*>(array1_in));
-    _DataType_output* result = static_cast<_DataType_output*>(result_out);
+    _DataType_input *array_1 =
+        static_cast<_DataType_input *>(const_cast<void *>(array1_in));
+    _DataType_output *result = static_cast<_DataType_output *>(result_out);
 
     const size_t n_iter =
-        std::accumulate(input_shape, input_shape + shape_size - 1, 1, std::multiplies<shape_elem_type>());
+        std::accumulate(input_shape, input_shape + shape_size - 1, 1,
+                        std::multiplies<shape_elem_type>());
 
     const size_t shift = input_shape[shape_size - 1];
 
     double backward_scale = 1.;
-    double forward_scale = 1.;
+    double forward_scale  = 1.;
 
     if (norm == 0) // norm = "backward"
     {
@@ -214,99 +229,101 @@ static void dpnp_fft_fft_mathlib_cmplx_to_cmplx_c(DPCTLSyclQueueRef q_ref,
     }
     else // norm = "ortho"
     {
-        if (inverse)
-        {
+        if (inverse) {
             backward_scale = 1. / sqrt(shift);
         }
-        else
-        {
+        else {
             forward_scale = 1. / sqrt(shift);
         }
     }
 
     std::vector<sycl::event> fft_events(n_iter);
 
-    for (size_t i = 0; i < n_iter; ++i)
-    {
-        std::unique_ptr<_Descriptor_type> desc = std::make_unique<_Descriptor_type>(shift);
+    for (size_t i = 0; i < n_iter; ++i) {
+        std::unique_ptr<_Descriptor_type> desc =
+            std::make_unique<_Descriptor_type>(shift);
         desc->set_value(mkl_dft::config_param::BACKWARD_SCALE, backward_scale);
         desc->set_value(mkl_dft::config_param::FORWARD_SCALE, forward_scale);
         desc->set_value(mkl_dft::config_param::PLACEMENT, DFTI_NOT_INPLACE);
         desc->commit(queue);
 
-        if (inverse)
-        {
-            fft_events[i] = mkl_dft::compute_backward<_Descriptor_type, _DataType_input, _DataType_output>(
-                *desc, array_1 + i * shift, result + i * shift);
+        if (inverse) {
+            fft_events[i] =
+                mkl_dft::compute_backward<_Descriptor_type, _DataType_input,
+                                          _DataType_output>(
+                    *desc, array_1 + i * shift, result + i * shift);
         }
-        else
-        {
-            fft_events[i] = mkl_dft::compute_forward<_Descriptor_type, _DataType_input, _DataType_output>(
-                *desc, array_1 + i * shift, result + i * shift);
+        else {
+            fft_events[i] =
+                mkl_dft::compute_forward<_Descriptor_type, _DataType_input,
+                                         _DataType_output>(
+                    *desc, array_1 + i * shift, result + i * shift);
         }
     }
 
     sycl::event::wait(fft_events);
 }
 
-template <typename _KernelNameSpecialization1, typename _KernelNameSpecialization2, typename _KernelNameSpecialization3>
+template <typename _KernelNameSpecialization1,
+          typename _KernelNameSpecialization2,
+          typename _KernelNameSpecialization3>
 class dpnp_fft_fft_mathlib_real_to_cmplx_c_kernel;
 
-template <typename _DataType_input, typename _DataType_output, typename _Descriptor_type>
-static DPCTLSyclEventRef dpnp_fft_fft_mathlib_real_to_cmplx_c(DPCTLSyclQueueRef q_ref,
-                                                              const void* array1_in,
-                                                              void* result_out,
-                                                              const shape_elem_type* input_shape,
-                                                              const shape_elem_type* result_shape,
-                                                              const size_t shape_size,
-                                                              const size_t input_size,
-                                                              const size_t result_size,
-                                                              size_t inverse,
-                                                              const size_t norm,
-                                                              const size_t real)
+template <typename _DataType_input,
+          typename _DataType_output,
+          typename _Descriptor_type>
+static DPCTLSyclEventRef
+    dpnp_fft_fft_mathlib_real_to_cmplx_c(DPCTLSyclQueueRef q_ref,
+                                         const void *array1_in,
+                                         void *result_out,
+                                         const shape_elem_type *input_shape,
+                                         const shape_elem_type *result_shape,
+                                         const size_t shape_size,
+                                         const size_t input_size,
+                                         const size_t result_size,
+                                         size_t inverse,
+                                         const size_t norm,
+                                         const size_t real)
 {
     // avoid warning unused variable
     (void)input_size;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    if (!shape_size)
-    {
+    if (!shape_size) {
         return event_ref;
     }
 
-    sycl::queue queue = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue queue = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    _DataType_input* array_1 = static_cast<_DataType_input*>(const_cast<void*>(array1_in));
-    _DataType_output* result = static_cast<_DataType_output*>(result_out);
+    _DataType_input *array_1 =
+        static_cast<_DataType_input *>(const_cast<void *>(array1_in));
+    _DataType_output *result = static_cast<_DataType_output *>(result_out);
 
     const size_t n_iter =
-        std::accumulate(input_shape, input_shape + shape_size - 1, 1, std::multiplies<shape_elem_type>());
+        std::accumulate(input_shape, input_shape + shape_size - 1, 1,
+                        std::multiplies<shape_elem_type>());
 
-    const size_t input_shift = input_shape[shape_size - 1];
+    const size_t input_shift  = input_shape[shape_size - 1];
     const size_t result_shift = result_shape[shape_size - 1];
 
     double backward_scale = 1.;
-    double forward_scale = 1.;
+    double forward_scale  = 1.;
 
     if (norm == 0) // norm = "backward"
     {
-        if (inverse)
-        {
+        if (inverse) {
             forward_scale = 1. / result_shift;
         }
-        else
-        {
+        else {
             backward_scale = 1. / result_shift;
         }
     }
     else if (norm == 1) // norm = "forward"
     {
-        if (inverse)
-        {
+        if (inverse) {
             backward_scale = 1. / result_shift;
         }
-        else
-        {
+        else {
             forward_scale = 1. / result_shift;
         }
     }
@@ -317,27 +334,33 @@ static DPCTLSyclEventRef dpnp_fft_fft_mathlib_real_to_cmplx_c(DPCTLSyclQueueRef 
 
     std::vector<sycl::event> fft_events(n_iter);
 
-    for (size_t i = 0; i < n_iter; ++i)
-    {
-        std::unique_ptr<_Descriptor_type> desc = std::make_unique<_Descriptor_type>(input_shift);
+    for (size_t i = 0; i < n_iter; ++i) {
+        std::unique_ptr<_Descriptor_type> desc =
+            std::make_unique<_Descriptor_type>(input_shift);
         desc->set_value(mkl_dft::config_param::BACKWARD_SCALE, backward_scale);
         desc->set_value(mkl_dft::config_param::FORWARD_SCALE, forward_scale);
         desc->set_value(mkl_dft::config_param::PLACEMENT, DFTI_NOT_INPLACE);
         desc->commit(queue);
 
-        // real result_size = 2 * result_size, because real type of "result" is twice wider than '_DataType_output'
-        fft_events[i] = mkl_dft::compute_forward<_Descriptor_type, _DataType_input, _DataType_output>(
-            *desc, array_1 + i * input_shift, result + i * result_shift * 2);
+        // real result_size = 2 * result_size, because real type of "result" is
+        // twice wider than '_DataType_output'
+        fft_events[i] =
+            mkl_dft::compute_forward<_Descriptor_type, _DataType_input,
+                                     _DataType_output>(
+                *desc, array_1 + i * input_shift,
+                result + i * result_shift * 2);
     }
 
     sycl::event::wait(fft_events);
 
-    if (real) // the output size of the rfft function is input_size/2 + 1 so we don't need to fill the second half of the output
+    if (real) // the output size of the rfft function is input_size/2 + 1 so we
+              // don't need to fill the second half of the output
     {
         return event_ref;
     }
 
-    size_t n_conj = result_shift % 2 == 0 ? result_shift / 2 - 1 : result_shift / 2;
+    size_t n_conj =
+        result_shift % 2 == 0 ? result_shift / 2 - 1 : result_shift / 2;
 
     sycl::event event;
 
@@ -348,28 +371,30 @@ static DPCTLSyclEventRef dpnp_fft_fft_mathlib_real_to_cmplx_c(DPCTLSyclQueueRef 
         {
             size_t j = global_id[1];
             {
-                *(reinterpret_cast<std::complex<_DataType_output>*>(result) + result_shift * (i + 1) - (j + 1)) =
+                *(reinterpret_cast<std::complex<_DataType_output> *>(result) +
+                  result_shift * (i + 1) - (j + 1)) =
                     std::conj(
-                        *(reinterpret_cast<std::complex<_DataType_output>*>(result) + result_shift * i + (j + 1)));
+                        *(reinterpret_cast<std::complex<_DataType_output> *>(
+                              result) +
+                          result_shift * i + (j + 1)));
             }
         }
     };
 
-    auto kernel_func = [&](sycl::handler& cgh) {
-        cgh.parallel_for<
-            class dpnp_fft_fft_mathlib_real_to_cmplx_c_kernel<_DataType_input, _DataType_output, _Descriptor_type>>(
+    auto kernel_func = [&](sycl::handler &cgh) {
+        cgh.parallel_for<class dpnp_fft_fft_mathlib_real_to_cmplx_c_kernel<
+            _DataType_input, _DataType_output, _Descriptor_type>>(
             gws, kernel_parallel_for_func);
     };
 
     event = queue.submit(kernel_func);
 
-    if (inverse)
-    {
+    if (inverse) {
         event.wait();
-        event = oneapi::mkl::vm::conj(queue,
-                                      result_size,
-                                      reinterpret_cast<std::complex<_DataType_output>*>(result),
-                                      reinterpret_cast<std::complex<_DataType_output>*>(result));
+        event = oneapi::mkl::vm::conj(
+            queue, result_size,
+            reinterpret_cast<std::complex<_DataType_output> *>(result),
+            reinterpret_cast<std::complex<_DataType_output> *>(result));
     }
 
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
@@ -378,10 +403,10 @@ static DPCTLSyclEventRef dpnp_fft_fft_mathlib_real_to_cmplx_c(DPCTLSyclQueueRef 
 
 template <typename _DataType_input, typename _DataType_output>
 DPCTLSyclEventRef dpnp_fft_fft_c(DPCTLSyclQueueRef q_ref,
-                                 const void* array1_in,
-                                 void* result_out,
-                                 const shape_elem_type* input_shape,
-                                 const shape_elem_type* result_shape,
+                                 const void *array1_in,
+                                 void *result_out,
+                                 const shape_elem_type *input_shape,
+                                 const shape_elem_type *result_shape,
                                  size_t shape_size,
                                  long axis,
                                  long input_boundarie,
@@ -391,63 +416,87 @@ DPCTLSyclEventRef dpnp_fft_fft_c(DPCTLSyclQueueRef q_ref,
 {
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!shape_size || !array1_in || !result_out)
-    {
+    if (!shape_size || !array1_in || !result_out) {
         return event_ref;
     }
 
     const size_t result_size =
-        std::accumulate(result_shape, result_shape + shape_size, 1, std::multiplies<shape_elem_type>());
+        std::accumulate(result_shape, result_shape + shape_size, 1,
+                        std::multiplies<shape_elem_type>());
     const size_t input_size =
-        std::accumulate(input_shape, input_shape + shape_size, 1, std::multiplies<shape_elem_type>());
+        std::accumulate(input_shape, input_shape + shape_size, 1,
+                        std::multiplies<shape_elem_type>());
 
     if constexpr (std::is_same<_DataType_output, std::complex<float>>::value ||
                   std::is_same<_DataType_output, std::complex<double>>::value)
     {
-        if constexpr (std::is_same<_DataType_input, std::complex<double>>::value &&
-                      std::is_same<_DataType_output, std::complex<double>>::value)
+        if constexpr (std::is_same<_DataType_input,
+                                   std::complex<double>>::value &&
+                      std::is_same<_DataType_output,
+                                   std::complex<double>>::value)
         {
-            dpnp_fft_fft_mathlib_cmplx_to_cmplx_c<_DataType_input, _DataType_output, desc_dp_cmplx_t>(
-                q_ref, array1_in, result_out, input_shape, result_shape, shape_size, input_size, result_size, inverse, norm);
+            dpnp_fft_fft_mathlib_cmplx_to_cmplx_c<
+                _DataType_input, _DataType_output, desc_dp_cmplx_t>(
+                q_ref, array1_in, result_out, input_shape, result_shape,
+                shape_size, input_size, result_size, inverse, norm);
         }
         /* complex-to-complex, single precision */
-        else if constexpr (std::is_same<_DataType_input, std::complex<float>>::value &&
-                           std::is_same<_DataType_output, std::complex<float>>::value)
+        else if constexpr (std::is_same<_DataType_input,
+                                        std::complex<float>>::value &&
+                           std::is_same<_DataType_output,
+                                        std::complex<float>>::value)
         {
-            dpnp_fft_fft_mathlib_cmplx_to_cmplx_c<_DataType_input, _DataType_output, desc_sp_cmplx_t>(
-                q_ref, array1_in, result_out, input_shape, result_shape, shape_size, input_size, result_size, inverse, norm);
+            dpnp_fft_fft_mathlib_cmplx_to_cmplx_c<
+                _DataType_input, _DataType_output, desc_sp_cmplx_t>(
+                q_ref, array1_in, result_out, input_shape, result_shape,
+                shape_size, input_size, result_size, inverse, norm);
         }
         /* real-to-complex, double precision */
         else if constexpr (std::is_same<_DataType_input, double>::value &&
-                           std::is_same<_DataType_output, std::complex<double>>::value)
+                           std::is_same<_DataType_output,
+                                        std::complex<double>>::value)
         {
-            event_ref = dpnp_fft_fft_mathlib_real_to_cmplx_c<_DataType_input, double, desc_dp_real_t>(
-                q_ref, array1_in, result_out, input_shape, result_shape, shape_size, input_size, result_size, inverse, norm, 0);
+            event_ref =
+                dpnp_fft_fft_mathlib_real_to_cmplx_c<_DataType_input, double,
+                                                     desc_dp_real_t>(
+                    q_ref, array1_in, result_out, input_shape, result_shape,
+                    shape_size, input_size, result_size, inverse, norm, 0);
         }
         /* real-to-complex, single precision */
         else if constexpr (std::is_same<_DataType_input, float>::value &&
-                           std::is_same<_DataType_output, std::complex<float>>::value)
+                           std::is_same<_DataType_output,
+                                        std::complex<float>>::value)
         {
-            event_ref = dpnp_fft_fft_mathlib_real_to_cmplx_c<_DataType_input, float, desc_sp_real_t>(
-                q_ref, array1_in, result_out, input_shape, result_shape, shape_size, input_size, result_size, inverse, norm, 0);
+            event_ref =
+                dpnp_fft_fft_mathlib_real_to_cmplx_c<_DataType_input, float,
+                                                     desc_sp_real_t>(
+                    q_ref, array1_in, result_out, input_shape, result_shape,
+                    shape_size, input_size, result_size, inverse, norm, 0);
         }
         else if constexpr (std::is_same<_DataType_input, int32_t>::value ||
                            std::is_same<_DataType_input, int64_t>::value)
         {
-            double* array1_copy = reinterpret_cast<double*>(dpnp_memory_alloc_c(q_ref, input_size * sizeof(double)));
+            double *array1_copy = reinterpret_cast<double *>(
+                dpnp_memory_alloc_c(q_ref, input_size * sizeof(double)));
 
-            shape_elem_type* copy_strides = reinterpret_cast<shape_elem_type*>(dpnp_memory_alloc_c(q_ref, sizeof(shape_elem_type)));
-            *copy_strides = 1;
-            shape_elem_type* copy_shape = reinterpret_cast<shape_elem_type*>(dpnp_memory_alloc_c(q_ref, sizeof(shape_elem_type)));
-            *copy_shape = input_size;
+            shape_elem_type *copy_strides = reinterpret_cast<shape_elem_type *>(
+                dpnp_memory_alloc_c(q_ref, sizeof(shape_elem_type)));
+            *copy_strides               = 1;
+            shape_elem_type *copy_shape = reinterpret_cast<shape_elem_type *>(
+                dpnp_memory_alloc_c(q_ref, sizeof(shape_elem_type)));
+            *copy_shape                     = input_size;
             shape_elem_type copy_shape_size = 1;
-            event_ref = dpnp_copyto_c<_DataType_input, double>(q_ref, array1_copy, input_size, copy_shape_size, copy_shape, copy_strides,
-                                                               array1_in, input_size, copy_shape_size, copy_shape, copy_strides, NULL, dep_event_vec_ref);
+            event_ref = dpnp_copyto_c<_DataType_input, double>(
+                q_ref, array1_copy, input_size, copy_shape_size, copy_shape,
+                copy_strides, array1_in, input_size, copy_shape_size,
+                copy_shape, copy_strides, NULL, dep_event_vec_ref);
             DPCTLEvent_WaitAndThrow(event_ref);
             DPCTLEvent_Delete(event_ref);
 
-            event_ref = dpnp_fft_fft_mathlib_real_to_cmplx_c<double, double, desc_dp_real_t>(
-                q_ref, array1_copy, result_out, input_shape, result_shape, shape_size, input_size, result_size, inverse, norm, 0);
+            event_ref = dpnp_fft_fft_mathlib_real_to_cmplx_c<double, double,
+                                                             desc_dp_real_t>(
+                q_ref, array1_copy, result_out, input_shape, result_shape,
+                shape_size, input_size, result_size, inverse, norm, 0);
 
             DPCTLEvent_WaitAndThrow(event_ref);
             DPCTLEvent_Delete(event_ref);
@@ -457,19 +506,11 @@ DPCTLSyclEventRef dpnp_fft_fft_c(DPCTLSyclQueueRef q_ref,
             dpnp_memory_free_c(q_ref, copy_strides);
             dpnp_memory_free_c(q_ref, copy_shape);
         }
-        else
-        {
-            dpnp_fft_fft_sycl_c<_DataType_input, _DataType_output>(q_ref,
-                                                                   array1_in,
-                                                                   result_out,
-                                                                   input_shape,
-                                                                   result_shape,
-                                                                   shape_size,
-                                                                   result_size,
-                                                                   input_size,
-                                                                   axis,
-                                                                   input_boundarie,
-                                                                   inverse);
+        else {
+            dpnp_fft_fft_sycl_c<_DataType_input, _DataType_output>(
+                q_ref, array1_in, result_out, input_shape, result_shape,
+                shape_size, result_size, input_size, axis, input_boundarie,
+                inverse);
         }
     }
 
@@ -477,10 +518,10 @@ DPCTLSyclEventRef dpnp_fft_fft_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType_input, typename _DataType_output>
-void dpnp_fft_fft_c(const void* array1_in,
-                    void* result1,
-                    const shape_elem_type* input_shape,
-                    const shape_elem_type* output_shape,
+void dpnp_fft_fft_c(const void *array1_in,
+                    void *result1,
+                    const shape_elem_type *input_shape,
+                    const shape_elem_type *output_shape,
                     size_t shape_size,
                     long axis,
                     long input_boundarie,
@@ -489,52 +530,46 @@ void dpnp_fft_fft_c(const void* array1_in,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_fft_fft_c<_DataType_input, _DataType_output>(q_ref,
-                                                                                    array1_in,
-                                                                                    result1,
-                                                                                    input_shape,
-                                                                                    output_shape,
-                                                                                    shape_size,
-                                                                                    axis,
-                                                                                    input_boundarie,
-                                                                                    inverse,
-                                                                                    norm,
-                                                                                    dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_fft_fft_c<_DataType_input, _DataType_output>(
+            q_ref, array1_in, result1, input_shape, output_shape, shape_size,
+            axis, input_boundarie, inverse, norm, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType_input, typename _DataType_output>
-void (*dpnp_fft_fft_default_c)(const void*,
-                               void*,
-                               const shape_elem_type*,
-                               const shape_elem_type*,
+void (*dpnp_fft_fft_default_c)(const void *,
+                               void *,
+                               const shape_elem_type *,
+                               const shape_elem_type *,
                                size_t,
                                long,
                                long,
                                size_t,
-                               const size_t) = dpnp_fft_fft_c<_DataType_input, _DataType_output>;
+                               const size_t) =
+    dpnp_fft_fft_c<_DataType_input, _DataType_output>;
 
 template <typename _DataType_input, typename _DataType_output>
 DPCTLSyclEventRef (*dpnp_fft_fft_ext_c)(DPCTLSyclQueueRef,
-                                        const void*,
-                                        void*,
-                                        const shape_elem_type*,
-                                        const shape_elem_type*,
+                                        const void *,
+                                        void *,
+                                        const shape_elem_type *,
+                                        const shape_elem_type *,
                                         size_t,
                                         long,
                                         long,
                                         size_t,
                                         const size_t,
-                                        const DPCTLEventVectorRef) = dpnp_fft_fft_c<_DataType_input, _DataType_output>;
-
+                                        const DPCTLEventVectorRef) =
+    dpnp_fft_fft_c<_DataType_input, _DataType_output>;
 
 template <typename _DataType_input, typename _DataType_output>
 DPCTLSyclEventRef dpnp_fft_rfft_c(DPCTLSyclQueueRef q_ref,
-                                  const void* array1_in,
-                                  void* result_out,
-                                  const shape_elem_type* input_shape,
-                                  const shape_elem_type* result_shape,
+                                  const void *array1_in,
+                                  void *result_out,
+                                  const shape_elem_type *input_shape,
+                                  const shape_elem_type *result_shape,
                                   size_t shape_size,
                                   long, // axis
                                   long, // input_boundary
@@ -544,49 +579,65 @@ DPCTLSyclEventRef dpnp_fft_rfft_c(DPCTLSyclQueueRef q_ref,
 {
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!shape_size || !array1_in || !result_out)
-    {
+    if (!shape_size || !array1_in || !result_out) {
         return event_ref;
     }
 
     const size_t result_size =
-        std::accumulate(result_shape, result_shape + shape_size, 1, std::multiplies<shape_elem_type>());
+        std::accumulate(result_shape, result_shape + shape_size, 1,
+                        std::multiplies<shape_elem_type>());
     const size_t input_size =
-        std::accumulate(input_shape, input_shape + shape_size, 1, std::multiplies<shape_elem_type>());
+        std::accumulate(input_shape, input_shape + shape_size, 1,
+                        std::multiplies<shape_elem_type>());
 
     if constexpr (std::is_same<_DataType_output, std::complex<float>>::value ||
                   std::is_same<_DataType_output, std::complex<double>>::value)
     {
         if constexpr (std::is_same<_DataType_input, double>::value &&
-                      std::is_same<_DataType_output, std::complex<double>>::value)
+                      std::is_same<_DataType_output,
+                                   std::complex<double>>::value)
         {
-            event_ref = dpnp_fft_fft_mathlib_real_to_cmplx_c<_DataType_input, double, desc_dp_real_t>(
-                q_ref, array1_in, result_out, input_shape, result_shape, shape_size, input_size, result_size, inverse, norm, 1);
+            event_ref =
+                dpnp_fft_fft_mathlib_real_to_cmplx_c<_DataType_input, double,
+                                                     desc_dp_real_t>(
+                    q_ref, array1_in, result_out, input_shape, result_shape,
+                    shape_size, input_size, result_size, inverse, norm, 1);
         }
         /* real-to-complex, single precision */
         else if constexpr (std::is_same<_DataType_input, float>::value &&
-                           std::is_same<_DataType_output, std::complex<float>>::value)
+                           std::is_same<_DataType_output,
+                                        std::complex<float>>::value)
         {
-            event_ref = dpnp_fft_fft_mathlib_real_to_cmplx_c<_DataType_input, float, desc_sp_real_t>(
-                q_ref, array1_in, result_out, input_shape, result_shape, shape_size, input_size, result_size, inverse, norm, 1);
+            event_ref =
+                dpnp_fft_fft_mathlib_real_to_cmplx_c<_DataType_input, float,
+                                                     desc_sp_real_t>(
+                    q_ref, array1_in, result_out, input_shape, result_shape,
+                    shape_size, input_size, result_size, inverse, norm, 1);
         }
         else if constexpr (std::is_same<_DataType_input, int32_t>::value ||
                            std::is_same<_DataType_input, int64_t>::value)
         {
-            double* array1_copy = reinterpret_cast<double*>(dpnp_memory_alloc_c(q_ref, input_size * sizeof(double)));
+            double *array1_copy = reinterpret_cast<double *>(
+                dpnp_memory_alloc_c(q_ref, input_size * sizeof(double)));
 
-            shape_elem_type* copy_strides = reinterpret_cast<shape_elem_type*>(dpnp_memory_alloc_c(q_ref, sizeof(shape_elem_type)));
-            *copy_strides = 1;
-            shape_elem_type* copy_shape = reinterpret_cast<shape_elem_type*>(dpnp_memory_alloc_c(q_ref, sizeof(shape_elem_type)));
-            *copy_shape = input_size;
+            shape_elem_type *copy_strides = reinterpret_cast<shape_elem_type *>(
+                dpnp_memory_alloc_c(q_ref, sizeof(shape_elem_type)));
+            *copy_strides               = 1;
+            shape_elem_type *copy_shape = reinterpret_cast<shape_elem_type *>(
+                dpnp_memory_alloc_c(q_ref, sizeof(shape_elem_type)));
+            *copy_shape                     = input_size;
             shape_elem_type copy_shape_size = 1;
-            event_ref = dpnp_copyto_c<_DataType_input, double>(q_ref, array1_copy, input_size, copy_shape_size, copy_shape, copy_strides,
-                                                               array1_in, input_size, copy_shape_size, copy_shape, copy_strides, NULL, dep_event_vec_ref);
+            event_ref = dpnp_copyto_c<_DataType_input, double>(
+                q_ref, array1_copy, input_size, copy_shape_size, copy_shape,
+                copy_strides, array1_in, input_size, copy_shape_size,
+                copy_shape, copy_strides, NULL, dep_event_vec_ref);
             DPCTLEvent_WaitAndThrow(event_ref);
             DPCTLEvent_Delete(event_ref);
 
-            event_ref = dpnp_fft_fft_mathlib_real_to_cmplx_c<double, double, desc_dp_real_t>(
-                q_ref, array1_copy, result_out, input_shape, result_shape, shape_size, input_size, result_size, inverse, norm, 1);
+            event_ref = dpnp_fft_fft_mathlib_real_to_cmplx_c<double, double,
+                                                             desc_dp_real_t>(
+                q_ref, array1_copy, result_out, input_shape, result_shape,
+                shape_size, input_size, result_size, inverse, norm, 1);
 
             DPCTLEvent_WaitAndThrow(event_ref);
             DPCTLEvent_Delete(event_ref);
@@ -601,12 +652,11 @@ DPCTLSyclEventRef dpnp_fft_rfft_c(DPCTLSyclQueueRef q_ref,
     return event_ref;
 }
 
-
 template <typename _DataType_input, typename _DataType_output>
-void dpnp_fft_rfft_c(const void* array1_in,
-                     void* result1,
-                     const shape_elem_type* input_shape,
-                     const shape_elem_type* output_shape,
+void dpnp_fft_rfft_c(const void *array1_in,
+                     void *result1,
+                     const shape_elem_type *input_shape,
+                     const shape_elem_type *output_shape,
                      size_t shape_size,
                      long axis,
                      long input_boundarie,
@@ -615,90 +665,96 @@ void dpnp_fft_rfft_c(const void* array1_in,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_fft_rfft_c<_DataType_input, _DataType_output>(q_ref,
-                                                                                     array1_in,
-                                                                                     result1,
-                                                                                     input_shape,
-                                                                                     output_shape,
-                                                                                     shape_size,
-                                                                                     axis,
-                                                                                     input_boundarie,
-                                                                                     inverse,
-                                                                                     norm,
-                                                                                     dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_fft_rfft_c<_DataType_input, _DataType_output>(
+            q_ref, array1_in, result1, input_shape, output_shape, shape_size,
+            axis, input_boundarie, inverse, norm, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType_input, typename _DataType_output>
-void (*dpnp_fft_rfft_default_c)(const void*,
-                                void*,
-                                const shape_elem_type*,
-                                const shape_elem_type*,
+void (*dpnp_fft_rfft_default_c)(const void *,
+                                void *,
+                                const shape_elem_type *,
+                                const shape_elem_type *,
                                 size_t,
                                 long,
                                 long,
                                 size_t,
-                                const size_t) = dpnp_fft_rfft_c<_DataType_input, _DataType_output>;
+                                const size_t) =
+    dpnp_fft_rfft_c<_DataType_input, _DataType_output>;
 
 template <typename _DataType_input, typename _DataType_output>
 DPCTLSyclEventRef (*dpnp_fft_rfft_ext_c)(DPCTLSyclQueueRef,
-                                         const void*,
-                                         void*,
-                                         const shape_elem_type*,
-                                         const shape_elem_type*,
+                                         const void *,
+                                         void *,
+                                         const shape_elem_type *,
+                                         const shape_elem_type *,
                                          size_t,
                                          long,
                                          long,
                                          size_t,
                                          const size_t,
-                                         const DPCTLEventVectorRef) = dpnp_fft_rfft_c<_DataType_input, _DataType_output>;
+                                         const DPCTLEventVectorRef) =
+    dpnp_fft_rfft_c<_DataType_input, _DataType_output>;
 
-void func_map_init_fft_func(func_map_t& fmap)
+void func_map_init_fft_func(func_map_t &fmap)
 {
     fmap[DPNPFuncName::DPNP_FN_FFT_FFT][eft_INT][eft_INT] = {
-        eft_C128, (void*)dpnp_fft_fft_default_c<int32_t, std::complex<double>>};
+        eft_C128,
+        (void *)dpnp_fft_fft_default_c<int32_t, std::complex<double>>};
     fmap[DPNPFuncName::DPNP_FN_FFT_FFT][eft_LNG][eft_LNG] = {
-        eft_C128, (void*)dpnp_fft_fft_default_c<int64_t, std::complex<double>>};
+        eft_C128,
+        (void *)dpnp_fft_fft_default_c<int64_t, std::complex<double>>};
     fmap[DPNPFuncName::DPNP_FN_FFT_FFT][eft_FLT][eft_FLT] = {
-        eft_C64, (void*)dpnp_fft_fft_default_c<float, std::complex<float>>};
+        eft_C64, (void *)dpnp_fft_fft_default_c<float, std::complex<float>>};
     fmap[DPNPFuncName::DPNP_FN_FFT_FFT][eft_DBL][eft_DBL] = {
-        eft_C128, (void*)dpnp_fft_fft_default_c<double, std::complex<double>>};
+        eft_C128, (void *)dpnp_fft_fft_default_c<double, std::complex<double>>};
     fmap[DPNPFuncName::DPNP_FN_FFT_FFT][eft_C64][eft_C64] = {
-        eft_C64, (void*)dpnp_fft_fft_default_c<std::complex<float>, std::complex<float>>};
+        eft_C64,
+        (void *)
+            dpnp_fft_fft_default_c<std::complex<float>, std::complex<float>>};
     fmap[DPNPFuncName::DPNP_FN_FFT_FFT][eft_C128][eft_C128] = {
-        eft_C128, (void*)dpnp_fft_fft_default_c<std::complex<double>, std::complex<double>>};
+        eft_C128,
+        (void *)
+            dpnp_fft_fft_default_c<std::complex<double>, std::complex<double>>};
 
     fmap[DPNPFuncName::DPNP_FN_FFT_FFT_EXT][eft_INT][eft_INT] = {
-        eft_C128, (void*)dpnp_fft_fft_ext_c<int32_t, std::complex<double>>};
+        eft_C128, (void *)dpnp_fft_fft_ext_c<int32_t, std::complex<double>>};
     fmap[DPNPFuncName::DPNP_FN_FFT_FFT_EXT][eft_LNG][eft_LNG] = {
-        eft_C128, (void*)dpnp_fft_fft_ext_c<int64_t, std::complex<double>>};
+        eft_C128, (void *)dpnp_fft_fft_ext_c<int64_t, std::complex<double>>};
     fmap[DPNPFuncName::DPNP_FN_FFT_FFT_EXT][eft_FLT][eft_FLT] = {
-        eft_C64, (void*)dpnp_fft_fft_ext_c<float, std::complex<float>>};
+        eft_C64, (void *)dpnp_fft_fft_ext_c<float, std::complex<float>>};
     fmap[DPNPFuncName::DPNP_FN_FFT_FFT_EXT][eft_DBL][eft_DBL] = {
-        eft_C128, (void*)dpnp_fft_fft_ext_c<double, std::complex<double>>};
+        eft_C128, (void *)dpnp_fft_fft_ext_c<double, std::complex<double>>};
     fmap[DPNPFuncName::DPNP_FN_FFT_FFT_EXT][eft_C64][eft_C64] = {
-        eft_C64, (void*)dpnp_fft_fft_ext_c<std::complex<float>, std::complex<float>>};
+        eft_C64,
+        (void *)dpnp_fft_fft_ext_c<std::complex<float>, std::complex<float>>};
     fmap[DPNPFuncName::DPNP_FN_FFT_FFT_EXT][eft_C128][eft_C128] = {
-        eft_C128, (void*)dpnp_fft_fft_ext_c<std::complex<double>, std::complex<double>>};
+        eft_C128,
+        (void *)dpnp_fft_fft_ext_c<std::complex<double>, std::complex<double>>};
 
     fmap[DPNPFuncName::DPNP_FN_FFT_RFFT][eft_INT][eft_INT] = {
-        eft_C128, (void*)dpnp_fft_rfft_default_c<int32_t, std::complex<double>>};
+        eft_C128,
+        (void *)dpnp_fft_rfft_default_c<int32_t, std::complex<double>>};
     fmap[DPNPFuncName::DPNP_FN_FFT_RFFT][eft_LNG][eft_LNG] = {
-        eft_C128, (void*)dpnp_fft_rfft_default_c<int64_t, std::complex<double>>};
+        eft_C128,
+        (void *)dpnp_fft_rfft_default_c<int64_t, std::complex<double>>};
     fmap[DPNPFuncName::DPNP_FN_FFT_RFFT][eft_FLT][eft_FLT] = {
-        eft_C64, (void*)dpnp_fft_rfft_default_c<float, std::complex<float>>};
+        eft_C64, (void *)dpnp_fft_rfft_default_c<float, std::complex<float>>};
     fmap[DPNPFuncName::DPNP_FN_FFT_RFFT][eft_DBL][eft_DBL] = {
-        eft_C128, (void*)dpnp_fft_rfft_default_c<double, std::complex<double>>};
+        eft_C128,
+        (void *)dpnp_fft_rfft_default_c<double, std::complex<double>>};
 
     fmap[DPNPFuncName::DPNP_FN_FFT_RFFT_EXT][eft_INT][eft_INT] = {
-        eft_C128, (void*)dpnp_fft_rfft_ext_c<int32_t, std::complex<double>>};
+        eft_C128, (void *)dpnp_fft_rfft_ext_c<int32_t, std::complex<double>>};
     fmap[DPNPFuncName::DPNP_FN_FFT_RFFT_EXT][eft_LNG][eft_LNG] = {
-        eft_C128, (void*)dpnp_fft_rfft_ext_c<int64_t, std::complex<double>>};
+        eft_C128, (void *)dpnp_fft_rfft_ext_c<int64_t, std::complex<double>>};
     fmap[DPNPFuncName::DPNP_FN_FFT_RFFT_EXT][eft_FLT][eft_FLT] = {
-        eft_C64, (void*)dpnp_fft_rfft_ext_c<float, std::complex<float>>};
+        eft_C64, (void *)dpnp_fft_rfft_ext_c<float, std::complex<float>>};
     fmap[DPNPFuncName::DPNP_FN_FFT_RFFT_EXT][eft_DBL][eft_DBL] = {
-        eft_C128, (void*)dpnp_fft_rfft_ext_c<double, std::complex<double>>};
+        eft_C128, (void *)dpnp_fft_rfft_ext_c<double, std::complex<double>>};
 
     return;
 }

--- a/dpnp/backend/kernels/dpnp_krnl_fft.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_fft.cpp
@@ -217,7 +217,7 @@ static void
     const size_t shift = input_shape[shape_size - 1];
 
     double backward_scale = 1.;
-    double forward_scale  = 1.;
+    double forward_scale = 1.;
 
     if (norm == 0) // norm = "backward"
     {
@@ -303,11 +303,11 @@ static DPCTLSyclEventRef
         std::accumulate(input_shape, input_shape + shape_size - 1, 1,
                         std::multiplies<shape_elem_type>());
 
-    const size_t input_shift  = input_shape[shape_size - 1];
+    const size_t input_shift = input_shape[shape_size - 1];
     const size_t result_shift = result_shape[shape_size - 1];
 
     double backward_scale = 1.;
-    double forward_scale  = 1.;
+    double forward_scale = 1.;
 
     if (norm == 0) // norm = "backward"
     {
@@ -481,10 +481,10 @@ DPCTLSyclEventRef dpnp_fft_fft_c(DPCTLSyclQueueRef q_ref,
 
             shape_elem_type *copy_strides = reinterpret_cast<shape_elem_type *>(
                 dpnp_memory_alloc_c(q_ref, sizeof(shape_elem_type)));
-            *copy_strides               = 1;
+            *copy_strides = 1;
             shape_elem_type *copy_shape = reinterpret_cast<shape_elem_type *>(
                 dpnp_memory_alloc_c(q_ref, sizeof(shape_elem_type)));
-            *copy_shape                     = input_size;
+            *copy_shape = input_size;
             shape_elem_type copy_shape_size = 1;
             event_ref = dpnp_copyto_c<_DataType_input, double>(
                 q_ref, array1_copy, input_size, copy_shape_size, copy_shape,
@@ -622,10 +622,10 @@ DPCTLSyclEventRef dpnp_fft_rfft_c(DPCTLSyclQueueRef q_ref,
 
             shape_elem_type *copy_strides = reinterpret_cast<shape_elem_type *>(
                 dpnp_memory_alloc_c(q_ref, sizeof(shape_elem_type)));
-            *copy_strides               = 1;
+            *copy_strides = 1;
             shape_elem_type *copy_shape = reinterpret_cast<shape_elem_type *>(
                 dpnp_memory_alloc_c(q_ref, sizeof(shape_elem_type)));
-            *copy_shape                     = input_size;
+            *copy_shape = input_size;
             shape_elem_type copy_shape_size = 1;
             event_ref = dpnp_copyto_c<_DataType_input, double>(
                 q_ref, array1_copy, input_size, copy_shape_size, copy_shape,

--- a/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
@@ -79,7 +79,7 @@ DPCTLSyclEventRef dpnp_choose_c(DPCTLSyclQueueRef q_ref,
     sycl::range<1> gws(size);
     auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
         const size_t idx = global_id[0];
-        result[idx]      = choices[array_in[idx]][idx];
+        result[idx] = choices[array_in[idx]][idx];
     };
 
     auto kernel_func = [&](sycl::handler &cgh) {
@@ -186,7 +186,7 @@ DPCTLSyclEventRef dpnp_diagonal_c(DPCTLSyclQueueRef q_ref,
     DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, res_size, true,
                                             true);
     _DataType *array_1 = input1_ptr.get_ptr();
-    _DataType *result  = result_ptr.get_ptr();
+    _DataType *result = result_ptr.get_ptr();
 
     if (res_ndim <= 1) {
         for (size_t i = 0; i < static_cast<size_t>(res_shape[res_ndim - 1]);
@@ -235,18 +235,18 @@ DPCTLSyclEventRef dpnp_diagonal_c(DPCTLSyclQueueRef q_ref,
                 else {
                     size_t ind_input_size = ind_list.size() + 2;
                     size_t ind_input_[ind_input_size];
-                    ind_input_[0]          = i;
-                    ind_input_[1]          = i + offset;
+                    ind_input_[0] = i;
+                    ind_input_[1] = i + offset;
                     size_t ind_output_size = ind_list.size() + 1;
                     size_t ind_output_[ind_output_size];
                     for (size_t k = 0; k < ind_list.size(); k++) {
                         ind_input_[k + 2] = ind_list.at(k);
-                        ind_output_[k]    = ind_list.at(k);
+                        ind_output_[k] = ind_list.at(k);
                     }
                     ind_output_[ind_list.size()] = i;
 
                     size_t ind_output = 0;
-                    size_t n          = 1;
+                    size_t n = 1;
                     for (size_t k = 0; k < ind_output_size; k++) {
                         size_t ind = ind_output_size - 1 - k;
                         ind_output += n * ind_output_[ind];
@@ -254,7 +254,7 @@ DPCTLSyclEventRef dpnp_diagonal_c(DPCTLSyclQueueRef q_ref,
                     }
 
                     size_t ind_input = 0;
-                    size_t m         = 1;
+                    size_t m = 1;
                     for (size_t k = 0; k < ind_input_size; k++) {
                         size_t ind = ind_input_size - 1 - k;
                         ind_input += m * ind_input_[ind];
@@ -281,7 +281,7 @@ void dpnp_diagonal_c(void *array1_in,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_diagonal_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_diagonal_c<_DataType>(
         q_ref, array1_in, input1_size, result1, offset, shape, res_shape,
         res_ndim, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
@@ -347,7 +347,7 @@ DPCTLSyclEventRef
 
     for (size_t i = 0; i < static_cast<size_t>(min_shape); ++i) {
         size_t ind = 0;
-        size_t n   = 1;
+        size_t n = 1;
         for (size_t k = 0; k < ndim; k++) {
             size_t ind_ = ndim - 1 - k;
             ind += n * i;
@@ -367,7 +367,7 @@ void dpnp_fill_diagonal_c(void *array1_in,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_fill_diagonal_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_fill_diagonal_c<_DataType>(
         q_ref, array1_in, val_in, shape, ndim, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -420,7 +420,7 @@ DPCTLSyclEventRef dpnp_nonzero_c(DPCTLSyclQueueRef q_ref,
                                             true);
     DPNPC_ptr_adapter<long> result_ptr(q_ref, result1, result_size, true, true);
     const _DataType *arr = input1_ptr.get_ptr();
-    long *result         = result_ptr.get_ptr();
+    long *result = result_ptr.get_ptr();
 
     size_t idx = 0;
     for (size_t i = 0; i < input1_size; ++i) {
@@ -429,9 +429,9 @@ DPCTLSyclEventRef dpnp_nonzero_c(DPCTLSyclQueueRef q_ref,
             size_t ind1 = input1_size;
             size_t ind2 = i;
             for (size_t k = 0; k < ndim; ++k) {
-                ind1   = ind1 / shape[k];
+                ind1 = ind1 / shape[k];
                 ids[k] = ind2 / ind1;
-                ind2   = ind2 % ind1;
+                ind2 = ind2 % ind1;
             }
 
             result[idx] = ids[j];
@@ -495,7 +495,7 @@ DPCTLSyclEventRef dpnp_place_c(DPCTLSyclQueueRef q_ref,
     DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, arr_in, arr_size, true,
                                             true);
     _DataType *vals = input1_ptr.get_ptr();
-    _DataType *arr  = result_ptr.get_ptr();
+    _DataType *arr = result_ptr.get_ptr();
 
     DPNPC_ptr_adapter<long> mask_ptr(q_ref, mask_in, arr_size, true);
     long *mask = mask_ptr.get_ptr();
@@ -561,8 +561,8 @@ DPCTLSyclEventRef dpnp_put_c(DPCTLSyclQueueRef q_ref,
     DPNPC_ptr_adapter<size_t> input1_ptr(q_ref, ind_in, size_ind, true);
     DPNPC_ptr_adapter<_DataType> input2_ptr(q_ref, v_in, size_v, true);
     DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, array1_in, size, true, true);
-    size_t *ind        = input1_ptr.get_ptr();
-    _DataType *v       = input2_ptr.get_ptr();
+    size_t *ind = input1_ptr.get_ptr();
+    _DataType *v = input2_ptr.get_ptr();
     _DataType *array_1 = result_ptr.get_ptr();
 
     for (size_t i = 0; i < size; ++i) {
@@ -630,7 +630,7 @@ DPCTLSyclEventRef
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     size_t res_ndim = ndim - 1;
     size_t res_shape[res_ndim];
@@ -642,9 +642,9 @@ DPCTLSyclEventRef
                                             true);
     DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, arr_in, size_arr, true,
                                             true);
-    size_t *indices   = input1_ptr.get_ptr();
+    size_t *indices = input1_ptr.get_ptr();
     _DataType *values = input2_ptr.get_ptr();
-    _DataType *arr    = result_ptr.get_ptr();
+    _DataType *arr = result_ptr.get_ptr();
 
     if (axis != res_ndim) {
         int ind = 0;
@@ -695,7 +695,7 @@ DPCTLSyclEventRef
             size_t xyz[res_ndim];
             size_t remainder = result_idx;
             for (size_t i = 0; i < res_ndim; ++i) {
-                xyz[i]    = remainder / output_shape_offsets[i];
+                xyz[i] = remainder / output_shape_offsets[i];
                 remainder = remainder - xyz[i] * output_shape_offsets[i];
             }
 
@@ -728,7 +728,7 @@ DPCTLSyclEventRef
             size_t xyz[ndim];
             size_t remainder = source_idx;
             for (size_t i = 0; i < ndim; ++i) {
-                xyz[i]    = remainder / arr_shape_offsets[i];
+                xyz[i] = remainder / arr_shape_offsets[i];
                 remainder = remainder - xyz[i] * arr_shape_offsets[i];
             }
 
@@ -754,7 +754,7 @@ DPCTLSyclEventRef
             }
 
             if (bool_ind_array[result_offset]) {
-                ind_array[result_offset]      = 0;
+                ind_array[result_offset] = 0;
                 bool_ind_array[result_offset] = false;
             }
             else {
@@ -790,7 +790,7 @@ void dpnp_put_along_axis_c(void *arr_in,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_put_along_axis_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_put_along_axis_c<_DataType>(
         q_ref, arr_in, indices_in, values_in, axis, shape, ndim, size_indices,
         values_size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
@@ -837,16 +837,16 @@ DPCTLSyclEventRef dpnp_take_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    _DataType *array_1    = reinterpret_cast<_DataType *>(array1_in);
+    _DataType *array_1 = reinterpret_cast<_DataType *>(array1_in);
     _IndecesType *indices = reinterpret_cast<_IndecesType *>(indices1);
-    _DataType *result     = reinterpret_cast<_DataType *>(result1);
+    _DataType *result = reinterpret_cast<_DataType *>(result1);
 
     sycl::range<1> gws(size);
     auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
         const size_t idx = global_id[0];
-        result[idx]      = array_1[indices[idx]];
+        result[idx] = array_1[indices[idx]];
     };
 
     auto kernel_func = [&](sycl::handler &cgh) {

--- a/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
@@ -27,19 +27,19 @@
 #include <list>
 #include <vector>
 
-#include <dpnp_iface.hpp>
 #include "dpnp_fptr.hpp"
 #include "dpnpc_memory_adapter.hpp"
 #include "queue_sycl.hpp"
+#include <dpnp_iface.hpp>
 
 template <typename _DataType1, typename _DataType2>
 class dpnp_choose_c_kernel;
 
 template <typename _DataType1, typename _DataType2>
 DPCTLSyclEventRef dpnp_choose_c(DPCTLSyclQueueRef q_ref,
-                                void* result1,
-                                void* array1_in,
-                                void** choices1,
+                                void *result1,
+                                void *array1_in,
+                                void **choices1,
                                 size_t size,
                                 size_t choices_size,
                                 size_t choice_size,
@@ -54,36 +54,37 @@ DPCTLSyclEventRef dpnp_choose_c(DPCTLSyclQueueRef q_ref,
     {
         return event_ref;
     }
-    if (!size || !choices_size || !choice_size)
-    {
+    if (!size || !choices_size || !choice_size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_DataType1> input1_ptr(q_ref, array1_in, size);
-    _DataType1* array_in = input1_ptr.get_ptr();
+    _DataType1 *array_in = input1_ptr.get_ptr();
 
-    DPNPC_ptr_adapter<_DataType2*> choices_ptr(q_ref, choices1, choices_size);
-    _DataType2** choices = choices_ptr.get_ptr();
+    DPNPC_ptr_adapter<_DataType2 *> choices_ptr(q_ref, choices1, choices_size);
+    _DataType2 **choices = choices_ptr.get_ptr();
 
-    for (size_t i = 0; i < choices_size; ++i)
-    {
-        DPNPC_ptr_adapter<_DataType2> choice_ptr(q_ref, choices[i], choice_size);
+    for (size_t i = 0; i < choices_size; ++i) {
+        DPNPC_ptr_adapter<_DataType2> choice_ptr(q_ref, choices[i],
+                                                 choice_size);
         choices[i] = choice_ptr.get_ptr();
     }
 
-    DPNPC_ptr_adapter<_DataType2> result1_ptr(q_ref, result1, size, false, true);
-    _DataType2* result = result1_ptr.get_ptr();
+    DPNPC_ptr_adapter<_DataType2> result1_ptr(q_ref, result1, size, false,
+                                              true);
+    _DataType2 *result = result1_ptr.get_ptr();
 
     sycl::range<1> gws(size);
     auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
         const size_t idx = global_id[0];
-        result[idx] = choices[array_in[idx]][idx];
+        result[idx]      = choices[array_in[idx]][idx];
     };
 
-    auto kernel_func = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class dpnp_choose_c_kernel<_DataType1, _DataType2>>(gws, kernel_parallel_for_func);
+    auto kernel_func = [&](sycl::handler &cgh) {
+        cgh.parallel_for<class dpnp_choose_c_kernel<_DataType1, _DataType2>>(
+            gws, kernel_parallel_for_func);
     };
 
     sycl::event event = q.submit(kernel_func);
@@ -94,73 +95,76 @@ DPCTLSyclEventRef dpnp_choose_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType1, typename _DataType2>
-void dpnp_choose_c(
-    void* result1, void* array1_in, void** choices1, size_t size, size_t choices_size, size_t choice_size)
+void dpnp_choose_c(void *result1,
+                   void *array1_in,
+                   void **choices1,
+                   size_t size,
+                   size_t choices_size,
+                   size_t choice_size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_choose_c<_DataType1, _DataType2>(q_ref,
-                                                                        result1,
-                                                                        array1_in,
-                                                                        choices1,
-                                                                        size,
-                                                                        choices_size,
-                                                                        choice_size,
-                                                                        dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref = dpnp_choose_c<_DataType1, _DataType2>(
+        q_ref, result1, array1_in, choices1, size, choices_size, choice_size,
+        dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType1, typename _DataType2>
-void (*dpnp_choose_default_c)(void*, void*, void**, size_t, size_t, size_t) = dpnp_choose_c<_DataType1, _DataType2>;
+void (*dpnp_choose_default_c)(void *, void *, void **, size_t, size_t, size_t) =
+    dpnp_choose_c<_DataType1, _DataType2>;
 
 template <typename _DataType1, typename _DataType2>
 DPCTLSyclEventRef (*dpnp_choose_ext_c)(DPCTLSyclQueueRef,
-                                       void*,
-                                       void*,
-                                       void**,
+                                       void *,
+                                       void *,
+                                       void **,
                                        size_t,
                                        size_t,
                                        size_t,
-                                       const DPCTLEventVectorRef) = dpnp_choose_c<_DataType1, _DataType2>;
+                                       const DPCTLEventVectorRef) =
+    dpnp_choose_c<_DataType1, _DataType2>;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_diag_indices_c(DPCTLSyclQueueRef q_ref,
-                                      void* result1,
-                                      size_t size,
-                                      const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_diag_indices_c(DPCTLSyclQueueRef q_ref,
+                        void *result1,
+                        size_t size,
+                        const DPCTLEventVectorRef dep_event_vec_ref)
 {
-    return dpnp_arange_c<_DataType>(q_ref, 0, 1, result1, size, dep_event_vec_ref);
+    return dpnp_arange_c<_DataType>(q_ref, 0, 1, result1, size,
+                                    dep_event_vec_ref);
 }
 
 template <typename _DataType>
-void dpnp_diag_indices_c(void* result1, size_t size)
+void dpnp_diag_indices_c(void *result1, size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_diag_indices_c<_DataType>(q_ref,
-                                                                 result1,
-                                                                 size,
-                                                                 dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_diag_indices_c<_DataType>(q_ref, result1, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_diag_indices_default_c)(void*, size_t) = dpnp_diag_indices_c<_DataType>;
+void (*dpnp_diag_indices_default_c)(void *,
+                                    size_t) = dpnp_diag_indices_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_diag_indices_ext_c)(DPCTLSyclQueueRef,
-                                             void*,
+                                             void *,
                                              size_t,
-                                             const DPCTLEventVectorRef) = dpnp_diag_indices_c<_DataType>;
+                                             const DPCTLEventVectorRef) =
+    dpnp_diag_indices_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_diagonal_c(DPCTLSyclQueueRef q_ref,
-                                  void* array1_in,
+                                  void *array1_in,
                                   const size_t input1_size,
-                                  void* result1,
+                                  void *result1,
                                   const size_t offset,
-                                  shape_elem_type* shape,
-                                  shape_elem_type* res_shape,
+                                  shape_elem_type *shape,
+                                  shape_elem_type *res_shape,
                                   const size_t res_ndim,
                                   const DPCTLEventVectorRef dep_event_vec_ref)
 {
@@ -169,48 +173,43 @@ DPCTLSyclEventRef dpnp_diagonal_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    const size_t res_size = std::accumulate(res_shape, res_shape + res_ndim, 1, std::multiplies<shape_elem_type>());
-    if (!(res_size && input1_size))
-    {
+    const size_t res_size = std::accumulate(res_shape, res_shape + res_ndim, 1,
+                                            std::multiplies<shape_elem_type>());
+    if (!(res_size && input1_size)) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, input1_size, true);
-    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, res_size, true, true);
-    _DataType* array_1 = input1_ptr.get_ptr();
-    _DataType* result = result_ptr.get_ptr();
+    DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, input1_size,
+                                            true);
+    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, res_size, true,
+                                            true);
+    _DataType *array_1 = input1_ptr.get_ptr();
+    _DataType *result  = result_ptr.get_ptr();
 
-    if (res_ndim <= 1)
-    {
-        for (size_t i = 0; i < static_cast<size_t>(res_shape[res_ndim - 1]); ++i)
-        {
+    if (res_ndim <= 1) {
+        for (size_t i = 0; i < static_cast<size_t>(res_shape[res_ndim - 1]);
+             ++i) {
             result[i] = array_1[i * shape[res_ndim] + i + offset];
         }
     }
-    else
-    {
+    else {
         std::map<size_t, std::vector<size_t>> xyz;
-        for (size_t i = 0; i < static_cast<size_t>(res_shape[0]); i++)
-        {
+        for (size_t i = 0; i < static_cast<size_t>(res_shape[0]); i++) {
             xyz[i] = {i};
         }
 
         size_t index = 1;
-        while (index < res_ndim - 1)
-        {
+        while (index < res_ndim - 1) {
             size_t shape_element = res_shape[index];
             std::map<size_t, std::vector<size_t>> new_shape_array;
             size_t ind = 0;
-            for (size_t i = 0; i < shape_element; i++)
-            {
-                for (size_t j = 0; j < xyz.size(); j++)
-                {
+            for (size_t i = 0; i < shape_element; i++) {
+                for (size_t j = 0; j < xyz.size(); j++) {
                     std::vector<size_t> new_shape;
                     std::vector<size_t> list_ind = xyz[j];
-                    for (size_t k = 0; k < list_ind.size(); k++)
-                    {
+                    for (size_t k = 0; k < list_ind.size(); k++) {
                         new_shape.push_back(list_ind.at(k));
                     }
                     new_shape.push_back(i);
@@ -220,50 +219,43 @@ DPCTLSyclEventRef dpnp_diagonal_c(DPCTLSyclQueueRef q_ref,
             }
             size_t len_new_shape_array = new_shape_array.size() * (index + 1);
 
-            for (size_t k = 0; k < len_new_shape_array; k++)
-            {
+            for (size_t k = 0; k < len_new_shape_array; k++) {
                 xyz[k] = new_shape_array[k];
             }
             index += 1;
         }
 
-        for (size_t i = 0; i < static_cast<size_t>(res_shape[res_ndim - 1]); i++)
-        {
-            for (size_t j = 0; j < xyz.size(); j++)
-            {
+        for (size_t i = 0; i < static_cast<size_t>(res_shape[res_ndim - 1]);
+             i++) {
+            for (size_t j = 0; j < xyz.size(); j++) {
                 std::vector<size_t> ind_list = xyz[j];
-                if (ind_list.size() == 0)
-                {
+                if (ind_list.size() == 0) {
                     continue;
                 }
-                else
-                {
+                else {
                     size_t ind_input_size = ind_list.size() + 2;
                     size_t ind_input_[ind_input_size];
-                    ind_input_[0] = i;
-                    ind_input_[1] = i + offset;
+                    ind_input_[0]          = i;
+                    ind_input_[1]          = i + offset;
                     size_t ind_output_size = ind_list.size() + 1;
                     size_t ind_output_[ind_output_size];
-                    for (size_t k = 0; k < ind_list.size(); k++)
-                    {
+                    for (size_t k = 0; k < ind_list.size(); k++) {
                         ind_input_[k + 2] = ind_list.at(k);
-                        ind_output_[k] = ind_list.at(k);
+                        ind_output_[k]    = ind_list.at(k);
                     }
                     ind_output_[ind_list.size()] = i;
 
                     size_t ind_output = 0;
-                    size_t n = 1;
-                    for (size_t k = 0; k < ind_output_size; k++)
-                    {
+                    size_t n          = 1;
+                    for (size_t k = 0; k < ind_output_size; k++) {
                         size_t ind = ind_output_size - 1 - k;
                         ind_output += n * ind_output_[ind];
                         n *= res_shape[ind];
                     }
 
                     size_t ind_input = 0;
-                    size_t m = 1;
-                    for (size_t k = 0; k < ind_input_size; k++)
-                    {
+                    size_t m         = 1;
+                    for (size_t k = 0; k < ind_input_size; k++) {
                         size_t ind = ind_input_size - 1 - k;
                         ind_input += m * ind_input_[ind];
                         m *= shape[ind];
@@ -279,91 +271,84 @@ DPCTLSyclEventRef dpnp_diagonal_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_diagonal_c(void* array1_in,
+void dpnp_diagonal_c(void *array1_in,
                      const size_t input1_size,
-                     void* result1,
+                     void *result1,
                      const size_t offset,
-                     shape_elem_type* shape,
-                     shape_elem_type* res_shape,
+                     shape_elem_type *shape,
+                     shape_elem_type *res_shape,
                      const size_t res_ndim)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_diagonal_c<_DataType>(q_ref,
-                                                             array1_in,
-                                                             input1_size,
-                                                             result1,
-                                                             offset,
-                                                             shape,
-                                                             res_shape,
-                                                             res_ndim,
-                                                             dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_diagonal_c<_DataType>(
+        q_ref, array1_in, input1_size, result1, offset, shape, res_shape,
+        res_ndim, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_diagonal_default_c)(void*,
+void (*dpnp_diagonal_default_c)(void *,
                                 const size_t,
-                                void*,
+                                void *,
                                 const size_t,
-                                shape_elem_type*,
-                                shape_elem_type*,
+                                shape_elem_type *,
+                                shape_elem_type *,
                                 const size_t) = dpnp_diagonal_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_diagonal_ext_c)(DPCTLSyclQueueRef,
-                                         void*,
+                                         void *,
                                          const size_t,
-                                         void*,
+                                         void *,
                                          const size_t,
-                                         shape_elem_type*,
-                                         shape_elem_type*,
+                                         shape_elem_type *,
+                                         shape_elem_type *,
                                          const size_t,
-                                         const DPCTLEventVectorRef) = dpnp_diagonal_c<_DataType>;
+                                         const DPCTLEventVectorRef) =
+    dpnp_diagonal_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_fill_diagonal_c(DPCTLSyclQueueRef q_ref,
-                                       void* array1_in,
-                                       void* val_in,
-                                       shape_elem_type* shape,
-                                       const size_t ndim,
-                                       const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_fill_diagonal_c(DPCTLSyclQueueRef q_ref,
+                         void *array1_in,
+                         void *val_in,
+                         shape_elem_type *shape,
+                         const size_t ndim,
+                         const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    const size_t result_size = std::accumulate(shape, shape + ndim, 1, std::multiplies<shape_elem_type>());
-    if (!(result_size && array1_in))
-    {
+    const size_t result_size = std::accumulate(
+        shape, shape + ndim, 1, std::multiplies<shape_elem_type>());
+    if (!(result_size && array1_in)) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, array1_in, result_size, true, true);
+    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, array1_in, result_size, true,
+                                            true);
     DPNPC_ptr_adapter<_DataType> val_ptr(q_ref, val_in, 1, true);
-    _DataType* array_1 = result_ptr.get_ptr();
-    _DataType* val_arr = val_ptr.get_ptr();
+    _DataType *array_1 = result_ptr.get_ptr();
+    _DataType *val_arr = val_ptr.get_ptr();
 
     shape_elem_type min_shape = shape[0];
-    for (size_t i = 0; i < ndim; ++i)
-    {
-        if (shape[i] < min_shape)
-        {
+    for (size_t i = 0; i < ndim; ++i) {
+        if (shape[i] < min_shape) {
             min_shape = shape[i];
         }
     }
 
     _DataType val = val_arr[0];
 
-    for (size_t i = 0; i < static_cast<size_t>(min_shape); ++i)
-    {
+    for (size_t i = 0; i < static_cast<size_t>(min_shape); ++i) {
         size_t ind = 0;
-        size_t n = 1;
-        for (size_t k = 0; k < ndim; k++)
-        {
+        size_t n   = 1;
+        for (size_t k = 0; k < ndim; k++) {
             size_t ind_ = ndim - 1 - k;
             ind += n * i;
             n *= shape[ind_];
@@ -375,36 +360,40 @@ DPCTLSyclEventRef dpnp_fill_diagonal_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_fill_diagonal_c(void* array1_in, void* val_in, shape_elem_type* shape, const size_t ndim)
+void dpnp_fill_diagonal_c(void *array1_in,
+                          void *val_in,
+                          shape_elem_type *shape,
+                          const size_t ndim)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_fill_diagonal_c<_DataType>(q_ref,
-                                                                  array1_in,
-                                                                  val_in,
-                                                                  shape,
-                                                                  ndim,
-                                                                  dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_fill_diagonal_c<_DataType>(
+        q_ref, array1_in, val_in, shape, ndim, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_fill_diagonal_default_c)(void*, void*, shape_elem_type*, const size_t) = dpnp_fill_diagonal_c<_DataType>;
+void (*dpnp_fill_diagonal_default_c)(void *,
+                                     void *,
+                                     shape_elem_type *,
+                                     const size_t) =
+    dpnp_fill_diagonal_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_fill_diagonal_ext_c)(DPCTLSyclQueueRef,
-                                              void*,
-                                              void*,
-                                              shape_elem_type*,
+                                              void *,
+                                              void *,
+                                              shape_elem_type *,
                                               const size_t,
-                                              const DPCTLEventVectorRef) = dpnp_fill_diagonal_c<_DataType>;
+                                              const DPCTLEventVectorRef) =
+    dpnp_fill_diagonal_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_nonzero_c(DPCTLSyclQueueRef q_ref,
-                                 const void* in_array1,
-                                 void* result1,
+                                 const void *in_array1,
+                                 void *result1,
                                  const size_t result_size,
-                                 const shape_elem_type* shape,
+                                 const shape_elem_type *shape,
                                  const size_t ndim,
                                  const size_t j,
                                  const DPCTLEventVectorRef dep_event_vec_ref)
@@ -414,38 +403,35 @@ DPCTLSyclEventRef dpnp_nonzero_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if ((in_array1 == nullptr) || (result1 == nullptr))
-    {
+    if ((in_array1 == nullptr) || (result1 == nullptr)) {
         return event_ref;
     }
 
-    if (ndim == 0)
-    {
+    if (ndim == 0) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    const size_t input1_size = std::accumulate(shape, shape + ndim, 1, std::multiplies<shape_elem_type>());
+    const size_t input1_size = std::accumulate(
+        shape, shape + ndim, 1, std::multiplies<shape_elem_type>());
 
-    DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, in_array1, input1_size, true);
+    DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, in_array1, input1_size,
+                                            true);
     DPNPC_ptr_adapter<long> result_ptr(q_ref, result1, result_size, true, true);
-    const _DataType* arr = input1_ptr.get_ptr();
-    long* result = result_ptr.get_ptr();
+    const _DataType *arr = input1_ptr.get_ptr();
+    long *result         = result_ptr.get_ptr();
 
     size_t idx = 0;
-    for (size_t i = 0; i < input1_size; ++i)
-    {
-        if (arr[i] != 0)
-        {
+    for (size_t i = 0; i < input1_size; ++i) {
+        if (arr[i] != 0) {
             size_t ids[ndim];
             size_t ind1 = input1_size;
             size_t ind2 = i;
-            for (size_t k = 0; k < ndim; ++k)
-            {
-                ind1 = ind1 / shape[k];
+            for (size_t k = 0; k < ndim; ++k) {
+                ind1   = ind1 / shape[k];
                 ids[k] = ind2 / ind1;
-                ind2 = ind2 % ind1;
+                ind2   = ind2 % ind1;
             }
 
             result[idx] = ids[j];
@@ -457,40 +443,35 @@ DPCTLSyclEventRef dpnp_nonzero_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_nonzero_c(const void* in_array1,
-                    void* result1,
+void dpnp_nonzero_c(const void *in_array1,
+                    void *result1,
                     const size_t result_size,
-                    const shape_elem_type* shape,
+                    const shape_elem_type *shape,
                     const size_t ndim,
                     const size_t j)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_nonzero_c<_DataType>(q_ref,
-                                                            in_array1,
-                                                            result1,
-                                                            result_size,
-                                                            shape,
-                                                            ndim,
-                                                            j,
-                                                            dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_nonzero_c<_DataType>(q_ref, in_array1, result1, result_size, shape,
+                                  ndim, j, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_nonzero_default_c)(const void*,
-                               void*,
+void (*dpnp_nonzero_default_c)(const void *,
+                               void *,
                                const size_t,
-                               const shape_elem_type*,
+                               const shape_elem_type *,
                                const size_t,
                                const size_t) = dpnp_nonzero_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_place_c(DPCTLSyclQueueRef q_ref,
-                               void* arr_in,
-                               long* mask_in,
-                               void* vals_in,
+                               void *arr_in,
+                               long *mask_in,
+                               void *vals_in,
                                const size_t arr_size,
                                const size_t vals_size,
                                const DPCTLEventVectorRef dep_event_vec_ref)
@@ -500,31 +481,28 @@ DPCTLSyclEventRef dpnp_place_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!arr_size)
-    {
+    if (!arr_size) {
         return event_ref;
     }
 
-    if (!vals_size)
-    {
+    if (!vals_size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, vals_in, vals_size, true);
-    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, arr_in, arr_size, true, true);
-    _DataType* vals = input1_ptr.get_ptr();
-    _DataType* arr = result_ptr.get_ptr();
+    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, arr_in, arr_size, true,
+                                            true);
+    _DataType *vals = input1_ptr.get_ptr();
+    _DataType *arr  = result_ptr.get_ptr();
 
     DPNPC_ptr_adapter<long> mask_ptr(q_ref, mask_in, arr_size, true);
-    long* mask = mask_ptr.get_ptr();
+    long *mask = mask_ptr.get_ptr();
 
     size_t counter = 0;
-    for (size_t i = 0; i < arr_size; ++i)
-    {
-        if (mask[i])
-        {
+    for (size_t i = 0; i < arr_size; ++i) {
+        if (mask[i]) {
             arr[i] = vals[counter % vals_size];
             counter += 1;
         }
@@ -534,29 +512,33 @@ DPCTLSyclEventRef dpnp_place_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_place_c(void* arr_in, long* mask_in, void* vals_in, const size_t arr_size, const size_t vals_size)
+void dpnp_place_c(void *arr_in,
+                  long *mask_in,
+                  void *vals_in,
+                  const size_t arr_size,
+                  const size_t vals_size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_place_c<_DataType>(q_ref,
-                                                          arr_in,
-                                                          mask_in,
-                                                          vals_in,
-                                                          arr_size,
-                                                          vals_size,
-                                                          dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_place_c<_DataType>(q_ref, arr_in, mask_in, vals_in, arr_size,
+                                vals_size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_place_default_c)(void*, long*, void*, const size_t, const size_t) = dpnp_place_c<_DataType>;
+void (*dpnp_place_default_c)(void *,
+                             long *,
+                             void *,
+                             const size_t,
+                             const size_t) = dpnp_place_c<_DataType>;
 
 template <typename _DataType, typename _IndecesType, typename _ValueType>
 DPCTLSyclEventRef dpnp_put_c(DPCTLSyclQueueRef q_ref,
-                             void* array1_in,
-                             void* ind_in,
-                             void* v_in,
+                             void *array1_in,
+                             void *ind_in,
+                             void *v_in,
                              const size_t size,
                              const size_t size_ind,
                              const size_t size_v,
@@ -567,30 +549,25 @@ DPCTLSyclEventRef dpnp_put_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if ((array1_in == nullptr) || (ind_in == nullptr) || (v_in == nullptr))
-    {
+    if ((array1_in == nullptr) || (ind_in == nullptr) || (v_in == nullptr)) {
         return event_ref;
     }
 
-    if (size_v == 0)
-    {
+    if (size_v == 0) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
     DPNPC_ptr_adapter<size_t> input1_ptr(q_ref, ind_in, size_ind, true);
     DPNPC_ptr_adapter<_DataType> input2_ptr(q_ref, v_in, size_v, true);
     DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, array1_in, size, true, true);
-    size_t* ind = input1_ptr.get_ptr();
-    _DataType* v = input2_ptr.get_ptr();
-    _DataType* array_1 = result_ptr.get_ptr();
+    size_t *ind        = input1_ptr.get_ptr();
+    _DataType *v       = input2_ptr.get_ptr();
+    _DataType *array_1 = result_ptr.get_ptr();
 
-    for (size_t i = 0; i < size; ++i)
-    {
-        for (size_t j = 0; j < size_ind; ++j)
-        {
-            if (i == ind[j] || (i == (size + ind[j])))
-            {
+    for (size_t i = 0; i < size; ++i) {
+        for (size_t j = 0; j < size_ind; ++j) {
+            if (i == ind[j] || (i == (size + ind[j]))) {
                 array_1[i] = v[j % size_v];
             }
         }
@@ -600,100 +577,99 @@ DPCTLSyclEventRef dpnp_put_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType, typename _IndecesType, typename _ValueType>
-void dpnp_put_c(
-    void* array1_in, void* ind_in, void* v_in, const size_t size, const size_t size_ind, const size_t size_v)
+void dpnp_put_c(void *array1_in,
+                void *ind_in,
+                void *v_in,
+                const size_t size,
+                const size_t size_ind,
+                const size_t size_v)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_put_c<_DataType, _IndecesType, _ValueType>(q_ref,
-                                                                                  array1_in,
-                                                                                  ind_in,
-                                                                                  v_in,
-                                                                                  size,
-                                                                                  size_ind,
-                                                                                  size_v,
-                                                                                  dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_put_c<_DataType, _IndecesType, _ValueType>(
+            q_ref, array1_in, ind_in, v_in, size, size_ind, size_v,
+            dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType, typename _IndecesType, typename _ValueType>
-void (*dpnp_put_default_c)(void*,
-                           void*,
-                           void*,
+void (*dpnp_put_default_c)(void *,
+                           void *,
+                           void *,
                            const size_t,
                            const size_t,
-                           const size_t) = dpnp_put_c<_DataType, _IndecesType, _ValueType>;
+                           const size_t) =
+    dpnp_put_c<_DataType, _IndecesType, _ValueType>;
 
 template <typename _DataType, typename _IndecesType, typename _ValueType>
 DPCTLSyclEventRef (*dpnp_put_ext_c)(DPCTLSyclQueueRef,
-                                    void*,
-                                    void*,
-                                    void*,
+                                    void *,
+                                    void *,
+                                    void *,
                                     const size_t,
                                     const size_t,
                                     const size_t,
-                                    const DPCTLEventVectorRef) = dpnp_put_c<_DataType, _IndecesType, _ValueType>;
+                                    const DPCTLEventVectorRef) =
+    dpnp_put_c<_DataType, _IndecesType, _ValueType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_put_along_axis_c(DPCTLSyclQueueRef q_ref,
-                                        void* arr_in,
-                                        long* indices_in,
-                                        void* values_in,
-                                        size_t axis,
-                                        const shape_elem_type* shape,
-                                        size_t ndim,
-                                        size_t size_indices,
-                                        size_t values_size,
-                                        const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_put_along_axis_c(DPCTLSyclQueueRef q_ref,
+                          void *arr_in,
+                          long *indices_in,
+                          void *values_in,
+                          size_t axis,
+                          const shape_elem_type *shape,
+                          size_t ndim,
+                          size_t size_indices,
+                          size_t values_size,
+                          const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     size_t res_ndim = ndim - 1;
     size_t res_shape[res_ndim];
-    const size_t size_arr = std::accumulate(shape, shape + ndim, 1, std::multiplies<shape_elem_type>());
+    const size_t size_arr = std::accumulate(shape, shape + ndim, 1,
+                                            std::multiplies<shape_elem_type>());
 
     DPNPC_ptr_adapter<size_t> input1_ptr(q_ref, indices_in, size_indices, true);
-    DPNPC_ptr_adapter<_DataType> input2_ptr(q_ref, values_in, values_size, true);
-    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, arr_in, size_arr, true, true);
-    size_t* indices = input1_ptr.get_ptr();
-    _DataType* values = input2_ptr.get_ptr();
-    _DataType* arr = result_ptr.get_ptr();
+    DPNPC_ptr_adapter<_DataType> input2_ptr(q_ref, values_in, values_size,
+                                            true);
+    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, arr_in, size_arr, true,
+                                            true);
+    size_t *indices   = input1_ptr.get_ptr();
+    _DataType *values = input2_ptr.get_ptr();
+    _DataType *arr    = result_ptr.get_ptr();
 
-    if (axis != res_ndim)
-    {
+    if (axis != res_ndim) {
         int ind = 0;
-        for (size_t i = 0; i < ndim; i++)
-        {
-            if (axis != i)
-            {
+        for (size_t i = 0; i < ndim; i++) {
+            if (axis != i) {
                 res_shape[ind] = shape[i];
                 ind++;
             }
         }
 
         size_t prod = 1;
-        for (size_t i = 0; i < res_ndim; ++i)
-        {
-            if (res_shape[i] != 0)
-            {
+        for (size_t i = 0; i < res_ndim; ++i) {
+            if (res_shape[i] != 0) {
                 prod *= res_shape[i];
             }
         }
 
         size_t ind_array[prod];
         bool bool_ind_array[prod];
-        for (size_t i = 0; i < prod; ++i)
-        {
+        for (size_t i = 0; i < prod; ++i) {
             bool_ind_array[i] = true;
         }
         size_t arr_shape_offsets[ndim];
         size_t acc = 1;
-        for (size_t i = ndim - 1; i > 0; --i)
-        {
+        for (size_t i = ndim - 1; i > 0; --i) {
             arr_shape_offsets[i] = acc;
             acc *= shape[i];
         }
@@ -701,10 +677,8 @@ DPCTLSyclEventRef dpnp_put_along_axis_c(DPCTLSyclQueueRef q_ref,
 
         size_t output_shape_offsets[res_ndim];
         acc = 1;
-        if (res_ndim > 0)
-        {
-            for (size_t i = res_ndim - 1; i > 0; --i)
-            {
+        if (res_ndim > 0) {
+            for (size_t i = res_ndim - 1; i > 0; --i) {
                 output_shape_offsets[i] = acc;
                 acc *= res_shape[i];
             }
@@ -712,43 +686,36 @@ DPCTLSyclEventRef dpnp_put_along_axis_c(DPCTLSyclQueueRef q_ref,
         output_shape_offsets[0] = acc;
 
         size_t size_result = 1;
-        for (size_t i = 0; i < res_ndim; ++i)
-        {
+        for (size_t i = 0; i < res_ndim; ++i) {
             size_result *= res_shape[i];
         }
 
-        //init result array
-        for (size_t result_idx = 0; result_idx < size_result; ++result_idx)
-        {
+        // init result array
+        for (size_t result_idx = 0; result_idx < size_result; ++result_idx) {
             size_t xyz[res_ndim];
             size_t remainder = result_idx;
-            for (size_t i = 0; i < res_ndim; ++i)
-            {
-                xyz[i] = remainder / output_shape_offsets[i];
+            for (size_t i = 0; i < res_ndim; ++i) {
+                xyz[i]    = remainder / output_shape_offsets[i];
                 remainder = remainder - xyz[i] * output_shape_offsets[i];
             }
 
             size_t source_axis[ndim];
             size_t result_axis_idx = 0;
-            for (size_t idx = 0; idx < ndim; ++idx)
-            {
+            for (size_t idx = 0; idx < ndim; ++idx) {
                 bool found = false;
-                if (axis == idx)
-                {
+                if (axis == idx) {
                     found = true;
                 }
-                if (found)
-                {
+                if (found) {
                     source_axis[idx] = 0;
                 }
-                else
-                {
+                else {
                     source_axis[idx] = xyz[result_axis_idx];
                     result_axis_idx++;
                 }
             }
 
-	    // FIXME: computed, but unused. Commented out per compiler warning
+            // FIXME: computed, but unused. Commented out per compiler warning
             // size_t source_idx = 0;
             // for (size_t i = 0; i < static_cast<size_t>(ndim); ++i)
             // {
@@ -756,30 +723,25 @@ DPCTLSyclEventRef dpnp_put_along_axis_c(DPCTLSyclQueueRef q_ref,
             // }
         }
 
-        for (size_t source_idx = 0; source_idx < size_arr; ++source_idx)
-        {
+        for (size_t source_idx = 0; source_idx < size_arr; ++source_idx) {
             // reconstruct x,y,z from linear source_idx
             size_t xyz[ndim];
             size_t remainder = source_idx;
-            for (size_t i = 0; i < ndim; ++i)
-            {
-                xyz[i] = remainder / arr_shape_offsets[i];
+            for (size_t i = 0; i < ndim; ++i) {
+                xyz[i]    = remainder / arr_shape_offsets[i];
                 remainder = remainder - xyz[i] * arr_shape_offsets[i];
             }
 
             // extract result axis
             size_t result_axis[res_ndim];
             size_t result_idx = 0;
-            for (size_t idx = 0; idx < ndim; ++idx)
-            {
+            for (size_t idx = 0; idx < ndim; ++idx) {
                 // try to find current idx in axis array
                 bool found = false;
-                if (axis == idx)
-                {
+                if (axis == idx) {
                     found = true;
                 }
-                if (!found)
-                {
+                if (!found) {
                     result_axis[result_idx] = xyz[idx];
                     result_idx++;
                 }
@@ -787,32 +749,29 @@ DPCTLSyclEventRef dpnp_put_along_axis_c(DPCTLSyclQueueRef q_ref,
 
             // Construct result offset
             size_t result_offset = 0;
-            for (size_t i = 0; i < res_ndim; ++i)
-            {
+            for (size_t i = 0; i < res_ndim; ++i) {
                 result_offset += output_shape_offsets[i] * result_axis[i];
             }
 
-            if (bool_ind_array[result_offset])
-            {
-                ind_array[result_offset] = 0;
+            if (bool_ind_array[result_offset]) {
+                ind_array[result_offset]      = 0;
                 bool_ind_array[result_offset] = false;
             }
-            else
-            {
+            else {
                 ind_array[result_offset] += 1;
             }
 
-            if ((ind_array[result_offset] % size_indices) == indices[result_offset % size_indices])
+            if ((ind_array[result_offset] % size_indices) ==
+                indices[result_offset % size_indices])
             {
                 arr[source_idx] = values[source_idx % values_size];
             }
         }
     }
-    else
-    {
-        for (size_t i = 0; i < size_arr; ++i)
-        {
-            size_t ind = size_indices * (i / size_indices) + indices[i % size_indices];
+    else {
+        for (size_t i = 0; i < size_arr; ++i) {
+            size_t ind =
+                size_indices * (i / size_indices) + indices[i % size_indices];
             arr[ind] = values[i % values_size];
         }
     }
@@ -820,61 +779,56 @@ DPCTLSyclEventRef dpnp_put_along_axis_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_put_along_axis_c(void* arr_in,
-                           long* indices_in,
-                           void* values_in,
+void dpnp_put_along_axis_c(void *arr_in,
+                           long *indices_in,
+                           void *values_in,
                            size_t axis,
-                           const shape_elem_type* shape,
+                           const shape_elem_type *shape,
                            size_t ndim,
                            size_t size_indices,
                            size_t values_size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_put_along_axis_c<_DataType>(q_ref,
-                                                                   arr_in,
-                                                                   indices_in,
-                                                                   values_in,
-                                                                   axis,
-                                                                   shape,
-                                                                   ndim,
-                                                                   size_indices,
-                                                                   values_size,
-                                                                   dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_put_along_axis_c<_DataType>(
+        q_ref, arr_in, indices_in, values_in, axis, shape, ndim, size_indices,
+        values_size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_put_along_axis_default_c)(void*,
-                                      long*,
-                                      void*,
+void (*dpnp_put_along_axis_default_c)(void *,
+                                      long *,
+                                      void *,
                                       size_t,
-                                      const shape_elem_type*,
+                                      const shape_elem_type *,
                                       size_t,
                                       size_t,
-                                      size_t) = dpnp_put_along_axis_c<_DataType>;
+                                      size_t) =
+    dpnp_put_along_axis_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_put_along_axis_ext_c)(DPCTLSyclQueueRef,
-                                               void*,
-                                               long*,
-                                               void*,
+                                               void *,
+                                               long *,
+                                               void *,
                                                size_t,
-                                               const shape_elem_type*,
+                                               const shape_elem_type *,
                                                size_t,
                                                size_t,
                                                size_t,
-                                               const DPCTLEventVectorRef) = dpnp_put_along_axis_c<_DataType>;
+                                               const DPCTLEventVectorRef) =
+    dpnp_put_along_axis_c<_DataType>;
 
 template <typename _DataType, typename _IndecesType>
 class dpnp_take_c_kernel;
 
 template <typename _DataType, typename _IndecesType>
 DPCTLSyclEventRef dpnp_take_c(DPCTLSyclQueueRef q_ref,
-                              void* array1_in,
+                              void *array1_in,
                               const size_t array1_size,
-                              void* indices1,
-                              void* result1,
+                              void *indices1,
+                              void *result1,
                               size_t size,
                               const DPCTLEventVectorRef dep_event_vec_ref)
 {
@@ -883,20 +837,21 @@ DPCTLSyclEventRef dpnp_take_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    _DataType* array_1 = reinterpret_cast<_DataType*>(array1_in);
-    _IndecesType* indices = reinterpret_cast<_IndecesType*>(indices1);
-    _DataType* result = reinterpret_cast<_DataType*>(result1);
+    _DataType *array_1    = reinterpret_cast<_DataType *>(array1_in);
+    _IndecesType *indices = reinterpret_cast<_IndecesType *>(indices1);
+    _DataType *result     = reinterpret_cast<_DataType *>(result1);
 
     sycl::range<1> gws(size);
     auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
         const size_t idx = global_id[0];
-        result[idx] = array_1[indices[idx]];
+        result[idx]      = array_1[indices[idx]];
     };
 
-    auto kernel_func = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class dpnp_take_c_kernel<_DataType, _IndecesType>>(gws, kernel_parallel_for_func);
+    auto kernel_func = [&](sycl::handler &cgh) {
+        cgh.parallel_for<class dpnp_take_c_kernel<_DataType, _IndecesType>>(
+            gws, kernel_parallel_for_func);
     };
 
     sycl::event event = q.submit(kernel_func);
@@ -906,175 +861,230 @@ DPCTLSyclEventRef dpnp_take_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType, typename _IndecesType>
-void dpnp_take_c(void* array1_in, const size_t array1_size, void* indices1, void* result1, size_t size)
+void dpnp_take_c(void *array1_in,
+                 const size_t array1_size,
+                 void *indices1,
+                 void *result1,
+                 size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_take_c<_DataType, _IndecesType>(q_ref,
-                                                                       array1_in,
-                                                                       array1_size,
-                                                                       indices1,
-                                                                       result1,
-                                                                       size,
-                                                                       dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref = dpnp_take_c<_DataType, _IndecesType>(
+        q_ref, array1_in, array1_size, indices1, result1, size,
+        dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType, typename _IndecesType>
-void (*dpnp_take_default_c)(void*, const size_t, void*, void*, size_t) = dpnp_take_c<_DataType, _IndecesType>;
+void (*dpnp_take_default_c)(void *, const size_t, void *, void *, size_t) =
+    dpnp_take_c<_DataType, _IndecesType>;
 
 template <typename _DataType, typename _IndecesType>
 DPCTLSyclEventRef (*dpnp_take_ext_c)(DPCTLSyclQueueRef,
-                                     void*,
+                                     void *,
                                      const size_t,
-                                     void*,
-                                     void*,
+                                     void *,
+                                     void *,
                                      size_t,
-                                     const DPCTLEventVectorRef) = dpnp_take_c<_DataType, _IndecesType>;
+                                     const DPCTLEventVectorRef) =
+    dpnp_take_c<_DataType, _IndecesType>;
 
-void func_map_init_indexing_func(func_map_t& fmap)
+void func_map_init_indexing_func(func_map_t &fmap)
 {
-    fmap[DPNPFuncName::DPNP_FN_CHOOSE][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_choose_default_c<int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_CHOOSE][eft_INT][eft_LNG] = {eft_LNG, (void*)dpnp_choose_default_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_CHOOSE][eft_INT][eft_FLT] = {eft_FLT, (void*)dpnp_choose_default_c<int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_CHOOSE][eft_INT][eft_DBL] = {eft_DBL, (void*)dpnp_choose_default_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_CHOOSE][eft_LNG][eft_INT] = {eft_INT, (void*)dpnp_choose_default_c<int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_CHOOSE][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_choose_default_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_CHOOSE][eft_LNG][eft_FLT] = {eft_FLT, (void*)dpnp_choose_default_c<int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_CHOOSE][eft_LNG][eft_DBL] = {eft_DBL, (void*)dpnp_choose_default_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_CHOOSE][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_choose_default_c<int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_CHOOSE][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_choose_default_c<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_CHOOSE][eft_INT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_choose_default_c<int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_CHOOSE][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_choose_default_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_CHOOSE][eft_LNG][eft_INT] = {
+        eft_INT, (void *)dpnp_choose_default_c<int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_CHOOSE][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_choose_default_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_CHOOSE][eft_LNG][eft_FLT] = {
+        eft_FLT, (void *)dpnp_choose_default_c<int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_CHOOSE][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_choose_default_c<int64_t, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_CHOOSE_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_choose_ext_c<int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_CHOOSE_EXT][eft_INT][eft_LNG] = {eft_LNG, (void*)dpnp_choose_ext_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_CHOOSE_EXT][eft_INT][eft_FLT] = {eft_FLT, (void*)dpnp_choose_ext_c<int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_CHOOSE_EXT][eft_INT][eft_DBL] = {eft_DBL, (void*)dpnp_choose_ext_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_CHOOSE_EXT][eft_LNG][eft_INT] = {eft_INT, (void*)dpnp_choose_ext_c<int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_CHOOSE_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_choose_ext_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_CHOOSE_EXT][eft_LNG][eft_FLT] = {eft_FLT, (void*)dpnp_choose_ext_c<int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_CHOOSE_EXT][eft_LNG][eft_DBL] = {eft_DBL, (void*)dpnp_choose_ext_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_CHOOSE_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_choose_ext_c<int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_CHOOSE_EXT][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_choose_ext_c<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_CHOOSE_EXT][eft_INT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_choose_ext_c<int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_CHOOSE_EXT][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_choose_ext_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_CHOOSE_EXT][eft_LNG][eft_INT] = {
+        eft_INT, (void *)dpnp_choose_ext_c<int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_CHOOSE_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_choose_ext_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_CHOOSE_EXT][eft_LNG][eft_FLT] = {
+        eft_FLT, (void *)dpnp_choose_ext_c<int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_CHOOSE_EXT][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_choose_ext_c<int64_t, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_DIAG_INDICES][eft_INT][eft_INT] = {eft_INT,
-                                                                  (void*)dpnp_diag_indices_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_DIAG_INDICES][eft_LNG][eft_LNG] = {eft_LNG,
-                                                                  (void*)dpnp_diag_indices_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_DIAG_INDICES][eft_FLT][eft_FLT] = {eft_FLT,
-                                                                  (void*)dpnp_diag_indices_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_DIAG_INDICES][eft_DBL][eft_DBL] = {eft_DBL,
-                                                                  (void*)dpnp_diag_indices_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_DIAG_INDICES][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_diag_indices_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_DIAG_INDICES][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_diag_indices_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_DIAG_INDICES][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_diag_indices_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_DIAG_INDICES][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_diag_indices_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_DIAG_INDICES_EXT][eft_INT][eft_INT] = {eft_INT,
-                                                                      (void*)dpnp_diag_indices_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_DIAG_INDICES_EXT][eft_LNG][eft_LNG] = {eft_LNG,
-                                                                      (void*)dpnp_diag_indices_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_DIAG_INDICES_EXT][eft_FLT][eft_FLT] = {eft_FLT,
-                                                                      (void*)dpnp_diag_indices_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_DIAG_INDICES_EXT][eft_DBL][eft_DBL] = {eft_DBL,
-                                                                      (void*)dpnp_diag_indices_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_DIAG_INDICES_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_diag_indices_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_DIAG_INDICES_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_diag_indices_ext_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_DIAG_INDICES_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_diag_indices_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_DIAG_INDICES_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_diag_indices_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_DIAGONAL][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_diagonal_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_DIAGONAL][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_diagonal_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_DIAGONAL][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_diagonal_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_DIAGONAL][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_diagonal_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_DIAGONAL][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_diagonal_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_DIAGONAL][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_diagonal_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_DIAGONAL][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_diagonal_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_DIAGONAL][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_diagonal_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_DIAGONAL_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_diagonal_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_DIAGONAL_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_diagonal_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_DIAGONAL_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_diagonal_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_DIAGONAL_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_diagonal_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_DIAGONAL_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_diagonal_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_DIAGONAL_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_diagonal_ext_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_DIAGONAL_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_diagonal_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_DIAGONAL_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_diagonal_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_FILL_DIAGONAL][eft_INT][eft_INT] = {eft_INT,
-                                                                   (void*)dpnp_fill_diagonal_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_FILL_DIAGONAL][eft_LNG][eft_LNG] = {eft_LNG,
-                                                                   (void*)dpnp_fill_diagonal_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_FILL_DIAGONAL][eft_FLT][eft_FLT] = {eft_FLT,
-                                                                   (void*)dpnp_fill_diagonal_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_FILL_DIAGONAL][eft_DBL][eft_DBL] = {eft_DBL,
-                                                                   (void*)dpnp_fill_diagonal_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_FILL_DIAGONAL][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_fill_diagonal_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_FILL_DIAGONAL][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_fill_diagonal_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_FILL_DIAGONAL][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_fill_diagonal_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_FILL_DIAGONAL][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_fill_diagonal_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_FILL_DIAGONAL_EXT][eft_INT][eft_INT] = {eft_INT,
-                                                                       (void*)dpnp_fill_diagonal_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_FILL_DIAGONAL_EXT][eft_LNG][eft_LNG] = {eft_LNG,
-                                                                       (void*)dpnp_fill_diagonal_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_FILL_DIAGONAL_EXT][eft_FLT][eft_FLT] = {eft_FLT,
-                                                                       (void*)dpnp_fill_diagonal_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_FILL_DIAGONAL_EXT][eft_DBL][eft_DBL] = {eft_DBL,
-                                                                       (void*)dpnp_fill_diagonal_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_FILL_DIAGONAL_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_fill_diagonal_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_FILL_DIAGONAL_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_fill_diagonal_ext_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_FILL_DIAGONAL_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_fill_diagonal_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_FILL_DIAGONAL_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_fill_diagonal_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_NONZERO][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_nonzero_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_NONZERO][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_nonzero_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_NONZERO][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_nonzero_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_NONZERO][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_nonzero_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_NONZERO][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_nonzero_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_NONZERO][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_nonzero_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_NONZERO][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_nonzero_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_NONZERO][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_nonzero_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_PLACE][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_place_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_PLACE][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_place_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_PLACE][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_place_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_PLACE][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_place_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_PLACE][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_place_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_PLACE][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_place_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_PLACE][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_place_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_PLACE][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_place_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_PUT][eft_INT][eft_INT] = {eft_INT,
-                                                         (void*)dpnp_put_default_c<int32_t, int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_PUT][eft_LNG][eft_LNG] = {eft_LNG,
-                                                         (void*)dpnp_put_default_c<int64_t, int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_PUT][eft_FLT][eft_FLT] = {eft_FLT,
-                                                         (void*)dpnp_put_default_c<float, int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_PUT][eft_DBL][eft_DBL] = {eft_DBL,
-                                                         (void*)dpnp_put_default_c<double, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_PUT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_put_default_c<int32_t, int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_PUT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_put_default_c<int64_t, int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_PUT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_put_default_c<float, int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_PUT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_put_default_c<double, int64_t, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_PUT_EXT][eft_INT][eft_INT] = {eft_INT,
-                                                             (void*)dpnp_put_ext_c<int32_t, int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_PUT_EXT][eft_LNG][eft_LNG] = {eft_LNG,
-                                                             (void*)dpnp_put_ext_c<int64_t, int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_PUT_EXT][eft_FLT][eft_FLT] = {eft_FLT,
-                                                             (void*)dpnp_put_ext_c<float, int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_PUT_EXT][eft_DBL][eft_DBL] = {eft_DBL,
-                                                             (void*)dpnp_put_ext_c<double, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_PUT_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_put_ext_c<int32_t, int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_PUT_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_put_ext_c<int64_t, int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_PUT_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_put_ext_c<float, int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_PUT_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_put_ext_c<double, int64_t, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_PUT_ALONG_AXIS][eft_INT][eft_INT] = {eft_INT,
-                                                                    (void*)dpnp_put_along_axis_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_PUT_ALONG_AXIS][eft_LNG][eft_LNG] = {eft_LNG,
-                                                                    (void*)dpnp_put_along_axis_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_PUT_ALONG_AXIS][eft_FLT][eft_FLT] = {eft_FLT,
-                                                                    (void*)dpnp_put_along_axis_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_PUT_ALONG_AXIS][eft_DBL][eft_DBL] = {eft_DBL,
-                                                                    (void*)dpnp_put_along_axis_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_PUT_ALONG_AXIS][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_put_along_axis_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_PUT_ALONG_AXIS][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_put_along_axis_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_PUT_ALONG_AXIS][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_put_along_axis_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_PUT_ALONG_AXIS][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_put_along_axis_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_PUT_ALONG_AXIS_EXT][eft_INT][eft_INT] = {eft_INT,
-                                                                        (void*)dpnp_put_along_axis_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_PUT_ALONG_AXIS_EXT][eft_LNG][eft_LNG] = {eft_LNG,
-                                                                        (void*)dpnp_put_along_axis_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_PUT_ALONG_AXIS_EXT][eft_FLT][eft_FLT] = {eft_FLT,
-                                                                        (void*)dpnp_put_along_axis_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_PUT_ALONG_AXIS_EXT][eft_DBL][eft_DBL] = {eft_DBL,
-                                                                        (void*)dpnp_put_along_axis_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_PUT_ALONG_AXIS_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_put_along_axis_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_PUT_ALONG_AXIS_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_put_along_axis_ext_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_PUT_ALONG_AXIS_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_put_along_axis_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_PUT_ALONG_AXIS_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_put_along_axis_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_TAKE][eft_BLN][eft_INT] = {eft_BLN, (void*)dpnp_take_default_c<bool, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_take_default_c<int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE][eft_LNG][eft_INT] = {eft_LNG, (void*)dpnp_take_default_c<int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE][eft_FLT][eft_INT] = {eft_FLT, (void*)dpnp_take_default_c<float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE][eft_DBL][eft_INT] = {eft_DBL, (void*)dpnp_take_default_c<double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE][eft_C128][eft_INT] = {eft_C128,
-                                                           (void*)dpnp_take_default_c<std::complex<double>, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE][eft_BLN][eft_LNG] = {eft_BLN, (void*)dpnp_take_default_c<bool, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE][eft_INT][eft_LNG] = {eft_INT, (void*)dpnp_take_default_c<int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_take_default_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE][eft_FLT][eft_LNG] = {eft_FLT, (void*)dpnp_take_default_c<float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE][eft_DBL][eft_LNG] = {eft_DBL, (void*)dpnp_take_default_c<double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE][eft_C128][eft_LNG] = {eft_C128,
-                                                           (void*)dpnp_take_default_c<std::complex<double>, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_TAKE][eft_BLN][eft_INT] = {
+        eft_BLN, (void *)dpnp_take_default_c<bool, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TAKE][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_take_default_c<int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TAKE][eft_LNG][eft_INT] = {
+        eft_LNG, (void *)dpnp_take_default_c<int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TAKE][eft_FLT][eft_INT] = {
+        eft_FLT, (void *)dpnp_take_default_c<float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TAKE][eft_DBL][eft_INT] = {
+        eft_DBL, (void *)dpnp_take_default_c<double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TAKE][eft_C128][eft_INT] = {
+        eft_C128, (void *)dpnp_take_default_c<std::complex<double>, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TAKE][eft_BLN][eft_LNG] = {
+        eft_BLN, (void *)dpnp_take_default_c<bool, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_TAKE][eft_INT][eft_LNG] = {
+        eft_INT, (void *)dpnp_take_default_c<int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TAKE][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_take_default_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_TAKE][eft_FLT][eft_LNG] = {
+        eft_FLT, (void *)dpnp_take_default_c<float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_TAKE][eft_DBL][eft_LNG] = {
+        eft_DBL, (void *)dpnp_take_default_c<double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_TAKE][eft_C128][eft_LNG] = {
+        eft_C128, (void *)dpnp_take_default_c<std::complex<double>, int64_t>};
 
-    // TODO: add a handling of other indexes types once DPCtl implementation of data copy is ready
-    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_BLN][eft_INT] = {eft_BLN, (void*)dpnp_take_ext_c<bool, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_take_ext_c<int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_LNG][eft_INT] = {eft_LNG, (void*)dpnp_take_ext_c<int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_FLT][eft_INT] = {eft_FLT, (void*)dpnp_take_ext_c<float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_DBL][eft_INT] = {eft_DBL, (void*)dpnp_take_ext_c<double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_C128][eft_INT] = {eft_C128,
-                                                               (void*)dpnp_take_ext_c<std::complex<double>, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_BLN][eft_LNG] = {eft_BLN, (void*)dpnp_take_ext_c<bool, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_INT][eft_LNG] = {eft_INT, (void*)dpnp_take_ext_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_take_ext_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_FLT][eft_LNG] = {eft_FLT, (void*)dpnp_take_ext_c<float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_DBL][eft_LNG] = {eft_DBL, (void*)dpnp_take_ext_c<double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_C128][eft_LNG] = {eft_C128,
-                                                               (void*)dpnp_take_ext_c<std::complex<double>, int64_t>};
+    // TODO: add a handling of other indexes types once DPCtl implementation of
+    // data copy is ready
+    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_BLN][eft_INT] = {
+        eft_BLN, (void *)dpnp_take_ext_c<bool, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_take_ext_c<int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_LNG][eft_INT] = {
+        eft_LNG, (void *)dpnp_take_ext_c<int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_FLT][eft_INT] = {
+        eft_FLT, (void *)dpnp_take_ext_c<float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_DBL][eft_INT] = {
+        eft_DBL, (void *)dpnp_take_ext_c<double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_C128][eft_INT] = {
+        eft_C128, (void *)dpnp_take_ext_c<std::complex<double>, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_BLN][eft_LNG] = {
+        eft_BLN, (void *)dpnp_take_ext_c<bool, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_INT][eft_LNG] = {
+        eft_INT, (void *)dpnp_take_ext_c<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_take_ext_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_FLT][eft_LNG] = {
+        eft_FLT, (void *)dpnp_take_ext_c<float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_DBL][eft_LNG] = {
+        eft_DBL, (void *)dpnp_take_ext_c<double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_C128][eft_LNG] = {
+        eft_C128, (void *)dpnp_take_ext_c<std::complex<double>, int64_t>};
 
     return;
 }

--- a/dpnp/backend/kernels/dpnp_krnl_linalg.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_linalg.cpp
@@ -32,7 +32,7 @@
 #include "queue_sycl.hpp"
 #include <dpnp_iface.hpp>
 
-namespace mkl_blas   = oneapi::mkl::blas::row_major;
+namespace mkl_blas = oneapi::mkl::blas::row_major;
 namespace mkl_lapack = oneapi::mkl::lapack;
 
 template <typename _DataType>
@@ -47,14 +47,14 @@ DPCTLSyclEventRef dpnp_cholesky_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     sycl::event event;
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, size, true);
     DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, size, true, true);
     _DataType *in_array = input1_ptr.get_ptr();
-    _DataType *result   = result_ptr.get_ptr();
+    _DataType *result = result_ptr.get_ptr();
 
     size_t iters = size / (data_size * data_size);
 
@@ -115,7 +115,7 @@ void dpnp_cholesky_c(void *array1_in,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_cholesky_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_cholesky_c<_DataType>(
         q_ref, array1_in, result1, size, data_size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
@@ -155,7 +155,7 @@ DPCTLSyclEventRef dpnp_det_c(DPCTLSyclQueueRef q_ref,
 
     sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    size_t n        = shape[ndim - 1];
+    size_t n = shape[ndim - 1];
     size_t size_out = 1;
     if (ndim != 2) {
         for (size_t i = 0; i < ndim - 2; i++) {
@@ -167,7 +167,7 @@ DPCTLSyclEventRef dpnp_det_c(DPCTLSyclQueueRef q_ref,
     DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, size_out, true,
                                             true);
     _DataType *array_1 = input1_ptr.get_ptr();
-    _DataType *result  = result_ptr.get_ptr();
+    _DataType *result = result_ptr.get_ptr();
 
     for (size_t i = 0; i < size_out; i++) {
         _DataType matrix[n][n];
@@ -197,7 +197,7 @@ DPCTLSyclEventRef dpnp_det_c(DPCTLSyclQueueRef q_ref,
                 for (size_t j = l; j < n; j++) {
                     if (matrix[j][l] != 0) {
                         for (size_t k = l; k < n; k++) {
-                            _DataType c  = matrix[l][k];
+                            _DataType c = matrix[l][k];
                             matrix[l][k] = -1 * matrix[j][k];
                             matrix[j][k] = c;
                         }
@@ -238,7 +238,7 @@ void dpnp_det_c(void *array1_in,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_det_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_det_c<_DataType>(
         q_ref, array1_in, result1, shape, ndim, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
@@ -283,7 +283,7 @@ DPCTLSyclEventRef dpnp_inv_c(DPCTLSyclQueueRef q_ref,
     DPNPC_ptr_adapter<_ResultType> result_ptr(q_ref, result1, input_size, true,
                                               true);
 
-    _DataType *array_1  = input1_ptr.get_ptr();
+    _DataType *array_1 = input1_ptr.get_ptr();
     _ResultType *result = result_ptr.get_ptr();
 
     size_t n = shape[0];
@@ -308,10 +308,10 @@ DPCTLSyclEventRef dpnp_inv_c(DPCTLSyclQueueRef q_ref,
             for (size_t i = k; i < n; ++i) {
                 if (a_arr[i][k] != 0) {
                     for (size_t j = 0; j < n; ++j) {
-                        float c     = a_arr[k][j];
+                        float c = a_arr[k][j];
                         a_arr[k][j] = a_arr[i][j];
                         a_arr[i][j] = c;
-                        float c_e   = e_arr[k][j];
+                        float c_e = e_arr[k][j];
                         e_arr[k][j] = e_arr[i][j];
                         e_arr[i][j] = c_e;
                     }
@@ -366,7 +366,7 @@ void dpnp_inv_c(void *array1_in,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_inv_c<_DataType, _ResultType>(
+    DPCTLSyclEventRef event_ref = dpnp_inv_c<_DataType, _ResultType>(
         q_ref, array1_in, result1, shape, ndim, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
@@ -420,8 +420,8 @@ DPCTLSyclEventRef dpnp_kron_c(DPCTLSyclQueueRef q_ref,
     DPNPC_ptr_adapter<_DataType2> input2_ptr(q_ref, array2_in, input2_size);
     DPNPC_ptr_adapter<_ResultType> result_ptr(q_ref, result1, result_size);
 
-    _DataType1 *array1  = input1_ptr.get_ptr();
-    _DataType2 *array2  = input2_ptr.get_ptr();
+    _DataType1 *array1 = input1_ptr.get_ptr();
+    _DataType2 *array2 = input2_ptr.get_ptr();
     _ResultType *result = result_ptr.get_ptr();
 
     shape_elem_type *_in1_shape = reinterpret_cast<shape_elem_type *>(
@@ -447,12 +447,12 @@ DPCTLSyclEventRef dpnp_kron_c(DPCTLSyclQueueRef q_ref,
     auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
         const size_t idx = global_id[0];
 
-        size_t idx1     = 0;
-        size_t idx2     = 0;
+        size_t idx1 = 0;
+        size_t idx2 = 0;
         size_t reminder = idx;
         for (size_t axis = 0; axis < ndim; ++axis) {
             const size_t res_axis = reminder / res_offsets[axis];
-            reminder              = reminder - res_axis * res_offsets[axis];
+            reminder = reminder - res_axis * res_offsets[axis];
 
             const size_t in1_axis = res_axis / _in2_shape[axis];
             const size_t in2_axis = res_axis - in1_axis * _in2_shape[axis];
@@ -543,7 +543,7 @@ DPCTLSyclEventRef
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, input_size, true);
     DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, 1, true, true);
     _DataType *array_1 = input1_ptr.get_ptr();
-    _DataType *result  = result_ptr.get_ptr();
+    _DataType *result = result_ptr.get_ptr();
 
     shape_elem_type elems = 1;
     if (ndim > 1) {
@@ -576,7 +576,7 @@ void dpnp_matrix_rank_c(void *array1_in,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_matrix_rank_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_matrix_rank_c<_DataType>(
         q_ref, array1_in, result1, shape, ndim, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
@@ -609,7 +609,7 @@ DPCTLSyclEventRef dpnp_qr_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     sycl::event event;
 
@@ -637,7 +637,7 @@ DPCTLSyclEventRef dpnp_qr_c(DPCTLSyclQueueRef q_ref,
                                               true, true);
     _ComputeDT *res_q = result1_ptr.get_ptr();
     _ComputeDT *res_r = result2_ptr.get_ptr();
-    _ComputeDT *tau   = result3_ptr.get_ptr();
+    _ComputeDT *tau = result3_ptr.get_ptr();
 
     const std::int64_t lda = size_m;
 
@@ -715,7 +715,7 @@ void dpnp_qr_c(void *array1_in,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_qr_c<_InputDT, _ComputeDT>(
+    DPCTLSyclEventRef event_ref = dpnp_qr_c<_InputDT, _ComputeDT>(
         q_ref, array1_in, result1, result2, result3, size_m, size_n,
         dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
@@ -751,7 +751,7 @@ DPCTLSyclEventRef dpnp_svd_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     sycl::event event;
 
@@ -774,15 +774,15 @@ DPCTLSyclEventRef dpnp_svd_c(DPCTLSyclQueueRef q_ref,
                                          std::min(size_m, size_n), true, true);
     DPNPC_ptr_adapter<_ComputeDT> result3_ptr(q_ref, result3, size_n * size_n,
                                               true, true);
-    _ComputeDT *res_u  = result1_ptr.get_ptr();
-    _SVDT *res_s       = result2_ptr.get_ptr();
+    _ComputeDT *res_u = result1_ptr.get_ptr();
+    _SVDT *res_s = result2_ptr.get_ptr();
     _ComputeDT *res_vt = result3_ptr.get_ptr();
 
     const std::int64_t m = size_m;
     const std::int64_t n = size_n;
 
-    const std::int64_t lda  = std::max<size_t>(1UL, n);
-    const std::int64_t ldu  = std::max<size_t>(1UL, m);
+    const std::int64_t lda = std::max<size_t>(1UL, n);
+    const std::int64_t ldu = std::max<size_t>(1UL, m);
     const std::int64_t ldvt = std::max<size_t>(1UL, n);
 
     const std::int64_t scratchpad_size =

--- a/dpnp/backend/kernels/dpnp_krnl_linalg.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_linalg.cpp
@@ -26,19 +26,19 @@
 #include <iostream>
 #include <list>
 
-#include <dpnp_iface.hpp>
 #include "dpnp_fptr.hpp"
 #include "dpnp_utils.hpp"
 #include "dpnpc_memory_adapter.hpp"
 #include "queue_sycl.hpp"
+#include <dpnp_iface.hpp>
 
-namespace mkl_blas = oneapi::mkl::blas::row_major;
+namespace mkl_blas   = oneapi::mkl::blas::row_major;
 namespace mkl_lapack = oneapi::mkl::lapack;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_cholesky_c(DPCTLSyclQueueRef q_ref,
-                                  void* array1_in,
-                                  void* result1,
+                                  void *array1_in,
+                                  void *result1,
                                   const size_t size,
                                   const size_t data_size,
                                   const DPCTLEventVectorRef dep_event_vec_ref)
@@ -47,24 +47,23 @@ DPCTLSyclEventRef dpnp_cholesky_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     sycl::event event;
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, size, true);
     DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, size, true, true);
-    _DataType* in_array = input1_ptr.get_ptr();
-    _DataType* result = result_ptr.get_ptr();
+    _DataType *in_array = input1_ptr.get_ptr();
+    _DataType *result   = result_ptr.get_ptr();
 
     size_t iters = size / (data_size * data_size);
 
     // math lib func overrides input
-    _DataType* in_a = reinterpret_cast<_DataType*>(sycl::malloc_shared(data_size * data_size * sizeof(_DataType), q));
+    _DataType *in_a = reinterpret_cast<_DataType *>(
+        sycl::malloc_shared(data_size * data_size * sizeof(_DataType), q));
 
-    for (size_t k = 0; k < iters; ++k)
-    {
-        for (size_t it = 0; it < data_size * data_size; ++it)
-        {
+    for (size_t k = 0; k < iters; ++k) {
+        for (size_t it = 0; it < data_size * data_size; ++it) {
             in_a[it] = in_array[k * (data_size * data_size) + it];
         }
 
@@ -73,25 +72,24 @@ DPCTLSyclEventRef dpnp_cholesky_c(DPCTLSyclQueueRef q_ref,
         const std::int64_t lda = std::max<size_t>(1UL, n);
 
         const std::int64_t scratchpad_size =
-            mkl_lapack::potrf_scratchpad_size<_DataType>(q, oneapi::mkl::uplo::upper, n, lda);
+            mkl_lapack::potrf_scratchpad_size<_DataType>(
+                q, oneapi::mkl::uplo::upper, n, lda);
 
-        _DataType* scratchpad = reinterpret_cast<_DataType*>(sycl::malloc_shared(scratchpad_size * sizeof(_DataType), q));
+        _DataType *scratchpad = reinterpret_cast<_DataType *>(
+            sycl::malloc_shared(scratchpad_size * sizeof(_DataType), q));
 
-        event = mkl_lapack::potrf(q, oneapi::mkl::uplo::upper, n, in_a, lda, scratchpad, scratchpad_size);
+        event = mkl_lapack::potrf(q, oneapi::mkl::uplo::upper, n, in_a, lda,
+                                  scratchpad, scratchpad_size);
 
         event.wait();
 
-        for (size_t i = 0; i < data_size; i++)
-        {
+        for (size_t i = 0; i < data_size; i++) {
             bool arg = false;
-            for (size_t j = 0; j < data_size; j++)
-            {
-                if (i == j - 1)
-                {
+            for (size_t j = 0; j < data_size; j++) {
+                if (i == j - 1) {
                     arg = true;
                 }
-                if (arg)
-                {
+                if (arg) {
                     in_a[i * data_size + j] = 0;
                 }
             }
@@ -99,8 +97,7 @@ DPCTLSyclEventRef dpnp_cholesky_c(DPCTLSyclQueueRef q_ref,
 
         sycl::free(scratchpad, q);
 
-        for (size_t t = 0; t < data_size * data_size; ++t)
-        {
+        for (size_t t = 0; t < data_size * data_size; ++t) {
             result[k * (data_size * data_size) + t] = in_a[t];
         }
     }
@@ -111,36 +108,37 @@ DPCTLSyclEventRef dpnp_cholesky_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_cholesky_c(void* array1_in, void* result1, const size_t size, const size_t data_size)
+void dpnp_cholesky_c(void *array1_in,
+                     void *result1,
+                     const size_t size,
+                     const size_t data_size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_cholesky_c<_DataType>(q_ref,
-                                                             array1_in,
-                                                             result1,
-                                                             size,
-                                                             data_size,
-                                                             dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_cholesky_c<_DataType>(
+        q_ref, array1_in, result1, size, data_size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_cholesky_default_c)(void*, void*, const size_t, const size_t) = dpnp_cholesky_c<_DataType>;
+void (*dpnp_cholesky_default_c)(void *, void *, const size_t, const size_t) =
+    dpnp_cholesky_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_cholesky_ext_c)(DPCTLSyclQueueRef,
-                                         void*,
-                                         void*,
+                                         void *,
+                                         void *,
                                          const size_t,
                                          const size_t,
-                                         const DPCTLEventVectorRef) = dpnp_cholesky_c<_DataType>;
+                                         const DPCTLEventVectorRef) =
+    dpnp_cholesky_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_det_c(DPCTLSyclQueueRef q_ref,
-                             void* array1_in,
-                             void* result1,
-                             shape_elem_type* shape,
+                             void *array1_in,
+                             void *result1,
+                             shape_elem_type *shape,
                              size_t ndim,
                              const DPCTLEventVectorRef dep_event_vec_ref)
 {
@@ -149,99 +147,79 @@ DPCTLSyclEventRef dpnp_det_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    const size_t input_size = std::accumulate(shape, shape + ndim, 1, std::multiplies<shape_elem_type>());
-    if (!input_size)
-    {
+    const size_t input_size = std::accumulate(
+        shape, shape + ndim, 1, std::multiplies<shape_elem_type>());
+    if (!input_size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    size_t n = shape[ndim - 1];
+    size_t n        = shape[ndim - 1];
     size_t size_out = 1;
-    if (ndim != 2)
-    {
-        for (size_t i = 0; i < ndim - 2; i++)
-        {
+    if (ndim != 2) {
+        for (size_t i = 0; i < ndim - 2; i++) {
             size_out *= shape[i];
         }
     }
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, input_size, true);
-    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, size_out, true, true);
-    _DataType* array_1 = input1_ptr.get_ptr();
-    _DataType* result = result_ptr.get_ptr();
+    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, size_out, true,
+                                            true);
+    _DataType *array_1 = input1_ptr.get_ptr();
+    _DataType *result  = result_ptr.get_ptr();
 
-    for (size_t i = 0; i < size_out; i++)
-    {
+    for (size_t i = 0; i < size_out; i++) {
         _DataType matrix[n][n];
-        if (size_out > 1)
-        {
+        if (size_out > 1) {
             _DataType elems[n * n];
-            for (size_t j = i * n * n; j < (i + 1) * n * n; j++)
-            {
+            for (size_t j = i * n * n; j < (i + 1) * n * n; j++) {
                 elems[j - i * n * n] = array_1[j];
             }
 
-            for (size_t j = 0; j < n; j++)
-            {
-                for (size_t k = 0; k < n; k++)
-                {
+            for (size_t j = 0; j < n; j++) {
+                for (size_t k = 0; k < n; k++) {
                     matrix[j][k] = elems[j * n + k];
                 }
             }
         }
-        else
-        {
-            for (size_t j = 0; j < n; j++)
-            {
-                for (size_t k = 0; k < n; k++)
-                {
+        else {
+            for (size_t j = 0; j < n; j++) {
+                for (size_t k = 0; k < n; k++) {
                     matrix[j][k] = array_1[j * n + k];
                 }
             }
         }
 
         _DataType det_val = 1;
-        for (size_t l = 0; l < n; l++)
-        {
-            if (matrix[l][l] == 0)
-            {
-                for (size_t j = l; j < n; j++)
-                {
-                    if (matrix[j][l] != 0)
-                    {
-                        for (size_t k = l; k < n; k++)
-                        {
-                            _DataType c = matrix[l][k];
+        for (size_t l = 0; l < n; l++) {
+            if (matrix[l][l] == 0) {
+                for (size_t j = l; j < n; j++) {
+                    if (matrix[j][l] != 0) {
+                        for (size_t k = l; k < n; k++) {
+                            _DataType c  = matrix[l][k];
                             matrix[l][k] = -1 * matrix[j][k];
                             matrix[j][k] = c;
                         }
                         break;
                     }
-                    if (j == n - 1 and matrix[j][l] == 0)
-                    {
+                    if (j == n - 1 and matrix[j][l] == 0) {
                         det_val = 0;
                     }
                 }
             }
-            if (det_val != 0)
-            {
-                for (size_t j = l + 1; j < n; j++)
-                {
+            if (det_val != 0) {
+                for (size_t j = l + 1; j < n; j++) {
                     _DataType quotient = -(matrix[j][l] / matrix[l][l]);
-                    for (size_t k = l + 1; k < n; k++)
-                    {
+                    for (size_t k = l + 1; k < n; k++) {
                         matrix[j][k] += quotient * matrix[l][k];
                     }
                 }
             }
         }
 
-        if (det_val != 0)
-        {
-            for (size_t l = 0; l < n; l++)
-            {
+        if (det_val != 0) {
+            for (size_t l = 0; l < n; l++) {
                 det_val *= matrix[l][l];
             }
         }
@@ -253,36 +231,37 @@ DPCTLSyclEventRef dpnp_det_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_det_c(void* array1_in, void* result1, shape_elem_type* shape, size_t ndim)
+void dpnp_det_c(void *array1_in,
+                void *result1,
+                shape_elem_type *shape,
+                size_t ndim)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_det_c<_DataType>(q_ref,
-                                                        array1_in,
-                                                        result1,
-                                                        shape,
-                                                        ndim,
-                                                        dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_det_c<_DataType>(
+        q_ref, array1_in, result1, shape, ndim, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_det_default_c)(void*, void*, shape_elem_type*, size_t) = dpnp_det_c<_DataType>;
+void (*dpnp_det_default_c)(void *, void *, shape_elem_type *, size_t) =
+    dpnp_det_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_det_ext_c)(DPCTLSyclQueueRef,
-                                    void*,
-                                    void*,
-                                    shape_elem_type*,
+                                    void *,
+                                    void *,
+                                    shape_elem_type *,
                                     size_t,
-                                    const DPCTLEventVectorRef) = dpnp_det_c<_DataType>;
+                                    const DPCTLEventVectorRef) =
+    dpnp_det_c<_DataType>;
 
 template <typename _DataType, typename _ResultType>
 DPCTLSyclEventRef dpnp_inv_c(DPCTLSyclQueueRef q_ref,
-                             void* array1_in,
-                             void* result1,
-                             shape_elem_type* shape,
+                             void *array1_in,
+                             void *result1,
+                             shape_elem_type *shape,
                              size_t ndim,
                              const DPCTLEventVectorRef dep_event_vec_ref)
 {
@@ -292,55 +271,47 @@ DPCTLSyclEventRef dpnp_inv_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    const size_t input_size = std::accumulate(shape, shape + ndim, 1, std::multiplies<shape_elem_type>());
-    if (!input_size)
-    {
+    const size_t input_size = std::accumulate(
+        shape, shape + ndim, 1, std::multiplies<shape_elem_type>());
+    if (!input_size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, input_size, true);
-    DPNPC_ptr_adapter<_ResultType> result_ptr(q_ref, result1, input_size, true, true);
+    DPNPC_ptr_adapter<_ResultType> result_ptr(q_ref, result1, input_size, true,
+                                              true);
 
-    _DataType* array_1 = input1_ptr.get_ptr();
-    _ResultType* result = result_ptr.get_ptr();
+    _DataType *array_1  = input1_ptr.get_ptr();
+    _ResultType *result = result_ptr.get_ptr();
 
     size_t n = shape[0];
 
     _ResultType a_arr[n][n];
     _ResultType e_arr[n][n];
 
-    for (size_t i = 0; i < n; ++i)
-    {
-        for (size_t j = 0; j < n; ++j)
-        {
+    for (size_t i = 0; i < n; ++i) {
+        for (size_t j = 0; j < n; ++j) {
             a_arr[i][j] = array_1[i * n + j];
-            if (i == j)
-            {
+            if (i == j) {
                 e_arr[i][j] = 1;
             }
-            else
-            {
+            else {
                 e_arr[i][j] = 0;
             }
         }
     }
 
-    for (size_t k = 0; k < n; ++k)
-    {
-        if (a_arr[k][k] == 0)
-        {
-            for (size_t i = k; i < n; ++i)
-            {
-                if (a_arr[i][k] != 0)
-                {
-                    for (size_t j = 0; j < n; ++j)
-                    {
-                        float c = a_arr[k][j];
+    for (size_t k = 0; k < n; ++k) {
+        if (a_arr[k][k] == 0) {
+            for (size_t i = k; i < n; ++i) {
+                if (a_arr[i][k] != 0) {
+                    for (size_t j = 0; j < n; ++j) {
+                        float c     = a_arr[k][j];
                         a_arr[k][j] = a_arr[i][j];
                         a_arr[i][j] = c;
-                        float c_e = e_arr[k][j];
+                        float c_e   = e_arr[k][j];
                         e_arr[k][j] = e_arr[i][j];
                         e_arr[i][j] = c_e;
                     }
@@ -351,43 +322,35 @@ DPCTLSyclEventRef dpnp_inv_c(DPCTLSyclQueueRef q_ref,
 
         float temp = a_arr[k][k];
 
-        for (size_t j = 0; j < n; ++j)
-        {
+        for (size_t j = 0; j < n; ++j) {
             a_arr[k][j] = a_arr[k][j] / temp;
             e_arr[k][j] = e_arr[k][j] / temp;
         }
 
-        for (size_t i = k + 1; i < n; ++i)
-        {
+        for (size_t i = k + 1; i < n; ++i) {
             temp = a_arr[i][k];
-            for (size_t j = 0; j < n; j++)
-            {
+            for (size_t j = 0; j < n; j++) {
                 a_arr[i][j] = a_arr[i][j] - a_arr[k][j] * temp;
                 e_arr[i][j] = e_arr[i][j] - e_arr[k][j] * temp;
             }
         }
     }
 
-    for (size_t k = 0; k < n - 1; ++k)
-    {
+    for (size_t k = 0; k < n - 1; ++k) {
         size_t ind_k = n - 1 - k;
-        for (size_t i = 0; i < ind_k; ++i)
-        {
+        for (size_t i = 0; i < ind_k; ++i) {
             size_t ind_i = ind_k - 1 - i;
 
             float temp = a_arr[ind_i][ind_k];
-            for (size_t j = 0; j < n; ++j)
-            {
+            for (size_t j = 0; j < n; ++j) {
                 a_arr[ind_i][j] = a_arr[ind_i][j] - a_arr[ind_k][j] * temp;
                 e_arr[ind_i][j] = e_arr[ind_i][j] - e_arr[ind_k][j] * temp;
             }
         }
     }
 
-    for (size_t i = 0; i < n; ++i)
-    {
-        for (size_t j = 0; j < n; ++j)
-        {
+    for (size_t i = 0; i < n; ++i) {
+        for (size_t j = 0; j < n; ++j) {
             result[i * n + j] = e_arr[i][j];
         }
     }
@@ -396,42 +359,43 @@ DPCTLSyclEventRef dpnp_inv_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType, typename _ResultType>
-void dpnp_inv_c(void* array1_in, void* result1, shape_elem_type* shape, size_t ndim)
+void dpnp_inv_c(void *array1_in,
+                void *result1,
+                shape_elem_type *shape,
+                size_t ndim)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_inv_c<_DataType, _ResultType>(q_ref,
-                                                                     array1_in,
-                                                                     result1,
-                                                                     shape,
-                                                                     ndim,
-                                                                     dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_inv_c<_DataType, _ResultType>(
+        q_ref, array1_in, result1, shape, ndim, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType, typename _ResultType>
-void (*dpnp_inv_default_c)(void*, void*, shape_elem_type*, size_t) = dpnp_inv_c<_DataType, _ResultType>;
+void (*dpnp_inv_default_c)(void *, void *, shape_elem_type *, size_t) =
+    dpnp_inv_c<_DataType, _ResultType>;
 
 template <typename _DataType, typename _ResultType>
 DPCTLSyclEventRef (*dpnp_inv_ext_c)(DPCTLSyclQueueRef,
-                                    void*,
-                                    void*,
-                                    shape_elem_type*,
+                                    void *,
+                                    void *,
+                                    shape_elem_type *,
                                     size_t,
-                                    const DPCTLEventVectorRef) = dpnp_inv_c<_DataType, _ResultType>;
+                                    const DPCTLEventVectorRef) =
+    dpnp_inv_c<_DataType, _ResultType>;
 
 template <typename _DataType1, typename _DataType2, typename _ResultType>
 class dpnp_kron_c_kernel;
 
 template <typename _DataType1, typename _DataType2, typename _ResultType>
 DPCTLSyclEventRef dpnp_kron_c(DPCTLSyclQueueRef q_ref,
-                              void* array1_in,
-                              void* array2_in,
-                              void* result1,
-                              shape_elem_type* in1_shape,
-                              shape_elem_type* in2_shape,
-                              shape_elem_type* res_shape,
+                              void *array1_in,
+                              void *array2_in,
+                              void *result1,
+                              shape_elem_type *in1_shape,
+                              shape_elem_type *in2_shape,
+                              shape_elem_type *res_shape,
                               size_t ndim,
                               const DPCTLEventVectorRef dep_event_vec_ref)
 {
@@ -440,38 +404,40 @@ DPCTLSyclEventRef dpnp_kron_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    const size_t input1_size = std::accumulate(in1_shape, in1_shape + ndim, 1, std::multiplies<shape_elem_type>());
-    const size_t input2_size = std::accumulate(in2_shape, in2_shape + ndim, 1, std::multiplies<shape_elem_type>());
-    const size_t result_size = std::accumulate(res_shape, res_shape + ndim, 1, std::multiplies<shape_elem_type>());
-    if (!(result_size && input1_size && input2_size))
-    {
+    const size_t input1_size = std::accumulate(
+        in1_shape, in1_shape + ndim, 1, std::multiplies<shape_elem_type>());
+    const size_t input2_size = std::accumulate(
+        in2_shape, in2_shape + ndim, 1, std::multiplies<shape_elem_type>());
+    const size_t result_size = std::accumulate(
+        res_shape, res_shape + ndim, 1, std::multiplies<shape_elem_type>());
+    if (!(result_size && input1_size && input2_size)) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_DataType1> input1_ptr(q_ref, array1_in, input1_size);
     DPNPC_ptr_adapter<_DataType2> input2_ptr(q_ref, array2_in, input2_size);
     DPNPC_ptr_adapter<_ResultType> result_ptr(q_ref, result1, result_size);
 
-    _DataType1* array1 = input1_ptr.get_ptr();
-    _DataType2* array2 = input2_ptr.get_ptr();
-    _ResultType* result = result_ptr.get_ptr();
+    _DataType1 *array1  = input1_ptr.get_ptr();
+    _DataType2 *array2  = input2_ptr.get_ptr();
+    _ResultType *result = result_ptr.get_ptr();
 
-    shape_elem_type* _in1_shape =
-        reinterpret_cast<shape_elem_type*>(sycl::malloc_shared(ndim * sizeof(shape_elem_type), q));
-    shape_elem_type* _in2_shape =
-        reinterpret_cast<shape_elem_type*>(sycl::malloc_shared(ndim * sizeof(shape_elem_type), q));
+    shape_elem_type *_in1_shape = reinterpret_cast<shape_elem_type *>(
+        sycl::malloc_shared(ndim * sizeof(shape_elem_type), q));
+    shape_elem_type *_in2_shape = reinterpret_cast<shape_elem_type *>(
+        sycl::malloc_shared(ndim * sizeof(shape_elem_type), q));
 
     q.memcpy(_in1_shape, in1_shape, ndim * sizeof(shape_elem_type)).wait();
     q.memcpy(_in2_shape, in2_shape, ndim * sizeof(shape_elem_type)).wait();
 
-    shape_elem_type* in1_offsets =
-        reinterpret_cast<shape_elem_type*>(sycl::malloc_shared(ndim * sizeof(shape_elem_type), q));
-    shape_elem_type* in2_offsets =
-        reinterpret_cast<shape_elem_type*>(sycl::malloc_shared(ndim * sizeof(shape_elem_type), q));
-    shape_elem_type* res_offsets =
-        reinterpret_cast<shape_elem_type*>(sycl::malloc_shared(ndim * sizeof(shape_elem_type), q));
+    shape_elem_type *in1_offsets = reinterpret_cast<shape_elem_type *>(
+        sycl::malloc_shared(ndim * sizeof(shape_elem_type), q));
+    shape_elem_type *in2_offsets = reinterpret_cast<shape_elem_type *>(
+        sycl::malloc_shared(ndim * sizeof(shape_elem_type), q));
+    shape_elem_type *res_offsets = reinterpret_cast<shape_elem_type *>(
+        sycl::malloc_shared(ndim * sizeof(shape_elem_type), q));
 
     get_shape_offsets_inkernel(in1_shape, ndim, in1_offsets);
     get_shape_offsets_inkernel(in2_shape, ndim, in2_offsets);
@@ -481,13 +447,12 @@ DPCTLSyclEventRef dpnp_kron_c(DPCTLSyclQueueRef q_ref,
     auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
         const size_t idx = global_id[0];
 
-        size_t idx1 = 0;
-        size_t idx2 = 0;
+        size_t idx1     = 0;
+        size_t idx2     = 0;
         size_t reminder = idx;
-        for (size_t axis = 0; axis < ndim; ++axis)
-        {
+        for (size_t axis = 0; axis < ndim; ++axis) {
             const size_t res_axis = reminder / res_offsets[axis];
-            reminder = reminder - res_axis * res_offsets[axis];
+            reminder              = reminder - res_axis * res_offsets[axis];
 
             const size_t in1_axis = res_axis / _in2_shape[axis];
             const size_t in2_axis = res_axis - in1_axis * _in2_shape[axis];
@@ -499,8 +464,10 @@ DPCTLSyclEventRef dpnp_kron_c(DPCTLSyclQueueRef q_ref,
         result[idx] = array1[idx1] * array2[idx2];
     };
 
-    auto kernel_func = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class dpnp_kron_c_kernel<_DataType1, _DataType2, _ResultType>>(gws, kernel_parallel_for_func);
+    auto kernel_func = [&](sycl::handler &cgh) {
+        cgh.parallel_for<
+            class dpnp_kron_c_kernel<_DataType1, _DataType2, _ResultType>>(
+            gws, kernel_parallel_for_func);
     };
 
     sycl::event event = q.submit(kernel_func);
@@ -511,94 +478,87 @@ DPCTLSyclEventRef dpnp_kron_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType1, typename _DataType2, typename _ResultType>
-void dpnp_kron_c(void* array1_in,
-                 void* array2_in,
-                 void* result1,
-                 shape_elem_type* in1_shape,
-                 shape_elem_type* in2_shape,
-                 shape_elem_type* res_shape,
+void dpnp_kron_c(void *array1_in,
+                 void *array2_in,
+                 void *result1,
+                 shape_elem_type *in1_shape,
+                 shape_elem_type *in2_shape,
+                 shape_elem_type *res_shape,
                  size_t ndim)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_kron_c<_DataType1, _DataType2, _ResultType>(q_ref,
-                                                                                   array1_in,
-                                                                                   array2_in,
-                                                                                   result1,
-                                                                                   in1_shape,
-                                                                                   in2_shape,
-                                                                                   res_shape,
-                                                                                   ndim,
-                                                                                   dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_kron_c<_DataType1, _DataType2, _ResultType>(
+            q_ref, array1_in, array2_in, result1, in1_shape, in2_shape,
+            res_shape, ndim, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType1, typename _DataType2, typename _ResultType>
-void (*dpnp_kron_default_c)(void*,
-                            void*,
-                            void*,
-                            shape_elem_type*,
-                            shape_elem_type*,
-                            shape_elem_type*,
-                            size_t) = dpnp_kron_c<_DataType1, _DataType2, _ResultType>;
+void (*dpnp_kron_default_c)(void *,
+                            void *,
+                            void *,
+                            shape_elem_type *,
+                            shape_elem_type *,
+                            shape_elem_type *,
+                            size_t) =
+    dpnp_kron_c<_DataType1, _DataType2, _ResultType>;
 
 template <typename _DataType1, typename _DataType2, typename _ResultType>
 DPCTLSyclEventRef (*dpnp_kron_ext_c)(DPCTLSyclQueueRef,
-                                     void*,
-                                     void*,
-                                     void*,
-                                     shape_elem_type*,
-                                     shape_elem_type*,
-                                     shape_elem_type*,
+                                     void *,
+                                     void *,
+                                     void *,
+                                     shape_elem_type *,
+                                     shape_elem_type *,
+                                     shape_elem_type *,
                                      size_t,
-                                     const DPCTLEventVectorRef) = dpnp_kron_c<_DataType1, _DataType2, _ResultType>;
+                                     const DPCTLEventVectorRef) =
+    dpnp_kron_c<_DataType1, _DataType2, _ResultType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_matrix_rank_c(DPCTLSyclQueueRef q_ref,
-                                     void* array1_in,
-                                     void* result1,
-                                     shape_elem_type* shape,
-                                     size_t ndim,
-                                     const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_matrix_rank_c(DPCTLSyclQueueRef q_ref,
+                       void *array1_in,
+                       void *result1,
+                       shape_elem_type *shape,
+                       size_t ndim,
+                       const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    const size_t input_size = std::accumulate(shape, shape + ndim, 1, std::multiplies<shape_elem_type>());
-    if (!input_size)
-    {
+    const size_t input_size = std::accumulate(
+        shape, shape + ndim, 1, std::multiplies<shape_elem_type>());
+    if (!input_size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, input_size, true);
     DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, 1, true, true);
-    _DataType* array_1 = input1_ptr.get_ptr();
-    _DataType* result = result_ptr.get_ptr();
+    _DataType *array_1 = input1_ptr.get_ptr();
+    _DataType *result  = result_ptr.get_ptr();
 
     shape_elem_type elems = 1;
-    if (ndim > 1)
-    {
+    if (ndim > 1) {
         elems = shape[0];
-        for (size_t i = 1; i < ndim; i++)
-        {
-            if (shape[i] < elems)
-            {
+        for (size_t i = 1; i < ndim; i++) {
+            if (shape[i] < elems) {
                 elems = shape[i];
             }
         }
     }
 
     _DataType acc = 0;
-    for (size_t i = 0; i < static_cast<size_t>(elems); i++)
-    {
+    for (size_t i = 0; i < static_cast<size_t>(elems); i++) {
         size_t ind = 0;
-        for (size_t j = 0; j < ndim; j++)
-        {
+        for (size_t j = 0; j < ndim; j++) {
             ind += (shape[j] - 1) * i;
         }
         acc += array_1[ind];
@@ -609,37 +569,38 @@ DPCTLSyclEventRef dpnp_matrix_rank_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_matrix_rank_c(void* array1_in, void* result1, shape_elem_type* shape, size_t ndim)
+void dpnp_matrix_rank_c(void *array1_in,
+                        void *result1,
+                        shape_elem_type *shape,
+                        size_t ndim)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_matrix_rank_c<_DataType>(q_ref,
-                                                                array1_in,
-                                                                result1,
-                                                                shape,
-                                                                ndim,
-                                                                dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_matrix_rank_c<_DataType>(
+        q_ref, array1_in, result1, shape, ndim, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_matrix_rank_default_c)(void*, void*, shape_elem_type*, size_t) = dpnp_matrix_rank_c<_DataType>;
+void (*dpnp_matrix_rank_default_c)(void *, void *, shape_elem_type *, size_t) =
+    dpnp_matrix_rank_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_matrix_rank_ext_c)(DPCTLSyclQueueRef,
-                                            void*,
-                                            void*,
-                                            shape_elem_type*,
+                                            void *,
+                                            void *,
+                                            shape_elem_type *,
                                             size_t,
-                                            const DPCTLEventVectorRef) = dpnp_matrix_rank_c<_DataType>;
+                                            const DPCTLEventVectorRef) =
+    dpnp_matrix_rank_c<_DataType>;
 
 template <typename _InputDT, typename _ComputeDT>
 DPCTLSyclEventRef dpnp_qr_c(DPCTLSyclQueueRef q_ref,
-                            void* array1_in,
-                            void* result1,
-                            void* result2,
-                            void* result3,
+                            void *array1_in,
+                            void *result1,
+                            void *result2,
+                            void *result3,
                             size_t size_m,
                             size_t size_n,
                             const DPCTLEventVectorRef dep_event_vec_ref)
@@ -648,44 +609,49 @@ DPCTLSyclEventRef dpnp_qr_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     sycl::event event;
 
-    DPNPC_ptr_adapter<_InputDT> input1_ptr(q_ref, array1_in, size_m * size_n, true);
-    _InputDT* in_array = input1_ptr.get_ptr();
+    DPNPC_ptr_adapter<_InputDT> input1_ptr(q_ref, array1_in, size_m * size_n,
+                                           true);
+    _InputDT *in_array = input1_ptr.get_ptr();
 
     // math lib func overrides input
-    _ComputeDT* in_a = reinterpret_cast<_ComputeDT*>(sycl::malloc_shared(size_m * size_n * sizeof(_ComputeDT), q));
+    _ComputeDT *in_a = reinterpret_cast<_ComputeDT *>(
+        sycl::malloc_shared(size_m * size_n * sizeof(_ComputeDT), q));
 
-    for (size_t i = 0; i < size_m; ++i)
-    {
-        for (size_t j = 0; j < size_n; ++j)
-        {
+    for (size_t i = 0; i < size_m; ++i) {
+        for (size_t j = 0; j < size_n; ++j) {
             // TODO transpose? use dpnp_transpose_c()
             in_a[j * size_m + i] = in_array[i * size_n + j];
         }
     }
 
     const size_t min_size_m_n = std::min<size_t>(size_m, size_n);
-    DPNPC_ptr_adapter<_ComputeDT> result1_ptr(q_ref, result1, size_m * min_size_m_n, true, true);
-    DPNPC_ptr_adapter<_ComputeDT> result2_ptr(q_ref, result2, min_size_m_n * size_n, true, true);
-    DPNPC_ptr_adapter<_ComputeDT> result3_ptr(q_ref, result3, min_size_m_n, true, true);
-    _ComputeDT* res_q = result1_ptr.get_ptr();
-    _ComputeDT* res_r = result2_ptr.get_ptr();
-    _ComputeDT* tau = result3_ptr.get_ptr();
+    DPNPC_ptr_adapter<_ComputeDT> result1_ptr(
+        q_ref, result1, size_m * min_size_m_n, true, true);
+    DPNPC_ptr_adapter<_ComputeDT> result2_ptr(
+        q_ref, result2, min_size_m_n * size_n, true, true);
+    DPNPC_ptr_adapter<_ComputeDT> result3_ptr(q_ref, result3, min_size_m_n,
+                                              true, true);
+    _ComputeDT *res_q = result1_ptr.get_ptr();
+    _ComputeDT *res_r = result2_ptr.get_ptr();
+    _ComputeDT *tau   = result3_ptr.get_ptr();
 
     const std::int64_t lda = size_m;
 
-    const std::int64_t geqrf_scratchpad_size = mkl_lapack::geqrf_scratchpad_size<_ComputeDT>(q, size_m, size_n, lda);
+    const std::int64_t geqrf_scratchpad_size =
+        mkl_lapack::geqrf_scratchpad_size<_ComputeDT>(q, size_m, size_n, lda);
 
-    _ComputeDT* geqrf_scratchpad =
-        reinterpret_cast<_ComputeDT*>(sycl::malloc_shared(geqrf_scratchpad_size * sizeof(_ComputeDT), q));
+    _ComputeDT *geqrf_scratchpad = reinterpret_cast<_ComputeDT *>(
+        sycl::malloc_shared(geqrf_scratchpad_size * sizeof(_ComputeDT), q));
 
     std::vector<sycl::event> depends(1);
     set_barrier_event(q, depends);
 
-    event = mkl_lapack::geqrf(q, size_m, size_n, in_a, lda, tau, geqrf_scratchpad, geqrf_scratchpad_size, depends);
+    event = mkl_lapack::geqrf(q, size_m, size_n, in_a, lda, tau,
+                              geqrf_scratchpad, geqrf_scratchpad_size, depends);
     event.wait();
 
     if (!depends.empty()) {
@@ -696,16 +662,12 @@ DPCTLSyclEventRef dpnp_qr_c(DPCTLSyclQueueRef q_ref,
 
     // R
     size_t mrefl = min_size_m_n;
-    for (size_t i = 0; i < mrefl; ++i)
-    {
-        for (size_t j = 0; j < size_n; ++j)
-        {
-            if (j >= i)
-            {
+    for (size_t i = 0; i < mrefl; ++i) {
+        for (size_t j = 0; j < size_n; ++j) {
+            if (j >= i) {
                 res_r[i * size_n + j] = in_a[j * size_m + i];
             }
-            else
-            {
+            else {
                 res_r[i * size_n + j] = _ComputeDT(0);
             }
         }
@@ -714,15 +676,16 @@ DPCTLSyclEventRef dpnp_qr_c(DPCTLSyclQueueRef q_ref,
     // Q
     const size_t nrefl = min_size_m_n;
     const std::int64_t orgqr_scratchpad_size =
-        mkl_lapack::orgqr_scratchpad_size<_ComputeDT>(q, size_m, nrefl, nrefl, lda);
+        mkl_lapack::orgqr_scratchpad_size<_ComputeDT>(q, size_m, nrefl, nrefl,
+                                                      lda);
 
-    _ComputeDT* orgqr_scratchpad =
-        reinterpret_cast<_ComputeDT*>(sycl::malloc_shared(orgqr_scratchpad_size * sizeof(_ComputeDT), q));
+    _ComputeDT *orgqr_scratchpad = reinterpret_cast<_ComputeDT *>(
+        sycl::malloc_shared(orgqr_scratchpad_size * sizeof(_ComputeDT), q));
 
     set_barrier_event(q, depends);
 
-    event =
-        mkl_lapack::orgqr(q, size_m, nrefl, nrefl, in_a, lda, tau, orgqr_scratchpad, orgqr_scratchpad_size, depends);
+    event = mkl_lapack::orgqr(q, size_m, nrefl, nrefl, in_a, lda, tau,
+                              orgqr_scratchpad, orgqr_scratchpad_size, depends);
     event.wait();
 
     if (!depends.empty()) {
@@ -731,10 +694,8 @@ DPCTLSyclEventRef dpnp_qr_c(DPCTLSyclQueueRef q_ref,
 
     sycl::free(orgqr_scratchpad, q);
 
-    for (size_t i = 0; i < size_m; ++i)
-    {
-        for (size_t j = 0; j < nrefl; ++j)
-        {
+    for (size_t i = 0; i < size_m; ++i) {
+        for (size_t j = 0; j < nrefl; ++j) {
             res_q[i * nrefl + j] = in_a[j * size_m + i];
         }
     }
@@ -745,41 +706,43 @@ DPCTLSyclEventRef dpnp_qr_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _InputDT, typename _ComputeDT>
-void dpnp_qr_c(void* array1_in, void* result1, void* result2, void* result3, size_t size_m, size_t size_n)
+void dpnp_qr_c(void *array1_in,
+               void *result1,
+               void *result2,
+               void *result3,
+               size_t size_m,
+               size_t size_n)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_qr_c<_InputDT, _ComputeDT>(q_ref,
-                                                                  array1_in,
-                                                                  result1,
-                                                                  result2,
-                                                                  result3,
-                                                                  size_m,
-                                                                  size_n,
-                                                                  dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_qr_c<_InputDT, _ComputeDT>(
+        q_ref, array1_in, result1, result2, result3, size_m, size_n,
+        dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _InputDT, typename _ComputeDT>
-void (*dpnp_qr_default_c)(void*, void*, void*, void*, size_t, size_t) = dpnp_qr_c<_InputDT, _ComputeDT>;
+void (*dpnp_qr_default_c)(void *, void *, void *, void *, size_t, size_t) =
+    dpnp_qr_c<_InputDT, _ComputeDT>;
 
 template <typename _InputDT, typename _ComputeDT>
 DPCTLSyclEventRef (*dpnp_qr_ext_c)(DPCTLSyclQueueRef,
-                                   void*,
-                                   void*,
-                                   void*,
-                                   void*,
+                                   void *,
+                                   void *,
+                                   void *,
+                                   void *,
                                    size_t,
                                    size_t,
-                                   const DPCTLEventVectorRef) = dpnp_qr_c<_InputDT, _ComputeDT>;
+                                   const DPCTLEventVectorRef) =
+    dpnp_qr_c<_InputDT, _ComputeDT>;
 
 template <typename _InputDT, typename _ComputeDT, typename _SVDT>
 DPCTLSyclEventRef dpnp_svd_c(DPCTLSyclQueueRef q_ref,
-                             void* array1_in,
-                             void* result1,
-                             void* result2,
-                             void* result3,
+                             void *array1_in,
+                             void *result1,
+                             void *result2,
+                             void *result3,
                              size_t size_m,
                              size_t size_n,
                              const DPCTLEventVectorRef dep_event_vec_ref)
@@ -788,54 +751,54 @@ DPCTLSyclEventRef dpnp_svd_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     sycl::event event;
 
-    DPNPC_ptr_adapter<_InputDT> input1_ptr(q_ref, array1_in, size_m * size_n, true); // TODO no need this if use dpnp_copy_to()
-    _InputDT* in_array = input1_ptr.get_ptr();
+    DPNPC_ptr_adapter<_InputDT> input1_ptr(
+        q_ref, array1_in, size_m * size_n,
+        true); // TODO no need this if use dpnp_copy_to()
+    _InputDT *in_array = input1_ptr.get_ptr();
 
     // math lib gesvd func overrides input
-    _ComputeDT* in_a = reinterpret_cast<_ComputeDT*>(sycl::malloc_shared(size_m * size_n * sizeof(_ComputeDT), q));
-    for (size_t it = 0; it < size_m * size_n; ++it)
-    {
-        in_a[it] = in_array[it]; // TODO Type conversion. memcpy can not be used directly. dpnp_copy_to() ?
+    _ComputeDT *in_a = reinterpret_cast<_ComputeDT *>(
+        sycl::malloc_shared(size_m * size_n * sizeof(_ComputeDT), q));
+    for (size_t it = 0; it < size_m * size_n; ++it) {
+        in_a[it] = in_array[it]; // TODO Type conversion. memcpy can not be used
+                                 // directly. dpnp_copy_to() ?
     }
 
-    DPNPC_ptr_adapter<_ComputeDT> result1_ptr(q_ref, result1, size_m * size_m, true, true);
-    DPNPC_ptr_adapter<_SVDT> result2_ptr(q_ref, result2, std::min(size_m, size_n), true, true);
-    DPNPC_ptr_adapter<_ComputeDT> result3_ptr(q_ref, result3, size_n * size_n, true, true);
-    _ComputeDT* res_u = result1_ptr.get_ptr();
-    _SVDT* res_s = result2_ptr.get_ptr();
-    _ComputeDT* res_vt = result3_ptr.get_ptr();
+    DPNPC_ptr_adapter<_ComputeDT> result1_ptr(q_ref, result1, size_m * size_m,
+                                              true, true);
+    DPNPC_ptr_adapter<_SVDT> result2_ptr(q_ref, result2,
+                                         std::min(size_m, size_n), true, true);
+    DPNPC_ptr_adapter<_ComputeDT> result3_ptr(q_ref, result3, size_n * size_n,
+                                              true, true);
+    _ComputeDT *res_u  = result1_ptr.get_ptr();
+    _SVDT *res_s       = result2_ptr.get_ptr();
+    _ComputeDT *res_vt = result3_ptr.get_ptr();
 
     const std::int64_t m = size_m;
     const std::int64_t n = size_n;
 
-    const std::int64_t lda = std::max<size_t>(1UL, n);
-    const std::int64_t ldu = std::max<size_t>(1UL, m);
+    const std::int64_t lda  = std::max<size_t>(1UL, n);
+    const std::int64_t ldu  = std::max<size_t>(1UL, m);
     const std::int64_t ldvt = std::max<size_t>(1UL, n);
 
-    const std::int64_t scratchpad_size = mkl_lapack::gesvd_scratchpad_size<_ComputeDT>(
-        q, oneapi::mkl::jobsvd::vectors, oneapi::mkl::jobsvd::vectors, n, m, lda, ldvt, ldu);
+    const std::int64_t scratchpad_size =
+        mkl_lapack::gesvd_scratchpad_size<_ComputeDT>(
+            q, oneapi::mkl::jobsvd::vectors, oneapi::mkl::jobsvd::vectors, n, m,
+            lda, ldvt, ldu);
 
-    _ComputeDT* scratchpad = reinterpret_cast<_ComputeDT*>(sycl::malloc_shared(scratchpad_size * sizeof(_ComputeDT),
-                                                                               q));
+    _ComputeDT *scratchpad = reinterpret_cast<_ComputeDT *>(
+        sycl::malloc_shared(scratchpad_size * sizeof(_ComputeDT), q));
 
-    event = mkl_lapack::gesvd(q,
-                              oneapi::mkl::jobsvd::vectors, // onemkl::job jobu,
-                              oneapi::mkl::jobsvd::vectors, // onemkl::job jobvt,
-                              n,
-                              m,
-                              in_a,
-                              lda,
-                              res_s,
-                              res_vt,
-                              ldvt,
-                              res_u,
-                              ldu,
-                              scratchpad,
-                              scratchpad_size);
+    event =
+        mkl_lapack::gesvd(q,
+                          oneapi::mkl::jobsvd::vectors, // onemkl::job jobu,
+                          oneapi::mkl::jobsvd::vectors, // onemkl::job jobvt,
+                          n, m, in_a, lda, res_s, res_vt, ldvt, res_u, ldu,
+                          scratchpad, scratchpad_size);
 
     event.wait();
 
@@ -845,210 +808,271 @@ DPCTLSyclEventRef dpnp_svd_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _InputDT, typename _ComputeDT, typename _SVDT>
-void dpnp_svd_c(void* array1_in, void* result1, void* result2, void* result3, size_t size_m, size_t size_n)
+void dpnp_svd_c(void *array1_in,
+                void *result1,
+                void *result2,
+                void *result3,
+                size_t size_m,
+                size_t size_n)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_svd_c<_InputDT, _ComputeDT, _SVDT>(q_ref,
-                                                                          array1_in,
-                                                                          result1,
-                                                                          result2,
-                                                                          result3,
-                                                                          size_m,
-                                                                          size_n,
-                                                                          dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref = dpnp_svd_c<_InputDT, _ComputeDT, _SVDT>(
+        q_ref, array1_in, result1, result2, result3, size_m, size_n,
+        dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _InputDT, typename _ComputeDT, typename _SVDT>
-void (*dpnp_svd_default_c)(void*, void*, void*, void*, size_t, size_t) = dpnp_svd_c<_InputDT, _ComputeDT, _SVDT>;
+void (*dpnp_svd_default_c)(void *, void *, void *, void *, size_t, size_t) =
+    dpnp_svd_c<_InputDT, _ComputeDT, _SVDT>;
 
 template <typename _InputDT, typename _ComputeDT, typename _SVDT>
 DPCTLSyclEventRef (*dpnp_svd_ext_c)(DPCTLSyclQueueRef,
-                                    void*,
-                                    void*,
-                                    void*,
-                                    void*,
+                                    void *,
+                                    void *,
+                                    void *,
+                                    void *,
                                     size_t,
                                     size_t,
-                                    const DPCTLEventVectorRef) = dpnp_svd_c<_InputDT, _ComputeDT, _SVDT>;
+                                    const DPCTLEventVectorRef) =
+    dpnp_svd_c<_InputDT, _ComputeDT, _SVDT>;
 
-void func_map_init_linalg_func(func_map_t& fmap)
+void func_map_init_linalg_func(func_map_t &fmap)
 {
-    fmap[DPNPFuncName::DPNP_FN_CHOLESKY][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_cholesky_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_CHOLESKY][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_cholesky_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_CHOLESKY][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_cholesky_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_CHOLESKY][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_cholesky_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_CHOLESKY_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_cholesky_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_CHOLESKY_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_cholesky_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_CHOLESKY_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_cholesky_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_CHOLESKY_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_cholesky_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_DET][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_det_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_DET][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_det_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_DET][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_det_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_DET][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_det_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_DET][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_det_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_DET][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_det_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_DET][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_det_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_DET][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_det_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_DET_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_det_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_DET_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_det_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_DET_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_det_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_DET_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_det_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_DET_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_det_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_DET_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_det_ext_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_DET_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_det_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_DET_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_det_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_INV][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_inv_default_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_INV][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_inv_default_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_INV][eft_FLT][eft_FLT] = {eft_DBL, (void*)dpnp_inv_default_c<float, double>};
-    fmap[DPNPFuncName::DPNP_FN_INV][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_inv_default_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_INV][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_inv_default_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_INV][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_inv_default_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_INV][eft_FLT][eft_FLT] = {
+        eft_DBL, (void *)dpnp_inv_default_c<float, double>};
+    fmap[DPNPFuncName::DPNP_FN_INV][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_inv_default_c<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_INV_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_inv_ext_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_INV_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_inv_ext_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_INV_EXT][eft_FLT][eft_FLT] = {eft_DBL, (void*)dpnp_inv_ext_c<float, double>};
-    fmap[DPNPFuncName::DPNP_FN_INV_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_inv_ext_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_INV_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_inv_ext_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_INV_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_inv_ext_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_INV_EXT][eft_FLT][eft_FLT] = {
+        eft_DBL, (void *)dpnp_inv_ext_c<float, double>};
+    fmap[DPNPFuncName::DPNP_FN_INV_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_inv_ext_c<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_KRON][eft_INT][eft_INT] = {eft_INT,
-                                                          (void*)dpnp_kron_default_c<int32_t, int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_KRON][eft_INT][eft_LNG] = {eft_LNG,
-                                                          (void*)dpnp_kron_default_c<int32_t, int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_KRON][eft_INT][eft_FLT] = {eft_FLT,
-                                                          (void*)dpnp_kron_default_c<int32_t, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_KRON][eft_INT][eft_DBL] = {eft_DBL,
-                                                          (void*)dpnp_kron_default_c<int32_t, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_KRON][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_kron_default_c<int32_t, int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_KRON][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_kron_default_c<int32_t, int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_KRON][eft_INT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_kron_default_c<int32_t, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_KRON][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_kron_default_c<int32_t, double, double>};
     // fmap[DPNPFuncName::DPNP_FN_KRON][eft_INT][eft_C128] = {
-    // eft_C128, (void*)dpnp_kron_default_c<int32_t, std::complex<double>, std::complex<double>>};
-    fmap[DPNPFuncName::DPNP_FN_KRON][eft_LNG][eft_INT] = {eft_LNG,
-                                                          (void*)dpnp_kron_default_c<int64_t, int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_KRON][eft_LNG][eft_LNG] = {eft_LNG,
-                                                          (void*)dpnp_kron_default_c<int64_t, int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_KRON][eft_LNG][eft_FLT] = {eft_FLT,
-                                                          (void*)dpnp_kron_default_c<int64_t, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_KRON][eft_LNG][eft_DBL] = {eft_DBL,
-                                                          (void*)dpnp_kron_default_c<int64_t, double, double>};
+    // eft_C128, (void*)dpnp_kron_default_c<int32_t, std::complex<double>,
+    // std::complex<double>>};
+    fmap[DPNPFuncName::DPNP_FN_KRON][eft_LNG][eft_INT] = {
+        eft_LNG, (void *)dpnp_kron_default_c<int64_t, int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_KRON][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_kron_default_c<int64_t, int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_KRON][eft_LNG][eft_FLT] = {
+        eft_FLT, (void *)dpnp_kron_default_c<int64_t, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_KRON][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_kron_default_c<int64_t, double, double>};
     // fmap[DPNPFuncName::DPNP_FN_KRON][eft_LNG][eft_C128] = {
-    // eft_C128, (void*)dpnp_kron_default_c<int64_t, std::complex<double>, std::complex<double>>};
-    fmap[DPNPFuncName::DPNP_FN_KRON][eft_FLT][eft_INT] = {eft_FLT,
-                                                          (void*)dpnp_kron_default_c<float, int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_KRON][eft_FLT][eft_LNG] = {eft_FLT,
-                                                          (void*)dpnp_kron_default_c<float, int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_KRON][eft_FLT][eft_FLT] = {eft_FLT,
-                                                          (void*)dpnp_kron_default_c<float, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_KRON][eft_FLT][eft_DBL] = {eft_DBL,
-                                                          (void*)dpnp_kron_default_c<float, double, double>};
+    // eft_C128, (void*)dpnp_kron_default_c<int64_t, std::complex<double>,
+    // std::complex<double>>};
+    fmap[DPNPFuncName::DPNP_FN_KRON][eft_FLT][eft_INT] = {
+        eft_FLT, (void *)dpnp_kron_default_c<float, int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_KRON][eft_FLT][eft_LNG] = {
+        eft_FLT, (void *)dpnp_kron_default_c<float, int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_KRON][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_kron_default_c<float, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_KRON][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_kron_default_c<float, double, double>};
     // fmap[DPNPFuncName::DPNP_FN_KRON][eft_FLT][eft_C128] = {
-    // eft_C128, (void*)dpnp_kron_default_c<float, std::complex<double>, std::complex<double>>};
-    fmap[DPNPFuncName::DPNP_FN_KRON][eft_DBL][eft_INT] = {eft_DBL,
-                                                          (void*)dpnp_kron_default_c<double, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_KRON][eft_DBL][eft_LNG] = {eft_DBL,
-                                                          (void*)dpnp_kron_default_c<double, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_KRON][eft_DBL][eft_FLT] = {eft_DBL,
-                                                          (void*)dpnp_kron_default_c<double, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_KRON][eft_DBL][eft_DBL] = {eft_DBL,
-                                                          (void*)dpnp_kron_default_c<double, double, double>};
+    // eft_C128, (void*)dpnp_kron_default_c<float, std::complex<double>,
+    // std::complex<double>>};
+    fmap[DPNPFuncName::DPNP_FN_KRON][eft_DBL][eft_INT] = {
+        eft_DBL, (void *)dpnp_kron_default_c<double, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_KRON][eft_DBL][eft_LNG] = {
+        eft_DBL, (void *)dpnp_kron_default_c<double, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_KRON][eft_DBL][eft_FLT] = {
+        eft_DBL, (void *)dpnp_kron_default_c<double, float, double>};
+    fmap[DPNPFuncName::DPNP_FN_KRON][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_kron_default_c<double, double, double>};
     fmap[DPNPFuncName::DPNP_FN_KRON][eft_DBL][eft_C128] = {
-        eft_C128, (void*)dpnp_kron_default_c<double, std::complex<double>, std::complex<double>>};
+        eft_C128, (void *)dpnp_kron_default_c<double, std::complex<double>,
+                                              std::complex<double>>};
     // fmap[DPNPFuncName::DPNP_FN_KRON][eft_C128][eft_INT] = {
-    // eft_C128, (void*)dpnp_kron_default_c<std::complex<double>, int32_t, std::complex<double>>};
+    // eft_C128, (void*)dpnp_kron_default_c<std::complex<double>, int32_t,
+    // std::complex<double>>};
     // fmap[DPNPFuncName::DPNP_FN_KRON][eft_C128][eft_LNG] = {
-    // eft_C128, (void*)dpnp_kron_default_c<std::complex<double>, int64_t, std::complex<double>>};
+    // eft_C128, (void*)dpnp_kron_default_c<std::complex<double>, int64_t,
+    // std::complex<double>>};
     // fmap[DPNPFuncName::DPNP_FN_KRON][eft_C128][eft_FLT] = {
-    // eft_C128, (void*)dpnp_kron_default_c<std::complex<double>, float, std::complex<double>>};
+    // eft_C128, (void*)dpnp_kron_default_c<std::complex<double>, float,
+    // std::complex<double>>};
     fmap[DPNPFuncName::DPNP_FN_KRON][eft_C128][eft_DBL] = {
-        eft_C128, (void*)dpnp_kron_default_c<std::complex<double>, double, std::complex<double>>};
+        eft_C128, (void *)dpnp_kron_default_c<std::complex<double>, double,
+                                              std::complex<double>>};
     fmap[DPNPFuncName::DPNP_FN_KRON][eft_C128][eft_C128] = {
-        eft_C128, (void*)dpnp_kron_default_c<std::complex<double>, std::complex<double>, std::complex<double>>};
+        eft_C128,
+        (void *)dpnp_kron_default_c<std::complex<double>, std::complex<double>,
+                                    std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_INT][eft_INT] = {eft_INT,
-                                                              (void*)dpnp_kron_ext_c<int32_t, int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_INT][eft_LNG] = {eft_LNG,
-                                                              (void*)dpnp_kron_ext_c<int32_t, int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_INT][eft_FLT] = {eft_FLT,
-                                                              (void*)dpnp_kron_ext_c<int32_t, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_INT][eft_DBL] = {eft_DBL,
-                                                              (void*)dpnp_kron_ext_c<int32_t, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_kron_ext_c<int32_t, int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_kron_ext_c<int32_t, int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_INT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_kron_ext_c<int32_t, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_kron_ext_c<int32_t, double, double>};
     // fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_INT][eft_C128] = {
-    // eft_C128, (void*)dpnp_kron_ext_c<int32_t, std::complex<double>, std::complex<double>>};
-    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_LNG][eft_INT] = {eft_LNG,
-                                                              (void*)dpnp_kron_ext_c<int64_t, int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_LNG][eft_LNG] = {eft_LNG,
-                                                              (void*)dpnp_kron_ext_c<int64_t, int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_LNG][eft_FLT] = {eft_FLT,
-                                                              (void*)dpnp_kron_ext_c<int64_t, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_LNG][eft_DBL] = {eft_DBL,
-                                                              (void*)dpnp_kron_ext_c<int64_t, double, double>};
+    // eft_C128, (void*)dpnp_kron_ext_c<int32_t, std::complex<double>,
+    // std::complex<double>>};
+    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_LNG][eft_INT] = {
+        eft_LNG, (void *)dpnp_kron_ext_c<int64_t, int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_kron_ext_c<int64_t, int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_LNG][eft_FLT] = {
+        eft_FLT, (void *)dpnp_kron_ext_c<int64_t, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_kron_ext_c<int64_t, double, double>};
     // fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_LNG][eft_C128] = {
-    // eft_C128, (void*)dpnp_kron_ext_c<int64_t, std::complex<double>, std::complex<double>>};
-    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_FLT][eft_INT] = {eft_FLT,
-                                                              (void*)dpnp_kron_ext_c<float, int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_FLT][eft_LNG] = {eft_FLT,
-                                                              (void*)dpnp_kron_ext_c<float, int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_FLT][eft_FLT] = {eft_FLT,
-                                                              (void*)dpnp_kron_ext_c<float, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_FLT][eft_DBL] = {eft_DBL,
-                                                              (void*)dpnp_kron_ext_c<float, double, double>};
+    // eft_C128, (void*)dpnp_kron_ext_c<int64_t, std::complex<double>,
+    // std::complex<double>>};
+    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_FLT][eft_INT] = {
+        eft_FLT, (void *)dpnp_kron_ext_c<float, int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_FLT][eft_LNG] = {
+        eft_FLT, (void *)dpnp_kron_ext_c<float, int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_kron_ext_c<float, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_kron_ext_c<float, double, double>};
     // fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_FLT][eft_C128] = {
-    // eft_C128, (void*)dpnp_kron_ext_c<float, std::complex<double>, std::complex<double>>};
-    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_DBL][eft_INT] = {eft_DBL,
-                                                              (void*)dpnp_kron_ext_c<double, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_DBL][eft_LNG] = {eft_DBL,
-                                                              (void*)dpnp_kron_ext_c<double, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_DBL][eft_FLT] = {eft_DBL,
-                                                              (void*)dpnp_kron_ext_c<double, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_DBL][eft_DBL] = {eft_DBL,
-                                                              (void*)dpnp_kron_ext_c<double, double, double>};
+    // eft_C128, (void*)dpnp_kron_ext_c<float, std::complex<double>,
+    // std::complex<double>>};
+    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_DBL][eft_INT] = {
+        eft_DBL, (void *)dpnp_kron_ext_c<double, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_DBL][eft_LNG] = {
+        eft_DBL, (void *)dpnp_kron_ext_c<double, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_DBL][eft_FLT] = {
+        eft_DBL, (void *)dpnp_kron_ext_c<double, float, double>};
+    fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_kron_ext_c<double, double, double>};
     fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_DBL][eft_C128] = {
-        eft_C128, (void*)dpnp_kron_ext_c<double, std::complex<double>, std::complex<double>>};
+        eft_C128, (void *)dpnp_kron_ext_c<double, std::complex<double>,
+                                          std::complex<double>>};
     // fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_C128][eft_INT] = {
-    // eft_C128, (void*)dpnp_kron_ext_c<std::complex<double>, int32_t, std::complex<double>>};
+    // eft_C128, (void*)dpnp_kron_ext_c<std::complex<double>, int32_t,
+    // std::complex<double>>};
     // fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_C128][eft_LNG] = {
-    // eft_C128, (void*)dpnp_kron_ext_c<std::complex<double>, int64_t, std::complex<double>>};
+    // eft_C128, (void*)dpnp_kron_ext_c<std::complex<double>, int64_t,
+    // std::complex<double>>};
     // fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_C128][eft_FLT] = {
-    // eft_C128, (void*)dpnp_kron_ext_c<std::complex<double>, float, std::complex<double>>};
+    // eft_C128, (void*)dpnp_kron_ext_c<std::complex<double>, float,
+    // std::complex<double>>};
     fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_C128][eft_DBL] = {
-        eft_C128, (void*)dpnp_kron_ext_c<std::complex<double>, double, std::complex<double>>};
+        eft_C128, (void *)dpnp_kron_ext_c<std::complex<double>, double,
+                                          std::complex<double>>};
     fmap[DPNPFuncName::DPNP_FN_KRON_EXT][eft_C128][eft_C128] = {
-        eft_C128, (void*)dpnp_kron_ext_c<std::complex<double>, std::complex<double>, std::complex<double>>};
+        eft_C128,
+        (void *)dpnp_kron_ext_c<std::complex<double>, std::complex<double>,
+                                std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_MATRIX_RANK][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_matrix_rank_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MATRIX_RANK][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_matrix_rank_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MATRIX_RANK][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_matrix_rank_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_MATRIX_RANK][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_matrix_rank_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_MATRIX_RANK][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_matrix_rank_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_MATRIX_RANK][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_matrix_rank_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_MATRIX_RANK][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_matrix_rank_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_MATRIX_RANK][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_matrix_rank_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_MATRIX_RANK_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_matrix_rank_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MATRIX_RANK_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_matrix_rank_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MATRIX_RANK_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_matrix_rank_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_MATRIX_RANK_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_matrix_rank_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_MATRIX_RANK_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_matrix_rank_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_MATRIX_RANK_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_matrix_rank_ext_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_MATRIX_RANK_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_matrix_rank_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_MATRIX_RANK_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_matrix_rank_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_QR][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_qr_default_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_QR][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_qr_default_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_QR][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_qr_default_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_QR][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_qr_default_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_QR][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_qr_default_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_QR][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_qr_default_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_QR][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_qr_default_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_QR][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_qr_default_c<double, double>};
     // fmap[DPNPFuncName::DPNP_FN_QR][eft_C128][eft_C128] = {
     // eft_C128, (void*)dpnp_qr_c<std::complex<double>, std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_QR_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_qr_ext_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_QR_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_qr_ext_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_QR_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_qr_ext_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_QR_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_qr_ext_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_QR_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_qr_ext_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_QR_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_qr_ext_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_QR_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_qr_ext_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_QR_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_qr_ext_c<double, double>};
     // fmap[DPNPFuncName::DPNP_FN_QR_EXT][eft_C128][eft_C128] = {
     // eft_C128, (void*)dpnp_qr_c<std::complex<double>, std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_SVD][eft_INT][eft_INT] = {eft_DBL,
-                                                         (void*)dpnp_svd_default_c<int32_t, double, double>};
-    fmap[DPNPFuncName::DPNP_FN_SVD][eft_LNG][eft_LNG] = {eft_DBL,
-                                                         (void*)dpnp_svd_default_c<int64_t, double, double>};
-    fmap[DPNPFuncName::DPNP_FN_SVD][eft_FLT][eft_FLT] = {eft_FLT,
-                                                         (void*)dpnp_svd_default_c<float, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_SVD][eft_DBL][eft_DBL] = {eft_DBL,
-                                                         (void*)dpnp_svd_default_c<double, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_SVD][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_svd_default_c<int32_t, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_SVD][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_svd_default_c<int64_t, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_SVD][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_svd_default_c<float, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_SVD][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_svd_default_c<double, double, double>};
     fmap[DPNPFuncName::DPNP_FN_SVD][eft_C128][eft_C128] = {
-        eft_C128, (void*)dpnp_svd_default_c<std::complex<double>, std::complex<double>, double>};
+        eft_C128, (void *)dpnp_svd_default_c<std::complex<double>,
+                                             std::complex<double>, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_SVD_EXT][eft_INT][eft_INT] = {eft_DBL,
-                                                             (void*)dpnp_svd_ext_c<int32_t, double, double>};
-    fmap[DPNPFuncName::DPNP_FN_SVD_EXT][eft_LNG][eft_LNG] = {eft_DBL,
-                                                             (void*)dpnp_svd_ext_c<int64_t, double, double>};
-    fmap[DPNPFuncName::DPNP_FN_SVD_EXT][eft_FLT][eft_FLT] = {eft_FLT,
-                                                             (void*)dpnp_svd_ext_c<float, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_SVD_EXT][eft_DBL][eft_DBL] = {eft_DBL,
-                                                             (void*)dpnp_svd_ext_c<double, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_SVD_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_svd_ext_c<int32_t, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_SVD_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_svd_ext_c<int64_t, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_SVD_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_svd_ext_c<float, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_SVD_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_svd_ext_c<double, double, double>};
     fmap[DPNPFuncName::DPNP_FN_SVD_EXT][eft_C128][eft_C128] = {
-        eft_C128, (void*)dpnp_svd_ext_c<std::complex<double>, std::complex<double>, double>};
+        eft_C128,
+        (void *)
+            dpnp_svd_ext_c<std::complex<double>, std::complex<double>, double>};
 
     return;
 }

--- a/dpnp/backend/kernels/dpnp_krnl_logic.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_logic.cpp
@@ -36,63 +36,65 @@ class dpnp_all_c_kernel;
 
 template <typename _DataType, typename _ResultType>
 DPCTLSyclEventRef dpnp_all_c(DPCTLSyclQueueRef q_ref,
-                             const void* array1_in,
-                             void* result1,
+                             const void *array1_in,
+                             void *result1,
                              const size_t size,
                              const DPCTLEventVectorRef dep_event_vec_ref)
 {
-    static_assert(std::is_same_v<_ResultType, bool>, "Boolean result type is required");
+    static_assert(std::is_same_v<_ResultType, bool>,
+                  "Boolean result type is required");
 
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!array1_in || !result1)
-    {
+    if (!array1_in || !result1) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    const _DataType* array_in = static_cast<const _DataType*>(array1_in);
-    bool* result = static_cast<bool*>(result1);
+    const _DataType *array_in = static_cast<const _DataType *>(array1_in);
+    bool *result              = static_cast<bool *>(result1);
 
     auto fill_event = q.fill(result, true, 1);
 
-    if (!size)
-    {
+    if (!size) {
         event_ref = reinterpret_cast<DPCTLSyclEventRef>(&fill_event);
         return DPCTLEvent_Copy(event_ref);
     }
 
-    constexpr size_t lws = 64;
+    constexpr size_t lws    = 64;
     constexpr size_t vec_sz = 8;
 
-    auto gws_range = sycl::range<1>(((size + lws * vec_sz - 1) / (lws * vec_sz)) * lws);
+    auto gws_range =
+        sycl::range<1>(((size + lws * vec_sz - 1) / (lws * vec_sz)) * lws);
     auto lws_range = sycl::range<1>(lws);
     sycl::nd_range<1> gws(gws_range, lws_range);
 
     auto kernel_parallel_for_func = [=](sycl::nd_item<1> nd_it) {
-        auto gr = nd_it.get_group();
+        auto gr                = nd_it.get_group();
         const auto max_gr_size = gr.get_max_local_range()[0];
         const size_t start =
-            vec_sz * (nd_it.get_group(0) * nd_it.get_local_range(0) + gr.get_group_id()[0] * max_gr_size);
+            vec_sz * (nd_it.get_group(0) * nd_it.get_local_range(0) +
+                      gr.get_group_id()[0] * max_gr_size);
         const size_t end = sycl::min(start + vec_sz * max_gr_size, size);
 
         // each work-item reduces over "vec_sz" elements in the input array
         bool local_reduction = sycl::joint_none_of(
-            gr, &array_in[start], &array_in[end], [&](_DataType elem) { return elem == static_cast<_DataType>(0); });
+            gr, &array_in[start], &array_in[end],
+            [&](_DataType elem) { return elem == static_cast<_DataType>(0); });
 
-        if (gr.leader() && (local_reduction == false))
-        {
+        if (gr.leader() && (local_reduction == false)) {
             result[0] = false;
         }
     };
 
-    auto kernel_func = [&](sycl::handler& cgh) {
+    auto kernel_func = [&](sycl::handler &cgh) {
         cgh.depends_on(fill_event);
-        cgh.parallel_for<class dpnp_all_c_kernel<_DataType, _ResultType>>(gws, kernel_parallel_for_func);
+        cgh.parallel_for<class dpnp_all_c_kernel<_DataType, _ResultType>>(
+            gws, kernel_parallel_for_func);
     };
 
     auto event = q.submit(kernel_func);
@@ -102,37 +104,37 @@ DPCTLSyclEventRef dpnp_all_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType, typename _ResultType>
-void dpnp_all_c(const void* array1_in, void* result1, const size_t size)
+void dpnp_all_c(const void *array1_in, void *result1, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_all_c<_DataType, _ResultType>(q_ref,
-                                                                     array1_in,
-                                                                     result1,
-                                                                     size,
-                                                                     dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_all_c<_DataType, _ResultType>(
+        q_ref, array1_in, result1, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType, typename _ResultType>
-void (*dpnp_all_default_c)(const void*, void*, const size_t) = dpnp_all_c<_DataType, _ResultType>;
+void (*dpnp_all_default_c)(const void *,
+                           void *,
+                           const size_t) = dpnp_all_c<_DataType, _ResultType>;
 
 template <typename _DataType, typename _ResultType>
 DPCTLSyclEventRef (*dpnp_all_ext_c)(DPCTLSyclQueueRef,
-                                    const void*,
-                                    void*,
+                                    const void *,
+                                    void *,
                                     const size_t,
-                                    const DPCTLEventVectorRef) = dpnp_all_c<_DataType, _ResultType>;
+                                    const DPCTLEventVectorRef) =
+    dpnp_all_c<_DataType, _ResultType>;
 
 template <typename _DataType1, typename _DataType2, typename _ResultType>
 class dpnp_allclose_c_kernel;
 
 template <typename _DataType1, typename _DataType2, typename _ResultType>
 DPCTLSyclEventRef dpnp_allclose_c(DPCTLSyclQueueRef q_ref,
-                                  const void* array1_in,
-                                  const void* array2_in,
-                                  void* result1,
+                                  const void *array1_in,
+                                  const void *array2_in,
+                                  void *result1,
                                   const size_t size,
                                   double rtol_val,
                                   double atol_val,
@@ -143,25 +145,23 @@ DPCTLSyclEventRef dpnp_allclose_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!array1_in || !result1)
-    {
+    if (!array1_in || !result1) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
     sycl::event event;
 
     DPNPC_ptr_adapter<_DataType1> input1_ptr(q_ref, array1_in, size);
     DPNPC_ptr_adapter<_DataType2> input2_ptr(q_ref, array2_in, size);
     DPNPC_ptr_adapter<_ResultType> result1_ptr(q_ref, result1, 1, true, true);
-    const _DataType1* array1 = input1_ptr.get_ptr();
-    const _DataType2* array2 = input2_ptr.get_ptr();
-    _ResultType* result = result1_ptr.get_ptr();
+    const _DataType1 *array1 = input1_ptr.get_ptr();
+    const _DataType2 *array2 = input2_ptr.get_ptr();
+    _ResultType *result      = result1_ptr.get_ptr();
 
     result[0] = true;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
@@ -169,15 +169,17 @@ DPCTLSyclEventRef dpnp_allclose_c(DPCTLSyclQueueRef q_ref,
     auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
         size_t i = global_id[0];
 
-        if (std::abs(array1[i] - array2[i]) > (atol_val + rtol_val * std::abs(array2[i])))
+        if (std::abs(array1[i] - array2[i]) >
+            (atol_val + rtol_val * std::abs(array2[i])))
         {
             result[0] = false;
         }
     };
 
-    auto kernel_func = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class dpnp_allclose_c_kernel<_DataType1, _DataType2, _ResultType>>(gws,
-                                                                                            kernel_parallel_for_func);
+    auto kernel_func = [&](sycl::handler &cgh) {
+        cgh.parallel_for<
+            class dpnp_allclose_c_kernel<_DataType1, _DataType2, _ResultType>>(
+            gws, kernel_parallel_for_func);
     };
 
     event = q.submit(kernel_func);
@@ -188,103 +190,106 @@ DPCTLSyclEventRef dpnp_allclose_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType1, typename _DataType2, typename _ResultType>
-void dpnp_allclose_c(
-    const void* array1_in, const void* array2_in, void* result1, const size_t size, double rtol_val, double atol_val)
+void dpnp_allclose_c(const void *array1_in,
+                     const void *array2_in,
+                     void *result1,
+                     const size_t size,
+                     double rtol_val,
+                     double atol_val)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_allclose_c<_DataType1, _DataType2, _ResultType>(q_ref,
-                                                                                       array1_in,
-                                                                                       array2_in,
-                                                                                       result1,
-                                                                                       size,
-                                                                                       rtol_val,
-                                                                                       atol_val,
-                                                                                       dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_allclose_c<_DataType1, _DataType2, _ResultType>(
+            q_ref, array1_in, array2_in, result1, size, rtol_val, atol_val,
+            dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType1, typename _DataType2, typename _ResultType>
-void (*dpnp_allclose_default_c)(const void*,
-                                const void*,
-                                void*,
+void (*dpnp_allclose_default_c)(const void *,
+                                const void *,
+                                void *,
                                 const size_t,
                                 double,
-                                double) = dpnp_allclose_c<_DataType1, _DataType2, _ResultType>;
+                                double) =
+    dpnp_allclose_c<_DataType1, _DataType2, _ResultType>;
 
 template <typename _DataType1, typename _DataType2, typename _ResultType>
-DPCTLSyclEventRef (*dpnp_allclose_ext_c)(
-    DPCTLSyclQueueRef,
-    const void*,
-    const void*,
-    void*,
-    const size_t,
-    double,
-    double,
-    const DPCTLEventVectorRef) = dpnp_allclose_c<_DataType1, _DataType2, _ResultType>;
+DPCTLSyclEventRef (*dpnp_allclose_ext_c)(DPCTLSyclQueueRef,
+                                         const void *,
+                                         const void *,
+                                         void *,
+                                         const size_t,
+                                         double,
+                                         double,
+                                         const DPCTLEventVectorRef) =
+    dpnp_allclose_c<_DataType1, _DataType2, _ResultType>;
 
 template <typename _DataType, typename _ResultType>
 class dpnp_any_c_kernel;
 
 template <typename _DataType, typename _ResultType>
 DPCTLSyclEventRef dpnp_any_c(DPCTLSyclQueueRef q_ref,
-                             const void* array1_in,
-                             void* result1,
+                             const void *array1_in,
+                             void *result1,
                              const size_t size,
                              const DPCTLEventVectorRef dep_event_vec_ref)
 {
-    static_assert(std::is_same_v<_ResultType, bool>, "Boolean result type is required");
+    static_assert(std::is_same_v<_ResultType, bool>,
+                  "Boolean result type is required");
 
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!array1_in || !result1)
-    {
+    if (!array1_in || !result1) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    const _DataType* array_in = static_cast<const _DataType*>(array1_in);
-    bool* result = static_cast<bool*>(result1);
+    const _DataType *array_in = static_cast<const _DataType *>(array1_in);
+    bool *result              = static_cast<bool *>(result1);
 
     auto fill_event = q.fill(result, false, 1);
 
-    if (!size)
-    {
+    if (!size) {
         event_ref = reinterpret_cast<DPCTLSyclEventRef>(&fill_event);
         return DPCTLEvent_Copy(event_ref);
     }
 
-    constexpr size_t lws = 64;
+    constexpr size_t lws    = 64;
     constexpr size_t vec_sz = 8;
 
-    auto gws_range = sycl::range<1>(((size + lws * vec_sz - 1) / (lws * vec_sz)) * lws);
+    auto gws_range =
+        sycl::range<1>(((size + lws * vec_sz - 1) / (lws * vec_sz)) * lws);
     auto lws_range = sycl::range<1>(lws);
     sycl::nd_range<1> gws(gws_range, lws_range);
 
     auto kernel_parallel_for_func = [=](sycl::nd_item<1> nd_it) {
-        auto gr = nd_it.get_group();
+        auto gr                = nd_it.get_group();
         const auto max_gr_size = gr.get_max_local_range()[0];
         const size_t start =
-            vec_sz * (nd_it.get_group(0) * nd_it.get_local_range(0) + gr.get_group_id()[0] * max_gr_size);
+            vec_sz * (nd_it.get_group(0) * nd_it.get_local_range(0) +
+                      gr.get_group_id()[0] * max_gr_size);
         const size_t end = sycl::min(start + vec_sz * max_gr_size, size);
 
         // each work-item reduces over "vec_sz" elements in the input array
         bool local_reduction = sycl::joint_any_of(
-            gr, &array_in[start], &array_in[end], [&](_DataType elem) { return elem != static_cast<_DataType>(0); });
+            gr, &array_in[start], &array_in[end],
+            [&](_DataType elem) { return elem != static_cast<_DataType>(0); });
 
-        if (gr.leader() && (local_reduction == true))
-        {
+        if (gr.leader() && (local_reduction == true)) {
             result[0] = true;
         }
     };
 
-    auto kernel_func = [&](sycl::handler& cgh) {
+    auto kernel_func = [&](sycl::handler &cgh) {
         cgh.depends_on(fill_event);
-        cgh.parallel_for<class dpnp_any_c_kernel<_DataType, _ResultType>>(gws, kernel_parallel_for_func);
+        cgh.parallel_for<class dpnp_any_c_kernel<_DataType, _ResultType>>(
+            gws, kernel_parallel_for_func);
     };
 
     auto event = q.submit(kernel_func);
@@ -294,578 +299,662 @@ DPCTLSyclEventRef dpnp_any_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType, typename _ResultType>
-void dpnp_any_c(const void* array1_in, void* result1, const size_t size)
+void dpnp_any_c(const void *array1_in, void *result1, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_any_c<_DataType, _ResultType>(q_ref,
-                                                                     array1_in,
-                                                                     result1,
-                                                                     size,
-                                                                     dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_any_c<_DataType, _ResultType>(
+        q_ref, array1_in, result1, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType, typename _ResultType>
-void (*dpnp_any_default_c)(const void*, void*, const size_t) = dpnp_any_c<_DataType, _ResultType>;
+void (*dpnp_any_default_c)(const void *,
+                           void *,
+                           const size_t) = dpnp_any_c<_DataType, _ResultType>;
 
 template <typename _DataType, typename _ResultType>
 DPCTLSyclEventRef (*dpnp_any_ext_c)(DPCTLSyclQueueRef,
-                                    const void*,
-                                    void*,
+                                    const void *,
+                                    void *,
                                     const size_t,
-                                    const DPCTLEventVectorRef) = dpnp_any_c<_DataType, _ResultType>;
+                                    const DPCTLEventVectorRef) =
+    dpnp_any_c<_DataType, _ResultType>;
 
-
-#define MACRO_1ARG_1TYPE_LOGIC_OP(__name__, __operation__)                                                             \
-    template <typename _KernelNameSpecialization>                                                                      \
-    class __name__##_kernel;                                                                                           \
-                                                                                                                       \
-    template <typename _KernelNameSpecialization>                                                                      \
-    class __name__##_broadcast_kernel;                                                                                 \
-                                                                                                                       \
-    template <typename _KernelNameSpecialization>                                                                      \
-    class __name__##_strides_kernel;                                                                                   \
-                                                                                                                       \
-    template <typename _DataType_input1>                                                                               \
-    DPCTLSyclEventRef __name__(DPCTLSyclQueueRef q_ref,                                                                \
-                               void* result_out,                                                                       \
-                               const size_t result_size,                                                               \
-                               const size_t result_ndim,                                                               \
-                               const shape_elem_type* result_shape,                                                    \
-                               const shape_elem_type* result_strides,                                                  \
-                               const void* input1_in,                                                                  \
-                               const size_t input1_size,                                                               \
-                               const size_t input1_ndim,                                                               \
-                               const shape_elem_type* input1_shape,                                                    \
-                               const shape_elem_type* input1_strides,                                                  \
-                               const size_t* where,                                                                    \
-                               const DPCTLEventVectorRef dep_event_vec_ref)                                            \
-    {                                                                                                                  \
-        /* avoid warning unused variable*/                                                                             \
-        (result_shape);                                                                                                \
-        (void)where;                                                                                                   \
-        (void)dep_event_vec_ref;                                                                                       \
-                                                                                                                       \
-        DPCTLSyclEventRef event_ref = nullptr;                                                                         \
-                                                                                                                       \
-        if (!input1_size)                                                                                              \
-        {                                                                                                              \
-            return event_ref;                                                                                          \
-        }                                                                                                              \
-                                                                                                                       \
-        sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));                                                     \
-                                                                                                                       \
-        _DataType_input1* input1_data = static_cast<_DataType_input1 *>(const_cast<void *>(input1_in));                \
-        bool* result = static_cast<bool *>(result_out);                                                                \
-                                                                                                                       \
-        shape_elem_type* input1_shape_offsets = new shape_elem_type[input1_ndim];                                      \
-                                                                                                                       \
-        get_shape_offsets_inkernel(input1_shape, input1_ndim, input1_shape_offsets);                                   \
-        bool use_strides = !array_equal(input1_strides, input1_ndim, input1_shape_offsets, input1_ndim);               \
-        delete[] input1_shape_offsets;                                                                                 \
-                                                                                                                       \
-        if (use_strides)                                                                                               \
-        {                                                                                                              \
-            if (result_ndim != input1_ndim)                                                                            \
-            {                                                                                                          \
-                throw std::runtime_error("Result ndim=" + std::to_string(result_ndim) +                                \
-                                         " mismatches with input1 ndim=" + std::to_string(input1_ndim));               \
-            }                                                                                                          \
-                                                                                                                       \
-            /* memory transfer optimization, use USM-host for temporary speeds up tranfer to device */                 \
-            using usm_host_allocatorT = sycl::usm_allocator<shape_elem_type, sycl::usm::alloc::host>;                  \
-                                                                                                                       \
-            size_t strides_size = 2 * result_ndim;                                                                     \
-            shape_elem_type *dev_strides_data = sycl::malloc_device<shape_elem_type>(strides_size, q);                 \
-                                                                                                                       \
-            /* create host temporary for packed strides managed by shared pointer */                                   \
-            auto strides_host_packed = std::vector<shape_elem_type, usm_host_allocatorT>(strides_size,                 \
-                                                                                         usm_host_allocatorT(q));      \
-                                                                                                                       \
-            /* packed vector is concatenation of result_strides and input1_strides */                                  \
-            std::copy(result_strides, result_strides + result_ndim, strides_host_packed.begin());                      \
-            std::copy(input1_strides, input1_strides + result_ndim, strides_host_packed.begin() + result_ndim);        \
-                                                                                                                       \
-            auto copy_strides_ev = q.copy<shape_elem_type>(strides_host_packed.data(),                                 \
-                                                           dev_strides_data,                                           \
-                                                           strides_host_packed.size());                                \
-                                                                                                                       \
-            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {                                               \
-                const size_t output_id = global_id[0]; /* for (size_t i = 0; i < result_size; ++i) */                  \
-                {                                                                                                      \
-                    const shape_elem_type *result_strides_data = &dev_strides_data[0];                                 \
-                    const shape_elem_type *input1_strides_data = &dev_strides_data[result_ndim];                       \
-                                                                                                                       \
-                    size_t input1_id = 0;                                                                              \
-                                                                                                                       \
-                    for (size_t i = 0; i < result_ndim; ++i)                                                           \
-                    {                                                                                                  \
-                        const size_t output_xyz_id =                                                                   \
-                            get_xyz_id_by_id_inkernel(output_id, result_strides_data, result_ndim, i);                 \
-                        input1_id += output_xyz_id * input1_strides_data[i];                                           \
-                    }                                                                                                  \
-                                                                                                                       \
-                    const _DataType_input1 input1_elem = input1_data[input1_id];                                       \
-                    result[output_id] = __operation__;                                                                 \
-                }                                                                                                      \
-            };                                                                                                         \
-            auto kernel_func = [&](sycl::handler& cgh) {                                                               \
-                cgh.depends_on(copy_strides_ev);                                                                       \
-                cgh.parallel_for<class __name__##_strides_kernel<_DataType_input1>>(                                   \
-                    sycl::range<1>(result_size), kernel_parallel_for_func);                                            \
-            };                                                                                                         \
-                                                                                                                       \
-            q.submit(kernel_func).wait();                                                                              \
-                                                                                                                       \
-            sycl::free(dev_strides_data, q);                                                                           \
-            return event_ref;                                                                                          \
-        }                                                                                                              \
-        else                                                                                                           \
-        {                                                                                                              \
-            constexpr size_t lws = 64;                                                                                 \
-            constexpr unsigned int vec_sz = 8;                                                                         \
-            constexpr sycl::access::address_space global_space = sycl::access::address_space::global_space;            \
-                                                                                                                       \
-            auto gws_range = sycl::range<1>(((result_size + lws * vec_sz - 1) / (lws * vec_sz)) * lws);                \
-            auto lws_range = sycl::range<1>(lws);                                                                      \
-                                                                                                                       \
-            auto kernel_parallel_for_func = [=](sycl::nd_item<1> nd_it) {                                              \
-                auto sg = nd_it.get_sub_group();                                                                       \
-                const auto max_sg_size = sg.get_max_local_range()[0];                                                  \
-                const size_t start = vec_sz * (nd_it.get_group(0) * nd_it.get_local_range(0) +                         \
-                                               sg.get_group_id()[0] * max_sg_size);                                    \
-                                                                                                                       \
-                if (start + static_cast<size_t>(vec_sz) * max_sg_size < result_size) {                                 \
-                    sycl::vec<_DataType_input1, vec_sz> x1 =                                                           \
-                        sg.load<vec_sz>(sycl::multi_ptr<_DataType_input1, global_space>(&input1_data[start]));         \
-                    sycl::vec<bool, vec_sz> res_vec;                                                                   \
-                                                                                                                       \
-                    for (size_t k = 0; k < vec_sz; ++k) {                                                              \
-                        const _DataType_input1 input1_elem = x1[k];                                                    \
-                        res_vec[k] = __operation__;                                                                    \
-                    }                                                                                                  \
-                    sg.store<vec_sz>(sycl::multi_ptr<bool, global_space>(&result[start]), res_vec);                    \
-                                                                                                                       \
-                }                                                                                                      \
-                else {                                                                                                 \
-                    for (size_t k = start; k < result_size; ++k) {                                                     \
-                        const _DataType_input1 input1_elem = input1_data[k];                                           \
-                        result[k] = __operation__;                                                                     \
-                    }                                                                                                  \
-                }                                                                                                      \
-            };                                                                                                         \
-                                                                                                                       \
-            auto kernel_func = [&](sycl::handler& cgh) {                                                               \
-                cgh.parallel_for<class __name__##_kernel<_DataType_input1>>(                                           \
-                    sycl::nd_range<1>(gws_range, lws_range), kernel_parallel_for_func);                                \
-            };                                                                                                         \
-            sycl::event event = q.submit(kernel_func);                                                                 \
-                                                                                                                       \
-            event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);                                                   \
-            return DPCTLEvent_Copy(event_ref);                                                                         \
-        }                                                                                                              \
-        return event_ref;                                                                                              \
-    }                                                                                                                  \
-                                                                                                                       \
-    template <typename _DataType_input1>                                                                               \
-    DPCTLSyclEventRef (*__name__##_ext)(DPCTLSyclQueueRef,                                                             \
-                                        void*,                                                                         \
-                                        const size_t,                                                                  \
-                                        const size_t,                                                                  \
-                                        const shape_elem_type*,                                                        \
-                                        const shape_elem_type*,                                                        \
-                                        const void*,                                                                   \
-                                        const size_t,                                                                  \
-                                        const size_t,                                                                  \
-                                        const shape_elem_type*,                                                        \
-                                        const shape_elem_type*,                                                        \
-                                        const size_t*,                                                                 \
-                                        const DPCTLEventVectorRef) = __name__<_DataType_input1>;
+#define MACRO_1ARG_1TYPE_LOGIC_OP(__name__, __operation__)                     \
+    template <typename _KernelNameSpecialization>                              \
+    class __name__##_kernel;                                                   \
+                                                                               \
+    template <typename _KernelNameSpecialization>                              \
+    class __name__##_broadcast_kernel;                                         \
+                                                                               \
+    template <typename _KernelNameSpecialization>                              \
+    class __name__##_strides_kernel;                                           \
+                                                                               \
+    template <typename _DataType_input1>                                       \
+    DPCTLSyclEventRef __name__(                                                \
+        DPCTLSyclQueueRef q_ref, void *result_out, const size_t result_size,   \
+        const size_t result_ndim, const shape_elem_type *result_shape,         \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const size_t *where,            \
+        const DPCTLEventVectorRef dep_event_vec_ref)                           \
+    {                                                                          \
+        /* avoid warning unused variable*/                                     \
+        (result_shape);                                                        \
+        (void)where;                                                           \
+        (void)dep_event_vec_ref;                                               \
+                                                                               \
+        DPCTLSyclEventRef event_ref = nullptr;                                 \
+                                                                               \
+        if (!input1_size) {                                                    \
+            return event_ref;                                                  \
+        }                                                                      \
+                                                                               \
+        sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));             \
+                                                                               \
+        _DataType_input1 *input1_data =                                        \
+            static_cast<_DataType_input1 *>(const_cast<void *>(input1_in));    \
+        bool *result = static_cast<bool *>(result_out);                        \
+                                                                               \
+        shape_elem_type *input1_shape_offsets =                                \
+            new shape_elem_type[input1_ndim];                                  \
+                                                                               \
+        get_shape_offsets_inkernel(input1_shape, input1_ndim,                  \
+                                   input1_shape_offsets);                      \
+        bool use_strides = !array_equal(input1_strides, input1_ndim,           \
+                                        input1_shape_offsets, input1_ndim);    \
+        delete[] input1_shape_offsets;                                         \
+                                                                               \
+        if (use_strides) {                                                     \
+            if (result_ndim != input1_ndim) {                                  \
+                throw std::runtime_error(                                      \
+                    "Result ndim=" + std::to_string(result_ndim) +             \
+                    " mismatches with input1 ndim=" +                          \
+                    std::to_string(input1_ndim));                              \
+            }                                                                  \
+                                                                               \
+            /* memory transfer optimization, use USM-host for temporary speeds \
+             * up tranfer to device */                                         \
+            using usm_host_allocatorT =                                        \
+                sycl::usm_allocator<shape_elem_type, sycl::usm::alloc::host>;  \
+                                                                               \
+            size_t strides_size = 2 * result_ndim;                             \
+            shape_elem_type *dev_strides_data =                                \
+                sycl::malloc_device<shape_elem_type>(strides_size, q);         \
+                                                                               \
+            /* create host temporary for packed strides managed by shared      \
+             * pointer */                                                      \
+            auto strides_host_packed =                                         \
+                std::vector<shape_elem_type, usm_host_allocatorT>(             \
+                    strides_size, usm_host_allocatorT(q));                     \
+                                                                               \
+            /* packed vector is concatenation of result_strides and            \
+             * input1_strides */                                               \
+            std::copy(result_strides, result_strides + result_ndim,            \
+                      strides_host_packed.begin());                            \
+            std::copy(input1_strides, input1_strides + result_ndim,            \
+                      strides_host_packed.begin() + result_ndim);              \
+                                                                               \
+            auto copy_strides_ev = q.copy<shape_elem_type>(                    \
+                strides_host_packed.data(), dev_strides_data,                  \
+                strides_host_packed.size());                                   \
+                                                                               \
+            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {       \
+                const size_t output_id =                                       \
+                    global_id[0]; /* for (size_t i = 0; i < result_size; ++i)  \
+                                   */                                          \
+                {                                                              \
+                    const shape_elem_type *result_strides_data =               \
+                        &dev_strides_data[0];                                  \
+                    const shape_elem_type *input1_strides_data =               \
+                        &dev_strides_data[result_ndim];                        \
+                                                                               \
+                    size_t input1_id = 0;                                      \
+                                                                               \
+                    for (size_t i = 0; i < result_ndim; ++i) {                 \
+                        const size_t output_xyz_id =                           \
+                            get_xyz_id_by_id_inkernel(output_id,               \
+                                                      result_strides_data,     \
+                                                      result_ndim, i);         \
+                        input1_id += output_xyz_id * input1_strides_data[i];   \
+                    }                                                          \
+                                                                               \
+                    const _DataType_input1 input1_elem =                       \
+                        input1_data[input1_id];                                \
+                    result[output_id] = __operation__;                         \
+                }                                                              \
+            };                                                                 \
+            auto kernel_func = [&](sycl::handler &cgh) {                       \
+                cgh.depends_on(copy_strides_ev);                               \
+                cgh.parallel_for<                                              \
+                    class __name__##_strides_kernel<_DataType_input1>>(        \
+                    sycl::range<1>(result_size), kernel_parallel_for_func);    \
+            };                                                                 \
+                                                                               \
+            q.submit(kernel_func).wait();                                      \
+                                                                               \
+            sycl::free(dev_strides_data, q);                                   \
+            return event_ref;                                                  \
+        }                                                                      \
+        else {                                                                 \
+            constexpr size_t lws          = 64;                                \
+            constexpr unsigned int vec_sz = 8;                                 \
+            constexpr sycl::access::address_space global_space =               \
+                sycl::access::address_space::global_space;                     \
+                                                                               \
+            auto gws_range = sycl::range<1>(                                   \
+                ((result_size + lws * vec_sz - 1) / (lws * vec_sz)) * lws);    \
+            auto lws_range = sycl::range<1>(lws);                              \
+                                                                               \
+            auto kernel_parallel_for_func = [=](sycl::nd_item<1> nd_it) {      \
+                auto sg                = nd_it.get_sub_group();                \
+                const auto max_sg_size = sg.get_max_local_range()[0];          \
+                const size_t start =                                           \
+                    vec_sz * (nd_it.get_group(0) * nd_it.get_local_range(0) +  \
+                              sg.get_group_id()[0] * max_sg_size);             \
+                                                                               \
+                if (start + static_cast<size_t>(vec_sz) * max_sg_size <        \
+                    result_size) {                                             \
+                    sycl::vec<_DataType_input1, vec_sz> x1 = sg.load<vec_sz>(  \
+                        sycl::multi_ptr<_DataType_input1, global_space>(       \
+                            &input1_data[start]));                             \
+                    sycl::vec<bool, vec_sz> res_vec;                           \
+                                                                               \
+                    for (size_t k = 0; k < vec_sz; ++k) {                      \
+                        const _DataType_input1 input1_elem = x1[k];            \
+                        res_vec[k]                         = __operation__;    \
+                    }                                                          \
+                    sg.store<vec_sz>(                                          \
+                        sycl::multi_ptr<bool, global_space>(&result[start]),   \
+                        res_vec);                                              \
+                }                                                              \
+                else {                                                         \
+                    for (size_t k = start; k < result_size; ++k) {             \
+                        const _DataType_input1 input1_elem = input1_data[k];   \
+                        result[k]                          = __operation__;    \
+                    }                                                          \
+                }                                                              \
+            };                                                                 \
+                                                                               \
+            auto kernel_func = [&](sycl::handler &cgh) {                       \
+                cgh.parallel_for<class __name__##_kernel<_DataType_input1>>(   \
+                    sycl::nd_range<1>(gws_range, lws_range),                   \
+                    kernel_parallel_for_func);                                 \
+            };                                                                 \
+            sycl::event event = q.submit(kernel_func);                         \
+                                                                               \
+            event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);           \
+            return DPCTLEvent_Copy(event_ref);                                 \
+        }                                                                      \
+        return event_ref;                                                      \
+    }                                                                          \
+                                                                               \
+    template <typename _DataType_input1>                                       \
+    DPCTLSyclEventRef (*__name__##_ext)(                                       \
+        DPCTLSyclQueueRef, void *, const size_t, const size_t,                 \
+        const shape_elem_type *, const shape_elem_type *, const void *,        \
+        const size_t, const size_t, const shape_elem_type *,                   \
+        const shape_elem_type *, const size_t *, const DPCTLEventVectorRef) =  \
+        __name__<_DataType_input1>;
 
 #include <dpnp_gen_1arg_1type_tbl.hpp>
 
-template <DPNPFuncType ... FTs>
-static void func_map_logic_1arg_1type_helper(func_map_t& fmap)
+template <DPNPFuncType... FTs>
+static void func_map_logic_1arg_1type_helper(func_map_t &fmap)
 {
     ((fmap[DPNPFuncName::DPNP_FN_LOGICAL_NOT_EXT][FTs][FTs] =
-        {eft_BLN, (void*)dpnp_logical_not_c_ext<func_type_map_t::find_type<FTs>>}), ...);
+          {eft_BLN,
+           (void *)dpnp_logical_not_c_ext<func_type_map_t::find_type<FTs>>}),
+     ...);
 }
 
-
-#define MACRO_2ARG_2TYPES_LOGIC_OP(__name__, __operation__)                                                            \
-    template <typename _KernelNameSpecialization1,                                                                     \
-              typename _KernelNameSpecialization2>                                                                     \
-    class __name__##_kernel;                                                                                           \
-                                                                                                                       \
-    template <typename _KernelNameSpecialization1,                                                                     \
-              typename _KernelNameSpecialization2>                                                                     \
-    class __name__##_broadcast_kernel;                                                                                 \
-                                                                                                                       \
-    template <typename _KernelNameSpecialization1,                                                                     \
-              typename _KernelNameSpecialization2>                                                                     \
-    class __name__##_strides_kernel;                                                                                   \
-                                                                                                                       \
-    template <typename _DataType_input1, typename _DataType_input2>                                                    \
-    DPCTLSyclEventRef __name__(DPCTLSyclQueueRef q_ref,                                                                \
-                               void* result_out,                                                                       \
-                               const size_t result_size,                                                               \
-                               const size_t result_ndim,                                                               \
-                               const shape_elem_type* result_shape,                                                    \
-                               const shape_elem_type* result_strides,                                                  \
-                               const void* input1_in,                                                                  \
-                               const size_t input1_size,                                                               \
-                               const size_t input1_ndim,                                                               \
-                               const shape_elem_type* input1_shape,                                                    \
-                               const shape_elem_type* input1_strides,                                                  \
-                               const void* input2_in,                                                                  \
-                               const size_t input2_size,                                                               \
-                               const size_t input2_ndim,                                                               \
-                               const shape_elem_type* input2_shape,                                                    \
-                               const shape_elem_type* input2_strides,                                                  \
-                               const size_t* where,                                                                    \
-                               const DPCTLEventVectorRef dep_event_vec_ref)                                            \
-    {                                                                                                                  \
-        /* avoid warning unused variable*/                                                                             \
-        (void)where;                                                                                                   \
-        (void)dep_event_vec_ref;                                                                                       \
-                                                                                                                       \
-        DPCTLSyclEventRef event_ref = nullptr;                                                                         \
-                                                                                                                       \
-        if (!input1_size || !input2_size)                                                                              \
-        {                                                                                                              \
-            return event_ref;                                                                                          \
-        }                                                                                                              \
-                                                                                                                       \
-        sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));                                                     \
-                                                                                                                       \
-        _DataType_input1* input1_data = static_cast<_DataType_input1 *>(const_cast<void *>(input1_in));                \
-        _DataType_input2* input2_data = static_cast<_DataType_input2 *>(const_cast<void *>(input2_in));                \
-        bool* result = static_cast<bool *>(result_out);                                                                \
-                                                                                                                       \
-        bool use_broadcasting = !array_equal(input1_shape, input1_ndim, input2_shape, input2_ndim);                    \
-                                                                                                                       \
-        shape_elem_type* input1_shape_offsets = new shape_elem_type[input1_ndim];                                      \
-                                                                                                                       \
-        get_shape_offsets_inkernel(input1_shape, input1_ndim, input1_shape_offsets);                                   \
-        bool use_strides = !array_equal(input1_strides, input1_ndim, input1_shape_offsets, input1_ndim);               \
-        delete[] input1_shape_offsets;                                                                                 \
-                                                                                                                       \
-        shape_elem_type* input2_shape_offsets = new shape_elem_type[input2_ndim];                                      \
-                                                                                                                       \
-        get_shape_offsets_inkernel(input2_shape, input2_ndim, input2_shape_offsets);                                   \
-        use_strides =                                                                                                  \
-            use_strides || !array_equal(input2_strides, input2_ndim, input2_shape_offsets, input2_ndim);               \
-        delete[] input2_shape_offsets;                                                                                 \
-                                                                                                                       \
-        sycl::event event;                                                                                             \
-        sycl::range<1> gws(result_size); /* used only when use_broadcasting or use_strides is true */                  \
-                                                                                                                       \
-        if (use_broadcasting)                                                                                          \
-        {                                                                                                              \
-            DPNPC_id<_DataType_input1>* input1_it;                                                                     \
-            const size_t input1_it_size_in_bytes = sizeof(DPNPC_id<_DataType_input1>);                                 \
-            input1_it = reinterpret_cast<DPNPC_id<_DataType_input1>*>(dpnp_memory_alloc_c(q_ref,                       \
-                                                                                          input1_it_size_in_bytes));   \
-            new (input1_it)                                                                                            \
-                DPNPC_id<_DataType_input1>(q_ref, input1_data, input1_shape, input1_strides, input1_ndim);             \
-                                                                                                                       \
-            input1_it->broadcast_to_shape(result_shape, result_ndim);                                                  \
-                                                                                                                       \
-            DPNPC_id<_DataType_input2>* input2_it;                                                                     \
-            const size_t input2_it_size_in_bytes = sizeof(DPNPC_id<_DataType_input2>);                                 \
-            input2_it = reinterpret_cast<DPNPC_id<_DataType_input2>*>(dpnp_memory_alloc_c(q_ref,                       \
-                                                                                          input2_it_size_in_bytes));   \
-            new (input2_it)                                                                                            \
-                DPNPC_id<_DataType_input2>(q_ref, input2_data, input2_shape, input2_strides, input2_ndim);             \
-                                                                                                                       \
-            input2_it->broadcast_to_shape(result_shape, result_ndim);                                                  \
-                                                                                                                       \
-            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {                                               \
-                const size_t i = global_id[0]; /* for (size_t i = 0; i < result_size; ++i) */                          \
-                {                                                                                                      \
-                    const _DataType_input1 input1_elem = (*input1_it)[i];                                              \
-                    const _DataType_input2 input2_elem = (*input2_it)[i];                                              \
-                    result[i] = __operation__;                                                                         \
-                }                                                                                                      \
-            };                                                                                                         \
-            auto kernel_func = [&](sycl::handler& cgh) {                                                               \
-                cgh.parallel_for<                                                                                      \
-                    class __name__##_broadcast_kernel<_DataType_input1, _DataType_input2>>(                            \
-                    gws, kernel_parallel_for_func);                                                                    \
-            };                                                                                                         \
-                                                                                                                       \
-            q.submit(kernel_func).wait();                                                                              \
-                                                                                                                       \
-            input1_it->~DPNPC_id();                                                                                    \
-            input2_it->~DPNPC_id();                                                                                    \
-                                                                                                                       \
-            return event_ref;                                                                                          \
-        }                                                                                                              \
-        else if (use_strides)                                                                                          \
-        {                                                                                                              \
-            if ((result_ndim != input1_ndim) || (result_ndim != input2_ndim))                                          \
-            {                                                                                                          \
-                throw std::runtime_error("Result ndim=" + std::to_string(result_ndim) +                                \
-                                         " mismatches with either input1 ndim=" + std::to_string(input1_ndim) +        \
-                                         " or input2 ndim=" + std::to_string(input2_ndim));                            \
-            }                                                                                                          \
-                                                                                                                       \
-            /* memory transfer optimization, use USM-host for temporary speeds up tranfer to device */                 \
-            using usm_host_allocatorT = sycl::usm_allocator<shape_elem_type, sycl::usm::alloc::host>;                  \
-                                                                                                                       \
-            size_t strides_size = 3 * result_ndim;                                                                     \
-            shape_elem_type *dev_strides_data = sycl::malloc_device<shape_elem_type>(strides_size, q);                 \
-                                                                                                                       \
-            /* create host temporary for packed strides managed by shared pointer */                                   \
-            auto strides_host_packed = std::vector<shape_elem_type, usm_host_allocatorT>(strides_size,                 \
-                                                                                         usm_host_allocatorT(q));      \
-                                                                                                                       \
-            /* packed vector is concatenation of result_strides, input1_strides and input2_strides */                  \
-            std::copy(result_strides, result_strides + result_ndim, strides_host_packed.begin());                      \
-            std::copy(input1_strides, input1_strides + result_ndim, strides_host_packed.begin() + result_ndim);        \
-            std::copy(input2_strides, input2_strides + result_ndim, strides_host_packed.begin() + 2 * result_ndim);    \
-                                                                                                                       \
-            auto copy_strides_ev = q.copy<shape_elem_type>(strides_host_packed.data(),                                 \
-                                                           dev_strides_data,                                           \
-                                                           strides_host_packed.size());                                \
-                                                                                                                       \
-            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {                                               \
-                const size_t output_id = global_id[0]; /* for (size_t i = 0; i < result_size; ++i) */                  \
-                {                                                                                                      \
-                    const shape_elem_type *result_strides_data = &dev_strides_data[0];                                 \
-                    const shape_elem_type *input1_strides_data = &dev_strides_data[result_ndim];                       \
-                    const shape_elem_type *input2_strides_data = &dev_strides_data[2 * result_ndim];                   \
-                                                                                                                       \
-                    size_t input1_id = 0;                                                                              \
-                    size_t input2_id = 0;                                                                              \
-                                                                                                                       \
-                    for (size_t i = 0; i < result_ndim; ++i)                                                           \
-                    {                                                                                                  \
-                        const size_t output_xyz_id =                                                                   \
-                            get_xyz_id_by_id_inkernel(output_id, result_strides_data, result_ndim, i);                 \
-                        input1_id += output_xyz_id * input1_strides_data[i];                                           \
-                        input2_id += output_xyz_id * input2_strides_data[i];                                           \
-                    }                                                                                                  \
-                                                                                                                       \
-                    const _DataType_input1 input1_elem = input1_data[input1_id];                                       \
-                    const _DataType_input2 input2_elem = input2_data[input2_id];                                       \
-                    result[output_id] = __operation__;                                                                 \
-                }                                                                                                      \
-            };                                                                                                         \
-            auto kernel_func = [&](sycl::handler& cgh) {                                                               \
-                cgh.depends_on(copy_strides_ev);                                                                       \
-                cgh.parallel_for<                                                                                      \
-                    class __name__##_strides_kernel<_DataType_input1, _DataType_input2>>(                              \
-                    gws, kernel_parallel_for_func);                                                                    \
-            };                                                                                                         \
-                                                                                                                       \
-            q.submit(kernel_func).wait();                                                                              \
-                                                                                                                       \
-            sycl::free(dev_strides_data, q);                                                                           \
-            return event_ref;                                                                                          \
-        }                                                                                                              \
-        else                                                                                                           \
-        {                                                                                                              \
-            constexpr size_t lws = 64;                                                                                 \
-            constexpr unsigned int vec_sz = 8;                                                                         \
-            constexpr sycl::access::address_space global_space = sycl::access::address_space::global_space;            \
-                                                                                                                       \
-            auto gws_range = sycl::range<1>(((result_size + lws * vec_sz - 1) / (lws * vec_sz)) * lws);                \
-            auto lws_range = sycl::range<1>(lws);                                                                      \
-                                                                                                                       \
-            auto kernel_parallel_for_func = [=](sycl::nd_item<1> nd_it) {                                              \
-                auto sg = nd_it.get_sub_group();                                                                       \
-                const auto max_sg_size = sg.get_max_local_range()[0];                                                  \
-                const size_t start = vec_sz * (nd_it.get_group(0) * nd_it.get_local_range(0) +                         \
-                                               sg.get_group_id()[0] * max_sg_size);                                    \
-                                                                                                                       \
-                if (start + static_cast<size_t>(vec_sz) * max_sg_size < result_size) {                                 \
-                    sycl::vec<_DataType_input1, vec_sz> x1 =                                                           \
-                        sg.load<vec_sz>(sycl::multi_ptr<_DataType_input1, global_space>(&input1_data[start]));         \
-                    sycl::vec<_DataType_input2, vec_sz> x2 =                                                           \
-                        sg.load<vec_sz>(sycl::multi_ptr<_DataType_input2, global_space>(&input2_data[start]));         \
-                    sycl::vec<bool, vec_sz> res_vec;                                                                   \
-                                                                                                                       \
-                    for (size_t k = 0; k < vec_sz; ++k) {                                                              \
-                        const _DataType_input1 input1_elem = x1[k];                                                    \
-                        const _DataType_input2 input2_elem = x2[k];                                                    \
-                        res_vec[k] = __operation__;                                                                    \
-                    }                                                                                                  \
-                    sg.store<vec_sz>(sycl::multi_ptr<bool, global_space>(&result[start]), res_vec);                    \
-                                                                                                                       \
-                }                                                                                                      \
-                else {                                                                                                 \
-                    for (size_t k = start; k < result_size; ++k) {                                                     \
-                        const _DataType_input1 input1_elem = input1_data[k];                                           \
-                        const _DataType_input2 input2_elem = input2_data[k];                                           \
-                        result[k] = __operation__;                                                                     \
-                    }                                                                                                  \
-                }                                                                                                      \
-            };                                                                                                         \
-                                                                                                                       \
-            auto kernel_func = [&](sycl::handler& cgh) {                                                               \
-                cgh.parallel_for<class __name__##_kernel<_DataType_input1, _DataType_input2>>(                         \
-                    sycl::nd_range<1>(gws_range, lws_range), kernel_parallel_for_func);                                \
-            };                                                                                                         \
-            event = q.submit(kernel_func);                                                                             \
-        }                                                                                                              \
-                                                                                                                       \
-        event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);                                                       \
-        return DPCTLEvent_Copy(event_ref);                                                                             \
-    }                                                                                                                  \
-                                                                                                                       \
-    template <typename _DataType_input1, typename _DataType_input2>                                                    \
-    DPCTLSyclEventRef (*__name__##_ext)(DPCTLSyclQueueRef,                                                             \
-                                        void*,                                                                         \
-                                        const size_t,                                                                  \
-                                        const size_t,                                                                  \
-                                        const shape_elem_type*,                                                        \
-                                        const shape_elem_type*,                                                        \
-                                        const void*,                                                                   \
-                                        const size_t,                                                                  \
-                                        const size_t,                                                                  \
-                                        const shape_elem_type*,                                                        \
-                                        const shape_elem_type*,                                                        \
-                                        const void*,                                                                   \
-                                        const size_t,                                                                  \
-                                        const size_t,                                                                  \
-                                        const shape_elem_type*,                                                        \
-                                        const shape_elem_type*,                                                        \
-                                        const size_t*,                                                                 \
-                                        const DPCTLEventVectorRef) = __name__<_DataType_input1,                        \
-                                                                              _DataType_input2>;
+#define MACRO_2ARG_2TYPES_LOGIC_OP(__name__, __operation__)                    \
+    template <typename _KernelNameSpecialization1,                             \
+              typename _KernelNameSpecialization2>                             \
+    class __name__##_kernel;                                                   \
+                                                                               \
+    template <typename _KernelNameSpecialization1,                             \
+              typename _KernelNameSpecialization2>                             \
+    class __name__##_broadcast_kernel;                                         \
+                                                                               \
+    template <typename _KernelNameSpecialization1,                             \
+              typename _KernelNameSpecialization2>                             \
+    class __name__##_strides_kernel;                                           \
+                                                                               \
+    template <typename _DataType_input1, typename _DataType_input2>            \
+    DPCTLSyclEventRef __name__(                                                \
+        DPCTLSyclQueueRef q_ref, void *result_out, const size_t result_size,   \
+        const size_t result_ndim, const shape_elem_type *result_shape,         \
+        const shape_elem_type *result_strides, const void *input1_in,          \
+        const size_t input1_size, const size_t input1_ndim,                    \
+        const shape_elem_type *input1_shape,                                   \
+        const shape_elem_type *input1_strides, const void *input2_in,          \
+        const size_t input2_size, const size_t input2_ndim,                    \
+        const shape_elem_type *input2_shape,                                   \
+        const shape_elem_type *input2_strides, const size_t *where,            \
+        const DPCTLEventVectorRef dep_event_vec_ref)                           \
+    {                                                                          \
+        /* avoid warning unused variable*/                                     \
+        (void)where;                                                           \
+        (void)dep_event_vec_ref;                                               \
+                                                                               \
+        DPCTLSyclEventRef event_ref = nullptr;                                 \
+                                                                               \
+        if (!input1_size || !input2_size) {                                    \
+            return event_ref;                                                  \
+        }                                                                      \
+                                                                               \
+        sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));             \
+                                                                               \
+        _DataType_input1 *input1_data =                                        \
+            static_cast<_DataType_input1 *>(const_cast<void *>(input1_in));    \
+        _DataType_input2 *input2_data =                                        \
+            static_cast<_DataType_input2 *>(const_cast<void *>(input2_in));    \
+        bool *result = static_cast<bool *>(result_out);                        \
+                                                                               \
+        bool use_broadcasting = !array_equal(input1_shape, input1_ndim,        \
+                                             input2_shape, input2_ndim);       \
+                                                                               \
+        shape_elem_type *input1_shape_offsets =                                \
+            new shape_elem_type[input1_ndim];                                  \
+                                                                               \
+        get_shape_offsets_inkernel(input1_shape, input1_ndim,                  \
+                                   input1_shape_offsets);                      \
+        bool use_strides = !array_equal(input1_strides, input1_ndim,           \
+                                        input1_shape_offsets, input1_ndim);    \
+        delete[] input1_shape_offsets;                                         \
+                                                                               \
+        shape_elem_type *input2_shape_offsets =                                \
+            new shape_elem_type[input2_ndim];                                  \
+                                                                               \
+        get_shape_offsets_inkernel(input2_shape, input2_ndim,                  \
+                                   input2_shape_offsets);                      \
+        use_strides =                                                          \
+            use_strides || !array_equal(input2_strides, input2_ndim,           \
+                                        input2_shape_offsets, input2_ndim);    \
+        delete[] input2_shape_offsets;                                         \
+                                                                               \
+        sycl::event event;                                                     \
+        sycl::range<1> gws(result_size); /* used only when use_broadcasting or \
+                                            use_strides is true */             \
+                                                                               \
+        if (use_broadcasting) {                                                \
+            DPNPC_id<_DataType_input1> *input1_it;                             \
+            const size_t input1_it_size_in_bytes =                             \
+                sizeof(DPNPC_id<_DataType_input1>);                            \
+            input1_it = reinterpret_cast<DPNPC_id<_DataType_input1> *>(        \
+                dpnp_memory_alloc_c(q_ref, input1_it_size_in_bytes));          \
+            new (input1_it)                                                    \
+                DPNPC_id<_DataType_input1>(q_ref, input1_data, input1_shape,   \
+                                           input1_strides, input1_ndim);       \
+                                                                               \
+            input1_it->broadcast_to_shape(result_shape, result_ndim);          \
+                                                                               \
+            DPNPC_id<_DataType_input2> *input2_it;                             \
+            const size_t input2_it_size_in_bytes =                             \
+                sizeof(DPNPC_id<_DataType_input2>);                            \
+            input2_it = reinterpret_cast<DPNPC_id<_DataType_input2> *>(        \
+                dpnp_memory_alloc_c(q_ref, input2_it_size_in_bytes));          \
+            new (input2_it)                                                    \
+                DPNPC_id<_DataType_input2>(q_ref, input2_data, input2_shape,   \
+                                           input2_strides, input2_ndim);       \
+                                                                               \
+            input2_it->broadcast_to_shape(result_shape, result_ndim);          \
+                                                                               \
+            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {       \
+                const size_t i = global_id[0]; /* for (size_t i = 0; i <       \
+                                                  result_size; ++i) */         \
+                {                                                              \
+                    const _DataType_input1 input1_elem = (*input1_it)[i];      \
+                    const _DataType_input2 input2_elem = (*input2_it)[i];      \
+                    result[i]                          = __operation__;        \
+                }                                                              \
+            };                                                                 \
+            auto kernel_func = [&](sycl::handler &cgh) {                       \
+                cgh.parallel_for<class __name__##_broadcast_kernel<            \
+                    _DataType_input1, _DataType_input2>>(                      \
+                    gws, kernel_parallel_for_func);                            \
+            };                                                                 \
+                                                                               \
+            q.submit(kernel_func).wait();                                      \
+                                                                               \
+            input1_it->~DPNPC_id();                                            \
+            input2_it->~DPNPC_id();                                            \
+                                                                               \
+            return event_ref;                                                  \
+        }                                                                      \
+        else if (use_strides) {                                                \
+            if ((result_ndim != input1_ndim) || (result_ndim != input2_ndim))  \
+            {                                                                  \
+                throw std::runtime_error(                                      \
+                    "Result ndim=" + std::to_string(result_ndim) +             \
+                    " mismatches with either input1 ndim=" +                   \
+                    std::to_string(input1_ndim) +                              \
+                    " or input2 ndim=" + std::to_string(input2_ndim));         \
+            }                                                                  \
+                                                                               \
+            /* memory transfer optimization, use USM-host for temporary speeds \
+             * up tranfer to device */                                         \
+            using usm_host_allocatorT =                                        \
+                sycl::usm_allocator<shape_elem_type, sycl::usm::alloc::host>;  \
+                                                                               \
+            size_t strides_size = 3 * result_ndim;                             \
+            shape_elem_type *dev_strides_data =                                \
+                sycl::malloc_device<shape_elem_type>(strides_size, q);         \
+                                                                               \
+            /* create host temporary for packed strides managed by shared      \
+             * pointer */                                                      \
+            auto strides_host_packed =                                         \
+                std::vector<shape_elem_type, usm_host_allocatorT>(             \
+                    strides_size, usm_host_allocatorT(q));                     \
+                                                                               \
+            /* packed vector is concatenation of result_strides,               \
+             * input1_strides and input2_strides */                            \
+            std::copy(result_strides, result_strides + result_ndim,            \
+                      strides_host_packed.begin());                            \
+            std::copy(input1_strides, input1_strides + result_ndim,            \
+                      strides_host_packed.begin() + result_ndim);              \
+            std::copy(input2_strides, input2_strides + result_ndim,            \
+                      strides_host_packed.begin() + 2 * result_ndim);          \
+                                                                               \
+            auto copy_strides_ev = q.copy<shape_elem_type>(                    \
+                strides_host_packed.data(), dev_strides_data,                  \
+                strides_host_packed.size());                                   \
+                                                                               \
+            auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {       \
+                const size_t output_id =                                       \
+                    global_id[0]; /* for (size_t i = 0; i < result_size; ++i)  \
+                                   */                                          \
+                {                                                              \
+                    const shape_elem_type *result_strides_data =               \
+                        &dev_strides_data[0];                                  \
+                    const shape_elem_type *input1_strides_data =               \
+                        &dev_strides_data[result_ndim];                        \
+                    const shape_elem_type *input2_strides_data =               \
+                        &dev_strides_data[2 * result_ndim];                    \
+                                                                               \
+                    size_t input1_id = 0;                                      \
+                    size_t input2_id = 0;                                      \
+                                                                               \
+                    for (size_t i = 0; i < result_ndim; ++i) {                 \
+                        const size_t output_xyz_id =                           \
+                            get_xyz_id_by_id_inkernel(output_id,               \
+                                                      result_strides_data,     \
+                                                      result_ndim, i);         \
+                        input1_id += output_xyz_id * input1_strides_data[i];   \
+                        input2_id += output_xyz_id * input2_strides_data[i];   \
+                    }                                                          \
+                                                                               \
+                    const _DataType_input1 input1_elem =                       \
+                        input1_data[input1_id];                                \
+                    const _DataType_input2 input2_elem =                       \
+                        input2_data[input2_id];                                \
+                    result[output_id] = __operation__;                         \
+                }                                                              \
+            };                                                                 \
+            auto kernel_func = [&](sycl::handler &cgh) {                       \
+                cgh.depends_on(copy_strides_ev);                               \
+                cgh.parallel_for<class __name__##_strides_kernel<              \
+                    _DataType_input1, _DataType_input2>>(                      \
+                    gws, kernel_parallel_for_func);                            \
+            };                                                                 \
+                                                                               \
+            q.submit(kernel_func).wait();                                      \
+                                                                               \
+            sycl::free(dev_strides_data, q);                                   \
+            return event_ref;                                                  \
+        }                                                                      \
+        else {                                                                 \
+            constexpr size_t lws          = 64;                                \
+            constexpr unsigned int vec_sz = 8;                                 \
+            constexpr sycl::access::address_space global_space =               \
+                sycl::access::address_space::global_space;                     \
+                                                                               \
+            auto gws_range = sycl::range<1>(                                   \
+                ((result_size + lws * vec_sz - 1) / (lws * vec_sz)) * lws);    \
+            auto lws_range = sycl::range<1>(lws);                              \
+                                                                               \
+            auto kernel_parallel_for_func = [=](sycl::nd_item<1> nd_it) {      \
+                auto sg                = nd_it.get_sub_group();                \
+                const auto max_sg_size = sg.get_max_local_range()[0];          \
+                const size_t start =                                           \
+                    vec_sz * (nd_it.get_group(0) * nd_it.get_local_range(0) +  \
+                              sg.get_group_id()[0] * max_sg_size);             \
+                                                                               \
+                if (start + static_cast<size_t>(vec_sz) * max_sg_size <        \
+                    result_size) {                                             \
+                    sycl::vec<_DataType_input1, vec_sz> x1 = sg.load<vec_sz>(  \
+                        sycl::multi_ptr<_DataType_input1, global_space>(       \
+                            &input1_data[start]));                             \
+                    sycl::vec<_DataType_input2, vec_sz> x2 = sg.load<vec_sz>(  \
+                        sycl::multi_ptr<_DataType_input2, global_space>(       \
+                            &input2_data[start]));                             \
+                    sycl::vec<bool, vec_sz> res_vec;                           \
+                                                                               \
+                    for (size_t k = 0; k < vec_sz; ++k) {                      \
+                        const _DataType_input1 input1_elem = x1[k];            \
+                        const _DataType_input2 input2_elem = x2[k];            \
+                        res_vec[k]                         = __operation__;    \
+                    }                                                          \
+                    sg.store<vec_sz>(                                          \
+                        sycl::multi_ptr<bool, global_space>(&result[start]),   \
+                        res_vec);                                              \
+                }                                                              \
+                else {                                                         \
+                    for (size_t k = start; k < result_size; ++k) {             \
+                        const _DataType_input1 input1_elem = input1_data[k];   \
+                        const _DataType_input2 input2_elem = input2_data[k];   \
+                        result[k]                          = __operation__;    \
+                    }                                                          \
+                }                                                              \
+            };                                                                 \
+                                                                               \
+            auto kernel_func = [&](sycl::handler &cgh) {                       \
+                cgh.parallel_for<class __name__##_kernel<_DataType_input1,     \
+                                                         _DataType_input2>>(   \
+                    sycl::nd_range<1>(gws_range, lws_range),                   \
+                    kernel_parallel_for_func);                                 \
+            };                                                                 \
+            event = q.submit(kernel_func);                                     \
+        }                                                                      \
+                                                                               \
+        event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);               \
+        return DPCTLEvent_Copy(event_ref);                                     \
+    }                                                                          \
+                                                                               \
+    template <typename _DataType_input1, typename _DataType_input2>            \
+    DPCTLSyclEventRef (*__name__##_ext)(                                       \
+        DPCTLSyclQueueRef, void *, const size_t, const size_t,                 \
+        const shape_elem_type *, const shape_elem_type *, const void *,        \
+        const size_t, const size_t, const shape_elem_type *,                   \
+        const shape_elem_type *, const void *, const size_t, const size_t,     \
+        const shape_elem_type *, const shape_elem_type *, const size_t *,      \
+        const DPCTLEventVectorRef) =                                           \
+        __name__<_DataType_input1, _DataType_input2>;
 
 #include <dpnp_gen_2arg_2type_tbl.hpp>
 
-template <DPNPFuncType FT1, DPNPFuncType ... FTs>
-static void func_map_logic_2arg_2type_core(func_map_t& fmap)
+template <DPNPFuncType FT1, DPNPFuncType... FTs>
+static void func_map_logic_2arg_2type_core(func_map_t &fmap)
 {
     ((fmap[DPNPFuncName::DPNP_FN_EQUAL_EXT][FT1][FTs] =
-        {eft_BLN, (void*)dpnp_equal_c_ext<func_type_map_t::find_type<FT1>, func_type_map_t::find_type<FTs>>}), ...);
+          {eft_BLN, (void *)dpnp_equal_c_ext<func_type_map_t::find_type<FT1>,
+                                             func_type_map_t::find_type<FTs>>}),
+     ...);
     ((fmap[DPNPFuncName::DPNP_FN_GREATER_EXT][FT1][FTs] =
-        {eft_BLN, (void*)dpnp_greater_c_ext<func_type_map_t::find_type<FT1>, func_type_map_t::find_type<FTs>>}), ...);
+          {eft_BLN,
+           (void *)dpnp_greater_c_ext<func_type_map_t::find_type<FT1>,
+                                      func_type_map_t::find_type<FTs>>}),
+     ...);
     ((fmap[DPNPFuncName::DPNP_FN_GREATER_EQUAL_EXT][FT1][FTs] =
-        {eft_BLN, (void*)dpnp_greater_equal_c_ext<func_type_map_t::find_type<FT1>, func_type_map_t::find_type<FTs>>}), ...);
+          {eft_BLN,
+           (void *)dpnp_greater_equal_c_ext<func_type_map_t::find_type<FT1>,
+                                            func_type_map_t::find_type<FTs>>}),
+     ...);
     ((fmap[DPNPFuncName::DPNP_FN_LESS_EXT][FT1][FTs] =
-        {eft_BLN, (void*)dpnp_less_c_ext<func_type_map_t::find_type<FT1>, func_type_map_t::find_type<FTs>>}), ...);
+          {eft_BLN, (void *)dpnp_less_c_ext<func_type_map_t::find_type<FT1>,
+                                            func_type_map_t::find_type<FTs>>}),
+     ...);
     ((fmap[DPNPFuncName::DPNP_FN_LESS_EQUAL_EXT][FT1][FTs] =
-        {eft_BLN, (void*)dpnp_less_equal_c_ext<func_type_map_t::find_type<FT1>, func_type_map_t::find_type<FTs>>}), ...);
+          {eft_BLN,
+           (void *)dpnp_less_equal_c_ext<func_type_map_t::find_type<FT1>,
+                                         func_type_map_t::find_type<FTs>>}),
+     ...);
     ((fmap[DPNPFuncName::DPNP_FN_LOGICAL_AND_EXT][FT1][FTs] =
-        {eft_BLN, (void*)dpnp_logical_and_c_ext<func_type_map_t::find_type<FT1>, func_type_map_t::find_type<FTs>>}), ...);
+          {eft_BLN,
+           (void *)dpnp_logical_and_c_ext<func_type_map_t::find_type<FT1>,
+                                          func_type_map_t::find_type<FTs>>}),
+     ...);
     ((fmap[DPNPFuncName::DPNP_FN_LOGICAL_OR_EXT][FT1][FTs] =
-        {eft_BLN, (void*)dpnp_logical_or_c_ext<func_type_map_t::find_type<FT1>, func_type_map_t::find_type<FTs>>}), ...);
+          {eft_BLN,
+           (void *)dpnp_logical_or_c_ext<func_type_map_t::find_type<FT1>,
+                                         func_type_map_t::find_type<FTs>>}),
+     ...);
     ((fmap[DPNPFuncName::DPNP_FN_LOGICAL_XOR_EXT][FT1][FTs] =
-        {eft_BLN, (void*)dpnp_logical_xor_c_ext<func_type_map_t::find_type<FT1>, func_type_map_t::find_type<FTs>>}), ...);
+          {eft_BLN,
+           (void *)dpnp_logical_xor_c_ext<func_type_map_t::find_type<FT1>,
+                                          func_type_map_t::find_type<FTs>>}),
+     ...);
     ((fmap[DPNPFuncName::DPNP_FN_NOT_EQUAL_EXT][FT1][FTs] =
-        {eft_BLN, (void*)dpnp_not_equal_c_ext<func_type_map_t::find_type<FT1>, func_type_map_t::find_type<FTs>>}), ...);
+          {eft_BLN,
+           (void *)dpnp_not_equal_c_ext<func_type_map_t::find_type<FT1>,
+                                        func_type_map_t::find_type<FTs>>}),
+     ...);
 }
 
-template <DPNPFuncType ... FTs>
-static void func_map_logic_2arg_2type_helper(func_map_t& fmap)
+template <DPNPFuncType... FTs>
+static void func_map_logic_2arg_2type_helper(func_map_t &fmap)
 {
     ((func_map_logic_2arg_2type_core<FTs, FTs...>(fmap)), ...);
 }
 
-void func_map_init_logic(func_map_t& fmap)
+void func_map_init_logic(func_map_t &fmap)
 {
-    fmap[DPNPFuncName::DPNP_FN_ALL][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_all_default_c<bool, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALL][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_all_default_c<int32_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALL][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_all_default_c<int64_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALL][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_all_default_c<float, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALL][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_all_default_c<double, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALL][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_all_default_c<bool, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALL][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_all_default_c<int32_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALL][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_all_default_c<int64_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALL][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_all_default_c<float, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALL][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_all_default_c<double, bool>};
 
-    fmap[DPNPFuncName::DPNP_FN_ALL_EXT][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_all_ext_c<bool, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALL_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_all_ext_c<int32_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALL_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_all_ext_c<int64_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALL_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_all_ext_c<float, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALL_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_all_ext_c<double, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALL_EXT][eft_C64][eft_C64] = {eft_C64, (void*)dpnp_all_ext_c<std::complex<float>, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALL_EXT][eft_C128][eft_C128] = {eft_C128, (void*)dpnp_all_ext_c<std::complex<double>, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALL_EXT][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_all_ext_c<bool, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALL_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_all_ext_c<int32_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALL_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_all_ext_c<int64_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALL_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_all_ext_c<float, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALL_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_all_ext_c<double, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALL_EXT][eft_C64][eft_C64] = {
+        eft_C64, (void *)dpnp_all_ext_c<std::complex<float>, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALL_EXT][eft_C128][eft_C128] = {
+        eft_C128, (void *)dpnp_all_ext_c<std::complex<double>, bool>};
 
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_INT][eft_INT] = {eft_BLN,
-                                                              (void*)dpnp_allclose_default_c<int32_t, int32_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_LNG][eft_INT] = {eft_BLN,
-                                                              (void*)dpnp_allclose_default_c<int64_t, int32_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_FLT][eft_INT] = {eft_BLN,
-                                                              (void*)dpnp_allclose_default_c<float, int32_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_DBL][eft_INT] = {eft_BLN,
-                                                              (void*)dpnp_allclose_default_c<double, int32_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_INT][eft_LNG] = {eft_BLN,
-                                                              (void*)dpnp_allclose_default_c<int32_t, int64_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_LNG][eft_LNG] = {eft_BLN,
-                                                              (void*)dpnp_allclose_default_c<int64_t, int64_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_FLT][eft_LNG] = {eft_BLN,
-                                                              (void*)dpnp_allclose_default_c<float, int64_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_DBL][eft_LNG] = {eft_BLN,
-                                                              (void*)dpnp_allclose_default_c<double, int64_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_INT][eft_FLT] = {eft_BLN,
-                                                              (void*)dpnp_allclose_default_c<int32_t, float, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_LNG][eft_FLT] = {eft_BLN,
-                                                              (void*)dpnp_allclose_default_c<int64_t, float, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_FLT][eft_FLT] = {eft_BLN,
-                                                              (void*)dpnp_allclose_default_c<float, float, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_DBL][eft_FLT] = {eft_BLN,
-                                                              (void*)dpnp_allclose_default_c<double, float, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_INT][eft_DBL] = {eft_BLN,
-                                                              (void*)dpnp_allclose_default_c<int32_t, double, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_LNG][eft_DBL] = {eft_BLN,
-                                                              (void*)dpnp_allclose_default_c<int64_t, double, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_FLT][eft_DBL] = {eft_BLN,
-                                                              (void*)dpnp_allclose_default_c<float, double, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_DBL][eft_DBL] = {eft_BLN,
-                                                              (void*)dpnp_allclose_default_c<double, double, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_INT][eft_INT] = {
+        eft_BLN, (void *)dpnp_allclose_default_c<int32_t, int32_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_LNG][eft_INT] = {
+        eft_BLN, (void *)dpnp_allclose_default_c<int64_t, int32_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_FLT][eft_INT] = {
+        eft_BLN, (void *)dpnp_allclose_default_c<float, int32_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_DBL][eft_INT] = {
+        eft_BLN, (void *)dpnp_allclose_default_c<double, int32_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_INT][eft_LNG] = {
+        eft_BLN, (void *)dpnp_allclose_default_c<int32_t, int64_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_LNG][eft_LNG] = {
+        eft_BLN, (void *)dpnp_allclose_default_c<int64_t, int64_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_FLT][eft_LNG] = {
+        eft_BLN, (void *)dpnp_allclose_default_c<float, int64_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_DBL][eft_LNG] = {
+        eft_BLN, (void *)dpnp_allclose_default_c<double, int64_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_INT][eft_FLT] = {
+        eft_BLN, (void *)dpnp_allclose_default_c<int32_t, float, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_LNG][eft_FLT] = {
+        eft_BLN, (void *)dpnp_allclose_default_c<int64_t, float, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_FLT][eft_FLT] = {
+        eft_BLN, (void *)dpnp_allclose_default_c<float, float, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_DBL][eft_FLT] = {
+        eft_BLN, (void *)dpnp_allclose_default_c<double, float, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_INT][eft_DBL] = {
+        eft_BLN, (void *)dpnp_allclose_default_c<int32_t, double, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_LNG][eft_DBL] = {
+        eft_BLN, (void *)dpnp_allclose_default_c<int64_t, double, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_FLT][eft_DBL] = {
+        eft_BLN, (void *)dpnp_allclose_default_c<float, double, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE][eft_DBL][eft_DBL] = {
+        eft_BLN, (void *)dpnp_allclose_default_c<double, double, bool>};
 
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_INT][eft_INT] = {eft_BLN,
-                                                                  (void*)dpnp_allclose_ext_c<int32_t, int32_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_LNG][eft_INT] = {eft_BLN,
-                                                                  (void*)dpnp_allclose_ext_c<int64_t, int32_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_FLT][eft_INT] = {eft_BLN,
-                                                                  (void*)dpnp_allclose_ext_c<float, int32_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_DBL][eft_INT] = {eft_BLN,
-                                                                  (void*)dpnp_allclose_ext_c<double, int32_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_INT][eft_LNG] = {eft_BLN,
-                                                                  (void*)dpnp_allclose_ext_c<int32_t, int64_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_LNG][eft_LNG] = {eft_BLN,
-                                                                  (void*)dpnp_allclose_ext_c<int64_t, int64_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_FLT][eft_LNG] = {eft_BLN,
-                                                                  (void*)dpnp_allclose_ext_c<float, int64_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_DBL][eft_LNG] = {eft_BLN,
-                                                                  (void*)dpnp_allclose_ext_c<double, int64_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_INT][eft_FLT] = {eft_BLN,
-                                                                  (void*)dpnp_allclose_ext_c<int32_t, float, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_LNG][eft_FLT] = {eft_BLN,
-                                                                  (void*)dpnp_allclose_ext_c<int64_t, float, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_FLT][eft_FLT] = {eft_BLN,
-                                                                  (void*)dpnp_allclose_ext_c<float, float, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_DBL][eft_FLT] = {eft_BLN,
-                                                                  (void*)dpnp_allclose_ext_c<double, float, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_INT][eft_DBL] = {eft_BLN,
-                                                                  (void*)dpnp_allclose_ext_c<int32_t, double, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_LNG][eft_DBL] = {eft_BLN,
-                                                                  (void*)dpnp_allclose_ext_c<int64_t, double, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_FLT][eft_DBL] = {eft_BLN,
-                                                                  (void*)dpnp_allclose_ext_c<float, double, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_DBL][eft_DBL] = {eft_BLN,
-                                                                  (void*)dpnp_allclose_ext_c<double, double, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_INT][eft_INT] = {
+        eft_BLN, (void *)dpnp_allclose_ext_c<int32_t, int32_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_LNG][eft_INT] = {
+        eft_BLN, (void *)dpnp_allclose_ext_c<int64_t, int32_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_FLT][eft_INT] = {
+        eft_BLN, (void *)dpnp_allclose_ext_c<float, int32_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_DBL][eft_INT] = {
+        eft_BLN, (void *)dpnp_allclose_ext_c<double, int32_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_INT][eft_LNG] = {
+        eft_BLN, (void *)dpnp_allclose_ext_c<int32_t, int64_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_LNG][eft_LNG] = {
+        eft_BLN, (void *)dpnp_allclose_ext_c<int64_t, int64_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_FLT][eft_LNG] = {
+        eft_BLN, (void *)dpnp_allclose_ext_c<float, int64_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_DBL][eft_LNG] = {
+        eft_BLN, (void *)dpnp_allclose_ext_c<double, int64_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_INT][eft_FLT] = {
+        eft_BLN, (void *)dpnp_allclose_ext_c<int32_t, float, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_LNG][eft_FLT] = {
+        eft_BLN, (void *)dpnp_allclose_ext_c<int64_t, float, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_FLT][eft_FLT] = {
+        eft_BLN, (void *)dpnp_allclose_ext_c<float, float, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_DBL][eft_FLT] = {
+        eft_BLN, (void *)dpnp_allclose_ext_c<double, float, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_INT][eft_DBL] = {
+        eft_BLN, (void *)dpnp_allclose_ext_c<int32_t, double, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_LNG][eft_DBL] = {
+        eft_BLN, (void *)dpnp_allclose_ext_c<int64_t, double, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_FLT][eft_DBL] = {
+        eft_BLN, (void *)dpnp_allclose_ext_c<float, double, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ALLCLOSE_EXT][eft_DBL][eft_DBL] = {
+        eft_BLN, (void *)dpnp_allclose_ext_c<double, double, bool>};
 
-    fmap[DPNPFuncName::DPNP_FN_ANY][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_any_default_c<bool, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ANY][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_any_default_c<int32_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ANY][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_any_default_c<int64_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ANY][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_any_default_c<float, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ANY][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_any_default_c<double, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ANY][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_any_default_c<bool, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ANY][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_any_default_c<int32_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ANY][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_any_default_c<int64_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ANY][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_any_default_c<float, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ANY][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_any_default_c<double, bool>};
 
-    fmap[DPNPFuncName::DPNP_FN_ANY_EXT][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_any_ext_c<bool, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ANY_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_any_ext_c<int32_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ANY_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_any_ext_c<int64_t, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ANY_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_any_ext_c<float, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ANY_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_any_ext_c<double, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ANY_EXT][eft_C64][eft_C64] = {eft_C64, (void*)dpnp_any_ext_c<std::complex<float>, bool>};
-    fmap[DPNPFuncName::DPNP_FN_ANY_EXT][eft_C128][eft_C128] = {eft_C128, (void*)dpnp_any_ext_c<std::complex<double>, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ANY_EXT][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_any_ext_c<bool, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ANY_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_any_ext_c<int32_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ANY_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_any_ext_c<int64_t, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ANY_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_any_ext_c<float, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ANY_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_any_ext_c<double, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ANY_EXT][eft_C64][eft_C64] = {
+        eft_C64, (void *)dpnp_any_ext_c<std::complex<float>, bool>};
+    fmap[DPNPFuncName::DPNP_FN_ANY_EXT][eft_C128][eft_C128] = {
+        eft_C128, (void *)dpnp_any_ext_c<std::complex<double>, bool>};
 
-    func_map_logic_1arg_1type_helper<eft_BLN, eft_INT, eft_LNG, eft_FLT, eft_DBL>(fmap);
-    func_map_logic_2arg_2type_helper<eft_BLN, eft_INT, eft_LNG, eft_FLT, eft_DBL>(fmap);
+    func_map_logic_1arg_1type_helper<eft_BLN, eft_INT, eft_LNG, eft_FLT,
+                                     eft_DBL>(fmap);
+    func_map_logic_2arg_2type_helper<eft_BLN, eft_INT, eft_LNG, eft_FLT,
+                                     eft_DBL>(fmap);
 
     return;
 }

--- a/dpnp/backend/kernels/dpnp_krnl_logic.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_logic.cpp
@@ -56,7 +56,7 @@ DPCTLSyclEventRef dpnp_all_c(DPCTLSyclQueueRef q_ref,
     sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     const _DataType *array_in = static_cast<const _DataType *>(array1_in);
-    bool *result              = static_cast<bool *>(result1);
+    bool *result = static_cast<bool *>(result1);
 
     auto fill_event = q.fill(result, true, 1);
 
@@ -65,7 +65,7 @@ DPCTLSyclEventRef dpnp_all_c(DPCTLSyclQueueRef q_ref,
         return DPCTLEvent_Copy(event_ref);
     }
 
-    constexpr size_t lws    = 64;
+    constexpr size_t lws = 64;
     constexpr size_t vec_sz = 8;
 
     auto gws_range =
@@ -74,7 +74,7 @@ DPCTLSyclEventRef dpnp_all_c(DPCTLSyclQueueRef q_ref,
     sycl::nd_range<1> gws(gws_range, lws_range);
 
     auto kernel_parallel_for_func = [=](sycl::nd_item<1> nd_it) {
-        auto gr                = nd_it.get_group();
+        auto gr = nd_it.get_group();
         const auto max_gr_size = gr.get_max_local_range()[0];
         const size_t start =
             vec_sz * (nd_it.get_group(0) * nd_it.get_local_range(0) +
@@ -108,7 +108,7 @@ void dpnp_all_c(const void *array1_in, void *result1, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_all_c<_DataType, _ResultType>(
+    DPCTLSyclEventRef event_ref = dpnp_all_c<_DataType, _ResultType>(
         q_ref, array1_in, result1, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
@@ -157,7 +157,7 @@ DPCTLSyclEventRef dpnp_allclose_c(DPCTLSyclQueueRef q_ref,
     DPNPC_ptr_adapter<_ResultType> result1_ptr(q_ref, result1, 1, true, true);
     const _DataType1 *array1 = input1_ptr.get_ptr();
     const _DataType2 *array2 = input2_ptr.get_ptr();
-    _ResultType *result      = result1_ptr.get_ptr();
+    _ResultType *result = result1_ptr.get_ptr();
 
     result[0] = true;
 
@@ -251,7 +251,7 @@ DPCTLSyclEventRef dpnp_any_c(DPCTLSyclQueueRef q_ref,
     sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     const _DataType *array_in = static_cast<const _DataType *>(array1_in);
-    bool *result              = static_cast<bool *>(result1);
+    bool *result = static_cast<bool *>(result1);
 
     auto fill_event = q.fill(result, false, 1);
 
@@ -260,7 +260,7 @@ DPCTLSyclEventRef dpnp_any_c(DPCTLSyclQueueRef q_ref,
         return DPCTLEvent_Copy(event_ref);
     }
 
-    constexpr size_t lws    = 64;
+    constexpr size_t lws = 64;
     constexpr size_t vec_sz = 8;
 
     auto gws_range =
@@ -269,7 +269,7 @@ DPCTLSyclEventRef dpnp_any_c(DPCTLSyclQueueRef q_ref,
     sycl::nd_range<1> gws(gws_range, lws_range);
 
     auto kernel_parallel_for_func = [=](sycl::nd_item<1> nd_it) {
-        auto gr                = nd_it.get_group();
+        auto gr = nd_it.get_group();
         const auto max_gr_size = gr.get_max_local_range()[0];
         const size_t start =
             vec_sz * (nd_it.get_group(0) * nd_it.get_local_range(0) +
@@ -303,7 +303,7 @@ void dpnp_any_c(const void *array1_in, void *result1, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_any_c<_DataType, _ResultType>(
+    DPCTLSyclEventRef event_ref = dpnp_any_c<_DataType, _ResultType>(
         q_ref, array1_in, result1, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
@@ -440,7 +440,7 @@ DPCTLSyclEventRef (*dpnp_any_ext_c)(DPCTLSyclQueueRef,
             return event_ref;                                                  \
         }                                                                      \
         else {                                                                 \
-            constexpr size_t lws          = 64;                                \
+            constexpr size_t lws = 64;                                         \
             constexpr unsigned int vec_sz = 8;                                 \
             constexpr sycl::access::address_space global_space =               \
                 sycl::access::address_space::global_space;                     \
@@ -450,7 +450,7 @@ DPCTLSyclEventRef (*dpnp_any_ext_c)(DPCTLSyclQueueRef,
             auto lws_range = sycl::range<1>(lws);                              \
                                                                                \
             auto kernel_parallel_for_func = [=](sycl::nd_item<1> nd_it) {      \
-                auto sg                = nd_it.get_sub_group();                \
+                auto sg = nd_it.get_sub_group();                               \
                 const auto max_sg_size = sg.get_max_local_range()[0];          \
                 const size_t start =                                           \
                     vec_sz * (nd_it.get_group(0) * nd_it.get_local_range(0) +  \
@@ -465,7 +465,7 @@ DPCTLSyclEventRef (*dpnp_any_ext_c)(DPCTLSyclQueueRef,
                                                                                \
                     for (size_t k = 0; k < vec_sz; ++k) {                      \
                         const _DataType_input1 input1_elem = x1[k];            \
-                        res_vec[k]                         = __operation__;    \
+                        res_vec[k] = __operation__;                            \
                     }                                                          \
                     sg.store<vec_sz>(                                          \
                         sycl::multi_ptr<bool, global_space>(&result[start]),   \
@@ -474,7 +474,7 @@ DPCTLSyclEventRef (*dpnp_any_ext_c)(DPCTLSyclQueueRef,
                 else {                                                         \
                     for (size_t k = start; k < result_size; ++k) {             \
                         const _DataType_input1 input1_elem = input1_data[k];   \
-                        result[k]                          = __operation__;    \
+                        result[k] = __operation__;                             \
                     }                                                          \
                 }                                                              \
             };                                                                 \
@@ -610,7 +610,7 @@ static void func_map_logic_1arg_1type_helper(func_map_t &fmap)
                 {                                                              \
                     const _DataType_input1 input1_elem = (*input1_it)[i];      \
                     const _DataType_input2 input2_elem = (*input2_it)[i];      \
-                    result[i]                          = __operation__;        \
+                    result[i] = __operation__;                                 \
                 }                                                              \
             };                                                                 \
             auto kernel_func = [&](sycl::handler &cgh) {                       \
@@ -708,7 +708,7 @@ static void func_map_logic_1arg_1type_helper(func_map_t &fmap)
             return event_ref;                                                  \
         }                                                                      \
         else {                                                                 \
-            constexpr size_t lws          = 64;                                \
+            constexpr size_t lws = 64;                                         \
             constexpr unsigned int vec_sz = 8;                                 \
             constexpr sycl::access::address_space global_space =               \
                 sycl::access::address_space::global_space;                     \
@@ -718,7 +718,7 @@ static void func_map_logic_1arg_1type_helper(func_map_t &fmap)
             auto lws_range = sycl::range<1>(lws);                              \
                                                                                \
             auto kernel_parallel_for_func = [=](sycl::nd_item<1> nd_it) {      \
-                auto sg                = nd_it.get_sub_group();                \
+                auto sg = nd_it.get_sub_group();                               \
                 const auto max_sg_size = sg.get_max_local_range()[0];          \
                 const size_t start =                                           \
                     vec_sz * (nd_it.get_group(0) * nd_it.get_local_range(0) +  \
@@ -737,7 +737,7 @@ static void func_map_logic_1arg_1type_helper(func_map_t &fmap)
                     for (size_t k = 0; k < vec_sz; ++k) {                      \
                         const _DataType_input1 input1_elem = x1[k];            \
                         const _DataType_input2 input2_elem = x2[k];            \
-                        res_vec[k]                         = __operation__;    \
+                        res_vec[k] = __operation__;                            \
                     }                                                          \
                     sg.store<vec_sz>(                                          \
                         sycl::multi_ptr<bool, global_space>(&result[start]),   \
@@ -747,7 +747,7 @@ static void func_map_logic_1arg_1type_helper(func_map_t &fmap)
                     for (size_t k = start; k < result_size; ++k) {             \
                         const _DataType_input1 input1_elem = input1_data[k];   \
                         const _DataType_input2 input2_elem = input2_data[k];   \
-                        result[k]                          = __operation__;    \
+                        result[k] = __operation__;                             \
                     }                                                          \
                 }                                                              \
             };                                                                 \

--- a/dpnp/backend/kernels/dpnp_krnl_manipulation.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_manipulation.cpp
@@ -63,12 +63,12 @@ DPCTLSyclEventRef dpnp_repeat_c(DPCTLSyclQueueRef q_ref,
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, size);
     const _DataType *array_in = input1_ptr.get_ptr();
-    _DataType *result         = reinterpret_cast<_DataType *>(result1);
+    _DataType *result = reinterpret_cast<_DataType *>(result1);
 
     sycl::range<2> gws(size, repeats);
     auto kernel_parallel_for_func = [=](sycl::id<2> global_id) {
-        size_t idx1                     = global_id[0];
-        size_t idx2                     = global_id[1];
+        size_t idx1 = global_id[0];
+        size_t idx2 = global_id[1];
         result[(idx1 * repeats) + idx2] = array_in[idx1];
     };
 
@@ -92,7 +92,7 @@ void dpnp_repeat_c(const void *array1_in,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_repeat_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_repeat_c<_DataType>(
         q_ref, array1_in, result1, repeats, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -164,11 +164,11 @@ DPCTLSyclEventRef
         const size_t idx = global_id[0];
 
         size_t output_index = 0;
-        size_t reminder     = idx;
+        size_t reminder = idx;
         for (size_t axis = 0; axis < ndim; ++axis) {
             /* reconstruct [x][y][z] from given linear idx */
             size_t xyz_id = reminder / input_offset_shape[axis];
-            reminder      = reminder % input_offset_shape[axis];
+            reminder = reminder % input_offset_shape[axis];
 
             /* calculate destination index based on reconstructed [x][y][z] */
             output_index += (xyz_id * result_offset_shape[axis]);

--- a/dpnp/backend/kernels/dpnp_krnl_manipulation.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_manipulation.cpp
@@ -39,8 +39,8 @@ class dpnp_repeat_c_kernel;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_repeat_c(DPCTLSyclQueueRef q_ref,
-                                const void* array1_in,
-                                void* result1,
+                                const void *array1_in,
+                                void *result1,
                                 const size_t repeats,
                                 const size_t size,
                                 const DPCTLEventVectorRef dep_event_vec_ref)
@@ -50,32 +50,31 @@ DPCTLSyclEventRef dpnp_repeat_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!array1_in || !result1)
-    {
+    if (!array1_in || !result1) {
         return event_ref;
     }
 
-    if (!size || !repeats)
-    {
+    if (!size || !repeats) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
     sycl::event event;
 
-    DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref,array1_in, size);
-    const _DataType* array_in = input1_ptr.get_ptr();
-    _DataType* result = reinterpret_cast<_DataType*>(result1);
+    DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, size);
+    const _DataType *array_in = input1_ptr.get_ptr();
+    _DataType *result         = reinterpret_cast<_DataType *>(result1);
 
     sycl::range<2> gws(size, repeats);
     auto kernel_parallel_for_func = [=](sycl::id<2> global_id) {
-        size_t idx1 = global_id[0];
-        size_t idx2 = global_id[1];
+        size_t idx1                     = global_id[0];
+        size_t idx2                     = global_id[1];
         result[(idx1 * repeats) + idx2] = array_in[idx1];
     };
 
-    auto kernel_func = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class dpnp_repeat_c_kernel<_DataType>>(gws, kernel_parallel_for_func);
+    auto kernel_func = [&](sycl::handler &cgh) {
+        cgh.parallel_for<class dpnp_repeat_c_kernel<_DataType>>(
+            gws, kernel_parallel_for_func);
     };
 
     event = q.submit(kernel_func);
@@ -86,74 +85,78 @@ DPCTLSyclEventRef dpnp_repeat_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_repeat_c(const void* array1_in, void* result1, const size_t repeats, const size_t size)
+void dpnp_repeat_c(const void *array1_in,
+                   void *result1,
+                   const size_t repeats,
+                   const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_repeat_c<_DataType>(q_ref,
-                                                           array1_in,
-                                                           result1,
-                                                           repeats,
-                                                           size,
-                                                           dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_repeat_c<_DataType>(
+        q_ref, array1_in, result1, repeats, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_repeat_default_c)(const void*, void*, const size_t, const size_t) = dpnp_repeat_c<_DataType>;
+void (*dpnp_repeat_default_c)(const void *,
+                              void *,
+                              const size_t,
+                              const size_t) = dpnp_repeat_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_repeat_ext_c)(DPCTLSyclQueueRef,
-                                       const void*,
-                                       void*,
+                                       const void *,
+                                       void *,
                                        const size_t,
                                        const size_t,
-                                       const DPCTLEventVectorRef) = dpnp_repeat_c<_DataType>;
+                                       const DPCTLEventVectorRef) =
+    dpnp_repeat_c<_DataType>;
 
 template <typename _KernelNameSpecialization>
 class dpnp_elemwise_transpose_c_kernel;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_elemwise_transpose_c(DPCTLSyclQueueRef q_ref,
-                                            void* array1_in,
-                                            const shape_elem_type* input_shape,
-                                            const shape_elem_type* result_shape,
-                                            const shape_elem_type* permute_axes,
-                                            size_t ndim,
-                                            void* result1,
-                                            size_t size,
-                                            const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_elemwise_transpose_c(DPCTLSyclQueueRef q_ref,
+                              void *array1_in,
+                              const shape_elem_type *input_shape,
+                              const shape_elem_type *result_shape,
+                              const shape_elem_type *permute_axes,
+                              size_t ndim,
+                              void *result1,
+                              size_t size,
+                              const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
     sycl::event event;
 
-    DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref,array1_in, size);
-    _DataType* array1 = input1_ptr.get_ptr();
-    _DataType* result = reinterpret_cast<_DataType*>(result1);
+    DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, size);
+    _DataType *array1 = input1_ptr.get_ptr();
+    _DataType *result = reinterpret_cast<_DataType *>(result1);
 
-    shape_elem_type* input_offset_shape =
-        reinterpret_cast<shape_elem_type*>(sycl::malloc_shared(ndim * sizeof(shape_elem_type), q));
+    shape_elem_type *input_offset_shape = reinterpret_cast<shape_elem_type *>(
+        sycl::malloc_shared(ndim * sizeof(shape_elem_type), q));
     get_shape_offsets_inkernel(input_shape, ndim, input_offset_shape);
 
-    shape_elem_type* temp_result_offset_shape =
-        reinterpret_cast<shape_elem_type*>(sycl::malloc_shared(ndim * sizeof(shape_elem_type), q));
+    shape_elem_type *temp_result_offset_shape =
+        reinterpret_cast<shape_elem_type *>(
+            sycl::malloc_shared(ndim * sizeof(shape_elem_type), q));
     get_shape_offsets_inkernel(result_shape, ndim, temp_result_offset_shape);
 
-    shape_elem_type* result_offset_shape =
-        reinterpret_cast<shape_elem_type*>(sycl::malloc_shared(ndim * sizeof(shape_elem_type), q));
-    for (size_t axis = 0; axis < ndim; ++axis)
-    {
-        result_offset_shape[permute_axes[axis]] = temp_result_offset_shape[axis];
+    shape_elem_type *result_offset_shape = reinterpret_cast<shape_elem_type *>(
+        sycl::malloc_shared(ndim * sizeof(shape_elem_type), q));
+    for (size_t axis = 0; axis < ndim; ++axis) {
+        result_offset_shape[permute_axes[axis]] =
+            temp_result_offset_shape[axis];
     }
 
     sycl::range<1> gws(size);
@@ -161,12 +164,11 @@ DPCTLSyclEventRef dpnp_elemwise_transpose_c(DPCTLSyclQueueRef q_ref,
         const size_t idx = global_id[0];
 
         size_t output_index = 0;
-        size_t reminder = idx;
-        for (size_t axis = 0; axis < ndim; ++axis)
-        {
+        size_t reminder     = idx;
+        for (size_t axis = 0; axis < ndim; ++axis) {
             /* reconstruct [x][y][z] from given linear idx */
             size_t xyz_id = reminder / input_offset_shape[axis];
-            reminder = reminder % input_offset_shape[axis];
+            reminder      = reminder % input_offset_shape[axis];
 
             /* calculate destination index based on reconstructed [x][y][z] */
             output_index += (xyz_id * result_offset_shape[axis]);
@@ -175,8 +177,9 @@ DPCTLSyclEventRef dpnp_elemwise_transpose_c(DPCTLSyclQueueRef q_ref,
         result[output_index] = array1[idx];
     };
 
-    auto kernel_func = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class dpnp_elemwise_transpose_c_kernel<_DataType>>(gws, kernel_parallel_for_func);
+    auto kernel_func = [&](sycl::handler &cgh) {
+        cgh.parallel_for<class dpnp_elemwise_transpose_c_kernel<_DataType>>(
+            gws, kernel_parallel_for_func);
     };
 
     event = q.submit(kernel_func);
@@ -191,57 +194,60 @@ DPCTLSyclEventRef dpnp_elemwise_transpose_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_elemwise_transpose_c(void* array1_in,
-                               const shape_elem_type* input_shape,
-                               const shape_elem_type* result_shape,
-                               const shape_elem_type* permute_axes,
+void dpnp_elemwise_transpose_c(void *array1_in,
+                               const shape_elem_type *input_shape,
+                               const shape_elem_type *result_shape,
+                               const shape_elem_type *permute_axes,
                                size_t ndim,
-                               void* result1,
+                               void *result1,
                                size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_elemwise_transpose_c<_DataType>(q_ref,
-                                                                       array1_in,
-                                                                       input_shape,
-                                                                       result_shape,
-                                                                       permute_axes,
-                                                                       ndim,
-                                                                       result1,
-                                                                       size,
-                                                                       dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref = dpnp_elemwise_transpose_c<_DataType>(
+        q_ref, array1_in, input_shape, result_shape, permute_axes, ndim,
+        result1, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_elemwise_transpose_default_c)(void*,
-                                          const shape_elem_type*,
-                                          const shape_elem_type*,
-                                          const shape_elem_type*,
+void (*dpnp_elemwise_transpose_default_c)(void *,
+                                          const shape_elem_type *,
+                                          const shape_elem_type *,
+                                          const shape_elem_type *,
                                           size_t,
-                                          void*,
-                                          size_t) = dpnp_elemwise_transpose_c<_DataType>;
+                                          void *,
+                                          size_t) =
+    dpnp_elemwise_transpose_c<_DataType>;
 
-void func_map_init_manipulation(func_map_t& fmap)
+void func_map_init_manipulation(func_map_t &fmap)
 {
-    fmap[DPNPFuncName::DPNP_FN_REPEAT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_repeat_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_REPEAT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_repeat_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_REPEAT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_repeat_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_REPEAT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_repeat_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_REPEAT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_repeat_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_REPEAT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_repeat_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_REPEAT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_repeat_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_REPEAT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_repeat_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_REPEAT_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_repeat_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_REPEAT_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_repeat_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_REPEAT_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_repeat_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_REPEAT_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_repeat_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_REPEAT_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_repeat_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_REPEAT_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_repeat_ext_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_REPEAT_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_repeat_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_REPEAT_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_repeat_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_TRANSPOSE][eft_INT][eft_INT] = {eft_INT,
-                                                               (void*)dpnp_elemwise_transpose_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRANSPOSE][eft_LNG][eft_LNG] = {eft_LNG,
-                                                               (void*)dpnp_elemwise_transpose_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRANSPOSE][eft_FLT][eft_FLT] = {eft_FLT,
-                                                               (void*)dpnp_elemwise_transpose_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_TRANSPOSE][eft_DBL][eft_DBL] = {eft_DBL,
-                                                               (void*)dpnp_elemwise_transpose_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_TRANSPOSE][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_elemwise_transpose_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRANSPOSE][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_elemwise_transpose_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_TRANSPOSE][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_elemwise_transpose_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_TRANSPOSE][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_elemwise_transpose_default_c<double>};
     return;
 }

--- a/dpnp/backend/kernels/dpnp_krnl_mathematical.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_mathematical.cpp
@@ -59,7 +59,7 @@ DPCTLSyclEventRef dpnp_around_c(DPCTLSyclQueueRef q_ref,
     sycl::event event;
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, input_in, input_size);
-    _DataType *input  = input1_ptr.get_ptr();
+    _DataType *input = input1_ptr.get_ptr();
     _DataType *result = reinterpret_cast<_DataType *>(result_out);
 
     if constexpr (std::is_same<_DataType, double>::value ||
@@ -97,7 +97,7 @@ void dpnp_around_c(const void *input_in,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_around_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_around_c<_DataType>(
         q_ref, input_in, result_out, input_size, decimals, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -155,7 +155,7 @@ DPCTLSyclEventRef
         static_assert(std::is_same_v<_DataType_input, _DataType_output>,
                       "Result type must match a type of input data");
 
-        constexpr size_t lws          = 64;
+        constexpr size_t lws = 64;
         constexpr unsigned int vec_sz = 8;
         constexpr sycl::access::address_space global_space =
             sycl::access::address_space::global_space;
@@ -165,7 +165,7 @@ DPCTLSyclEventRef
         auto lws_range = sycl::range<1>(lws);
 
         auto kernel_parallel_for_func = [=](sycl::nd_item<1> nd_it) {
-            auto sg                = nd_it.get_sub_group();
+            auto sg = nd_it.get_sub_group();
             const auto max_sg_size = sg.get_max_local_range()[0];
             const size_t start =
                 vec_sz * (nd_it.get_group(0) * nd_it.get_local_range(0) +
@@ -266,7 +266,7 @@ DPCTLSyclEventRef dpnp_cross_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_DataType_input1> input1_ptr(q_ref, input1_in,
                                                    input1_size, true);
@@ -276,7 +276,7 @@ DPCTLSyclEventRef dpnp_cross_c(DPCTLSyclQueueRef q_ref,
                                                    input1_size, true, true);
     const _DataType_input1 *input1 = input1_ptr.get_ptr();
     const _DataType_input2 *input2 = input2_ptr.get_ptr();
-    _DataType_output *result       = result_ptr.get_ptr();
+    _DataType_output *result = result_ptr.get_ptr();
 
     result[0] = input1[1] * input2[2] - input1[2] * input2[1];
 
@@ -368,7 +368,7 @@ DPCTLSyclEventRef dpnp_cumprod_c(DPCTLSyclQueueRef q_ref,
     DPNPC_ptr_adapter<_DataType_input> input1_ptr(q_ref, array1_in, size, true);
     DPNPC_ptr_adapter<_DataType_output> result_ptr(q_ref, result1, size, true,
                                                    true);
-    _DataType_input *array1  = input1_ptr.get_ptr();
+    _DataType_input *array1 = input1_ptr.get_ptr();
     _DataType_output *result = result_ptr.get_ptr();
 
     _DataType_output cur_res = 1;
@@ -429,7 +429,7 @@ DPCTLSyclEventRef dpnp_cumsum_c(DPCTLSyclQueueRef q_ref,
     DPNPC_ptr_adapter<_DataType_input> input1_ptr(q_ref, array1_in, size, true);
     DPNPC_ptr_adapter<_DataType_output> result_ptr(q_ref, result1, size, true,
                                                    true);
-    _DataType_input *array1  = input1_ptr.get_ptr();
+    _DataType_input *array1 = input1_ptr.get_ptr();
     _DataType_output *result = result_ptr.get_ptr();
 
     _DataType_output cur_res = 0;
@@ -508,7 +508,7 @@ DPCTLSyclEventRef dpnp_ediff1d_c(DPCTLSyclQueueRef q_ref,
                                                    result_size, false, true);
 
     _DataType_input *input1_data = input1_ptr.get_ptr();
-    _DataType_output *result     = result_ptr.get_ptr();
+    _DataType_output *result = result_ptr.get_ptr();
 
     cl::sycl::event event;
     cl::sycl::range<1> gws(result_size);
@@ -519,7 +519,7 @@ DPCTLSyclEventRef dpnp_ediff1d_c(DPCTLSyclQueueRef q_ref,
         {
             const _DataType_output curr_elem = input1_data[output_id];
             const _DataType_output next_elem = input1_data[output_id + 1];
-            result[output_id]                = next_elem - curr_elem;
+            result[output_id] = next_elem - curr_elem;
         }
     };
     auto kernel_func = [&](cl::sycl::handler &cgh) {
@@ -662,7 +662,7 @@ DPCTLSyclEventRef
         const _DataType_output input2_elem = (*input2_it)[i];
 
         double div = (double)input1_elem / (double)input2_elem;
-        result[i]  = static_cast<_DataType_output>(sycl::floor(div));
+        result[i] = static_cast<_DataType_output>(sycl::floor(div));
     };
     auto kernel_func = [&](sycl::handler &cgh) {
         cgh.parallel_for<class dpnp_floor_divide_c_kernel<
@@ -910,12 +910,12 @@ DPCTLSyclEventRef dpnp_remainder_c(DPCTLSyclQueueRef q_ref,
 
     sycl::range<1> gws(result_size);
     auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
-        const size_t i                     = global_id[0];
+        const size_t i = global_id[0];
         const _DataType_output input1_elem = (*input1_it)[i];
         const _DataType_output input2_elem = (*input2_it)[i];
         double fmod_res = sycl::fmod((double)input1_elem, (double)input2_elem);
-        double add      = fmod_res + input2_elem;
-        result[i]       = sycl::fmod(add, (double)input2_elem);
+        double add = fmod_res + input2_elem;
+        result[i] = sycl::fmod(add, (double)input2_elem);
     };
     auto kernel_func = [&](sycl::handler &cgh) {
         cgh.parallel_for<class dpnp_remainder_c_kernel<

--- a/dpnp/backend/kernels/dpnp_krnl_mathematical.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_mathematical.cpp
@@ -40,8 +40,8 @@ class dpnp_around_c_kernel;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_around_c(DPCTLSyclQueueRef q_ref,
-                                const void* input_in,
-                                void* result_out,
+                                const void *input_in,
+                                void *result_out,
                                 const size_t input_size,
                                 const int decimals,
                                 const DPCTLEventVectorRef dep_event_vec_ref)
@@ -51,24 +51,23 @@ DPCTLSyclEventRef dpnp_around_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!input_size)
-    {
+    if (!input_size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
     sycl::event event;
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, input_in, input_size);
-    _DataType* input = input1_ptr.get_ptr();
-    _DataType* result = reinterpret_cast<_DataType*>(result_out);
+    _DataType *input  = input1_ptr.get_ptr();
+    _DataType *result = reinterpret_cast<_DataType *>(result_out);
 
-    if constexpr (std::is_same<_DataType, double>::value || std::is_same<_DataType, float>::value)
+    if constexpr (std::is_same<_DataType, double>::value ||
+                  std::is_same<_DataType, float>::value)
     {
         event = oneapi::mkl::vm::rint(q, input_size, input, result);
     }
-    else
-    {
+    else {
         sycl::range<1> gws(input_size);
         auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
             size_t i = global_id[0];
@@ -77,8 +76,9 @@ DPCTLSyclEventRef dpnp_around_c(DPCTLSyclQueueRef q_ref,
             }
         };
 
-        auto kernel_func = [&](sycl::handler& cgh) {
-            cgh.parallel_for<class dpnp_around_c_kernel<_DataType>>(gws, kernel_parallel_for_func);
+        auto kernel_func = [&](sycl::handler &cgh) {
+            cgh.parallel_for<class dpnp_around_c_kernel<_DataType>>(
+                gws, kernel_parallel_for_func);
         };
 
         event = q.submit(kernel_func);
@@ -90,109 +90,124 @@ DPCTLSyclEventRef dpnp_around_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_around_c(const void* input_in, void* result_out, const size_t input_size, const int decimals)
+void dpnp_around_c(const void *input_in,
+                   void *result_out,
+                   const size_t input_size,
+                   const int decimals)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_around_c<_DataType>(q_ref,
-                                                           input_in,
-                                                           result_out,
-                                                           input_size,
-                                                           decimals,
-                                                           dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_around_c<_DataType>(
+        q_ref, input_in, result_out, input_size, decimals, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_around_default_c)(const void*, void*, const size_t, const int) = dpnp_around_c<_DataType>;
+void (*dpnp_around_default_c)(const void *, void *, const size_t, const int) =
+    dpnp_around_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_around_ext_c)(DPCTLSyclQueueRef,
-                                       const void*,
-                                       void*,
+                                       const void *,
+                                       void *,
                                        const size_t,
                                        const int,
-                                       const DPCTLEventVectorRef) = dpnp_around_c<_DataType>;
+                                       const DPCTLEventVectorRef) =
+    dpnp_around_c<_DataType>;
 
-template <typename _KernelNameSpecialization1, typename _KernelNameSpecialization2>
+template <typename _KernelNameSpecialization1,
+          typename _KernelNameSpecialization2>
 class dpnp_elemwise_absolute_c_kernel;
 
 template <typename _DataType_input, typename _DataType_output>
-DPCTLSyclEventRef dpnp_elemwise_absolute_c(DPCTLSyclQueueRef q_ref,
-                                           const void* input1_in,
-                                           void* result1,
-                                           size_t size,
-                                           const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_elemwise_absolute_c(DPCTLSyclQueueRef q_ref,
+                             const void *input1_in,
+                             void *result1,
+                             size_t size,
+                             const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
     sycl::event event;
 
-    _DataType_input* array1 = static_cast<_DataType_input*>(const_cast<void*>(input1_in));
-    _DataType_output* result = static_cast<_DataType_output*>(result1);
+    _DataType_input *array1 =
+        static_cast<_DataType_input *>(const_cast<void *>(input1_in));
+    _DataType_output *result = static_cast<_DataType_output *>(result1);
 
-    if constexpr (is_any_v<_DataType_input, float, double, std::complex<float>, std::complex<double>>)
+    if constexpr (is_any_v<_DataType_input, float, double, std::complex<float>,
+                           std::complex<double>>)
     {
         event = oneapi::mkl::vm::abs(q, size, array1, result);
     }
-    else
-    {
-        static_assert(is_any_v<_DataType_input, int32_t, int64_t>,
-                      "Integer types are only expected to pass in 'abs' kernel");
-        static_assert(std::is_same_v<_DataType_input, _DataType_output>, "Result type must match a type of input data");
+    else {
+        static_assert(
+            is_any_v<_DataType_input, int32_t, int64_t>,
+            "Integer types are only expected to pass in 'abs' kernel");
+        static_assert(std::is_same_v<_DataType_input, _DataType_output>,
+                      "Result type must match a type of input data");
 
-        constexpr size_t lws = 64;
+        constexpr size_t lws          = 64;
         constexpr unsigned int vec_sz = 8;
-        constexpr sycl::access::address_space global_space = sycl::access::address_space::global_space;
+        constexpr sycl::access::address_space global_space =
+            sycl::access::address_space::global_space;
 
-        auto gws_range = sycl::range<1>(((size + lws * vec_sz - 1) / (lws * vec_sz)) * lws);
+        auto gws_range =
+            sycl::range<1>(((size + lws * vec_sz - 1) / (lws * vec_sz)) * lws);
         auto lws_range = sycl::range<1>(lws);
 
         auto kernel_parallel_for_func = [=](sycl::nd_item<1> nd_it) {
-            auto sg = nd_it.get_sub_group();
+            auto sg                = nd_it.get_sub_group();
             const auto max_sg_size = sg.get_max_local_range()[0];
             const size_t start =
-                vec_sz * (nd_it.get_group(0) * nd_it.get_local_range(0) + sg.get_group_id()[0] * max_sg_size);
+                vec_sz * (nd_it.get_group(0) * nd_it.get_local_range(0) +
+                          sg.get_group_id()[0] * max_sg_size);
 
-            if (start + static_cast<size_t>(vec_sz) * max_sg_size < size)
-            {
-                using input_ptrT = sycl::multi_ptr<_DataType_input, global_space>;
-                using result_ptrT = sycl::multi_ptr<_DataType_output, global_space>;
+            if (start + static_cast<size_t>(vec_sz) * max_sg_size < size) {
+                using input_ptrT =
+                    sycl::multi_ptr<_DataType_input, global_space>;
+                using result_ptrT =
+                    sycl::multi_ptr<_DataType_output, global_space>;
 
-                sycl::vec<_DataType_input, vec_sz> data_vec = sg.load<vec_sz>(input_ptrT(&array1[start]));
+                sycl::vec<_DataType_input, vec_sz> data_vec =
+                    sg.load<vec_sz>(input_ptrT(&array1[start]));
 
 #if (__SYCL_COMPILER_VERSION < __SYCL_COMPILER_VECTOR_ABS_CHANGED)
-                // sycl::abs() returns unsigned integers only, so explicit casting to signed ones is required
-                using result_absT = typename cl::sycl::detail::make_unsigned<_DataType_output>::type;
+                // sycl::abs() returns unsigned integers only, so explicit
+                // casting to signed ones is required
+                using result_absT = typename cl::sycl::detail::make_unsigned<
+                    _DataType_output>::type;
                 sycl::vec<_DataType_output, vec_sz> res_vec =
-                    dpnp_vec_cast<_DataType_output, result_absT, vec_sz>(sycl::abs(data_vec));
+                    dpnp_vec_cast<_DataType_output, result_absT, vec_sz>(
+                        sycl::abs(data_vec));
 #else
-                sycl::vec<_DataType_output, vec_sz> res_vec = sycl::abs(data_vec);
+                sycl::vec<_DataType_output, vec_sz> res_vec =
+                    sycl::abs(data_vec);
 #endif
 
                 sg.store<vec_sz>(result_ptrT(&result[start]), res_vec);
             }
-            else
-            {
-                for (size_t k = start + sg.get_local_id()[0]; k < size; k += max_sg_size)
-                {
+            else {
+                for (size_t k = start + sg.get_local_id()[0]; k < size;
+                     k += max_sg_size) {
                     result[k] = std::abs(array1[k]);
                 }
             }
         };
 
-        auto kernel_func = [&](sycl::handler& cgh) {
-            cgh.parallel_for<class dpnp_elemwise_absolute_c_kernel<_DataType_input, _DataType_output>>(
-                sycl::nd_range<1>(gws_range, lws_range), kernel_parallel_for_func);
+        auto kernel_func = [&](sycl::handler &cgh) {
+            cgh.parallel_for<class dpnp_elemwise_absolute_c_kernel<
+                _DataType_input, _DataType_output>>(
+                sycl::nd_range<1>(gws_range, lws_range),
+                kernel_parallel_for_func);
         };
         event = q.submit(kernel_func);
     }
@@ -202,41 +217,43 @@ DPCTLSyclEventRef dpnp_elemwise_absolute_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_elemwise_absolute_c(const void* input1_in, void* result1, size_t size)
+void dpnp_elemwise_absolute_c(const void *input1_in, void *result1, size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_elemwise_absolute_c<_DataType, _DataType>(q_ref,
-                                                                                 input1_in,
-                                                                                 result1,
-                                                                                 size,
-                                                                                 dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_elemwise_absolute_c<_DataType, _DataType>(
+            q_ref, input1_in, result1, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_elemwise_absolute_default_c)(const void*, void*, size_t) = dpnp_elemwise_absolute_c<_DataType>;
+void (*dpnp_elemwise_absolute_default_c)(const void *, void *, size_t) =
+    dpnp_elemwise_absolute_c<_DataType>;
 
 template <typename _DataType_input, typename _DataType_output = _DataType_input>
 DPCTLSyclEventRef (*dpnp_elemwise_absolute_ext_c)(DPCTLSyclQueueRef,
-                                                  const void*,
-                                                  void*,
+                                                  const void *,
+                                                  void *,
                                                   size_t,
-                                                  const DPCTLEventVectorRef) = dpnp_elemwise_absolute_c<_DataType_input, _DataType_output>;
+                                                  const DPCTLEventVectorRef) =
+    dpnp_elemwise_absolute_c<_DataType_input, _DataType_output>;
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
 DPCTLSyclEventRef dpnp_cross_c(DPCTLSyclQueueRef q_ref,
-                               void* result_out,
-                               const void* input1_in,
+                               void *result_out,
+                               const void *input1_in,
                                const size_t input1_size,
-                               const shape_elem_type* input1_shape,
+                               const shape_elem_type *input1_shape,
                                const size_t input1_shape_ndim,
-                               const void* input2_in,
+                               const void *input2_in,
                                const size_t input2_size,
-                               const shape_elem_type* input2_shape,
+                               const shape_elem_type *input2_shape,
                                const size_t input2_shape_ndim,
-                               const size_t* where,
+                               const size_t *where,
                                const DPCTLEventVectorRef dep_event_vec_ref)
 {
     (void)input1_size; // avoid warning unused variable
@@ -249,14 +266,17 @@ DPCTLSyclEventRef dpnp_cross_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    DPNPC_ptr_adapter<_DataType_input1> input1_ptr(q_ref, input1_in, input1_size, true);
-    DPNPC_ptr_adapter<_DataType_input2> input2_ptr(q_ref, input2_in, input2_size, true);
-    DPNPC_ptr_adapter<_DataType_output> result_ptr(q_ref, result_out, input1_size, true, true);
-    const _DataType_input1* input1 = input1_ptr.get_ptr();
-    const _DataType_input2* input2 = input2_ptr.get_ptr();
-    _DataType_output* result = result_ptr.get_ptr();
+    DPNPC_ptr_adapter<_DataType_input1> input1_ptr(q_ref, input1_in,
+                                                   input1_size, true);
+    DPNPC_ptr_adapter<_DataType_input2> input2_ptr(q_ref, input2_in,
+                                                   input2_size, true);
+    DPNPC_ptr_adapter<_DataType_output> result_ptr(q_ref, result_out,
+                                                   input1_size, true, true);
+    const _DataType_input1 *input1 = input1_ptr.get_ptr();
+    const _DataType_input2 *input2 = input2_ptr.get_ptr();
+    _DataType_output *result       = result_ptr.get_ptr();
 
     result[0] = input1[1] * input2[2] - input1[2] * input2[1];
 
@@ -267,69 +287,70 @@ DPCTLSyclEventRef dpnp_cross_c(DPCTLSyclQueueRef q_ref,
     return event_ref;
 }
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
-void dpnp_cross_c(void* result_out,
-                  const void* input1_in,
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
+void dpnp_cross_c(void *result_out,
+                  const void *input1_in,
                   const size_t input1_size,
-                  const shape_elem_type* input1_shape,
+                  const shape_elem_type *input1_shape,
                   const size_t input1_shape_ndim,
-                  const void* input2_in,
+                  const void *input2_in,
                   const size_t input2_size,
-                  const shape_elem_type* input2_shape,
+                  const shape_elem_type *input2_shape,
                   const size_t input2_shape_ndim,
-                  const size_t* where)
+                  const size_t *where)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_cross_c<_DataType_output, _DataType_input1, _DataType_input2>(q_ref,
-                                                                                                     result_out,
-                                                                                                     input1_in,
-                                                                                                     input1_size,
-                                                                                                     input1_shape,
-                                                                                                     input1_shape_ndim,
-                                                                                                     input2_in,
-                                                                                                     input2_size,
-                                                                                                     input2_shape,
-                                                                                                     input2_shape_ndim,
-                                                                                                     where,
-                                                                                                     dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_cross_c<_DataType_output, _DataType_input1, _DataType_input2>(
+            q_ref, result_out, input1_in, input1_size, input1_shape,
+            input1_shape_ndim, input2_in, input2_size, input2_shape,
+            input2_shape_ndim, where, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
-void (*dpnp_cross_default_c)(void*,
-                             const void*,
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
+void (*dpnp_cross_default_c)(void *,
+                             const void *,
                              const size_t,
-                             const shape_elem_type*,
+                             const shape_elem_type *,
                              const size_t,
-                             const void*,
+                             const void *,
                              const size_t,
-                             const shape_elem_type*,
+                             const shape_elem_type *,
                              const size_t,
-                             const size_t*) = dpnp_cross_c<_DataType_output, _DataType_input1, _DataType_input2>;
+                             const size_t *) =
+    dpnp_cross_c<_DataType_output, _DataType_input1, _DataType_input2>;
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
-DPCTLSyclEventRef (*dpnp_cross_ext_c)(
-    DPCTLSyclQueueRef,
-    void*,
-    const void*,
-    const size_t,
-    const shape_elem_type*,
-    const size_t,
-    const void*,
-    const size_t,
-    const shape_elem_type*,
-    const size_t,
-    const size_t*,
-    const DPCTLEventVectorRef) = dpnp_cross_c<_DataType_output, _DataType_input1, _DataType_input2>;
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
+DPCTLSyclEventRef (*dpnp_cross_ext_c)(DPCTLSyclQueueRef,
+                                      void *,
+                                      const void *,
+                                      const size_t,
+                                      const shape_elem_type *,
+                                      const size_t,
+                                      const void *,
+                                      const size_t,
+                                      const shape_elem_type *,
+                                      const size_t,
+                                      const size_t *,
+                                      const DPCTLEventVectorRef) =
+    dpnp_cross_c<_DataType_output, _DataType_input1, _DataType_input2>;
 
-template <typename _KernelNameSpecialization1, typename _KernelNameSpecialization2>
+template <typename _KernelNameSpecialization1,
+          typename _KernelNameSpecialization2>
 class dpnp_cumprod_c_kernel;
 
 template <typename _DataType_input, typename _DataType_output>
 DPCTLSyclEventRef dpnp_cumprod_c(DPCTLSyclQueueRef q_ref,
-                                 void* array1_in,
-                                 void* result1,
+                                 void *array1_in,
+                                 void *result1,
                                  size_t size,
                                  const DPCTLEventVectorRef dep_event_vec_ref)
 {
@@ -338,22 +359,21 @@ DPCTLSyclEventRef dpnp_cumprod_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_DataType_input> input1_ptr(q_ref, array1_in, size, true);
-    DPNPC_ptr_adapter<_DataType_output> result_ptr(q_ref, result1, size, true, true);
-    _DataType_input* array1 = input1_ptr.get_ptr();
-    _DataType_output* result = result_ptr.get_ptr();
+    DPNPC_ptr_adapter<_DataType_output> result_ptr(q_ref, result1, size, true,
+                                                   true);
+    _DataType_input *array1  = input1_ptr.get_ptr();
+    _DataType_output *result = result_ptr.get_ptr();
 
     _DataType_output cur_res = 1;
 
-    for (size_t i = 0; i < size; ++i)
-    {
+    for (size_t i = 0; i < size; ++i) {
         cur_res *= array1[i];
         result[i] = cur_res;
     }
@@ -362,35 +382,36 @@ DPCTLSyclEventRef dpnp_cumprod_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType_input, typename _DataType_output>
-void dpnp_cumprod_c(void* array1_in, void* result1, size_t size)
+void dpnp_cumprod_c(void *array1_in, void *result1, size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_cumprod_c<_DataType_input, _DataType_output>(q_ref,
-                                                                                    array1_in,
-                                                                                    result1,
-                                                                                    size,
-                                                                                    dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_cumprod_c<_DataType_input, _DataType_output>(
+            q_ref, array1_in, result1, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType_input, typename _DataType_output>
-void (*dpnp_cumprod_default_c)(void*, void*, size_t) = dpnp_cumprod_c<_DataType_input, _DataType_output>;
+void (*dpnp_cumprod_default_c)(void *, void *, size_t) =
+    dpnp_cumprod_c<_DataType_input, _DataType_output>;
 
 template <typename _DataType_input, typename _DataType_output>
 DPCTLSyclEventRef (*dpnp_cumprod_ext_c)(DPCTLSyclQueueRef,
-                                        void*,
-                                        void*,
+                                        void *,
+                                        void *,
                                         size_t,
-                                        const DPCTLEventVectorRef) = dpnp_cumprod_c<_DataType_input, _DataType_output>;
+                                        const DPCTLEventVectorRef) =
+    dpnp_cumprod_c<_DataType_input, _DataType_output>;
 
-template <typename _KernelNameSpecialization1, typename _KernelNameSpecialization2>
+template <typename _KernelNameSpecialization1,
+          typename _KernelNameSpecialization2>
 class dpnp_cumsum_c_kernel;
 
 template <typename _DataType_input, typename _DataType_output>
 DPCTLSyclEventRef dpnp_cumsum_c(DPCTLSyclQueueRef q_ref,
-                                void* array1_in,
-                                void* result1,
+                                void *array1_in,
+                                void *result1,
                                 size_t size,
                                 const DPCTLEventVectorRef dep_event_vec_ref)
 {
@@ -399,22 +420,21 @@ DPCTLSyclEventRef dpnp_cumsum_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_DataType_input> input1_ptr(q_ref, array1_in, size, true);
-    DPNPC_ptr_adapter<_DataType_output> result_ptr(q_ref, result1, size, true, true);
-    _DataType_input* array1 = input1_ptr.get_ptr();
-    _DataType_output* result = result_ptr.get_ptr();
+    DPNPC_ptr_adapter<_DataType_output> result_ptr(q_ref, result1, size, true,
+                                                   true);
+    _DataType_input *array1  = input1_ptr.get_ptr();
+    _DataType_output *result = result_ptr.get_ptr();
 
     _DataType_output cur_res = 0;
 
-    for (size_t i = 0; i < size; ++i)
-    {
+    for (size_t i = 0; i < size; ++i) {
         cur_res += array1[i];
         result[i] = cur_res;
     }
@@ -423,44 +443,45 @@ DPCTLSyclEventRef dpnp_cumsum_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType_input, typename _DataType_output>
-void dpnp_cumsum_c(void* array1_in, void* result1, size_t size)
+void dpnp_cumsum_c(void *array1_in, void *result1, size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_cumsum_c<_DataType_input, _DataType_output>(q_ref,
-                                                                                   array1_in,
-                                                                                   result1,
-                                                                                   size,
-                                                                                   dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_cumsum_c<_DataType_input, _DataType_output>(
+            q_ref, array1_in, result1, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType_input, typename _DataType_output>
-void (*dpnp_cumsum_default_c)(void*, void*, size_t) = dpnp_cumsum_c<_DataType_input, _DataType_output>;
+void (*dpnp_cumsum_default_c)(void *, void *, size_t) =
+    dpnp_cumsum_c<_DataType_input, _DataType_output>;
 
 template <typename _DataType_input, typename _DataType_output>
 DPCTLSyclEventRef (*dpnp_cumsum_ext_c)(DPCTLSyclQueueRef,
-                                       void*,
-                                       void*,
+                                       void *,
+                                       void *,
                                        size_t,
-                                       const DPCTLEventVectorRef) = dpnp_cumsum_c<_DataType_input, _DataType_output>;
+                                       const DPCTLEventVectorRef) =
+    dpnp_cumsum_c<_DataType_input, _DataType_output>;
 
-template <typename _KernelNameSpecialization1, typename _KernelNameSpecialization2>
+template <typename _KernelNameSpecialization1,
+          typename _KernelNameSpecialization2>
 class dpnp_ediff1d_c_kernel;
 
 template <typename _DataType_input, typename _DataType_output>
 DPCTLSyclEventRef dpnp_ediff1d_c(DPCTLSyclQueueRef q_ref,
-                                 void* result_out,
+                                 void *result_out,
                                  const size_t result_size,
                                  const size_t result_ndim,
-                                 const shape_elem_type* result_shape,
-                                 const shape_elem_type* result_strides,
-                                 const void* input1_in,
+                                 const shape_elem_type *result_shape,
+                                 const shape_elem_type *result_strides,
+                                 const void *input1_in,
                                  const size_t input1_size,
                                  const size_t input1_ndim,
-                                 const shape_elem_type* input1_shape,
-                                 const shape_elem_type* input1_strides,
-                                 const size_t* where,
+                                 const shape_elem_type *input1_shape,
+                                 const shape_elem_type *input1_strides,
+                                 const size_t *where,
                                  const DPCTLEventVectorRef dep_event_vec_ref)
 {
     /* avoid warning unused variable*/
@@ -475,32 +496,35 @@ DPCTLSyclEventRef dpnp_ediff1d_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!input1_size)
-    {
+    if (!input1_size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    DPNPC_ptr_adapter<_DataType_input> input1_ptr(q_ref, input1_in, input1_size);
-    DPNPC_ptr_adapter<_DataType_output> result_ptr(q_ref, result_out, result_size, false, true);
+    DPNPC_ptr_adapter<_DataType_input> input1_ptr(q_ref, input1_in,
+                                                  input1_size);
+    DPNPC_ptr_adapter<_DataType_output> result_ptr(q_ref, result_out,
+                                                   result_size, false, true);
 
-    _DataType_input* input1_data = input1_ptr.get_ptr();
-    _DataType_output* result = result_ptr.get_ptr();
+    _DataType_input *input1_data = input1_ptr.get_ptr();
+    _DataType_output *result     = result_ptr.get_ptr();
 
     cl::sycl::event event;
     cl::sycl::range<1> gws(result_size);
 
     auto kernel_parallel_for_func = [=](cl::sycl::id<1> global_id) {
-        size_t output_id = global_id[0]; /*for (size_t i = 0; i < result_size; ++i)*/
+        size_t output_id =
+            global_id[0]; /*for (size_t i = 0; i < result_size; ++i)*/
         {
             const _DataType_output curr_elem = input1_data[output_id];
             const _DataType_output next_elem = input1_data[output_id + 1];
-            result[output_id] = next_elem - curr_elem;
+            result[output_id]                = next_elem - curr_elem;
         }
     };
-    auto kernel_func = [&](cl::sycl::handler& cgh) {
-        cgh.parallel_for<class dpnp_ediff1d_c_kernel<_DataType_input, _DataType_output>>(
+    auto kernel_func = [&](cl::sycl::handler &cgh) {
+        cgh.parallel_for<
+            class dpnp_ediff1d_c_kernel<_DataType_input, _DataType_output>>(
             gws, kernel_parallel_for_func);
     };
     event = q.submit(kernel_func);
@@ -513,80 +537,79 @@ DPCTLSyclEventRef dpnp_ediff1d_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType_input, typename _DataType_output>
-void dpnp_ediff1d_c(void* result_out,
+void dpnp_ediff1d_c(void *result_out,
                     const size_t result_size,
                     const size_t result_ndim,
-                    const shape_elem_type* result_shape,
-                    const shape_elem_type* result_strides,
-                    const void* input1_in,
+                    const shape_elem_type *result_shape,
+                    const shape_elem_type *result_strides,
+                    const void *input1_in,
                     const size_t input1_size,
                     const size_t input1_ndim,
-                    const shape_elem_type* input1_shape,
-                    const shape_elem_type* input1_strides,
-                    const size_t* where)
+                    const shape_elem_type *input1_shape,
+                    const shape_elem_type *input1_strides,
+                    const size_t *where)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_ediff1d_c<_DataType_input, _DataType_output>(q_ref,
-                                                                                    result_out,
-                                                                                    result_size,
-                                                                                    result_ndim,
-                                                                                    result_shape,
-                                                                                    result_strides,
-                                                                                    input1_in,
-                                                                                    input1_size,
-                                                                                    input1_ndim,
-                                                                                    input1_shape,
-                                                                                    input1_strides,
-                                                                                    where,
-                                                                                    dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_ediff1d_c<_DataType_input, _DataType_output>(
+            q_ref, result_out, result_size, result_ndim, result_shape,
+            result_strides, input1_in, input1_size, input1_ndim, input1_shape,
+            input1_strides, where, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType_input, typename _DataType_output>
-void (*dpnp_ediff1d_default_c)(void*,
+void (*dpnp_ediff1d_default_c)(void *,
                                const size_t,
                                const size_t,
-                               const shape_elem_type*,
-                               const shape_elem_type*,
-                               const void*,
+                               const shape_elem_type *,
+                               const shape_elem_type *,
+                               const void *,
                                const size_t,
                                const size_t,
-                               const shape_elem_type*,
-                               const shape_elem_type*,
-                               const size_t*) = dpnp_ediff1d_c<_DataType_input, _DataType_output>;
+                               const shape_elem_type *,
+                               const shape_elem_type *,
+                               const size_t *) =
+    dpnp_ediff1d_c<_DataType_input, _DataType_output>;
 
 template <typename _DataType_input, typename _DataType_output>
 DPCTLSyclEventRef (*dpnp_ediff1d_ext_c)(DPCTLSyclQueueRef,
-                                        void*,
+                                        void *,
                                         const size_t,
                                         const size_t,
-                                        const shape_elem_type*,
-                                        const shape_elem_type*,
-                                        const void*,
+                                        const shape_elem_type *,
+                                        const shape_elem_type *,
+                                        const void *,
                                         const size_t,
                                         const size_t,
-                                        const shape_elem_type*,
-                                        const shape_elem_type*,
-                                        const size_t*,
-                                        const DPCTLEventVectorRef) = dpnp_ediff1d_c<_DataType_input, _DataType_output>;
+                                        const shape_elem_type *,
+                                        const shape_elem_type *,
+                                        const size_t *,
+                                        const DPCTLEventVectorRef) =
+    dpnp_ediff1d_c<_DataType_input, _DataType_output>;
 
-template <typename _KernelNameSpecialization1, typename _KernelNameSpecialization2, typename _KernelNameSpecialization3>
+template <typename _KernelNameSpecialization1,
+          typename _KernelNameSpecialization2,
+          typename _KernelNameSpecialization3>
 class dpnp_floor_divide_c_kernel;
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
-DPCTLSyclEventRef dpnp_floor_divide_c(DPCTLSyclQueueRef q_ref,
-                                      void* result_out,
-                                      const void* input1_in,
-                                      const size_t input1_size,
-                                      const shape_elem_type* input1_shape,
-                                      const size_t input1_shape_ndim,
-                                      const void* input2_in,
-                                      const size_t input2_size,
-                                      const shape_elem_type* input2_shape,
-                                      const size_t input2_shape_ndim,
-                                      const size_t* where,
-                                      const DPCTLEventVectorRef dep_event_vec_ref)
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
+DPCTLSyclEventRef
+    dpnp_floor_divide_c(DPCTLSyclQueueRef q_ref,
+                        void *result_out,
+                        const void *input1_in,
+                        const size_t input1_size,
+                        const shape_elem_type *input1_shape,
+                        const size_t input1_shape_ndim,
+                        const void *input2_in,
+                        const size_t input2_size,
+                        const shape_elem_type *input2_shape,
+                        const size_t input2_shape_ndim,
+                        const size_t *where,
+                        const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)where;
@@ -594,33 +617,38 @@ DPCTLSyclEventRef dpnp_floor_divide_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!input1_size || !input2_size)
-    {
+    if (!input1_size || !input2_size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    DPNPC_ptr_adapter<_DataType_input1> input1_ptr(q_ref, input1_in, input1_size);
-    DPNPC_ptr_adapter<_DataType_input2> input2_ptr(q_ref, input2_in, input2_size);
-    _DataType_input1* input1_data = input1_ptr.get_ptr();
-    _DataType_input2* input2_data = input2_ptr.get_ptr();
-    _DataType_output* result = reinterpret_cast<_DataType_output*>(result_out);
+    DPNPC_ptr_adapter<_DataType_input1> input1_ptr(q_ref, input1_in,
+                                                   input1_size);
+    DPNPC_ptr_adapter<_DataType_input2> input2_ptr(q_ref, input2_in,
+                                                   input2_size);
+    _DataType_input1 *input1_data = input1_ptr.get_ptr();
+    _DataType_input2 *input2_data = input2_ptr.get_ptr();
+    _DataType_output *result = reinterpret_cast<_DataType_output *>(result_out);
 
-    std::vector<shape_elem_type> result_shape =
-        get_result_shape(input1_shape, input1_shape_ndim, input2_shape, input2_shape_ndim);
+    std::vector<shape_elem_type> result_shape = get_result_shape(
+        input1_shape, input1_shape_ndim, input2_shape, input2_shape_ndim);
 
-    DPNPC_id<_DataType_input1>* input1_it;
+    DPNPC_id<_DataType_input1> *input1_it;
     const size_t input1_it_size_in_bytes = sizeof(DPNPC_id<_DataType_input1>);
-    input1_it = reinterpret_cast<DPNPC_id<_DataType_input1>*>(dpnp_memory_alloc_c(q_ref, input1_it_size_in_bytes));
-    new (input1_it) DPNPC_id<_DataType_input1>(q_ref, input1_data, input1_shape, input1_shape_ndim);
+    input1_it = reinterpret_cast<DPNPC_id<_DataType_input1> *>(
+        dpnp_memory_alloc_c(q_ref, input1_it_size_in_bytes));
+    new (input1_it) DPNPC_id<_DataType_input1>(q_ref, input1_data, input1_shape,
+                                               input1_shape_ndim);
 
     input1_it->broadcast_to_shape(result_shape);
 
-    DPNPC_id<_DataType_input2>* input2_it;
+    DPNPC_id<_DataType_input2> *input2_it;
     const size_t input2_it_size_in_bytes = sizeof(DPNPC_id<_DataType_input2>);
-    input2_it = reinterpret_cast<DPNPC_id<_DataType_input2>*>(dpnp_memory_alloc_c(q_ref, input2_it_size_in_bytes));
-    new (input2_it) DPNPC_id<_DataType_input2>(q_ref, input2_data, input2_shape, input2_shape_ndim);
+    input2_it = reinterpret_cast<DPNPC_id<_DataType_input2> *>(
+        dpnp_memory_alloc_c(q_ref, input2_it_size_in_bytes));
+    new (input2_it) DPNPC_id<_DataType_input2>(q_ref, input2_data, input2_shape,
+                                               input2_shape_ndim);
 
     input2_it->broadcast_to_shape(result_shape);
 
@@ -628,36 +656,37 @@ DPCTLSyclEventRef dpnp_floor_divide_c(DPCTLSyclQueueRef q_ref,
 
     sycl::range<1> gws(result_size);
     auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
-        const size_t i = global_id[0]; /* for (size_t i = 0; i < result_size; ++i) */
+        const size_t i =
+            global_id[0]; /* for (size_t i = 0; i < result_size; ++i) */
         const _DataType_output input1_elem = (*input1_it)[i];
         const _DataType_output input2_elem = (*input2_it)[i];
 
         double div = (double)input1_elem / (double)input2_elem;
-        result[i] = static_cast<_DataType_output>(sycl::floor(div));
+        result[i]  = static_cast<_DataType_output>(sycl::floor(div));
     };
-    auto kernel_func = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class dpnp_floor_divide_c_kernel<_DataType_output, _DataType_input1, _DataType_input2>>(
+    auto kernel_func = [&](sycl::handler &cgh) {
+        cgh.parallel_for<class dpnp_floor_divide_c_kernel<
+            _DataType_output, _DataType_input1, _DataType_input2>>(
             gws, kernel_parallel_for_func);
     };
 
     sycl::event event;
 
-    if (input1_size == input2_size)
-    {
-        if constexpr ((std::is_same<_DataType_input1, double>::value || std::is_same<_DataType_input1, float>::value) &&
+    if (input1_size == input2_size) {
+        if constexpr ((std::is_same<_DataType_input1, double>::value ||
+                       std::is_same<_DataType_input1, float>::value) &&
                       std::is_same<_DataType_input2, _DataType_input1>::value)
         {
-            event = oneapi::mkl::vm::div(q, input1_size, input1_data, input2_data, result);
+            event = oneapi::mkl::vm::div(q, input1_size, input1_data,
+                                         input2_data, result);
             event.wait();
             event = oneapi::mkl::vm::floor(q, input1_size, result, result);
         }
-        else
-        {
+        else {
             event = q.submit(kernel_func);
         }
     }
-    else
-    {
+    else {
         event = q.submit(kernel_func);
     }
 
@@ -672,73 +701,73 @@ DPCTLSyclEventRef dpnp_floor_divide_c(DPCTLSyclQueueRef q_ref,
     return event_ref;
 }
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
-void dpnp_floor_divide_c(void* result_out,
-                         const void* input1_in,
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
+void dpnp_floor_divide_c(void *result_out,
+                         const void *input1_in,
                          const size_t input1_size,
-                         const shape_elem_type* input1_shape,
+                         const shape_elem_type *input1_shape,
                          const size_t input1_shape_ndim,
-                         const void* input2_in,
+                         const void *input2_in,
                          const size_t input2_size,
-                         const shape_elem_type* input2_shape,
+                         const shape_elem_type *input2_shape,
                          const size_t input2_shape_ndim,
-                         const size_t* where)
+                         const size_t *where)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_floor_divide_c<_DataType_output, _DataType_input1, _DataType_input2>(
-        q_ref,
-        result_out,
-        input1_in,
-        input1_size,
-        input1_shape,
-        input1_shape_ndim,
-        input2_in,
-        input2_size,
-        input2_shape,
-        input2_shape_ndim,
-        where,
-        dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_floor_divide_c<_DataType_output, _DataType_input1,
+                            _DataType_input2>(
+            q_ref, result_out, input1_in, input1_size, input1_shape,
+            input1_shape_ndim, input2_in, input2_size, input2_shape,
+            input2_shape_ndim, where, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
-void (*dpnp_floor_divide_default_c)(
-      void*,
-      const void*,
-      const size_t,
-      const shape_elem_type*,
-      const size_t,
-      const void*,
-      const size_t,
-      const shape_elem_type*,
-      const size_t,
-      const size_t*) = dpnp_floor_divide_c<_DataType_output, _DataType_input1, _DataType_input2>;
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
+void (*dpnp_floor_divide_default_c)(void *,
+                                    const void *,
+                                    const size_t,
+                                    const shape_elem_type *,
+                                    const size_t,
+                                    const void *,
+                                    const size_t,
+                                    const shape_elem_type *,
+                                    const size_t,
+                                    const size_t *) =
+    dpnp_floor_divide_c<_DataType_output, _DataType_input1, _DataType_input2>;
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
-DPCTLSyclEventRef (*dpnp_floor_divide_ext_c)(
-    DPCTLSyclQueueRef,
-    void*,
-    const void*,
-    const size_t,
-    const shape_elem_type*,
-    const size_t,
-    const void*,
-    const size_t,
-    const shape_elem_type*,
-    const size_t,
-    const size_t*,
-    const DPCTLEventVectorRef) = dpnp_floor_divide_c<_DataType_output, _DataType_input1, _DataType_input2>;
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
+DPCTLSyclEventRef (*dpnp_floor_divide_ext_c)(DPCTLSyclQueueRef,
+                                             void *,
+                                             const void *,
+                                             const size_t,
+                                             const shape_elem_type *,
+                                             const size_t,
+                                             const void *,
+                                             const size_t,
+                                             const shape_elem_type *,
+                                             const size_t,
+                                             const size_t *,
+                                             const DPCTLEventVectorRef) =
+    dpnp_floor_divide_c<_DataType_output, _DataType_input1, _DataType_input2>;
 
-template <typename _KernelNameSpecialization1, typename _KernelNameSpecialization2>
+template <typename _KernelNameSpecialization1,
+          typename _KernelNameSpecialization2>
 class dpnp_modf_c_kernel;
 
 template <typename _DataType_input, typename _DataType_output>
 DPCTLSyclEventRef dpnp_modf_c(DPCTLSyclQueueRef q_ref,
-                              void* array1_in,
-                              void* result1_out,
-                              void* result2_out,
+                              void *array1_in,
+                              void *result1_out,
+                              void *result2_out,
                               size_t size,
                               const DPCTLEventVectorRef dep_event_vec_ref)
 {
@@ -747,20 +776,22 @@ DPCTLSyclEventRef dpnp_modf_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
     sycl::event event;
 
     DPNPC_ptr_adapter<_DataType_input> input1_ptr(q_ref, array1_in, size);
-    _DataType_input* array1 = input1_ptr.get_ptr();
-    _DataType_output* result1 = reinterpret_cast<_DataType_output*>(result1_out);
-    _DataType_output* result2 = reinterpret_cast<_DataType_output*>(result2_out);
+    _DataType_input *array1 = input1_ptr.get_ptr();
+    _DataType_output *result1 =
+        reinterpret_cast<_DataType_output *>(result1_out);
+    _DataType_output *result2 =
+        reinterpret_cast<_DataType_output *>(result2_out);
 
-    if constexpr (std::is_same<_DataType_input, double>::value || std::is_same<_DataType_input, float>::value)
+    if constexpr (std::is_same<_DataType_input, double>::value ||
+                  std::is_same<_DataType_input, float>::value)
     {
         event = oneapi::mkl::vm::modf(q, size, array1, result2, result1);
     }
-    else
-    {
+    else {
         sycl::range<1> gws(size);
         auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
             size_t i = global_id[0]; /*for (size_t i = 0; i < size; ++i)*/
@@ -770,9 +801,10 @@ DPCTLSyclEventRef dpnp_modf_c(DPCTLSyclQueueRef q_ref,
             }
         };
 
-        auto kernel_func = [&](sycl::handler& cgh) {
-            cgh.parallel_for<class dpnp_modf_c_kernel<_DataType_input, _DataType_output>>(gws,
-                                                                                          kernel_parallel_for_func);
+        auto kernel_func = [&](sycl::handler &cgh) {
+            cgh.parallel_for<
+                class dpnp_modf_c_kernel<_DataType_input, _DataType_output>>(
+                gws, kernel_parallel_for_func);
         };
 
         event = q.submit(kernel_func);
@@ -784,46 +816,53 @@ DPCTLSyclEventRef dpnp_modf_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType_input, typename _DataType_output>
-void dpnp_modf_c(void* array1_in, void* result1_out, void* result2_out, size_t size)
+void dpnp_modf_c(void *array1_in,
+                 void *result1_out,
+                 void *result2_out,
+                 size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_modf_c<_DataType_input, _DataType_output>(q_ref,
-                                                                                 array1_in,
-                                                                                 result1_out,
-                                                                                 result2_out,
-                                                                                 size,
-                                                                                 dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_modf_c<_DataType_input, _DataType_output>(q_ref, array1_in,
+                                                       result1_out, result2_out,
+                                                       size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType_input, typename _DataType_output>
-void (*dpnp_modf_default_c)(void*, void*, void*, size_t) = dpnp_modf_c<_DataType_input, _DataType_output>;
+void (*dpnp_modf_default_c)(void *, void *, void *, size_t) =
+    dpnp_modf_c<_DataType_input, _DataType_output>;
 
 template <typename _DataType_input, typename _DataType_output>
 DPCTLSyclEventRef (*dpnp_modf_ext_c)(DPCTLSyclQueueRef,
-                                     void*,
-                                     void*,
-                                     void*,
+                                     void *,
+                                     void *,
+                                     void *,
                                      size_t,
-                                     const DPCTLEventVectorRef) = dpnp_modf_c<_DataType_input, _DataType_output>;
+                                     const DPCTLEventVectorRef) =
+    dpnp_modf_c<_DataType_input, _DataType_output>;
 
-template <typename _KernelNameSpecialization1, typename _KernelNameSpecialization2, typename _KernelNameSpecialization3>
+template <typename _KernelNameSpecialization1,
+          typename _KernelNameSpecialization2,
+          typename _KernelNameSpecialization3>
 class dpnp_remainder_c_kernel;
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
 DPCTLSyclEventRef dpnp_remainder_c(DPCTLSyclQueueRef q_ref,
-                                   void* result_out,
-                                   const void* input1_in,
+                                   void *result_out,
+                                   const void *input1_in,
                                    const size_t input1_size,
-                                   const shape_elem_type* input1_shape,
+                                   const shape_elem_type *input1_shape,
                                    const size_t input1_shape_ndim,
-                                   const void* input2_in,
+                                   const void *input2_in,
                                    const size_t input2_size,
-                                   const shape_elem_type* input2_shape,
+                                   const shape_elem_type *input2_shape,
                                    const size_t input2_shape_ndim,
-                                   const size_t* where,
+                                   const size_t *where,
                                    const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
@@ -832,33 +871,38 @@ DPCTLSyclEventRef dpnp_remainder_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!input1_size || !input2_size)
-    {
+    if (!input1_size || !input2_size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    DPNPC_ptr_adapter<_DataType_input1> input1_ptr(q_ref, input1_in, input1_size);
-    DPNPC_ptr_adapter<_DataType_input2> input2_ptr(q_ref, input2_in, input2_size);
-    _DataType_input1* input1_data = input1_ptr.get_ptr();
-    _DataType_input2* input2_data = input2_ptr.get_ptr();
-    _DataType_output* result = reinterpret_cast<_DataType_output*>(result_out);
+    DPNPC_ptr_adapter<_DataType_input1> input1_ptr(q_ref, input1_in,
+                                                   input1_size);
+    DPNPC_ptr_adapter<_DataType_input2> input2_ptr(q_ref, input2_in,
+                                                   input2_size);
+    _DataType_input1 *input1_data = input1_ptr.get_ptr();
+    _DataType_input2 *input2_data = input2_ptr.get_ptr();
+    _DataType_output *result = reinterpret_cast<_DataType_output *>(result_out);
 
-    std::vector<shape_elem_type> result_shape =
-        get_result_shape(input1_shape, input1_shape_ndim, input2_shape, input2_shape_ndim);
+    std::vector<shape_elem_type> result_shape = get_result_shape(
+        input1_shape, input1_shape_ndim, input2_shape, input2_shape_ndim);
 
-    DPNPC_id<_DataType_input1>* input1_it;
+    DPNPC_id<_DataType_input1> *input1_it;
     const size_t input1_it_size_in_bytes = sizeof(DPNPC_id<_DataType_input1>);
-    input1_it = reinterpret_cast<DPNPC_id<_DataType_input1>*>(dpnp_memory_alloc_c(q_ref, input1_it_size_in_bytes));
-    new (input1_it) DPNPC_id<_DataType_input1>(q_ref, input1_data, input1_shape, input1_shape_ndim);
+    input1_it = reinterpret_cast<DPNPC_id<_DataType_input1> *>(
+        dpnp_memory_alloc_c(q_ref, input1_it_size_in_bytes));
+    new (input1_it) DPNPC_id<_DataType_input1>(q_ref, input1_data, input1_shape,
+                                               input1_shape_ndim);
 
     input1_it->broadcast_to_shape(result_shape);
 
-    DPNPC_id<_DataType_input2>* input2_it;
+    DPNPC_id<_DataType_input2> *input2_it;
     const size_t input2_it_size_in_bytes = sizeof(DPNPC_id<_DataType_input2>);
-    input2_it = reinterpret_cast<DPNPC_id<_DataType_input2>*>(dpnp_memory_alloc_c(q_ref, input2_it_size_in_bytes));
-    new (input2_it) DPNPC_id<_DataType_input2>(q_ref, input2_data, input2_shape, input2_shape_ndim);
+    input2_it = reinterpret_cast<DPNPC_id<_DataType_input2> *>(
+        dpnp_memory_alloc_c(q_ref, input2_it_size_in_bytes));
+    new (input2_it) DPNPC_id<_DataType_input2>(q_ref, input2_data, input2_shape,
+                                               input2_shape_ndim);
 
     input2_it->broadcast_to_shape(result_shape);
 
@@ -866,38 +910,40 @@ DPCTLSyclEventRef dpnp_remainder_c(DPCTLSyclQueueRef q_ref,
 
     sycl::range<1> gws(result_size);
     auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
-        const size_t i = global_id[0];
+        const size_t i                     = global_id[0];
         const _DataType_output input1_elem = (*input1_it)[i];
         const _DataType_output input2_elem = (*input2_it)[i];
         double fmod_res = sycl::fmod((double)input1_elem, (double)input2_elem);
-        double add = fmod_res + input2_elem;
-        result[i] = sycl::fmod(add, (double)input2_elem);
+        double add      = fmod_res + input2_elem;
+        result[i]       = sycl::fmod(add, (double)input2_elem);
     };
-    auto kernel_func = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class dpnp_remainder_c_kernel<_DataType_output, _DataType_input1, _DataType_input2>>(
+    auto kernel_func = [&](sycl::handler &cgh) {
+        cgh.parallel_for<class dpnp_remainder_c_kernel<
+            _DataType_output, _DataType_input1, _DataType_input2>>(
             gws, kernel_parallel_for_func);
     };
 
     sycl::event event;
 
-    if (input1_size == input2_size)
-    {
-        if constexpr ((std::is_same<_DataType_input1, double>::value || std::is_same<_DataType_input1, float>::value) &&
+    if (input1_size == input2_size) {
+        if constexpr ((std::is_same<_DataType_input1, double>::value ||
+                       std::is_same<_DataType_input1, float>::value) &&
                       std::is_same<_DataType_input2, _DataType_input1>::value)
         {
-            event = oneapi::mkl::vm::fmod(q, input1_size, input1_data, input2_data, result);
+            event = oneapi::mkl::vm::fmod(q, input1_size, input1_data,
+                                          input2_data, result);
             event.wait();
-            event = oneapi::mkl::vm::add(q, input1_size, result, input2_data, result);
+            event = oneapi::mkl::vm::add(q, input1_size, result, input2_data,
+                                         result);
             event.wait();
-            event = oneapi::mkl::vm::fmod(q, input1_size, result, input2_data, result);
+            event = oneapi::mkl::vm::fmod(q, input1_size, result, input2_data,
+                                          result);
         }
-        else
-        {
+        else {
             event = q.submit(kernel_func);
         }
     }
-    else
-    {
+    else {
         event = q.submit(kernel_func);
     }
 
@@ -909,73 +955,75 @@ DPCTLSyclEventRef dpnp_remainder_c(DPCTLSyclQueueRef q_ref,
     return event_ref;
 }
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
-void dpnp_remainder_c(void* result_out,
-                      const void* input1_in,
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
+void dpnp_remainder_c(void *result_out,
+                      const void *input1_in,
                       const size_t input1_size,
-                      const shape_elem_type* input1_shape,
+                      const shape_elem_type *input1_shape,
                       const size_t input1_shape_ndim,
-                      const void* input2_in,
+                      const void *input2_in,
                       const size_t input2_size,
-                      const shape_elem_type* input2_shape,
+                      const shape_elem_type *input2_shape,
                       const size_t input2_shape_ndim,
-                      const size_t* where)
+                      const size_t *where)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_remainder_c<_DataType_output, _DataType_input1, _DataType_input2>(
-        q_ref,
-        result_out,
-        input1_in,
-        input1_size,
-        input1_shape,
-        input1_shape_ndim,
-        input2_in,
-        input2_size,
-        input2_shape,
-        input2_shape_ndim,
-        where,
-        dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_remainder_c<_DataType_output, _DataType_input1, _DataType_input2>(
+            q_ref, result_out, input1_in, input1_size, input1_shape,
+            input1_shape_ndim, input2_in, input2_size, input2_shape,
+            input2_shape_ndim, where, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
-void (*dpnp_remainder_default_c)(
-    void*,
-    const void*,
-    const size_t,
-    const shape_elem_type*,
-    const size_t,
-    const void*,
-    const size_t,
-    const shape_elem_type*,
-    const size_t,
-    const size_t*) = dpnp_remainder_c<_DataType_output, _DataType_input1, _DataType_input2>;
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
+void (*dpnp_remainder_default_c)(void *,
+                                 const void *,
+                                 const size_t,
+                                 const shape_elem_type *,
+                                 const size_t,
+                                 const void *,
+                                 const size_t,
+                                 const shape_elem_type *,
+                                 const size_t,
+                                 const size_t *) =
+    dpnp_remainder_c<_DataType_output, _DataType_input1, _DataType_input2>;
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
-DPCTLSyclEventRef (*dpnp_remainder_ext_c)(
-    DPCTLSyclQueueRef,
-    void*,
-    const void*,
-    const size_t,
-    const shape_elem_type*,
-    const size_t,
-    const void*,
-    const size_t,
-    const shape_elem_type*,
-    const size_t,
-    const size_t*,
-    const DPCTLEventVectorRef) = dpnp_remainder_c<_DataType_output, _DataType_input1, _DataType_input2>;
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
+DPCTLSyclEventRef (*dpnp_remainder_ext_c)(DPCTLSyclQueueRef,
+                                          void *,
+                                          const void *,
+                                          const size_t,
+                                          const shape_elem_type *,
+                                          const size_t,
+                                          const void *,
+                                          const size_t,
+                                          const shape_elem_type *,
+                                          const size_t,
+                                          const size_t *,
+                                          const DPCTLEventVectorRef) =
+    dpnp_remainder_c<_DataType_output, _DataType_input1, _DataType_input2>;
 
-template <typename _KernelNameSpecialization1, typename _KernelNameSpecialization2, typename _KernelNameSpecialization3>
+template <typename _KernelNameSpecialization1,
+          typename _KernelNameSpecialization2,
+          typename _KernelNameSpecialization3>
 class dpnp_trapz_c_kernel;
 
-template <typename _DataType_input1, typename _DataType_input2, typename _DataType_output>
+template <typename _DataType_input1,
+          typename _DataType_input2,
+          typename _DataType_output>
 DPCTLSyclEventRef dpnp_trapz_c(DPCTLSyclQueueRef q_ref,
-                               const void* array1_in,
-                               const void* array2_in,
-                               void* result1,
+                               const void *array1_in,
+                               const void *array2_in,
+                               void *result1,
                                double dx,
                                size_t array1_size,
                                size_t array2_size,
@@ -986,34 +1034,34 @@ DPCTLSyclEventRef dpnp_trapz_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if ((array1_in == nullptr) || (array2_in == nullptr && array2_size > 1))
-    {
+    if ((array1_in == nullptr) || (array2_in == nullptr && array2_size > 1)) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
     sycl::event event;
 
-    DPNPC_ptr_adapter<_DataType_input1> input1_ptr(q_ref, array1_in, array1_size);
-    DPNPC_ptr_adapter<_DataType_input2> input2_ptr(q_ref, array2_in, array2_size);
-    _DataType_input1* array1 = input1_ptr.get_ptr();
-    _DataType_input2* array2 = input2_ptr.get_ptr();
-    _DataType_output* result = reinterpret_cast<_DataType_output*>(result1);
+    DPNPC_ptr_adapter<_DataType_input1> input1_ptr(q_ref, array1_in,
+                                                   array1_size);
+    DPNPC_ptr_adapter<_DataType_input2> input2_ptr(q_ref, array2_in,
+                                                   array2_size);
+    _DataType_input1 *array1 = input1_ptr.get_ptr();
+    _DataType_input2 *array2 = input2_ptr.get_ptr();
+    _DataType_output *result = reinterpret_cast<_DataType_output *>(result1);
 
-    if (array1_size < 2)
-    {
+    if (array1_size < 2) {
         const _DataType_output init_val = 0;
-        q.memcpy(result, &init_val, sizeof(_DataType_output)).wait(); // result[0] = 0;
+        q.memcpy(result, &init_val, sizeof(_DataType_output))
+            .wait(); // result[0] = 0;
 
         return event_ref;
     }
 
-    if (array1_size == array2_size)
-    {
+    if (array1_size == array2_size) {
         size_t cur_res_size = array1_size - 2;
 
-        _DataType_output* cur_res =
-            reinterpret_cast<_DataType_output*>(sycl::malloc_shared((cur_res_size) * sizeof(_DataType_output), q));
+        _DataType_output *cur_res = reinterpret_cast<_DataType_output *>(
+            sycl::malloc_shared((cur_res_size) * sizeof(_DataType_output), q));
 
         sycl::range<1> gws(cur_res_size);
         auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
@@ -1023,8 +1071,9 @@ DPCTLSyclEventRef dpnp_trapz_c(DPCTLSyclQueueRef q_ref,
             }
         };
 
-        auto kernel_func = [&](sycl::handler& cgh) {
-            cgh.parallel_for<class dpnp_trapz_c_kernel<_DataType_input1, _DataType_input2, _DataType_output>>(
+        auto kernel_func = [&](sycl::handler &cgh) {
+            cgh.parallel_for<class dpnp_trapz_c_kernel<
+                _DataType_input1, _DataType_input2, _DataType_output>>(
                 gws, kernel_parallel_for_func);
         };
 
@@ -1033,19 +1082,21 @@ DPCTLSyclEventRef dpnp_trapz_c(DPCTLSyclQueueRef q_ref,
         event.wait();
 
         shape_elem_type _shape = cur_res_size;
-        dpnp_sum_c<_DataType_output, _DataType_output>(result, cur_res, &_shape, 1, NULL, 0, NULL, NULL);
+        dpnp_sum_c<_DataType_output, _DataType_output>(result, cur_res, &_shape,
+                                                       1, NULL, 0, NULL, NULL);
 
         sycl::free(cur_res, q);
 
         result[0] += array1[0] * (array2[1] - array2[0]) +
-                     array1[array1_size - 1] * (array2[array2_size - 1] - array2[array2_size - 2]);
+                     array1[array1_size - 1] *
+                         (array2[array2_size - 1] - array2[array2_size - 2]);
 
         result[0] *= 0.5;
     }
-    else
-    {
+    else {
         shape_elem_type _shape = array1_size;
-        dpnp_sum_c<_DataType_output, _DataType_input1>(result, array1, &_shape, 1, NULL, 0, NULL, NULL);
+        dpnp_sum_c<_DataType_output, _DataType_input1>(result, array1, &_shape,
+                                                       1, NULL, 0, NULL, NULL);
 
         result[0] -= (array1[0] + array1[array1_size - 1]) * 0.5;
         result[0] *= dx;
@@ -1053,378 +1104,433 @@ DPCTLSyclEventRef dpnp_trapz_c(DPCTLSyclQueueRef q_ref,
     return event_ref;
 }
 
-template <typename _DataType_input1, typename _DataType_input2, typename _DataType_output>
-void dpnp_trapz_c(
-    const void* array1_in, const void* array2_in, void* result1, double dx, size_t array1_size, size_t array2_size)
+template <typename _DataType_input1,
+          typename _DataType_input2,
+          typename _DataType_output>
+void dpnp_trapz_c(const void *array1_in,
+                  const void *array2_in,
+                  void *result1,
+                  double dx,
+                  size_t array1_size,
+                  size_t array2_size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_trapz_c<_DataType_input1, _DataType_input2, _DataType_output>(q_ref,
-                                                                                                     array1_in,
-                                                                                                     array2_in,
-                                                                                                     result1,
-                                                                                                     dx,
-                                                                                                     array1_size,
-                                                                                                     array2_size,
-                                                                                                     dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_trapz_c<_DataType_input1, _DataType_input2, _DataType_output>(
+            q_ref, array1_in, array2_in, result1, dx, array1_size, array2_size,
+            dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
-template <typename _DataType_input1, typename _DataType_input2, typename _DataType_output>
-void (*dpnp_trapz_default_c)(const void*,
-                             const void*,
-                             void*,
+template <typename _DataType_input1,
+          typename _DataType_input2,
+          typename _DataType_output>
+void (*dpnp_trapz_default_c)(const void *,
+                             const void *,
+                             void *,
                              double,
                              size_t,
-                             size_t) = dpnp_trapz_c<_DataType_input1, _DataType_input2, _DataType_output>;
+                             size_t) =
+    dpnp_trapz_c<_DataType_input1, _DataType_input2, _DataType_output>;
 
-template <typename _DataType_input1, typename _DataType_input2, typename _DataType_output>
-DPCTLSyclEventRef (*dpnp_trapz_ext_c)(
-    DPCTLSyclQueueRef,
-    const void*,
-    const void*,
-    void*,
-    double,
-    size_t,
-    size_t,
-    const DPCTLEventVectorRef) = dpnp_trapz_c<_DataType_input1, _DataType_input2, _DataType_output>;
+template <typename _DataType_input1,
+          typename _DataType_input2,
+          typename _DataType_output>
+DPCTLSyclEventRef (*dpnp_trapz_ext_c)(DPCTLSyclQueueRef,
+                                      const void *,
+                                      const void *,
+                                      void *,
+                                      double,
+                                      size_t,
+                                      size_t,
+                                      const DPCTLEventVectorRef) =
+    dpnp_trapz_c<_DataType_input1, _DataType_input2, _DataType_output>;
 
-void func_map_init_mathematical(func_map_t& fmap)
+void func_map_init_mathematical(func_map_t &fmap)
 {
-    fmap[DPNPFuncName::DPNP_FN_ABSOLUTE][eft_INT][eft_INT] = {eft_INT,
-                                                              (void*)dpnp_elemwise_absolute_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ABSOLUTE][eft_LNG][eft_LNG] = {eft_LNG,
-                                                              (void*)dpnp_elemwise_absolute_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ABSOLUTE][eft_FLT][eft_FLT] = {eft_FLT,
-                                                              (void*)dpnp_elemwise_absolute_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_ABSOLUTE][eft_DBL][eft_DBL] = {eft_DBL,
-                                                              (void*)dpnp_elemwise_absolute_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_ABSOLUTE][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_elemwise_absolute_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ABSOLUTE][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_elemwise_absolute_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ABSOLUTE][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_elemwise_absolute_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_ABSOLUTE][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_elemwise_absolute_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_ABSOLUTE_EXT][eft_INT][eft_INT] = {eft_INT,
-                                                                  (void*)dpnp_elemwise_absolute_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ABSOLUTE_EXT][eft_LNG][eft_LNG] = {eft_LNG,
-                                                                  (void*)dpnp_elemwise_absolute_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ABSOLUTE_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_elemwise_absolute_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_ABSOLUTE_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_elemwise_absolute_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_ABSOLUTE_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_elemwise_absolute_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ABSOLUTE_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_elemwise_absolute_ext_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ABSOLUTE_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_elemwise_absolute_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_ABSOLUTE_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_elemwise_absolute_ext_c<double>};
     fmap[DPNPFuncName::DPNP_FN_ABSOLUTE_EXT][eft_C64][eft_C64] = {
-        eft_FLT, (void*)dpnp_elemwise_absolute_ext_c<std::complex<float>, float>};
+        eft_FLT,
+        (void *)dpnp_elemwise_absolute_ext_c<std::complex<float>, float>};
     fmap[DPNPFuncName::DPNP_FN_ABSOLUTE_EXT][eft_C128][eft_C128] = {
-        eft_DBL, (void*)dpnp_elemwise_absolute_ext_c<std::complex<double>, double>};
+        eft_DBL,
+        (void *)dpnp_elemwise_absolute_ext_c<std::complex<double>, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_AROUND][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_around_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_AROUND][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_around_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_AROUND][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_around_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_AROUND][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_around_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_AROUND][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_around_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_AROUND][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_around_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_AROUND][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_around_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_AROUND][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_around_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_AROUND_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_around_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_AROUND_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_around_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_AROUND_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_around_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_AROUND_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_around_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_AROUND_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_around_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_AROUND_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_around_ext_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_AROUND_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_around_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_AROUND_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_around_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_INT][eft_INT] = {eft_INT,
-                                                           (void*)dpnp_cross_default_c<int32_t, int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_INT][eft_LNG] = {eft_LNG,
-                                                           (void*)dpnp_cross_default_c<int64_t, int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_INT][eft_FLT] = {eft_DBL,
-                                                           (void*)dpnp_cross_default_c<double, int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_INT][eft_DBL] = {eft_DBL,
-                                                           (void*)dpnp_cross_default_c<double, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_LNG][eft_INT] = {eft_LNG,
-                                                           (void*)dpnp_cross_default_c<int64_t, int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_LNG][eft_LNG] = {eft_LNG,
-                                                           (void*)dpnp_cross_default_c<int64_t, int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_LNG][eft_FLT] = {eft_DBL,
-                                                           (void*)dpnp_cross_default_c<double, int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_LNG][eft_DBL] = {eft_DBL,
-                                                           (void*)dpnp_cross_default_c<double, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_FLT][eft_INT] = {eft_DBL,
-                                                           (void*)dpnp_cross_default_c<double, float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_FLT][eft_LNG] = {eft_DBL,
-                                                           (void*)dpnp_cross_default_c<double, float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_FLT][eft_FLT] = {eft_FLT,
-                                                           (void*)dpnp_cross_default_c<float, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_FLT][eft_DBL] = {eft_DBL,
-                                                           (void*)dpnp_cross_default_c<double, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_DBL][eft_INT] = {eft_DBL,
-                                                           (void*)dpnp_cross_default_c<double, double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_DBL][eft_LNG] = {eft_DBL,
-                                                           (void*)dpnp_cross_default_c<double, double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_DBL][eft_FLT] = {eft_DBL,
-                                                           (void*)dpnp_cross_default_c<double, double, float>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_DBL][eft_DBL] = {eft_DBL,
-                                                           (void*)dpnp_cross_default_c<double, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_cross_default_c<int32_t, int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_cross_default_c<int64_t, int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_INT][eft_FLT] = {
+        eft_DBL, (void *)dpnp_cross_default_c<double, int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_cross_default_c<double, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_LNG][eft_INT] = {
+        eft_LNG, (void *)dpnp_cross_default_c<int64_t, int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_cross_default_c<int64_t, int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_LNG][eft_FLT] = {
+        eft_DBL, (void *)dpnp_cross_default_c<double, int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_cross_default_c<double, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_FLT][eft_INT] = {
+        eft_DBL, (void *)dpnp_cross_default_c<double, float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_FLT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_cross_default_c<double, float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_cross_default_c<float, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_cross_default_c<double, float, double>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_DBL][eft_INT] = {
+        eft_DBL, (void *)dpnp_cross_default_c<double, double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_DBL][eft_LNG] = {
+        eft_DBL, (void *)dpnp_cross_default_c<double, double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_DBL][eft_FLT] = {
+        eft_DBL, (void *)dpnp_cross_default_c<double, double, float>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_cross_default_c<double, double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_INT][eft_INT] = {eft_INT,
-                                                               (void*)dpnp_cross_ext_c<int32_t, int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_INT][eft_LNG] = {eft_LNG,
-                                                               (void*)dpnp_cross_ext_c<int64_t, int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_INT][eft_FLT] = {eft_DBL,
-                                                               (void*)dpnp_cross_ext_c<double, int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_INT][eft_DBL] = {eft_DBL,
-                                                               (void*)dpnp_cross_ext_c<double, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_LNG][eft_INT] = {eft_LNG,
-                                                               (void*)dpnp_cross_ext_c<int64_t, int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_LNG][eft_LNG] = {eft_LNG,
-                                                               (void*)dpnp_cross_ext_c<int64_t, int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_LNG][eft_FLT] = {eft_DBL,
-                                                               (void*)dpnp_cross_ext_c<double, int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_LNG][eft_DBL] = {eft_DBL,
-                                                               (void*)dpnp_cross_ext_c<double, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_FLT][eft_INT] = {eft_DBL,
-                                                               (void*)dpnp_cross_ext_c<double, float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_FLT][eft_LNG] = {eft_DBL,
-                                                               (void*)dpnp_cross_ext_c<double, float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_FLT][eft_FLT] = {eft_FLT,
-                                                               (void*)dpnp_cross_ext_c<float, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_FLT][eft_DBL] = {eft_DBL,
-                                                               (void*)dpnp_cross_ext_c<double, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_DBL][eft_INT] = {eft_DBL,
-                                                               (void*)dpnp_cross_ext_c<double, double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_DBL][eft_LNG] = {eft_DBL,
-                                                               (void*)dpnp_cross_ext_c<double, double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_DBL][eft_FLT] = {eft_DBL,
-                                                               (void*)dpnp_cross_ext_c<double, double, float>};
-    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_DBL][eft_DBL] = {eft_DBL,
-                                                               (void*)dpnp_cross_ext_c<double, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_cross_ext_c<int32_t, int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_cross_ext_c<int64_t, int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_INT][eft_FLT] = {
+        eft_DBL, (void *)dpnp_cross_ext_c<double, int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_cross_ext_c<double, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_LNG][eft_INT] = {
+        eft_LNG, (void *)dpnp_cross_ext_c<int64_t, int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_cross_ext_c<int64_t, int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_LNG][eft_FLT] = {
+        eft_DBL, (void *)dpnp_cross_ext_c<double, int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_cross_ext_c<double, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_FLT][eft_INT] = {
+        eft_DBL, (void *)dpnp_cross_ext_c<double, float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_FLT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_cross_ext_c<double, float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_cross_ext_c<float, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_cross_ext_c<double, float, double>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_DBL][eft_INT] = {
+        eft_DBL, (void *)dpnp_cross_ext_c<double, double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_DBL][eft_LNG] = {
+        eft_DBL, (void *)dpnp_cross_ext_c<double, double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_DBL][eft_FLT] = {
+        eft_DBL, (void *)dpnp_cross_ext_c<double, double, float>};
+    fmap[DPNPFuncName::DPNP_FN_CROSS_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_cross_ext_c<double, double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_CUMPROD][eft_INT][eft_INT] = {eft_LNG, (void*)dpnp_cumprod_default_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_CUMPROD][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_cumprod_default_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_CUMPROD][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_cumprod_default_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_CUMPROD][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_cumprod_default_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_CUMPROD][eft_INT][eft_INT] = {
+        eft_LNG, (void *)dpnp_cumprod_default_c<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_CUMPROD][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_cumprod_default_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_CUMPROD][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_cumprod_default_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_CUMPROD][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_cumprod_default_c<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_CUMPROD_EXT][eft_INT][eft_INT] = {eft_LNG, (void*)dpnp_cumprod_ext_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_CUMPROD_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_cumprod_ext_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_CUMPROD_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_cumprod_ext_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_CUMPROD_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_cumprod_ext_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_CUMPROD_EXT][eft_INT][eft_INT] = {
+        eft_LNG, (void *)dpnp_cumprod_ext_c<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_CUMPROD_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_cumprod_ext_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_CUMPROD_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_cumprod_ext_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_CUMPROD_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_cumprod_ext_c<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_CUMSUM][eft_INT][eft_INT] = {eft_LNG, (void*)dpnp_cumsum_default_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_CUMSUM][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_cumsum_default_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_CUMSUM][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_cumsum_default_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_CUMSUM][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_cumsum_default_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_CUMSUM][eft_INT][eft_INT] = {
+        eft_LNG, (void *)dpnp_cumsum_default_c<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_CUMSUM][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_cumsum_default_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_CUMSUM][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_cumsum_default_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_CUMSUM][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_cumsum_default_c<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_CUMSUM_EXT][eft_INT][eft_INT] = {eft_LNG, (void*)dpnp_cumsum_ext_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_CUMSUM_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_cumsum_ext_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_CUMSUM_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_cumsum_ext_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_CUMSUM_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_cumsum_ext_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_CUMSUM_EXT][eft_INT][eft_INT] = {
+        eft_LNG, (void *)dpnp_cumsum_ext_c<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_CUMSUM_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_cumsum_ext_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_CUMSUM_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_cumsum_ext_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_CUMSUM_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_cumsum_ext_c<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_EDIFF1D][eft_INT][eft_INT] = {eft_LNG, (void*)dpnp_ediff1d_default_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_EDIFF1D][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_ediff1d_default_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_EDIFF1D][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_ediff1d_default_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_EDIFF1D][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_ediff1d_default_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_EDIFF1D][eft_INT][eft_INT] = {
+        eft_LNG, (void *)dpnp_ediff1d_default_c<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_EDIFF1D][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_ediff1d_default_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_EDIFF1D][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_ediff1d_default_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_EDIFF1D][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_ediff1d_default_c<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_EDIFF1D_EXT][eft_INT][eft_INT] = {eft_LNG, (void*)dpnp_ediff1d_ext_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_EDIFF1D_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_ediff1d_ext_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_EDIFF1D_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_ediff1d_ext_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_EDIFF1D_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_ediff1d_ext_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_EDIFF1D_EXT][eft_INT][eft_INT] = {
+        eft_LNG, (void *)dpnp_ediff1d_ext_c<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_EDIFF1D_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_ediff1d_ext_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_EDIFF1D_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_ediff1d_ext_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_EDIFF1D_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_ediff1d_ext_c<double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE][eft_INT][eft_INT] = {
-        eft_INT, (void*)dpnp_floor_divide_default_c<int32_t, int32_t, int32_t>};
+        eft_INT,
+        (void *)dpnp_floor_divide_default_c<int32_t, int32_t, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE][eft_INT][eft_LNG] = {
-        eft_LNG, (void*)dpnp_floor_divide_default_c<int64_t, int32_t, int64_t>};
+        eft_LNG,
+        (void *)dpnp_floor_divide_default_c<int64_t, int32_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE][eft_INT][eft_FLT] = {
-        eft_DBL, (void*)dpnp_floor_divide_default_c<double, int32_t, float>};
+        eft_DBL, (void *)dpnp_floor_divide_default_c<double, int32_t, float>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE][eft_INT][eft_DBL] = {
-        eft_DBL, (void*)dpnp_floor_divide_default_c<double, int32_t, double>};
+        eft_DBL, (void *)dpnp_floor_divide_default_c<double, int32_t, double>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE][eft_LNG][eft_INT] = {
-        eft_LNG, (void*)dpnp_floor_divide_default_c<int64_t, int64_t, int32_t>};
+        eft_LNG,
+        (void *)dpnp_floor_divide_default_c<int64_t, int64_t, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE][eft_LNG][eft_LNG] = {
-        eft_LNG, (void*)dpnp_floor_divide_default_c<int64_t, int64_t, int64_t>};
+        eft_LNG,
+        (void *)dpnp_floor_divide_default_c<int64_t, int64_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE][eft_LNG][eft_FLT] = {
-        eft_DBL, (void*)dpnp_floor_divide_default_c<double, int64_t, float>};
+        eft_DBL, (void *)dpnp_floor_divide_default_c<double, int64_t, float>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE][eft_LNG][eft_DBL] = {
-        eft_DBL, (void*)dpnp_floor_divide_default_c<double, int64_t, double>};
+        eft_DBL, (void *)dpnp_floor_divide_default_c<double, int64_t, double>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE][eft_FLT][eft_INT] = {
-        eft_DBL, (void*)dpnp_floor_divide_default_c<double, float, int32_t>};
+        eft_DBL, (void *)dpnp_floor_divide_default_c<double, float, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE][eft_FLT][eft_LNG] = {
-        eft_DBL, (void*)dpnp_floor_divide_default_c<double, float, int64_t>};
+        eft_DBL, (void *)dpnp_floor_divide_default_c<double, float, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE][eft_FLT][eft_FLT] = {
-        eft_FLT, (void*)dpnp_floor_divide_default_c<float, float, float>};
+        eft_FLT, (void *)dpnp_floor_divide_default_c<float, float, float>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE][eft_FLT][eft_DBL] = {
-        eft_DBL, (void*)dpnp_floor_divide_default_c<double, float, double>};
+        eft_DBL, (void *)dpnp_floor_divide_default_c<double, float, double>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE][eft_DBL][eft_INT] = {
-        eft_DBL, (void*)dpnp_floor_divide_default_c<double, double, int32_t>};
+        eft_DBL, (void *)dpnp_floor_divide_default_c<double, double, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE][eft_DBL][eft_LNG] = {
-        eft_DBL, (void*)dpnp_floor_divide_default_c<double, double, int64_t>};
+        eft_DBL, (void *)dpnp_floor_divide_default_c<double, double, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE][eft_DBL][eft_FLT] = {
-        eft_DBL, (void*)dpnp_floor_divide_default_c<double, double, float>};
+        eft_DBL, (void *)dpnp_floor_divide_default_c<double, double, float>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE][eft_DBL][eft_DBL] = {
-        eft_DBL, (void*)dpnp_floor_divide_default_c<double, double, double>};
+        eft_DBL, (void *)dpnp_floor_divide_default_c<double, double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE_EXT][eft_INT][eft_INT] = {
-        eft_INT, (void*)dpnp_floor_divide_ext_c<int32_t, int32_t, int32_t>};
+        eft_INT, (void *)dpnp_floor_divide_ext_c<int32_t, int32_t, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE_EXT][eft_INT][eft_LNG] = {
-        eft_LNG, (void*)dpnp_floor_divide_ext_c<int64_t, int32_t, int64_t>};
+        eft_LNG, (void *)dpnp_floor_divide_ext_c<int64_t, int32_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE_EXT][eft_INT][eft_FLT] = {
-        eft_DBL, (void*)dpnp_floor_divide_ext_c<double, int32_t, float>};
+        eft_DBL, (void *)dpnp_floor_divide_ext_c<double, int32_t, float>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE_EXT][eft_INT][eft_DBL] = {
-        eft_DBL, (void*)dpnp_floor_divide_ext_c<double, int32_t, double>};
+        eft_DBL, (void *)dpnp_floor_divide_ext_c<double, int32_t, double>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE_EXT][eft_LNG][eft_INT] = {
-        eft_LNG, (void*)dpnp_floor_divide_ext_c<int64_t, int64_t, int32_t>};
+        eft_LNG, (void *)dpnp_floor_divide_ext_c<int64_t, int64_t, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE_EXT][eft_LNG][eft_LNG] = {
-        eft_LNG, (void*)dpnp_floor_divide_ext_c<int64_t, int64_t, int64_t>};
+        eft_LNG, (void *)dpnp_floor_divide_ext_c<int64_t, int64_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE_EXT][eft_LNG][eft_FLT] = {
-        eft_DBL, (void*)dpnp_floor_divide_ext_c<double, int64_t, float>};
+        eft_DBL, (void *)dpnp_floor_divide_ext_c<double, int64_t, float>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE_EXT][eft_LNG][eft_DBL] = {
-        eft_DBL, (void*)dpnp_floor_divide_ext_c<double, int64_t, double>};
+        eft_DBL, (void *)dpnp_floor_divide_ext_c<double, int64_t, double>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE_EXT][eft_FLT][eft_INT] = {
-        eft_DBL, (void*)dpnp_floor_divide_ext_c<double, float, int32_t>};
+        eft_DBL, (void *)dpnp_floor_divide_ext_c<double, float, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE_EXT][eft_FLT][eft_LNG] = {
-        eft_DBL, (void*)dpnp_floor_divide_ext_c<double, float, int64_t>};
+        eft_DBL, (void *)dpnp_floor_divide_ext_c<double, float, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE_EXT][eft_FLT][eft_FLT] = {
-        eft_FLT, (void*)dpnp_floor_divide_ext_c<float, float, float>};
+        eft_FLT, (void *)dpnp_floor_divide_ext_c<float, float, float>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE_EXT][eft_FLT][eft_DBL] = {
-        eft_DBL, (void*)dpnp_floor_divide_ext_c<double, float, double>};
+        eft_DBL, (void *)dpnp_floor_divide_ext_c<double, float, double>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE_EXT][eft_DBL][eft_INT] = {
-        eft_DBL, (void*)dpnp_floor_divide_ext_c<double, double, int32_t>};
+        eft_DBL, (void *)dpnp_floor_divide_ext_c<double, double, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE_EXT][eft_DBL][eft_LNG] = {
-        eft_DBL, (void*)dpnp_floor_divide_ext_c<double, double, int64_t>};
+        eft_DBL, (void *)dpnp_floor_divide_ext_c<double, double, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE_EXT][eft_DBL][eft_FLT] = {
-        eft_DBL, (void*)dpnp_floor_divide_ext_c<double, double, float>};
+        eft_DBL, (void *)dpnp_floor_divide_ext_c<double, double, float>};
     fmap[DPNPFuncName::DPNP_FN_FLOOR_DIVIDE_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void*)dpnp_floor_divide_ext_c<double, double, double>};
+        eft_DBL, (void *)dpnp_floor_divide_ext_c<double, double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_MODF][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_modf_default_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_MODF][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_modf_default_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_MODF][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_modf_default_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_MODF][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_modf_default_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_MODF][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_modf_default_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_MODF][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_modf_default_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_MODF][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_modf_default_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_MODF][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_modf_default_c<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_MODF_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_modf_ext_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_MODF_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_modf_ext_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_MODF_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_modf_ext_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_MODF_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_modf_ext_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_MODF_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_modf_ext_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_MODF_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_modf_ext_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_MODF_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_modf_ext_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_MODF_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_modf_ext_c<double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_REMAINDER][eft_INT][eft_INT] = {
-        eft_INT, (void*)dpnp_remainder_default_c<int32_t, int32_t, int32_t>};
+        eft_INT, (void *)dpnp_remainder_default_c<int32_t, int32_t, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER][eft_INT][eft_LNG] = {
-        eft_LNG, (void*)dpnp_remainder_default_c<int64_t, int32_t, int64_t>};
+        eft_LNG, (void *)dpnp_remainder_default_c<int64_t, int32_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER][eft_INT][eft_FLT] = {
-        eft_DBL, (void*)dpnp_remainder_default_c<double, int32_t, float>};
+        eft_DBL, (void *)dpnp_remainder_default_c<double, int32_t, float>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER][eft_INT][eft_DBL] = {
-        eft_DBL, (void*)dpnp_remainder_default_c<double, int32_t, double>};
+        eft_DBL, (void *)dpnp_remainder_default_c<double, int32_t, double>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER][eft_LNG][eft_INT] = {
-        eft_LNG, (void*)dpnp_remainder_default_c<int64_t, int64_t, int32_t>};
+        eft_LNG, (void *)dpnp_remainder_default_c<int64_t, int64_t, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER][eft_LNG][eft_LNG] = {
-        eft_LNG, (void*)dpnp_remainder_default_c<int64_t, int64_t, int64_t>};
+        eft_LNG, (void *)dpnp_remainder_default_c<int64_t, int64_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER][eft_LNG][eft_FLT] = {
-        eft_DBL, (void*)dpnp_remainder_default_c<double, int64_t, float>};
+        eft_DBL, (void *)dpnp_remainder_default_c<double, int64_t, float>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER][eft_LNG][eft_DBL] = {
-        eft_DBL, (void*)dpnp_remainder_default_c<double, int64_t, double>};
+        eft_DBL, (void *)dpnp_remainder_default_c<double, int64_t, double>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER][eft_FLT][eft_INT] = {
-        eft_DBL, (void*)dpnp_remainder_default_c<double, float, int32_t>};
+        eft_DBL, (void *)dpnp_remainder_default_c<double, float, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER][eft_FLT][eft_LNG] = {
-        eft_DBL, (void*)dpnp_remainder_default_c<double, float, int64_t>};
+        eft_DBL, (void *)dpnp_remainder_default_c<double, float, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER][eft_FLT][eft_FLT] = {
-        eft_FLT, (void*)dpnp_remainder_default_c<float, float, float>};
+        eft_FLT, (void *)dpnp_remainder_default_c<float, float, float>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER][eft_FLT][eft_DBL] = {
-        eft_DBL, (void*)dpnp_remainder_default_c<double, float, double>};
+        eft_DBL, (void *)dpnp_remainder_default_c<double, float, double>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER][eft_DBL][eft_INT] = {
-        eft_DBL, (void*)dpnp_remainder_default_c<double, double, int32_t>};
+        eft_DBL, (void *)dpnp_remainder_default_c<double, double, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER][eft_DBL][eft_LNG] = {
-        eft_DBL, (void*)dpnp_remainder_default_c<double, double, int64_t>};
+        eft_DBL, (void *)dpnp_remainder_default_c<double, double, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER][eft_DBL][eft_FLT] = {
-        eft_DBL, (void*)dpnp_remainder_default_c<double, double, float>};
+        eft_DBL, (void *)dpnp_remainder_default_c<double, double, float>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER][eft_DBL][eft_DBL] = {
-        eft_DBL, (void*)dpnp_remainder_default_c<double, double, double>};
+        eft_DBL, (void *)dpnp_remainder_default_c<double, double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_REMAINDER_EXT][eft_INT][eft_INT] = {
-        eft_INT, (void*)dpnp_remainder_ext_c<int32_t, int32_t, int32_t>};
+        eft_INT, (void *)dpnp_remainder_ext_c<int32_t, int32_t, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER_EXT][eft_INT][eft_LNG] = {
-        eft_LNG, (void*)dpnp_remainder_ext_c<int64_t, int32_t, int64_t>};
+        eft_LNG, (void *)dpnp_remainder_ext_c<int64_t, int32_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER_EXT][eft_INT][eft_FLT] = {
-        eft_DBL, (void*)dpnp_remainder_ext_c<double, int32_t, float>};
+        eft_DBL, (void *)dpnp_remainder_ext_c<double, int32_t, float>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER_EXT][eft_INT][eft_DBL] = {
-        eft_DBL, (void*)dpnp_remainder_ext_c<double, int32_t, double>};
+        eft_DBL, (void *)dpnp_remainder_ext_c<double, int32_t, double>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER_EXT][eft_LNG][eft_INT] = {
-        eft_LNG, (void*)dpnp_remainder_ext_c<int64_t, int64_t, int32_t>};
+        eft_LNG, (void *)dpnp_remainder_ext_c<int64_t, int64_t, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER_EXT][eft_LNG][eft_LNG] = {
-        eft_LNG, (void*)dpnp_remainder_ext_c<int64_t, int64_t, int64_t>};
+        eft_LNG, (void *)dpnp_remainder_ext_c<int64_t, int64_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER_EXT][eft_LNG][eft_FLT] = {
-        eft_DBL, (void*)dpnp_remainder_ext_c<double, int64_t, float>};
+        eft_DBL, (void *)dpnp_remainder_ext_c<double, int64_t, float>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER_EXT][eft_LNG][eft_DBL] = {
-        eft_DBL, (void*)dpnp_remainder_ext_c<double, int64_t, double>};
+        eft_DBL, (void *)dpnp_remainder_ext_c<double, int64_t, double>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER_EXT][eft_FLT][eft_INT] = {
-        eft_DBL, (void*)dpnp_remainder_ext_c<double, float, int32_t>};
+        eft_DBL, (void *)dpnp_remainder_ext_c<double, float, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER_EXT][eft_FLT][eft_LNG] = {
-        eft_DBL, (void*)dpnp_remainder_ext_c<double, float, int64_t>};
+        eft_DBL, (void *)dpnp_remainder_ext_c<double, float, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER_EXT][eft_FLT][eft_FLT] = {
-        eft_FLT, (void*)dpnp_remainder_ext_c<float, float, float>};
+        eft_FLT, (void *)dpnp_remainder_ext_c<float, float, float>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER_EXT][eft_FLT][eft_DBL] = {
-        eft_DBL, (void*)dpnp_remainder_ext_c<double, float, double>};
+        eft_DBL, (void *)dpnp_remainder_ext_c<double, float, double>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER_EXT][eft_DBL][eft_INT] = {
-        eft_DBL, (void*)dpnp_remainder_ext_c<double, double, int32_t>};
+        eft_DBL, (void *)dpnp_remainder_ext_c<double, double, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER_EXT][eft_DBL][eft_LNG] = {
-        eft_DBL, (void*)dpnp_remainder_ext_c<double, double, int64_t>};
+        eft_DBL, (void *)dpnp_remainder_ext_c<double, double, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER_EXT][eft_DBL][eft_FLT] = {
-        eft_DBL, (void*)dpnp_remainder_ext_c<double, double, float>};
+        eft_DBL, (void *)dpnp_remainder_ext_c<double, double, float>};
     fmap[DPNPFuncName::DPNP_FN_REMAINDER_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void*)dpnp_remainder_ext_c<double, double, double>};
+        eft_DBL, (void *)dpnp_remainder_ext_c<double, double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_INT][eft_INT] = {eft_DBL,
-                                                           (void*)dpnp_trapz_default_c<int32_t, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_INT][eft_LNG] = {eft_DBL,
-                                                           (void*)dpnp_trapz_default_c<int32_t, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_INT][eft_FLT] = {eft_DBL,
-                                                           (void*)dpnp_trapz_default_c<int32_t, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_INT][eft_DBL] = {eft_DBL,
-                                                           (void*)dpnp_trapz_default_c<int32_t, double, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_LNG][eft_INT] = {eft_DBL,
-                                                           (void*)dpnp_trapz_default_c<int64_t, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_LNG][eft_LNG] = {eft_DBL,
-                                                           (void*)dpnp_trapz_default_c<int64_t, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_LNG][eft_FLT] = {eft_DBL,
-                                                           (void*)dpnp_trapz_default_c<int64_t, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_LNG][eft_DBL] = {eft_DBL,
-                                                           (void*)dpnp_trapz_default_c<int64_t, double, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_FLT][eft_INT] = {eft_DBL,
-                                                           (void*)dpnp_trapz_default_c<float, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_FLT][eft_LNG] = {eft_DBL,
-                                                           (void*)dpnp_trapz_default_c<float, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_FLT][eft_FLT] = {eft_FLT,
-                                                           (void*)dpnp_trapz_default_c<float, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_FLT][eft_DBL] = {eft_DBL,
-                                                           (void*)dpnp_trapz_default_c<float, double, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_DBL][eft_INT] = {eft_DBL,
-                                                           (void*)dpnp_trapz_default_c<double, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_DBL][eft_LNG] = {eft_DBL,
-                                                           (void*)dpnp_trapz_default_c<double, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_DBL][eft_FLT] = {eft_DBL,
-                                                           (void*)dpnp_trapz_default_c<double, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_DBL][eft_DBL] = {eft_DBL,
-                                                           (void*)dpnp_trapz_default_c<double, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_trapz_default_c<int32_t, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_INT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_trapz_default_c<int32_t, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_INT][eft_FLT] = {
+        eft_DBL, (void *)dpnp_trapz_default_c<int32_t, float, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_trapz_default_c<int32_t, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_LNG][eft_INT] = {
+        eft_DBL, (void *)dpnp_trapz_default_c<int64_t, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_trapz_default_c<int64_t, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_LNG][eft_FLT] = {
+        eft_DBL, (void *)dpnp_trapz_default_c<int64_t, float, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_trapz_default_c<int64_t, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_FLT][eft_INT] = {
+        eft_DBL, (void *)dpnp_trapz_default_c<float, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_FLT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_trapz_default_c<float, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_trapz_default_c<float, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_trapz_default_c<float, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_DBL][eft_INT] = {
+        eft_DBL, (void *)dpnp_trapz_default_c<double, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_DBL][eft_LNG] = {
+        eft_DBL, (void *)dpnp_trapz_default_c<double, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_DBL][eft_FLT] = {
+        eft_DBL, (void *)dpnp_trapz_default_c<double, float, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_trapz_default_c<double, double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_INT][eft_INT] = {eft_DBL,
-                                                               (void*)dpnp_trapz_ext_c<int32_t, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_INT][eft_LNG] = {eft_DBL,
-                                                               (void*)dpnp_trapz_ext_c<int32_t, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_INT][eft_FLT] = {eft_DBL,
-                                                               (void*)dpnp_trapz_ext_c<int32_t, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_INT][eft_DBL] = {eft_DBL,
-                                                               (void*)dpnp_trapz_ext_c<int32_t, double, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_LNG][eft_INT] = {eft_DBL,
-                                                               (void*)dpnp_trapz_ext_c<int64_t, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_LNG][eft_LNG] = {eft_DBL,
-                                                               (void*)dpnp_trapz_ext_c<int64_t, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_LNG][eft_FLT] = {eft_DBL,
-                                                               (void*)dpnp_trapz_ext_c<int64_t, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_LNG][eft_DBL] = {eft_DBL,
-                                                               (void*)dpnp_trapz_ext_c<int64_t, double, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_FLT][eft_INT] = {eft_DBL,
-                                                               (void*)dpnp_trapz_ext_c<float, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_FLT][eft_LNG] = {eft_DBL,
-                                                               (void*)dpnp_trapz_ext_c<float, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_FLT][eft_FLT] = {eft_FLT,
-                                                               (void*)dpnp_trapz_ext_c<float, float, float>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_FLT][eft_DBL] = {eft_DBL,
-                                                               (void*)dpnp_trapz_ext_c<float, double, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_DBL][eft_INT] = {eft_DBL,
-                                                               (void*)dpnp_trapz_ext_c<double, int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_DBL][eft_LNG] = {eft_DBL,
-                                                               (void*)dpnp_trapz_ext_c<double, int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_DBL][eft_FLT] = {eft_DBL,
-                                                               (void*)dpnp_trapz_ext_c<double, float, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_DBL][eft_DBL] = {eft_DBL,
-                                                               (void*)dpnp_trapz_ext_c<double, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_trapz_ext_c<int32_t, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_INT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_trapz_ext_c<int32_t, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_INT][eft_FLT] = {
+        eft_DBL, (void *)dpnp_trapz_ext_c<int32_t, float, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_trapz_ext_c<int32_t, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_LNG][eft_INT] = {
+        eft_DBL, (void *)dpnp_trapz_ext_c<int64_t, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_trapz_ext_c<int64_t, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_LNG][eft_FLT] = {
+        eft_DBL, (void *)dpnp_trapz_ext_c<int64_t, float, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_trapz_ext_c<int64_t, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_FLT][eft_INT] = {
+        eft_DBL, (void *)dpnp_trapz_ext_c<float, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_FLT][eft_LNG] = {
+        eft_DBL, (void *)dpnp_trapz_ext_c<float, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_trapz_ext_c<float, float, float>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_trapz_ext_c<float, double, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_DBL][eft_INT] = {
+        eft_DBL, (void *)dpnp_trapz_ext_c<double, int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_DBL][eft_LNG] = {
+        eft_DBL, (void *)dpnp_trapz_ext_c<double, int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_DBL][eft_FLT] = {
+        eft_DBL, (void *)dpnp_trapz_ext_c<double, float, double>};
+    fmap[DPNPFuncName::DPNP_FN_TRAPZ_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_trapz_ext_c<double, double, double>};
 
     return;
 }

--- a/dpnp/backend/kernels/dpnp_krnl_random.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_random.cpp
@@ -41,8 +41,8 @@ static_assert(INTEL_MKL_VERSION >= __INTEL_MKL_2023_VERSION_REQUIRED,
               "MKL does not meet minimum version requirement");
 
 namespace mkl_blas = oneapi::mkl::blas;
-namespace mkl_rng  = oneapi::mkl::rng;
-namespace mkl_vm   = oneapi::mkl::vm;
+namespace mkl_rng = oneapi::mkl::rng;
+namespace mkl_vm = oneapi::mkl::vm;
 
 /**
  * Use get/set functions to access/modify this variable
@@ -188,7 +188,7 @@ void dpnp_rng_beta_c(void *result,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_rng_beta_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_rng_beta_c<_DataType>(
         q_ref, result, a, b, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -263,7 +263,7 @@ void dpnp_rng_binomial_c(void *result,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_rng_binomial_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_rng_binomial_c<_DataType>(
         q_ref, result, ntrial, p, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -319,7 +319,7 @@ void dpnp_rng_chisquare_c(void *result, const int df, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_rng_chisquare_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_rng_chisquare_c<_DataType>(
         q_ref, result, df, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -377,7 +377,7 @@ void dpnp_rng_exponential_c(void *result,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_rng_exponential_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_rng_exponential_c<_DataType>(
         q_ref, result, beta, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -418,7 +418,7 @@ DPCTLSyclEventRef dpnp_rng_f_c(DPCTLSyclQueueRef q_ref,
 
     _DataType shape = 0.5 * df_num;
     _DataType scale = 2.0 / df_num;
-    _DataType *den  = nullptr;
+    _DataType *den = nullptr;
 
     DPNPC_ptr_adapter<_DataType> result1_ptr(q_ref, result, size, true, true);
     _DataType *result1 = result1_ptr.get_ptr();
@@ -454,7 +454,7 @@ void dpnp_rng_f_c(void *result,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_rng_f_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_rng_f_c<_DataType>(
         q_ref, result, df_num, df_den, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -500,7 +500,7 @@ DPCTLSyclEventRef dpnp_rng_gamma_c(DPCTLSyclQueueRef q_ref,
     }
     else {
         _DataType *result1 = reinterpret_cast<_DataType *>(result);
-        const _DataType a  = (_DataType(0.0));
+        const _DataType a = (_DataType(0.0));
 
         mkl_rng::gamma<_DataType> distribution(shape, a, scale);
         event_out =
@@ -519,7 +519,7 @@ void dpnp_rng_gamma_c(void *result,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_rng_gamma_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_rng_gamma_c<_DataType>(
         q_ref, result, shape, scale, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -578,7 +578,7 @@ void dpnp_rng_gaussian_c(void *result,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_rng_gaussian_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_rng_gaussian_c<_DataType>(
         q_ref, result, mean, stddev, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -639,7 +639,7 @@ void dpnp_rng_geometric_c(void *result, const float p, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_rng_geometric_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_rng_geometric_c<_DataType>(
         q_ref, result, p, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -688,9 +688,9 @@ DPCTLSyclEventRef dpnp_rng_gumbel_c(DPCTLSyclQueueRef q_ref,
     }
     else {
         const _DataType alpha = (_DataType(-1.0));
-        std::int64_t incx     = 1;
-        _DataType *result1    = reinterpret_cast<_DataType *>(result);
-        double negloc         = loc * (double(-1.0));
+        std::int64_t incx = 1;
+        _DataType *result1 = reinterpret_cast<_DataType *>(result);
+        double negloc = loc * (double(-1.0));
 
         mkl_rng::gumbel<_DataType> distribution(negloc, scale);
         auto event_distribution =
@@ -711,7 +711,7 @@ void dpnp_rng_gumbel_c(void *result,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_rng_gumbel_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_rng_gumbel_c<_DataType>(
         q_ref, result, loc, scale, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -853,7 +853,7 @@ void dpnp_rng_laplace_c(void *result,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_rng_laplace_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_rng_laplace_c<_DataType>(
         q_ref, result, loc, scale, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -899,7 +899,7 @@ DPCTLSyclEventRef
     sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     const _DataType d_zero = _DataType(0.0);
-    const _DataType d_one  = _DataType(1.0);
+    const _DataType d_one = _DataType(1.0);
 
     _DataType *result1 = reinterpret_cast<_DataType *>(result);
 
@@ -909,7 +909,7 @@ DPCTLSyclEventRef
 
     sycl::range<1> gws(size);
     auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
-        size_t i   = global_id[0];
+        size_t i = global_id[0];
         result1[i] = sycl::log(result1[i] / (1.0 - result1[i]));
         result1[i] = loc + scale * result1[i];
     };
@@ -919,7 +919,7 @@ DPCTLSyclEventRef
             gws, kernel_parallel_for_func);
     };
     auto event = q.submit(kernel_func);
-    event_ref  = reinterpret_cast<DPCTLSyclEventRef>(&event);
+    event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
 
     return DPCTLEvent_Copy(event_ref);
 }
@@ -932,7 +932,7 @@ void dpnp_rng_logistic_c(void *result,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_rng_logistic_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_rng_logistic_c<_DataType>(
         q_ref, result, loc, scale, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -989,7 +989,7 @@ DPCTLSyclEventRef
     }
     else {
         const _DataType displacement = _DataType(0.0);
-        const _DataType scalefactor  = _DataType(1.0);
+        const _DataType scalefactor = _DataType(1.0);
 
         mkl_rng::lognormal<_DataType> distribution(mean, stddev, displacement,
                                                    scalefactor);
@@ -1008,7 +1008,7 @@ void dpnp_rng_lognormal_c(void *result,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_rng_lognormal_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_rng_lognormal_c<_DataType>(
         q_ref, result, mean, stddev, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -1092,7 +1092,7 @@ DPCTLSyclEventRef
             DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result, size, true,
                                                     true);
             _DataType *result1 = result_ptr.get_ptr();
-            int errcode        = viRngMultinomial(
+            int errcode = viRngMultinomial(
                 VSL_RNG_METHOD_MULTINOMIAL_MULTPOISSON, get_rng_stream(), n,
                 result1, ntrial, p_size, p_data);
             if (errcode != VSL_STATUS_OK) {
@@ -1113,7 +1113,7 @@ void dpnp_rng_multinomial_c(void *result,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_rng_multinomial_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_rng_multinomial_c<_DataType>(
         q_ref, result, ntrial, p_in, p_size, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
@@ -1168,7 +1168,7 @@ DPCTLSyclEventRef
     _DataType *result1 = static_cast<_DataType *>(result);
 
     auto mean = sycl::span<double>{mean_data, mean_size};
-    auto cov  = sycl::span<double>{cov_data, cov_size};
+    auto cov = sycl::span<double>{cov_data, cov_size};
 
     // `result` is a array for random numbers
     // `size` is a `result`'s len.
@@ -1314,8 +1314,8 @@ DPCTLSyclEventRef
     _DataType *result1 = result1_ptr.get_ptr();
 
     const _DataType d_zero = _DataType(0.0);
-    const _DataType d_one  = _DataType(1.0);
-    const _DataType d_two  = _DataType(2.0);
+    const _DataType d_one = _DataType(1.0);
+    const _DataType d_two = _DataType(2.0);
 
     _DataType shape, loc;
     size_t i;
@@ -1362,15 +1362,15 @@ DPCTLSyclEventRef
 
         shape = 0.5 * df;
         if (0.125 * size > sqrt(lambda)) {
-            size_t *idx    = nullptr;
+            size_t *idx = nullptr;
             _DataType *tmp = nullptr;
-            idx            = reinterpret_cast<size_t *>(
+            idx = reinterpret_cast<size_t *>(
                 sycl::malloc_shared(size * sizeof(size_t), q));
 
             sycl::range<1> gws1(size);
             auto kernel_parallel_for_func1 = [=](sycl::id<1> global_id) {
                 size_t i = global_id[0];
-                idx[i]   = i;
+                idx[i] = i;
             };
             auto kernel_func1 = [&](sycl::handler &cgh) {
                 cgh.parallel_for<
@@ -1409,7 +1409,7 @@ DPCTLSyclEventRef
 
                 sycl::range<1> gws2(j - i);
                 auto kernel_parallel_for_func2 = [=](sycl::id<1> global_id) {
-                    size_t index            = global_id[0];
+                    size_t index = global_id[0];
                     result1[idx[index + i]] = tmp[index];
                 };
                 auto kernel_func2 = [&](sycl::handler &cgh) {
@@ -1491,7 +1491,7 @@ DPCTLSyclEventRef dpnp_rng_normal_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue *q              = reinterpret_cast<sycl::queue *>(q_ref);
+    sycl::queue *q = reinterpret_cast<sycl::queue *>(q_ref);
 
     if (!size) {
         return event_ref;
@@ -1534,14 +1534,14 @@ void dpnp_rng_normal_c(void *result,
                        const _DataType stddev,
                        const size_t size)
 {
-    sycl::queue *q          = &DPNP_QUEUE;
+    sycl::queue *q = &DPNP_QUEUE;
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(q);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = nullptr;
+    DPCTLSyclEventRef event_ref = nullptr;
 
     if (q->get_device().is_cpu()) {
         mt19937_struct *mt19937 = new mt19937_struct();
-        mt19937->engine         = &DPNP_RNG_ENGINE;
+        mt19937->engine = &DPNP_RNG_ENGINE;
 
         event_ref = dpnp_rng_normal_c<_DataType>(q_ref, result, mean, stddev,
                                                  static_cast<int64_t>(size),
@@ -1554,7 +1554,7 @@ void dpnp_rng_normal_c(void *result,
         // MCG59 engine is assumed to provide a better performance on GPU than
         // MT19937
         mcg59_struct *mcg59 = new mcg59_struct();
-        mcg59->engine       = &DPNP_RNG_MCG59_ENGINE;
+        mcg59->engine = &DPNP_RNG_MCG59_ENGINE;
 
         event_ref = dpnp_rng_normal_c<_DataType>(q_ref, result, mean, stddev,
                                                  static_cast<int64_t>(size),
@@ -1601,8 +1601,8 @@ DPCTLSyclEventRef dpnp_rng_pareto_c(DPCTLSyclQueueRef q_ref,
     std::vector<sycl::event> no_deps;
 
     const _DataType d_zero = _DataType(0.0);
-    const _DataType d_one  = _DataType(1.0);
-    _DataType neg_rec_alp  = -1.0 / alpha;
+    const _DataType d_one = _DataType(1.0);
+    _DataType neg_rec_alp = -1.0 / alpha;
 
     _DataType *result1 = reinterpret_cast<_DataType *>(result);
 
@@ -1623,7 +1623,7 @@ void dpnp_rng_pareto_c(void *result, const double alpha, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_rng_pareto_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_rng_pareto_c<_DataType>(
         q_ref, result, alpha, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -1676,7 +1676,7 @@ void dpnp_rng_poisson_c(void *result, const double lambda, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_rng_poisson_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_rng_poisson_c<_DataType>(
         q_ref, result, lambda, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -1713,8 +1713,8 @@ DPCTLSyclEventRef dpnp_rng_power_c(DPCTLSyclQueueRef q_ref,
     std::vector<sycl::event> no_deps;
 
     const _DataType d_zero = _DataType(0.0);
-    const _DataType d_one  = _DataType(1.0);
-    _DataType neg_rec_alp  = 1.0 / alpha;
+    const _DataType d_one = _DataType(1.0);
+    _DataType neg_rec_alp = 1.0 / alpha;
 
     _DataType *result1 = reinterpret_cast<_DataType *>(result);
 
@@ -1735,7 +1735,7 @@ void dpnp_rng_power_c(void *result, const double alpha, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_rng_power_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_rng_power_c<_DataType>(
         q_ref, result, alpha, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -1773,7 +1773,7 @@ DPCTLSyclEventRef
     sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
     std::vector<sycl::event> no_deps;
 
-    const _DataType a    = 0.0;
+    const _DataType a = 0.0;
     const _DataType beta = 2.0;
 
     DPNPC_ptr_adapter<_DataType> result1_ptr(q_ref, result, size);
@@ -1786,7 +1786,7 @@ DPCTLSyclEventRef
     auto sqrt_event = mkl_vm::sqrt(q, size, result1, result1,
                                    {exponential_rng_event}, mkl_vm::mode::ha);
     auto scal_event = mkl_blas::scal(q, size, scale, result1, 1, {sqrt_event});
-    event_ref       = reinterpret_cast<DPCTLSyclEventRef>(&scal_event);
+    event_ref = reinterpret_cast<DPCTLSyclEventRef>(&scal_event);
 
     return DPCTLEvent_Copy(event_ref);
 }
@@ -1796,7 +1796,7 @@ void dpnp_rng_rayleigh_c(void *result, const _DataType scale, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_rng_rayleigh_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_rng_rayleigh_c<_DataType>(
         q_ref, result, scale, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -1843,7 +1843,7 @@ DPCTLSyclEventRef
     char *result1 = result1_ptr.get_ptr();
 
     size_t uvec_size = high_dim_size - 1;
-    double *Uvec     = reinterpret_cast<double *>(
+    double *Uvec = reinterpret_cast<double *>(
         sycl::malloc_shared(uvec_size * sizeof(double), q));
     mkl_rng::uniform<double> uniform_distribution(0.0, 1.0);
     auto uniform_event = mkl_rng::generate(uniform_distribution,
@@ -1901,7 +1901,7 @@ void dpnp_rng_shuffle_c(void *result,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_rng_shuffle_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_rng_shuffle_c<_DataType>(
         q_ref, result, itemsize, ndim, high_dim_size, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -2108,10 +2108,10 @@ DPCTLSyclEventRef
 
     sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    _DataType *result1     = reinterpret_cast<_DataType *>(result);
+    _DataType *result1 = reinterpret_cast<_DataType *>(result);
     const _DataType d_zero = 0.0, d_one = 1.0;
     _DataType shape = df / 2;
-    _DataType *sn   = nullptr;
+    _DataType *sn = nullptr;
 
     mkl_rng::gamma<_DataType> gamma_distribution(shape, d_zero, 1.0 / shape);
     auto gamma_distr_event =
@@ -2142,7 +2142,7 @@ void dpnp_rng_standard_t_c(void *result, const _DataType df, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_rng_standard_t_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_rng_standard_t_c<_DataType>(
         q_ref, result, df, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -2183,9 +2183,9 @@ DPCTLSyclEventRef
 
     sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    _DataType *result1     = reinterpret_cast<_DataType *>(result);
+    _DataType *result1 = reinterpret_cast<_DataType *>(result);
     const _DataType d_zero = (_DataType(0));
-    const _DataType d_one  = (_DataType(1));
+    const _DataType d_one = (_DataType(1));
 
     _DataType ratio, lpr, rpr;
 
@@ -2197,12 +2197,12 @@ DPCTLSyclEventRef
         _DataType wtot, wl, wr;
 
         wtot = x_max - x_min;
-        wl   = x_mode - x_min;
-        wr   = x_max - x_mode;
+        wl = x_mode - x_min;
+        wr = x_max - x_mode;
 
         ratio = wl / wtot;
-        lpr   = wl * wtot;
-        rpr   = wr * wtot;
+        lpr = wl * wtot;
+        rpr = wr * wtot;
     }
 
     if (!(0 <= ratio && ratio <= 1)) {
@@ -2250,7 +2250,7 @@ void dpnp_rng_triangular_c(void *result,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_rng_triangular_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_rng_triangular_c<_DataType>(
         q_ref, result, x_min, x_mode, x_max, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -2327,14 +2327,14 @@ void dpnp_rng_uniform_c(void *result,
                         const long high,
                         const size_t size)
 {
-    sycl::queue *q          = &DPNP_QUEUE;
+    sycl::queue *q = &DPNP_QUEUE;
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(q);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = nullptr;
+    DPCTLSyclEventRef event_ref = nullptr;
 
     if (q->get_device().is_cpu()) {
         mt19937_struct *mt19937 = new mt19937_struct();
-        mt19937->engine         = &DPNP_RNG_ENGINE;
+        mt19937->engine = &DPNP_RNG_ENGINE;
 
         event_ref = dpnp_rng_uniform_c<_DataType>(
             q_ref, result, static_cast<double>(low), static_cast<double>(high),
@@ -2347,7 +2347,7 @@ void dpnp_rng_uniform_c(void *result,
         // MCG59 engine is assumed to provide a better performance on GPU than
         // MT19937
         mcg59_struct *mcg59 = new mcg59_struct();
-        mcg59->engine       = &DPNP_RNG_MCG59_ENGINE;
+        mcg59->engine = &DPNP_RNG_MCG59_ENGINE;
 
         event_ref = dpnp_rng_uniform_c<_DataType>(
             q_ref, result, static_cast<double>(low), static_cast<double>(high),
@@ -2405,8 +2405,8 @@ DPCTLSyclEventRef
 
     _DataType r_over_two_kappa, recip_two_kappa;
     _DataType s_minus_one, hpt, r_over_two_kappa_minus_one, rho_minus_one;
-    _DataType *Uvec        = nullptr;
-    _DataType *Vvec        = nullptr;
+    _DataType *Uvec = nullptr;
+    _DataType *Vvec = nullptr;
     const _DataType d_zero = 0.0, d_one = 1.0;
 
     assert(kappa > 1.0);
@@ -2418,7 +2418,7 @@ DPCTLSyclEventRef
     r_over_two_kappa_minus_one =
         recip_two_kappa * (1 + recip_two_kappa / (1 + hpt));
     r_over_two_kappa = 1 + r_over_two_kappa_minus_one;
-    rho_minus_one    = r_over_two_kappa_minus_one -
+    rho_minus_one = r_over_two_kappa_minus_one -
                     sqrt(2 * r_over_two_kappa * recip_two_kappa);
     s_minus_one = rho_minus_one * (0.5 * rho_minus_one / (1 + rho_minus_one));
 
@@ -2446,14 +2446,14 @@ DPCTLSyclEventRef
             _DataType sn, cn, sn2, cn2;
             _DataType neg_W_minus_one, V, Y;
 
-            sn  = sin(Uvec[i]);
-            cn  = cos(Uvec[i]);
-            V   = Vvec[i];
+            sn = sin(Uvec[i]);
+            cn = cos(Uvec[i]);
+            V = Vvec[i];
             sn2 = sn * sn;
             cn2 = cn * cn;
 
             neg_W_minus_one = s_minus_one * sn2 / (0.5 * s_minus_one + cn2);
-            Y               = kappa * (s_minus_one + neg_W_minus_one);
+            Y = kappa * (s_minus_one + neg_W_minus_one);
 
             if ((Y * (2 - Y) >= V) || (log(Y / V) + 1 >= Y)) {
                 Y = neg_W_minus_one * (2 - neg_W_minus_one);
@@ -2480,9 +2480,9 @@ DPCTLSyclEventRef
         cgh.parallel_for(gws, [=](sycl::id<1> global_id) {
             size_t i = global_id[0];
             double mod, resi;
-            resi       = (Vvec[i] < 0.5) ? mu - result1[i] : mu + result1[i];
-            mod        = sycl::fabs(resi);
-            mod        = (sycl::fmod(mod + M_PI, 2 * M_PI) - M_PI);
+            resi = (Vvec[i] < 0.5) ? mu - result1[i] : mu + result1[i];
+            mod = sycl::fabs(resi);
+            mod = (sycl::fmod(mod + M_PI, 2 * M_PI) - M_PI);
             result1[i] = (resi < 0) ? -mod : mod;
         });
     };
@@ -2553,9 +2553,9 @@ DPCTLSyclEventRef
 
     assert(0. < kappa <= 1.0);
 
-    r              = 1 + sqrt(1 + 4 * kappa * kappa);
+    r = 1 + sqrt(1 + 4 * kappa * kappa);
     rho_over_kappa = (2) / (r + sqrt(2 * r));
-    rho            = rho_over_kappa * kappa;
+    rho = rho_over_kappa * kappa;
 
     /* s times kappa */
     s_kappa = (1 + rho * rho) / (2 * rho_over_kappa);
@@ -2604,9 +2604,9 @@ DPCTLSyclEventRef
         cgh.parallel_for(gws, [=](sycl::id<1> global_id) {
             size_t i = global_id[0];
             double mod, resi;
-            resi       = (Vvec[i] < 0.5) ? mu - result1[i] : mu + result1[i];
-            mod        = sycl::fabs(resi);
-            mod        = (sycl::fmod(mod + M_PI, 2 * M_PI) - M_PI);
+            resi = (Vvec[i] < 0.5) ? mu - result1[i] : mu + result1[i];
+            mod = sycl::fabs(resi);
+            mod = (sycl::fmod(mod + M_PI, 2 * M_PI) - M_PI);
             result1[i] = (resi < 0) ? -mod : mod;
         });
     };
@@ -2684,7 +2684,7 @@ void dpnp_rng_vonmises_c(void *result,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_rng_vonmises_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_rng_vonmises_c<_DataType>(
         q_ref, result, mu, kappa, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -2731,11 +2731,11 @@ DPCTLSyclEventRef dpnp_rng_wald_c(DPCTLSyclQueueRef q_ref,
     sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     _DataType *result1 = reinterpret_cast<_DataType *>(result);
-    _DataType *uvec    = nullptr;
+    _DataType *uvec = nullptr;
 
     const _DataType d_zero = _DataType(0.0);
-    const _DataType d_one  = _DataType(1.0);
-    _DataType gsc          = sqrt(0.5 * mean / scale);
+    const _DataType d_one = _DataType(1.0);
+    _DataType gsc = sqrt(0.5 * mean / scale);
 
     mkl_rng::gaussian<_DataType> gaussian_distribution(d_zero, gsc);
 
@@ -2800,7 +2800,7 @@ void dpnp_rng_wald_c(void *result,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_rng_wald_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_rng_wald_c<_DataType>(
         q_ref, result, mean, scale, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -2845,8 +2845,8 @@ DPCTLSyclEventRef
             dpnp_zeros_c<_DataType>(q_ref, result, size, dep_event_vec_ref);
     }
     else {
-        _DataType *result1   = reinterpret_cast<_DataType *>(result);
-        const _DataType a    = (_DataType(0.0));
+        _DataType *result1 = reinterpret_cast<_DataType *>(result);
+        const _DataType a = (_DataType(0.0));
         const _DataType beta = (_DataType(1.0));
 
         mkl_rng::weibull<_DataType> distribution(alpha, a, beta);
@@ -2862,7 +2862,7 @@ void dpnp_rng_weibull_c(void *result, const double alpha, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_rng_weibull_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_rng_weibull_c<_DataType>(
         q_ref, result, alpha, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -2903,13 +2903,13 @@ DPCTLSyclEventRef dpnp_rng_zipf_c(DPCTLSyclQueueRef q_ref,
     _DataType *Uvec = nullptr, *Vvec = nullptr;
     long X;
     const _DataType d_zero = 0.0;
-    const _DataType d_one  = 1.0;
+    const _DataType d_one = 1.0;
 
     DPNPC_ptr_adapter<_DataType> result1_ptr(q_ref, result, size, true, true);
     _DataType *result1 = result1_ptr.get_ptr();
 
     am1 = a - d_one;
-    b   = pow(2.0, am1);
+    b = pow(2.0, am1);
 
     Uvec = reinterpret_cast<_DataType *>(
         sycl::malloc_shared(size * 2 * sizeof(_DataType), q));

--- a/dpnp/backend/kernels/dpnp_krnl_random.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_random.cpp
@@ -32,17 +32,17 @@
 #include <dpnp_iface.hpp>
 
 #include "dpnp_fptr.hpp"
+#include "dpnp_random_state.hpp"
 #include "dpnp_utils.hpp"
 #include "dpnpc_memory_adapter.hpp"
 #include "queue_sycl.hpp"
-#include "dpnp_random_state.hpp"
 
 static_assert(INTEL_MKL_VERSION >= __INTEL_MKL_2023_VERSION_REQUIRED,
               "MKL does not meet minimum version requirement");
 
 namespace mkl_blas = oneapi::mkl::blas;
-namespace mkl_rng = oneapi::mkl::rng;
-namespace mkl_vm = oneapi::mkl::vm;
+namespace mkl_rng  = oneapi::mkl::rng;
+namespace mkl_vm   = oneapi::mkl::vm;
 
 /**
  * Use get/set functions to access/modify this variable
@@ -51,8 +51,7 @@ static VSLStreamStatePtr rng_stream = nullptr;
 
 static void set_rng_stream(size_t seed = 1)
 {
-    if (rng_stream)
-    {
+    if (rng_stream) {
         vslDeleteStream(&rng_stream);
         rng_stream = nullptr;
     }
@@ -62,8 +61,7 @@ static void set_rng_stream(size_t seed = 1)
 
 static VSLStreamStatePtr get_rng_stream()
 {
-    if (!rng_stream)
-    {
+    if (!rng_stream) {
         set_rng_stream();
     }
 
@@ -77,20 +75,20 @@ void dpnp_rng_srand_c(size_t seed)
 }
 
 template <typename _DistrType, typename _EngineType, typename _DataType>
-static inline DPCTLSyclEventRef
-    dpnp_rng_generate(const _DistrType& distr, _EngineType& engine, const int64_t size, _DataType* result)
+static inline DPCTLSyclEventRef dpnp_rng_generate(const _DistrType &distr,
+                                                  _EngineType &engine,
+                                                  const int64_t size,
+                                                  _DataType *result)
 {
     DPCTLSyclEventRef event_ref = nullptr;
     sycl::event event;
 
     // perform rng generation
-    try
-    {
-        event = mkl_rng::generate<_DistrType, _EngineType>(distr, engine, size, result);
+    try {
+        event = mkl_rng::generate<_DistrType, _EngineType>(distr, engine, size,
+                                                           result);
         event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
-    }
-    catch (const std::exception& e)
-    {
+    } catch (const std::exception &e) {
         // TODO: add error reporting
         return event_ref;
     }
@@ -98,43 +96,41 @@ static inline DPCTLSyclEventRef
 }
 
 template <typename _EngineType, typename _DataType>
-static inline DPCTLSyclEventRef dpnp_rng_generate_uniform(
-    _EngineType& engine, sycl::queue* q, const _DataType a, const _DataType b, const int64_t size, _DataType* result)
+static inline DPCTLSyclEventRef dpnp_rng_generate_uniform(_EngineType &engine,
+                                                          sycl::queue *q,
+                                                          const _DataType a,
+                                                          const _DataType b,
+                                                          const int64_t size,
+                                                          _DataType *result)
 {
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if constexpr (std::is_same<_DataType, int32_t>::value)
-    {
-        if (q->get_device().has(sycl::aspect::fp64))
-        {
+    if constexpr (std::is_same<_DataType, int32_t>::value) {
+        if (q->get_device().has(sycl::aspect::fp64)) {
             /**
              * A note from oneMKL for oneapi::mkl::rng::uniform (Discrete):
-             * The oneapi::mkl::rng::uniform_method::standard uses the s BRNG type on GPU devices.
-             * This might cause the produced numbers to have incorrect statistics (due to rounding error)
-             * when abs(b-a) > 2^23 || abs(b) > 2^23 || abs(a) > 2^23. To get proper statistics for this case,
-             * use the oneapi::mkl::rng::uniform_method::accurate method instead.
+             * The oneapi::mkl::rng::uniform_method::standard uses the s BRNG
+             * type on GPU devices. This might cause the produced numbers to
+             * have incorrect statistics (due to rounding error)
+             * when abs(b-a) > 2^23 || abs(b) > 2^23 || abs(a) > 2^23.
+             * To get proper statistics for this case, use the
+             * oneapi::mkl::rng::uniform_method::accurate method instead.
              */
             using method_type = mkl_rng::uniform_method::accurate;
             mkl_rng::uniform<_DataType, method_type> distribution(a, b);
 
             // perform generation
-            try
-            {
-                sycl::event event = mkl_rng::generate(distribution, engine, size, result);
+            try {
+                sycl::event event =
+                    mkl_rng::generate(distribution, engine, size, result);
 
                 event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
                 return DPCTLEvent_Copy(event_ref);
-            }
-            catch (const oneapi::mkl::unsupported_device&)
-            {
+            } catch (const oneapi::mkl::unsupported_device &) {
                 // fall through to try with uniform_method::standard
-            }
-            catch (const oneapi::mkl::unimplemented&)
-            {
+            } catch (const oneapi::mkl::unimplemented &) {
                 // fall through to try with uniform_method::standard
-            }
-            catch (const std::exception& e)
-            {
+            } catch (const std::exception &e) {
                 // TODO: add error reporting
                 return event_ref;
             }
@@ -151,7 +147,7 @@ static inline DPCTLSyclEventRef dpnp_rng_generate_uniform(
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_rng_beta_c(DPCTLSyclQueueRef q_ref,
-                                  void* result,
+                                  void *result,
                                   const _DataType a,
                                   const _DataType b,
                                   const size_t size,
@@ -162,22 +158,22 @@ DPCTLSyclEventRef dpnp_rng_beta_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     _DataType displacement = _DataType(0.0);
 
     _DataType scalefactor = _DataType(1.0);
 
-    _DataType* result1 = reinterpret_cast<_DataType*>(result);
+    _DataType *result1 = reinterpret_cast<_DataType *>(result);
 
     mkl_rng::beta<_DataType> distribution(a, b, displacement, scalefactor);
     // perform generation
-    auto event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
+    auto event_out =
+        mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
 
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event_out);
 
@@ -185,126 +181,133 @@ DPCTLSyclEventRef dpnp_rng_beta_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_rng_beta_c(void* result, const _DataType a, const _DataType b, const size_t size)
+void dpnp_rng_beta_c(void *result,
+                     const _DataType a,
+                     const _DataType b,
+                     const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_beta_c<_DataType>(q_ref,
-                                                             result,
-                                                             a,
-                                                             b,
-                                                             size,
-                                                             dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_rng_beta_c<_DataType>(
+        q_ref, result, a, b, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_beta_default_c)(void*, const _DataType, const _DataType, const size_t) = dpnp_rng_beta_c<_DataType>;
+void (*dpnp_rng_beta_default_c)(void *,
+                                const _DataType,
+                                const _DataType,
+                                const size_t) = dpnp_rng_beta_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_beta_ext_c)(DPCTLSyclQueueRef,
-                                         void*,
+                                         void *,
                                          const _DataType,
                                          const _DataType,
                                          const size_t,
-                                         const DPCTLEventVectorRef) = dpnp_rng_beta_c<_DataType>;
+                                         const DPCTLEventVectorRef) =
+    dpnp_rng_beta_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_binomial_c(DPCTLSyclQueueRef q_ref,
-                                      void* result,
-                                      const int ntrial,
-                                      const double p,
-                                      const size_t size,
-                                      const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_binomial_c(DPCTLSyclQueueRef q_ref,
+                        void *result,
+                        const int ntrial,
+                        const double p,
+                        const size_t size,
+                        const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (result == nullptr)
-    {
+    if (result == nullptr) {
         return event_ref;
     }
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    if (ntrial == 0 || p == 0)
-    {
-        event_ref = dpnp_zeros_c<_DataType>(q_ref, result, size, dep_event_vec_ref);
+    if (ntrial == 0 || p == 0) {
+        event_ref =
+            dpnp_zeros_c<_DataType>(q_ref, result, size, dep_event_vec_ref);
     }
-    else if (p == 1)
-    {
-        _DataType* fill_value = reinterpret_cast<_DataType*>(sycl::malloc_shared(sizeof(_DataType), q));
+    else if (p == 1) {
+        _DataType *fill_value = reinterpret_cast<_DataType *>(
+            sycl::malloc_shared(sizeof(_DataType), q));
         fill_value[0] = static_cast<_DataType>(ntrial);
 
-        event_ref = dpnp_initval_c<_DataType>(q_ref, result, fill_value, size, dep_event_vec_ref);
+        event_ref = dpnp_initval_c<_DataType>(q_ref, result, fill_value, size,
+                                              dep_event_vec_ref);
         DPCTLEvent_Wait(event_ref);
         dpnp_memory_free_c(q_ref, fill_value);
     }
-    else
-    {
-        _DataType* result1 = reinterpret_cast<_DataType*>(result);
+    else {
+        _DataType *result1 = reinterpret_cast<_DataType *>(result);
         mkl_rng::binomial<_DataType> distribution(ntrial, p);
-        auto event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
+        auto event_out =
+            mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
         event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event_out);
     }
     return DPCTLEvent_Copy(event_ref);
-
 }
 
 template <typename _DataType>
-void dpnp_rng_binomial_c(void* result, const int ntrial, const double p, const size_t size)
+void dpnp_rng_binomial_c(void *result,
+                         const int ntrial,
+                         const double p,
+                         const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_binomial_c<_DataType>(q_ref,
-                                                                 result,
-                                                                 ntrial,
-                                                                 p,
-                                                                 size,
-                                                                 dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_rng_binomial_c<_DataType>(
+        q_ref, result, ntrial, p, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_binomial_default_c)(void*, const int, const double, const size_t) = dpnp_rng_binomial_c<_DataType>;
+void (*dpnp_rng_binomial_default_c)(void *,
+                                    const int,
+                                    const double,
+                                    const size_t) =
+    dpnp_rng_binomial_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_binomial_ext_c)(DPCTLSyclQueueRef,
-                                             void*,
+                                             void *,
                                              const int,
                                              const double,
                                              const size_t,
-                                             const DPCTLEventVectorRef) = dpnp_rng_binomial_c<_DataType>;
+                                             const DPCTLEventVectorRef) =
+    dpnp_rng_binomial_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_chisquare_c(DPCTLSyclQueueRef q_ref,
-                                       void* result,
-                                       const int df,
-                                       const size_t size,
-                                       const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_chisquare_c(DPCTLSyclQueueRef q_ref,
+                         void *result,
+                         const int df,
+                         const size_t size,
+                         const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    _DataType* result1 = reinterpret_cast<_DataType*>(result);
+    _DataType *result1 = reinterpret_cast<_DataType *>(result);
 
     mkl_rng::chi_square<_DataType> distribution(df);
-    auto event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
+    auto event_out =
+        mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
 
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event_out);
 
@@ -312,55 +315,55 @@ DPCTLSyclEventRef dpnp_rng_chisquare_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_rng_chisquare_c(void* result, const int df, const size_t size)
+void dpnp_rng_chisquare_c(void *result, const int df, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_chisquare_c<_DataType>(q_ref,
-                                                                  result,
-                                                                  df,
-                                                                  size,
-                                                                  dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_rng_chisquare_c<_DataType>(
+        q_ref, result, df, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_chisquare_default_c)(void*, const int, const size_t) = dpnp_rng_chisquare_c<_DataType>;
+void (*dpnp_rng_chisquare_default_c)(void *, const int, const size_t) =
+    dpnp_rng_chisquare_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_chisquare_ext_c)(DPCTLSyclQueueRef,
-                                              void*,
+                                              void *,
                                               const int,
                                               const size_t,
-                                              const DPCTLEventVectorRef) = dpnp_rng_chisquare_c<_DataType>;
+                                              const DPCTLEventVectorRef) =
+    dpnp_rng_chisquare_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_exponential_c(DPCTLSyclQueueRef q_ref,
-                                         void* result,
-                                         const _DataType beta,
-                                         const size_t size,
-                                         const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_exponential_c(DPCTLSyclQueueRef q_ref,
+                           void *result,
+                           const _DataType beta,
+                           const size_t size,
+                           const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     // set displacement a
     const _DataType a = (_DataType(0.0));
 
-    _DataType* result1 = reinterpret_cast<_DataType*>(result);
+    _DataType *result1 = reinterpret_cast<_DataType *>(result);
 
     mkl_rng::exponential<_DataType> distribution(a, beta);
     // perform generation
-    auto event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
+    auto event_out =
+        mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
 
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event_out);
 
@@ -368,31 +371,32 @@ DPCTLSyclEventRef dpnp_rng_exponential_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_rng_exponential_c(void* result, const _DataType beta, const size_t size)
+void dpnp_rng_exponential_c(void *result,
+                            const _DataType beta,
+                            const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_exponential_c<_DataType>(q_ref,
-                                                                    result,
-                                                                    beta,
-                                                                    size,
-                                                                    dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_rng_exponential_c<_DataType>(
+        q_ref, result, beta, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_exponential_default_c)(void*, const _DataType, const size_t) = dpnp_rng_exponential_c<_DataType>;
+void (*dpnp_rng_exponential_default_c)(void *, const _DataType, const size_t) =
+    dpnp_rng_exponential_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_exponential_ext_c)(DPCTLSyclQueueRef,
-                                              void*,
-                                              const _DataType,
-                                              const size_t,
-                                              const DPCTLEventVectorRef) = dpnp_rng_exponential_c<_DataType>;
+                                                void *,
+                                                const _DataType,
+                                                const size_t,
+                                                const DPCTLEventVectorRef) =
+    dpnp_rng_exponential_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_rng_f_c(DPCTLSyclQueueRef q_ref,
-                               void* result,
+                               void *result,
                                const _DataType df_num,
                                const _DataType df_den,
                                const size_t size,
@@ -403,39 +407,38 @@ DPCTLSyclEventRef dpnp_rng_f_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
     std::vector<sycl::event> no_deps;
 
     const _DataType d_zero = (_DataType(0.0));
 
     _DataType shape = 0.5 * df_num;
     _DataType scale = 2.0 / df_num;
-    _DataType* den = nullptr;
+    _DataType *den  = nullptr;
 
     DPNPC_ptr_adapter<_DataType> result1_ptr(q_ref, result, size, true, true);
-    _DataType* result1 = result1_ptr.get_ptr();
+    _DataType *result1 = result1_ptr.get_ptr();
 
     mkl_rng::gamma<_DataType> gamma_distribution1(shape, d_zero, scale);
-    auto event_gamma_distribution1 = mkl_rng::generate(gamma_distribution1, DPNP_RNG_ENGINE, size, result1);
+    auto event_gamma_distribution1 =
+        mkl_rng::generate(gamma_distribution1, DPNP_RNG_ENGINE, size, result1);
 
-    den = reinterpret_cast<_DataType*>(sycl::malloc_shared(size * sizeof(_DataType), q));
+    den = reinterpret_cast<_DataType *>(
+        sycl::malloc_shared(size * sizeof(_DataType), q));
     shape = 0.5 * df_den;
     scale = 2.0 / df_den;
     mkl_rng::gamma<_DataType> gamma_distribution2(shape, d_zero, scale);
-    auto event_gamma_distribution2 = mkl_rng::generate(gamma_distribution2, DPNP_RNG_ENGINE, size, den);
+    auto event_gamma_distribution2 =
+        mkl_rng::generate(gamma_distribution2, DPNP_RNG_ENGINE, size, den);
 
-    auto event_out = mkl_vm::div(q,
-                                 size,
-                                 result1,
-                                 den,
-                                 result1,
-                                 {event_gamma_distribution1, event_gamma_distribution2},
-                                 mkl_vm::mode::ha);
+    auto event_out =
+        mkl_vm::div(q, size, result1, den, result1,
+                    {event_gamma_distribution1, event_gamma_distribution2},
+                    mkl_vm::mode::ha);
     event_out.wait();
 
     sycl::free(den, q);
@@ -444,37 +447,40 @@ DPCTLSyclEventRef dpnp_rng_f_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_rng_f_c(void* result, const _DataType df_num, const _DataType df_den, const size_t size)
+void dpnp_rng_f_c(void *result,
+                  const _DataType df_num,
+                  const _DataType df_den,
+                  const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_f_c<_DataType>(q_ref,
-                                                          result,
-                                                          df_num,
-                                                          df_den,
-                                                          size,
-                                                          dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_rng_f_c<_DataType>(
+        q_ref, result, df_num, df_den, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_f_default_c)(void*, const _DataType, const _DataType, const size_t) = dpnp_rng_f_c<_DataType>;
+void (*dpnp_rng_f_default_c)(void *,
+                             const _DataType,
+                             const _DataType,
+                             const size_t) = dpnp_rng_f_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_f_ext_c)(DPCTLSyclQueueRef,
-                                              void*,
-                                              const _DataType,
-                                              const _DataType,
-                                              const size_t,
-                                              const DPCTLEventVectorRef) = dpnp_rng_f_c<_DataType>;
+                                      void *,
+                                      const _DataType,
+                                      const _DataType,
+                                      const size_t,
+                                      const DPCTLEventVectorRef) =
+    dpnp_rng_f_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_rng_gamma_c(DPCTLSyclQueueRef q_ref,
-                      void* result,
-                      const _DataType shape,
-                      const _DataType scale,
-                      const size_t size,
-                      const DPCTLEventVectorRef dep_event_vec_ref)
+                                   void *result,
+                                   const _DataType shape,
+                                   const _DataType scale,
+                                   const size_t size,
+                                   const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
@@ -482,24 +488,23 @@ DPCTLSyclEventRef dpnp_rng_gamma_c(DPCTLSyclQueueRef q_ref,
     DPCTLSyclEventRef event_ref = nullptr;
     sycl::event event_out;
 
-    if (!size || result == nullptr)
-    {
+    if (!size || result == nullptr) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    if (shape == 0.0 || scale == 0.0)
-    {
-        event_ref = dpnp_zeros_c<_DataType>(q_ref, result, size, dep_event_vec_ref);
+    if (shape == 0.0 || scale == 0.0) {
+        event_ref =
+            dpnp_zeros_c<_DataType>(q_ref, result, size, dep_event_vec_ref);
     }
-    else
-    {
-        _DataType* result1 = reinterpret_cast<_DataType*>(result);
-        const _DataType a = (_DataType(0.0));
+    else {
+        _DataType *result1 = reinterpret_cast<_DataType *>(result);
+        const _DataType a  = (_DataType(0.0));
 
         mkl_rng::gamma<_DataType> distribution(shape, a, scale);
-        event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
+        event_out =
+            mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
         event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event_out);
     }
 
@@ -507,94 +512,100 @@ DPCTLSyclEventRef dpnp_rng_gamma_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_rng_gamma_c(void* result, const _DataType shape, const _DataType scale, const size_t size)
+void dpnp_rng_gamma_c(void *result,
+                      const _DataType shape,
+                      const _DataType scale,
+                      const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_gamma_c<_DataType>(q_ref,
-                                                              result,
-                                                              shape,
-                                                              scale,
-                                                              size,
-                                                              dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_rng_gamma_c<_DataType>(
+        q_ref, result, shape, scale, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_gamma_default_c)(void*, const _DataType, const _DataType, const size_t) = dpnp_rng_gamma_c<_DataType>;
+void (*dpnp_rng_gamma_default_c)(void *,
+                                 const _DataType,
+                                 const _DataType,
+                                 const size_t) = dpnp_rng_gamma_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_gamma_ext_c)(DPCTLSyclQueueRef,
-                                          void*,
+                                          void *,
                                           const _DataType,
                                           const _DataType,
                                           const size_t,
-                                          const DPCTLEventVectorRef) = dpnp_rng_gamma_c<_DataType>;
+                                          const DPCTLEventVectorRef) =
+    dpnp_rng_gamma_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_gaussian_c(DPCTLSyclQueueRef q_ref,
-                                      void* result,
-                                      const _DataType mean,
-                                      const _DataType stddev,
-                                      const size_t size,
-                                      const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_gaussian_c(DPCTLSyclQueueRef q_ref,
+                        void *result,
+                        const _DataType mean,
+                        const _DataType stddev,
+                        const size_t size,
+                        const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    _DataType* result1 = reinterpret_cast<_DataType*>(result);
+    _DataType *result1 = reinterpret_cast<_DataType *>(result);
 
     mkl_rng::gaussian<_DataType> distribution(mean, stddev);
     // perform generation
-    auto event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
+    auto event_out =
+        mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event_out);
 
     return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType>
-void dpnp_rng_gaussian_c(void* result, const _DataType mean, const _DataType stddev, const size_t size)
+void dpnp_rng_gaussian_c(void *result,
+                         const _DataType mean,
+                         const _DataType stddev,
+                         const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_gaussian_c<_DataType>(q_ref,
-                                                                 result,
-                                                                 mean,
-                                                                 stddev,
-                                                                 size,
-                                                                 dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_rng_gaussian_c<_DataType>(
+        q_ref, result, mean, stddev, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_gaussian_default_c)(void*,
+void (*dpnp_rng_gaussian_default_c)(void *,
                                     const _DataType,
                                     const _DataType,
-                                    const size_t) = dpnp_rng_gaussian_c<_DataType>;
+                                    const size_t) =
+    dpnp_rng_gaussian_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_gaussian_ext_c)(DPCTLSyclQueueRef,
-                                             void*,
+                                             void *,
                                              const _DataType,
                                              const _DataType,
                                              const size_t,
-                                             const DPCTLEventVectorRef) = dpnp_rng_gaussian_c<_DataType>;
+                                             const DPCTLEventVectorRef) =
+    dpnp_rng_gaussian_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_geometric_c(DPCTLSyclQueueRef q_ref,
-                                       void* result,
-                                       const float p,
-                                       const size_t size,
-                                       const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_geometric_c(DPCTLSyclQueueRef q_ref,
+                         void *result,
+                         const float p,
+                         const size_t size,
+                         const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
@@ -602,54 +613,52 @@ DPCTLSyclEventRef dpnp_rng_geometric_c(DPCTLSyclQueueRef q_ref,
     DPCTLSyclEventRef event_ref = nullptr;
     sycl::event event_out;
 
-    if (!size || !result)
-    {
+    if (!size || !result) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    if (p == 1.0)
-    {
-        event_ref = dpnp_ones_c<_DataType>(q_ref, result, size, dep_event_vec_ref);
+    if (p == 1.0) {
+        event_ref =
+            dpnp_ones_c<_DataType>(q_ref, result, size, dep_event_vec_ref);
     }
-    else
-    {
-        _DataType* result1 = reinterpret_cast<_DataType*>(result);
+    else {
+        _DataType *result1 = reinterpret_cast<_DataType *>(result);
         mkl_rng::geometric<_DataType> distribution(p);
         // perform generation
-        event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
+        event_out =
+            mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
         event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event_out);
     }
     return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType>
-void dpnp_rng_geometric_c(void* result, const float p, const size_t size)
+void dpnp_rng_geometric_c(void *result, const float p, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_geometric_c<_DataType>(q_ref,
-                                                                  result,
-                                                                  p,
-                                                                  size,
-                                                                  dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_rng_geometric_c<_DataType>(
+        q_ref, result, p, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_geometric_default_c)(void*, const float, const size_t) = dpnp_rng_geometric_c<_DataType>;
+void (*dpnp_rng_geometric_default_c)(void *, const float, const size_t) =
+    dpnp_rng_geometric_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_geometric_ext_c)(DPCTLSyclQueueRef,
-                                              void*,
+                                              void *,
                                               const float,
                                               const size_t,
-                                              const DPCTLEventVectorRef) = dpnp_rng_geometric_c<_DataType>;
+                                              const DPCTLEventVectorRef) =
+    dpnp_rng_geometric_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_rng_gumbel_c(DPCTLSyclQueueRef q_ref,
-                                    void* result,
+                                    void *result,
                                     const double loc,
                                     const double scale,
                                     const size_t size,
@@ -661,71 +670,76 @@ DPCTLSyclEventRef dpnp_rng_gumbel_c(DPCTLSyclQueueRef q_ref,
     DPCTLSyclEventRef event_ref = nullptr;
     sycl::event event_out;
 
-    if (!size || !result)
-    {
+    if (!size || !result) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    if (scale == 0.0)
-    {
-        _DataType* fill_value = reinterpret_cast<_DataType*>(sycl::malloc_shared(sizeof(_DataType), q));
+    if (scale == 0.0) {
+        _DataType *fill_value = reinterpret_cast<_DataType *>(
+            sycl::malloc_shared(sizeof(_DataType), q));
         fill_value[0] = static_cast<_DataType>(loc);
 
-        event_ref = dpnp_initval_c<_DataType>(q_ref, result, fill_value, size, dep_event_vec_ref);
+        event_ref = dpnp_initval_c<_DataType>(q_ref, result, fill_value, size,
+                                              dep_event_vec_ref);
         DPCTLEvent_Wait(event_ref);
         dpnp_memory_free_c(q_ref, fill_value);
     }
-    else
-    {
+    else {
         const _DataType alpha = (_DataType(-1.0));
-        std::int64_t incx = 1;
-        _DataType* result1 = reinterpret_cast<_DataType*>(result);
-        double negloc = loc * (double(-1.0));
+        std::int64_t incx     = 1;
+        _DataType *result1    = reinterpret_cast<_DataType *>(result);
+        double negloc         = loc * (double(-1.0));
 
         mkl_rng::gumbel<_DataType> distribution(negloc, scale);
-        auto event_distribution = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
+        auto event_distribution =
+            mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
 
-        event_out = mkl_blas::scal(q, size, alpha, result1, incx, {event_distribution});
+        event_out =
+            mkl_blas::scal(q, size, alpha, result1, incx, {event_distribution});
         event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event_out);
     }
     return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType>
-void dpnp_rng_gumbel_c(void* result, const double loc, const double scale, const size_t size)
+void dpnp_rng_gumbel_c(void *result,
+                       const double loc,
+                       const double scale,
+                       const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_gumbel_c<_DataType>(q_ref,
-                                                               result,
-                                                               loc,
-                                                               scale,
-                                                               size,
-                                                               dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_rng_gumbel_c<_DataType>(
+        q_ref, result, loc, scale, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_gumbel_default_c)(void*, const double, const double, const size_t) = dpnp_rng_gumbel_c<_DataType>;
+void (*dpnp_rng_gumbel_default_c)(void *,
+                                  const double,
+                                  const double,
+                                  const size_t) = dpnp_rng_gumbel_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_gumbel_ext_c)(DPCTLSyclQueueRef,
-                                           void*,
+                                           void *,
                                            const double,
                                            const double,
                                            const size_t,
-                                           const DPCTLEventVectorRef) = dpnp_rng_gumbel_c<_DataType>;
+                                           const DPCTLEventVectorRef) =
+    dpnp_rng_gumbel_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_hypergeometric_c(DPCTLSyclQueueRef q_ref,
-                                            void* result,
-                                            const int l,
-                                            const int s,
-                                            const int m,
-                                            const size_t size,
-                                            const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_hypergeometric_c(DPCTLSyclQueueRef q_ref,
+                              void *result,
+                              const int l,
+                              const int s,
+                              const int m,
+                              const size_t size,
+                              const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
@@ -733,75 +747,76 @@ DPCTLSyclEventRef dpnp_rng_hypergeometric_c(DPCTLSyclQueueRef q_ref,
     DPCTLSyclEventRef event_ref = nullptr;
     sycl::event event_out;
 
-    if (!size || !result)
-    {
+    if (!size || !result) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    if (m == 0)
-    {
-        event_ref = dpnp_zeros_c<_DataType>(q_ref, result, size, dep_event_vec_ref);
+    if (m == 0) {
+        event_ref =
+            dpnp_zeros_c<_DataType>(q_ref, result, size, dep_event_vec_ref);
     }
-    else if (l == m)
-    {
-        _DataType* fill_value = reinterpret_cast<_DataType*>(sycl::malloc_shared(sizeof(_DataType), q));
+    else if (l == m) {
+        _DataType *fill_value = reinterpret_cast<_DataType *>(
+            sycl::malloc_shared(sizeof(_DataType), q));
         fill_value[0] = static_cast<_DataType>(s);
 
-        event_ref = dpnp_initval_c<_DataType>(q_ref, result, fill_value, size, dep_event_vec_ref);
+        event_ref = dpnp_initval_c<_DataType>(q_ref, result, fill_value, size,
+                                              dep_event_vec_ref);
         DPCTLEvent_Wait(event_ref);
         dpnp_memory_free_c(q_ref, fill_value);
     }
-    else
-    {
-        _DataType* result1 = reinterpret_cast<_DataType*>(result);
+    else {
+        _DataType *result1 = reinterpret_cast<_DataType *>(result);
         mkl_rng::hypergeometric<_DataType> distribution(l, s, m);
-        event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
+        event_out =
+            mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
         event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event_out);
-
     }
     return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType>
-void dpnp_rng_hypergeometric_c(void* result, const int l, const int s, const int m, const size_t size)
+void dpnp_rng_hypergeometric_c(void *result,
+                               const int l,
+                               const int s,
+                               const int m,
+                               const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_hypergeometric_c<_DataType>(q_ref,
-                                                                       result,
-                                                                       l,
-                                                                       s,
-                                                                       m,
-                                                                       size,
-                                                                       dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref = dpnp_rng_hypergeometric_c<_DataType>(
+        q_ref, result, l, s, m, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_hypergeometric_default_c)(void*,
+void (*dpnp_rng_hypergeometric_default_c)(void *,
                                           const int,
                                           const int,
                                           const int,
-                                          const size_t) = dpnp_rng_hypergeometric_c<_DataType>;
+                                          const size_t) =
+    dpnp_rng_hypergeometric_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_hypergeometric_ext_c)(DPCTLSyclQueueRef,
-                                                   void*,
+                                                   void *,
                                                    const int,
                                                    const int,
                                                    const int,
                                                    const size_t,
-                                                   const DPCTLEventVectorRef) = dpnp_rng_hypergeometric_c<_DataType>;
+                                                   const DPCTLEventVectorRef) =
+    dpnp_rng_hypergeometric_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_laplace_c(DPCTLSyclQueueRef q_ref,
-                                     void* result,
-                                     const double loc,
-                                     const double scale,
-                                     const size_t size,
-                                     const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_laplace_c(DPCTLSyclQueueRef q_ref,
+                       void *result,
+                       const double loc,
+                       const double scale,
+                       const size_t size,
+                       const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
@@ -809,133 +824,143 @@ DPCTLSyclEventRef dpnp_rng_laplace_c(DPCTLSyclQueueRef q_ref,
     DPCTLSyclEventRef event_ref = nullptr;
     sycl::event event_out;
 
-    if (!size || !result)
-    {
+    if (!size || !result) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    if (scale == 0.0)
-    {
-        event_ref = dpnp_zeros_c<_DataType>(q_ref, result, size, dep_event_vec_ref);
+    if (scale == 0.0) {
+        event_ref =
+            dpnp_zeros_c<_DataType>(q_ref, result, size, dep_event_vec_ref);
     }
-    else
-    {
-        _DataType* result1 = reinterpret_cast<_DataType*>(result);
+    else {
+        _DataType *result1 = reinterpret_cast<_DataType *>(result);
         mkl_rng::laplace<_DataType> distribution(loc, scale);
         // perform generation
-        event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
+        event_out =
+            mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
         event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event_out);
     }
     return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType>
-void dpnp_rng_laplace_c(void* result, const double loc, const double scale, const size_t size)
+void dpnp_rng_laplace_c(void *result,
+                        const double loc,
+                        const double scale,
+                        const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_laplace_c<_DataType>(q_ref,
-                                                                result,
-                                                                loc,
-                                                                scale,
-                                                                size,
-                                                                dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_rng_laplace_c<_DataType>(
+        q_ref, result, loc, scale, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_laplace_default_c)(void*, const double, const double, const size_t) = dpnp_rng_laplace_c<_DataType>;
+void (*dpnp_rng_laplace_default_c)(void *,
+                                   const double,
+                                   const double,
+                                   const size_t) =
+    dpnp_rng_laplace_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_laplace_ext_c)(DPCTLSyclQueueRef,
-                                            void*,
+                                            void *,
                                             const double,
                                             const double,
                                             const size_t,
-                                            const DPCTLEventVectorRef) = dpnp_rng_laplace_c<_DataType>;
+                                            const DPCTLEventVectorRef) =
+    dpnp_rng_laplace_c<_DataType>;
 
 template <typename _KernelNameSpecialization>
 class dpnp_rng_logistic_c_kernel;
 
 /*   Logistic(loc, scale) ~ loc + scale * log(u/(1.0 - u)) */
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_logistic_c(DPCTLSyclQueueRef q_ref,
-                                      void* result,
-                                      const double loc,
-                                      const double scale,
-                                      const size_t size,
-                                      const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_logistic_c(DPCTLSyclQueueRef q_ref,
+                        void *result,
+                        const double loc,
+                        const double scale,
+                        const size_t size,
+                        const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size || !result)
-    {
+    if (!size || !result) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     const _DataType d_zero = _DataType(0.0);
-    const _DataType d_one = _DataType(1.0);
+    const _DataType d_one  = _DataType(1.0);
 
-    _DataType* result1 = reinterpret_cast<_DataType*>(result);
+    _DataType *result1 = reinterpret_cast<_DataType *>(result);
 
     mkl_rng::uniform<_DataType> distribution(d_zero, d_one);
-    auto event_distribution = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
+    auto event_distribution =
+        mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
 
     sycl::range<1> gws(size);
     auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
-        size_t i = global_id[0];
+        size_t i   = global_id[0];
         result1[i] = sycl::log(result1[i] / (1.0 - result1[i]));
         result1[i] = loc + scale * result1[i];
     };
-    auto kernel_func = [&](sycl::handler& cgh) {
+    auto kernel_func = [&](sycl::handler &cgh) {
         cgh.depends_on({event_distribution});
-        cgh.parallel_for<class dpnp_rng_logistic_c_kernel<_DataType>>(gws, kernel_parallel_for_func);
+        cgh.parallel_for<class dpnp_rng_logistic_c_kernel<_DataType>>(
+            gws, kernel_parallel_for_func);
     };
     auto event = q.submit(kernel_func);
-    event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
+    event_ref  = reinterpret_cast<DPCTLSyclEventRef>(&event);
 
     return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType>
-void dpnp_rng_logistic_c(void* result, const double loc, const double scale, const size_t size)
+void dpnp_rng_logistic_c(void *result,
+                         const double loc,
+                         const double scale,
+                         const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_logistic_c<_DataType>(q_ref,
-                                                                 result,
-                                                                 loc,
-                                                                 scale,
-                                                                 size,
-                                                                 dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_rng_logistic_c<_DataType>(
+        q_ref, result, loc, scale, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_logistic_default_c)(void*, const double, const double, const size_t) = dpnp_rng_logistic_c<_DataType>;
+void (*dpnp_rng_logistic_default_c)(void *,
+                                    const double,
+                                    const double,
+                                    const size_t) =
+    dpnp_rng_logistic_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_logistic_ext_c)(DPCTLSyclQueueRef,
-                                             void*,
+                                             void *,
                                              const double,
                                              const double,
                                              const size_t,
-                                             const DPCTLEventVectorRef) = dpnp_rng_logistic_c<_DataType>;
+                                             const DPCTLEventVectorRef) =
+    dpnp_rng_logistic_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_lognormal_c(DPCTLSyclQueueRef q_ref,
-                                       void* result,
-                                       const _DataType mean,
-                                       const _DataType stddev,
-                                       const size_t size,
-                                       const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_lognormal_c(DPCTLSyclQueueRef q_ref,
+                         void *result,
+                         const _DataType mean,
+                         const _DataType stddev,
+                         const size_t size,
+                         const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
@@ -943,72 +968,76 @@ DPCTLSyclEventRef dpnp_rng_lognormal_c(DPCTLSyclQueueRef q_ref,
     DPCTLSyclEventRef event_ref = nullptr;
     sycl::event event_out;
 
-    if (!size || !result)
-    {
+    if (!size || !result) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    _DataType* result1 = reinterpret_cast<_DataType*>(result);
+    _DataType *result1 = reinterpret_cast<_DataType *>(result);
 
-    if (stddev == 0.0)
-    {
-        _DataType* fill_value = reinterpret_cast<_DataType*>(sycl::malloc_shared(sizeof(_DataType), q));
-        fill_value[0] = static_cast<_DataType>(std::exp(mean + (stddev * stddev) / 2));
+    if (stddev == 0.0) {
+        _DataType *fill_value = reinterpret_cast<_DataType *>(
+            sycl::malloc_shared(sizeof(_DataType), q));
+        fill_value[0] =
+            static_cast<_DataType>(std::exp(mean + (stddev * stddev) / 2));
 
-        event_ref = dpnp_initval_c<_DataType>(q_ref, result, fill_value, size, dep_event_vec_ref);
+        event_ref = dpnp_initval_c<_DataType>(q_ref, result, fill_value, size,
+                                              dep_event_vec_ref);
         DPCTLEvent_Wait(event_ref);
         dpnp_memory_free_c(q_ref, fill_value);
     }
-    else
-    {
+    else {
         const _DataType displacement = _DataType(0.0);
-        const _DataType scalefactor = _DataType(1.0);
+        const _DataType scalefactor  = _DataType(1.0);
 
-        mkl_rng::lognormal<_DataType> distribution(mean, stddev, displacement, scalefactor);
-        event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
+        mkl_rng::lognormal<_DataType> distribution(mean, stddev, displacement,
+                                                   scalefactor);
+        event_out =
+            mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
         event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event_out);
     }
     return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType>
-void dpnp_rng_lognormal_c(void* result, const _DataType mean, const _DataType stddev, const size_t size)
+void dpnp_rng_lognormal_c(void *result,
+                          const _DataType mean,
+                          const _DataType stddev,
+                          const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_lognormal_c<_DataType>(q_ref,
-                                                                  result,
-                                                                  mean,
-                                                                  stddev,
-                                                                  size,
-                                                                  dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_rng_lognormal_c<_DataType>(
+        q_ref, result, mean, stddev, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_lognormal_default_c)(void*,
+void (*dpnp_rng_lognormal_default_c)(void *,
                                      const _DataType,
                                      const _DataType,
-                                     const size_t) = dpnp_rng_lognormal_c<_DataType>;
+                                     const size_t) =
+    dpnp_rng_lognormal_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_lognormal_ext_c)(DPCTLSyclQueueRef,
-                                              void*,
+                                              void *,
                                               const _DataType,
                                               const _DataType,
                                               const size_t,
-                                              const DPCTLEventVectorRef) = dpnp_rng_lognormal_c<_DataType>;
+                                              const DPCTLEventVectorRef) =
+    dpnp_rng_lognormal_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_multinomial_c(DPCTLSyclQueueRef q_ref,
-                                         void* result,
-                                         const int ntrial,
-                                         void* p_in,
-                                         const size_t p_size,
-                                         const size_t size,
-                                         const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_multinomial_c(DPCTLSyclQueueRef q_ref,
+                           void *result,
+                           const int ntrial,
+                           void *p_in,
+                           const size_t p_size,
+                           const size_t size,
+                           const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
@@ -1016,21 +1045,19 @@ DPCTLSyclEventRef dpnp_rng_multinomial_c(DPCTLSyclQueueRef q_ref,
     DPCTLSyclEventRef event_ref = nullptr;
     sycl::event event_out;
 
-    if (!size || !result || (ntrial < 0))
-    {
+    if (!size || !result || (ntrial < 0)) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    if (ntrial == 0)
-    {
-        event_ref = dpnp_zeros_c<_DataType>(q_ref, result, size, dep_event_vec_ref);
+    if (ntrial == 0) {
+        event_ref =
+            dpnp_zeros_c<_DataType>(q_ref, result, size, dep_event_vec_ref);
     }
-    else
-    {
+    else {
         DPNPC_ptr_adapter<double> p_ptr(q_ref, p_in, p_size, true);
-        double* p_data = p_ptr.get_ptr();
+        double *p_data = p_ptr.get_ptr();
 
         // size = size
         // `result` is a array for random numbers
@@ -1040,32 +1067,37 @@ DPCTLSyclEventRef dpnp_rng_multinomial_c(DPCTLSyclQueueRef q_ref,
 
         size_t is_cpu_queue = dpnp_queue_is_cpu_c();
 
-        // math library supports the distribution generation on GPU device with input parameters
-        // which follow the condition
-        if (is_cpu_queue || (!is_cpu_queue && (p_size >= ((size_t)ntrial * 16)) && (ntrial <= 16)))
+        // math library supports the distribution generation on GPU device with
+        // input parameters which follow the condition
+        if (is_cpu_queue ||
+            (!is_cpu_queue && (p_size >= ((size_t)ntrial * 16)) &&
+             (ntrial <= 16)))
         {
-            DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result, size, true, true);
-            _DataType* result1 = result_ptr.get_ptr();
+            DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result, size, true,
+                                                    true);
+            _DataType *result1 = result_ptr.get_ptr();
 
             auto p = sycl::span<double>{p_data, p_size};
             mkl_rng::multinomial<_DataType> distribution(ntrial, p);
 
             // perform generation
-            event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, n, result1);
+            event_out =
+                mkl_rng::generate(distribution, DPNP_RNG_ENGINE, n, result1);
             event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event_out);
 
             p_ptr.depends_on(event_out);
             result_ptr.depends_on(event_out);
         }
-        else
-        {
-            DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result, size, true, true);
-            _DataType* result1 = result_ptr.get_ptr();
-            int errcode = viRngMultinomial(
-                VSL_RNG_METHOD_MULTINOMIAL_MULTPOISSON, get_rng_stream(), n, result1, ntrial, p_size, p_data);
-            if (errcode != VSL_STATUS_OK)
-            {
-                throw std::runtime_error("DPNP RNG Error: dpnp_rng_multinomial_c() failed.");
+        else {
+            DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result, size, true,
+                                                    true);
+            _DataType *result1 = result_ptr.get_ptr();
+            int errcode        = viRngMultinomial(
+                VSL_RNG_METHOD_MULTINOMIAL_MULTPOISSON, get_rng_stream(), n,
+                result1, ntrial, p_size, p_data);
+            if (errcode != VSL_STATUS_OK) {
+                throw std::runtime_error(
+                    "DPNP RNG Error: dpnp_rng_multinomial_c() failed.");
             }
         }
     }
@@ -1073,70 +1105,70 @@ DPCTLSyclEventRef dpnp_rng_multinomial_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_rng_multinomial_c(
-    void* result, const int ntrial, void* p_in, const size_t p_size, const size_t size)
+void dpnp_rng_multinomial_c(void *result,
+                            const int ntrial,
+                            void *p_in,
+                            const size_t p_size,
+                            const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_multinomial_c<_DataType>(q_ref,
-                                                                    result,
-                                                                    ntrial,
-                                                                    p_in,
-                                                                    p_size,
-                                                                    size,
-                                                                    dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_rng_multinomial_c<_DataType>(
+        q_ref, result, ntrial, p_in, p_size, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_multinomial_default_c)(void*,
+void (*dpnp_rng_multinomial_default_c)(void *,
                                        const int,
-                                       void*,
+                                       void *,
                                        const size_t,
-                                       const size_t) = dpnp_rng_multinomial_c<_DataType>;
+                                       const size_t) =
+    dpnp_rng_multinomial_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_multinomial_ext_c)(DPCTLSyclQueueRef,
-                                              void*,
-                                              const int,
-                                              void*,
-                                              const size_t,
-                                              const size_t,
-                                              const DPCTLEventVectorRef) = dpnp_rng_multinomial_c<_DataType>;
+                                                void *,
+                                                const int,
+                                                void *,
+                                                const size_t,
+                                                const size_t,
+                                                const DPCTLEventVectorRef) =
+    dpnp_rng_multinomial_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_multivariate_normal_c(DPCTLSyclQueueRef q_ref,
-                                                 void* result,
-                                                 const int dimen,
-                                                 void* mean_in,
-                                                 const size_t mean_size,
-                                                 void* cov_in,
-                                                 const size_t cov_size,
-                                                 const size_t size,
-                                                 const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_multivariate_normal_c(DPCTLSyclQueueRef q_ref,
+                                   void *result,
+                                   const int dimen,
+                                   void *mean_in,
+                                   const size_t mean_size,
+                                   void *cov_in,
+                                   const size_t cov_size,
+                                   const size_t size,
+                                   const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<double> mean_ptr(q_ref, mean_in, mean_size, true);
-    double* mean_data = mean_ptr.get_ptr();
+    double *mean_data = mean_ptr.get_ptr();
     DPNPC_ptr_adapter<double> cov_ptr(q_ref, cov_in, cov_size, true);
-    double* cov_data = cov_ptr.get_ptr();
+    double *cov_data = cov_ptr.get_ptr();
 
-    _DataType* result1 = static_cast<_DataType *>(result);
+    _DataType *result1 = static_cast<_DataType *>(result);
 
     auto mean = sycl::span<double>{mean_data, mean_size};
-    auto cov = sycl::span<double>{cov_data, cov_size};
+    auto cov  = sycl::span<double>{cov_data, cov_size};
 
     // `result` is a array for random numbers
     // `size` is a `result`'s len.
@@ -1144,7 +1176,8 @@ DPCTLSyclEventRef dpnp_rng_multivariate_normal_c(DPCTLSyclQueueRef q_ref,
     size_t size1 = size / dimen;
 
     mkl_rng::gaussian_mv<_DataType> distribution(dimen, mean, cov);
-    auto event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size1, result1);
+    auto event_out =
+        mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size1, result1);
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event_out);
 
     mean_ptr.depends_on(event_out);
@@ -1154,101 +1187,98 @@ DPCTLSyclEventRef dpnp_rng_multivariate_normal_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_rng_multivariate_normal_c(void* result,
+void dpnp_rng_multivariate_normal_c(void *result,
                                     const int dimen,
-                                    void* mean_in,
+                                    void *mean_in,
                                     const size_t mean_size,
-                                    void* cov_in,
+                                    void *cov_in,
                                     const size_t cov_size,
                                     const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_multivariate_normal_c<_DataType>(q_ref,
-                                                                            result,
-                                                                            dimen,
-                                                                            mean_in,
-                                                                            mean_size,
-                                                                            cov_in,
-                                                                            cov_size,
-                                                                            size,
-                                                                            dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref = dpnp_rng_multivariate_normal_c<_DataType>(
+        q_ref, result, dimen, mean_in, mean_size, cov_in, cov_size, size,
+        dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_multivariate_normal_default_c)(void*,
+void (*dpnp_rng_multivariate_normal_default_c)(void *,
                                                const int,
-                                               void*,
+                                               void *,
                                                const size_t,
-                                               void*,
+                                               void *,
                                                const size_t,
-                                               const size_t) = dpnp_rng_multivariate_normal_c<_DataType>;
+                                               const size_t) =
+    dpnp_rng_multivariate_normal_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef (*dpnp_rng_multivariate_normal_ext_c)(DPCTLSyclQueueRef,
-                                                        void*,
-                                                        const int,
-                                                        void*,
-                                                        const size_t,
-                                                        void*,
-                                                        const size_t,
-                                                        const size_t,
-                                                        const DPCTLEventVectorRef) = dpnp_rng_multivariate_normal_c<_DataType>;
+DPCTLSyclEventRef (*dpnp_rng_multivariate_normal_ext_c)(
+    DPCTLSyclQueueRef,
+    void *,
+    const int,
+    void *,
+    const size_t,
+    void *,
+    const size_t,
+    const size_t,
+    const DPCTLEventVectorRef) = dpnp_rng_multivariate_normal_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_negative_binomial_c(DPCTLSyclQueueRef q_ref,
-                                               void* result,
-                                               const double a,
-                                               const double p,
-                                               const size_t size,
-                                               const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_negative_binomial_c(DPCTLSyclQueueRef q_ref,
+                                 void *result,
+                                 const double a,
+                                 const double p,
+                                 const size_t size,
+                                 const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    _DataType* result1 = reinterpret_cast<_DataType*>(result);
+    _DataType *result1 = reinterpret_cast<_DataType *>(result);
     mkl_rng::negative_binomial<_DataType> distribution(a, p);
-    auto event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
+    auto event_out =
+        mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event_out);
 
     return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType>
-void dpnp_rng_negative_binomial_c(void* result, const double a, const double p, const size_t size)
+void dpnp_rng_negative_binomial_c(void *result,
+                                  const double a,
+                                  const double p,
+                                  const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_negative_binomial_c<_DataType>(q_ref,
-                                                                          result,
-                                                                          a,
-                                                                          p,
-                                                                          size,
-                                                                          dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref = dpnp_rng_negative_binomial_c<_DataType>(
+        q_ref, result, a, p, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_negative_binomial_default_c)(void*,
+void (*dpnp_rng_negative_binomial_default_c)(void *,
                                              const double,
                                              const double,
-                                             const size_t) = dpnp_rng_negative_binomial_c<_DataType>;
+                                             const size_t) =
+    dpnp_rng_negative_binomial_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_negative_binomial_ext_c)(
     DPCTLSyclQueueRef,
-    void*,
+    void *,
     const double,
     const double,
     const size_t,
@@ -1260,12 +1290,13 @@ template <typename _KernelNameSpecialization>
 class dpnp_rng_noncentral_chisquare_c_kernel2;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_noncentral_chisquare_c(DPCTLSyclQueueRef q_ref,
-                                                  void* result,
-                                                  const _DataType df,
-                                                  const _DataType nonc,
-                                                  const size_t size,
-                                                  const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_noncentral_chisquare_c(DPCTLSyclQueueRef q_ref,
+                                    void *result,
+                                    const _DataType df,
+                                    const _DataType nonc,
+                                    const size_t size,
+                                    const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
@@ -1273,107 +1304,118 @@ DPCTLSyclEventRef dpnp_rng_noncentral_chisquare_c(DPCTLSyclQueueRef q_ref,
     DPCTLSyclEventRef event_ref = nullptr;
     sycl::event event_out;
 
-    if (!size || !result)
-    {
+    if (!size || !result) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_DataType> result1_ptr(q_ref, result, size, false, true);
-    _DataType* result1 = result1_ptr.get_ptr();
+    _DataType *result1 = result1_ptr.get_ptr();
 
     const _DataType d_zero = _DataType(0.0);
-    const _DataType d_one = _DataType(1.0);
-    const _DataType d_two = _DataType(2.0);
+    const _DataType d_one  = _DataType(1.0);
+    const _DataType d_two  = _DataType(2.0);
 
     _DataType shape, loc;
     size_t i;
 
-    if (df > 1)
-    {
-        _DataType* nvec = nullptr;
+    if (df > 1) {
+        _DataType *nvec = nullptr;
 
         shape = 0.5 * (df - 1.0);
         /* res has chi^2 with (df - 1) */
         mkl_rng::gamma<_DataType> gamma_distribution(shape, d_zero, d_two);
-        auto event_gamma_distr = mkl_rng::generate(gamma_distribution, DPNP_RNG_ENGINE, size, result1);
+        auto event_gamma_distr = mkl_rng::generate(
+            gamma_distribution, DPNP_RNG_ENGINE, size, result1);
 
-        nvec = reinterpret_cast<_DataType*>(sycl::malloc_shared(size * sizeof(_DataType), q));
+        nvec = reinterpret_cast<_DataType *>(
+            sycl::malloc_shared(size * sizeof(_DataType), q));
 
         loc = sqrt(nonc);
 
         mkl_rng::gaussian<_DataType> gaussian_distribution(loc, d_one);
-        auto event_gaussian_distr = mkl_rng::generate(gaussian_distribution, DPNP_RNG_ENGINE, size, nvec);
+        auto event_gaussian_distr = mkl_rng::generate(
+            gaussian_distribution, DPNP_RNG_ENGINE, size, nvec);
 
         /* squaring could result in an overflow */
-        auto event_sqr_out =
-            mkl_vm::sqr(q, size, nvec, nvec, {event_gamma_distr, event_gaussian_distr}, mkl_vm::mode::ha);
-        auto event_add_out = mkl_vm::add(q, size, result1, nvec, result1, {event_sqr_out}, mkl_vm::mode::ha);
+        auto event_sqr_out = mkl_vm::sqr(
+            q, size, nvec, nvec, {event_gamma_distr, event_gaussian_distr},
+            mkl_vm::mode::ha);
+        auto event_add_out = mkl_vm::add(q, size, result1, nvec, result1,
+                                         {event_sqr_out}, mkl_vm::mode::ha);
         event_add_out.wait();
         sycl::free(nvec, q);
     }
-    else if (df < 1)
-    {
+    else if (df < 1) {
         /* noncentral_chisquare(df, nonc) ~ G( df/2 + Poisson(nonc/2), 2) */
         double lambda;
-        int* pvec = nullptr;
-        pvec = reinterpret_cast<int*>(sycl::malloc_shared(size * sizeof(int), q));
+        int *pvec = nullptr;
+        pvec =
+            reinterpret_cast<int *>(sycl::malloc_shared(size * sizeof(int), q));
         lambda = 0.5 * nonc;
 
         mkl_rng::poisson<int> poisson_distribution(lambda);
-        event_out = mkl_rng::generate(poisson_distribution, DPNP_RNG_ENGINE, size, pvec);
+        event_out = mkl_rng::generate(poisson_distribution, DPNP_RNG_ENGINE,
+                                      size, pvec);
         event_out.wait();
 
         shape = 0.5 * df;
-        if (0.125 * size > sqrt(lambda))
-        {
-            size_t* idx = nullptr;
-            _DataType* tmp = nullptr;
-            idx = reinterpret_cast<size_t*>(sycl::malloc_shared(size * sizeof(size_t), q));
+        if (0.125 * size > sqrt(lambda)) {
+            size_t *idx    = nullptr;
+            _DataType *tmp = nullptr;
+            idx            = reinterpret_cast<size_t *>(
+                sycl::malloc_shared(size * sizeof(size_t), q));
 
             sycl::range<1> gws1(size);
             auto kernel_parallel_for_func1 = [=](sycl::id<1> global_id) {
                 size_t i = global_id[0];
-                idx[i] = i;
+                idx[i]   = i;
             };
-            auto kernel_func1 = [&](sycl::handler& cgh) {
-                cgh.parallel_for<class dpnp_rng_noncentral_chisquare_c_kernel1<_DataType>>(gws1,
-                                                                                           kernel_parallel_for_func1);
+            auto kernel_func1 = [&](sycl::handler &cgh) {
+                cgh.parallel_for<
+                    class dpnp_rng_noncentral_chisquare_c_kernel1<_DataType>>(
+                    gws1, kernel_parallel_for_func1);
             };
             event_out = q.submit(kernel_func1);
             event_out.wait();
 
-            std::sort(idx, idx + size, [pvec](size_t i1, size_t i2) { return pvec[i1] < pvec[i2]; });
+            std::sort(idx, idx + size, [pvec](size_t i1, size_t i2) {
+                return pvec[i1] < pvec[i2];
+            });
             /* idx now contains original indexes of ordered Poisson outputs */
 
-            /* allocate workspace to store samples of gamma, enough to hold entire output */
-            tmp = reinterpret_cast<_DataType*>(sycl::malloc_shared(size * sizeof(_DataType), q));
-            for (i = 0; i < size;)
-            {
+            /* allocate workspace to store samples of gamma, enough to hold
+             * entire output */
+            tmp = reinterpret_cast<_DataType *>(
+                sycl::malloc_shared(size * sizeof(_DataType), q));
+            for (i = 0; i < size;) {
                 size_t j;
                 int cv = pvec[idx[i]];
                 // TODO vectorize
-                for (j = i + 1; (j < size) && (pvec[idx[j]] == cv); j++)
-                {
+                for (j = i + 1; (j < size) && (pvec[idx[j]] == cv); j++) {
                 }
 
-                if (j <= i)
-                {
-                    throw std::runtime_error("DPNP RNG Error: dpnp_rng_noncentral_chisquare_c() failed.");
+                if (j <= i) {
+                    throw std::runtime_error(
+                        "DPNP RNG Error: dpnp_rng_noncentral_chisquare_c() "
+                        "failed.");
                 }
-                mkl_rng::gamma<_DataType> gamma_distribution(shape + cv, d_zero, d_two);
-                event_out = mkl_rng::generate(gamma_distribution, DPNP_RNG_ENGINE, j - i, tmp);
+                mkl_rng::gamma<_DataType> gamma_distribution(shape + cv, d_zero,
+                                                             d_two);
+                event_out = mkl_rng::generate(gamma_distribution,
+                                              DPNP_RNG_ENGINE, j - i, tmp);
                 event_out.wait();
 
                 sycl::range<1> gws2(j - i);
                 auto kernel_parallel_for_func2 = [=](sycl::id<1> global_id) {
-                    size_t index = global_id[0];
+                    size_t index            = global_id[0];
                     result1[idx[index + i]] = tmp[index];
                 };
-                auto kernel_func2 = [&](sycl::handler& cgh) {
-                    cgh.parallel_for<class dpnp_rng_noncentral_chisquare_c_kernel2<_DataType>>(
-                        gws2, kernel_parallel_for_func2);
+                auto kernel_func2 = [&](sycl::handler &cgh) {
+                    cgh.parallel_for<
+                        class dpnp_rng_noncentral_chisquare_c_kernel2<
+                            _DataType>>(gws2, kernel_parallel_for_func2);
                 };
                 event_out = q.submit(kernel_func2);
                 event_out.wait();
@@ -1383,53 +1425,54 @@ DPCTLSyclEventRef dpnp_rng_noncentral_chisquare_c(DPCTLSyclQueueRef q_ref,
             sycl::free(tmp, q);
             sycl::free(idx, q);
         }
-        else
-        {
-            for (i = 0; i < size; i++)
-            {
-                mkl_rng::gamma<_DataType> gamma_distribution(shape + pvec[i], d_zero, d_two);
-                event_out = mkl_rng::generate(gamma_distribution, DPNP_RNG_ENGINE, 1, result1 + 1);
+        else {
+            for (i = 0; i < size; i++) {
+                mkl_rng::gamma<_DataType> gamma_distribution(shape + pvec[i],
+                                                             d_zero, d_two);
+                event_out = mkl_rng::generate(gamma_distribution,
+                                              DPNP_RNG_ENGINE, 1, result1 + 1);
                 event_out.wait();
             }
         }
         sycl::free(pvec, q);
     }
-    else
-    {
+    else {
         /* noncentral_chisquare(1, nonc) ~ (Z + sqrt(nonc))**2 for df == 1 */
         loc = sqrt(nonc);
         mkl_rng::gaussian<_DataType> gaussian_distribution(loc, d_one);
-        auto event_gaussian_distr = mkl_rng::generate(gaussian_distribution, DPNP_RNG_ENGINE, size, result1);
-        event_out = mkl_vm::sqr(q, size, result1, result1, {event_gaussian_distr}, mkl_vm::mode::ha);
+        auto event_gaussian_distr = mkl_rng::generate(
+            gaussian_distribution, DPNP_RNG_ENGINE, size, result1);
+        event_out = mkl_vm::sqr(q, size, result1, result1,
+                                {event_gaussian_distr}, mkl_vm::mode::ha);
         event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event_out);
     }
     return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType>
-void dpnp_rng_noncentral_chisquare_c(void* result, const _DataType df, const _DataType nonc, const size_t size)
+void dpnp_rng_noncentral_chisquare_c(void *result,
+                                     const _DataType df,
+                                     const _DataType nonc,
+                                     const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_noncentral_chisquare_c<_DataType>(q_ref,
-                                                                             result,
-                                                                             df,
-                                                                             nonc,
-                                                                             size,
-                                                                             dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref = dpnp_rng_noncentral_chisquare_c<_DataType>(
+        q_ref, result, df, nonc, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_noncentral_chisquare_default_c)(void*,
+void (*dpnp_rng_noncentral_chisquare_default_c)(void *,
                                                 const _DataType,
                                                 const _DataType,
-                                                const size_t) = dpnp_rng_noncentral_chisquare_c<_DataType>;
+                                                const size_t) =
+    dpnp_rng_noncentral_chisquare_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_noncentral_chisquare_ext_c)(
     DPCTLSyclQueueRef,
-    void*,
+    void *,
     const _DataType,
     const _DataType,
     const size_t,
@@ -1437,26 +1480,25 @@ DPCTLSyclEventRef (*dpnp_rng_noncentral_chisquare_ext_c)(
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_rng_normal_c(DPCTLSyclQueueRef q_ref,
-                                    void* result_out,
+                                    void *result_out,
                                     const double mean_in,
                                     const double stddev_in,
                                     const int64_t size,
-                                    void* random_state_in,
+                                    void *random_state_in,
                                     const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue* q = reinterpret_cast<sycl::queue*>(q_ref);
+    sycl::queue *q              = reinterpret_cast<sycl::queue *>(q_ref);
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
     assert(q != nullptr);
 
-    _DataType* result = static_cast<_DataType*>(result_out);
+    _DataType *result = static_cast<_DataType *>(result_out);
 
     // set mean of distribution
     const _DataType mean = static_cast<_DataType>(mean_in);
@@ -1465,18 +1507,20 @@ DPCTLSyclEventRef dpnp_rng_normal_c(DPCTLSyclQueueRef q_ref,
 
     mkl_rng::gaussian<_DataType> distribution(mean, stddev);
 
-    if (q->get_device().is_cpu())
-    {
-        mt19937_struct* random_state = static_cast<mt19937_struct*>(random_state_in);
-        mkl_rng::mt19937* engine = static_cast<mkl_rng::mt19937*>(random_state->engine);
+    if (q->get_device().is_cpu()) {
+        mt19937_struct *random_state =
+            static_cast<mt19937_struct *>(random_state_in);
+        mkl_rng::mt19937 *engine =
+            static_cast<mkl_rng::mt19937 *>(random_state->engine);
 
         // perform generation with MT19937 engine
         event_ref = dpnp_rng_generate(distribution, *engine, size, result);
     }
-    else
-    {
-        mcg59_struct* random_state = static_cast<mcg59_struct*>(random_state_in);
-        mkl_rng::mcg59* engine = static_cast<mkl_rng::mcg59*>(random_state->engine);
+    else {
+        mcg59_struct *random_state =
+            static_cast<mcg59_struct *>(random_state_in);
+        mkl_rng::mcg59 *engine =
+            static_cast<mkl_rng::mcg59 *>(random_state->engine);
 
         // perform generation with MCG59 engine
         event_ref = dpnp_rng_generate(distribution, *engine, size, result);
@@ -1485,32 +1529,36 @@ DPCTLSyclEventRef dpnp_rng_normal_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_rng_normal_c(void* result, const _DataType mean, const _DataType stddev, const size_t size)
+void dpnp_rng_normal_c(void *result,
+                       const _DataType mean,
+                       const _DataType stddev,
+                       const size_t size)
 {
-    sycl::queue* q = &DPNP_QUEUE;
+    sycl::queue *q          = &DPNP_QUEUE;
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(q);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = nullptr;
+    DPCTLSyclEventRef event_ref           = nullptr;
 
-    if (q->get_device().is_cpu())
-    {
-        mt19937_struct* mt19937 = new mt19937_struct();
-        mt19937->engine = &DPNP_RNG_ENGINE;
+    if (q->get_device().is_cpu()) {
+        mt19937_struct *mt19937 = new mt19937_struct();
+        mt19937->engine         = &DPNP_RNG_ENGINE;
 
-        event_ref = dpnp_rng_normal_c<_DataType>(
-            q_ref, result, mean, stddev, static_cast<int64_t>(size), mt19937, dep_event_vec_ref);
+        event_ref = dpnp_rng_normal_c<_DataType>(q_ref, result, mean, stddev,
+                                                 static_cast<int64_t>(size),
+                                                 mt19937, dep_event_vec_ref);
         DPCTLEvent_WaitAndThrow(event_ref);
         DPCTLEvent_Delete(event_ref);
         delete mt19937;
     }
-    else
-    {
-        // MCG59 engine is assumed to provide a better performance on GPU than MT19937
-        mcg59_struct* mcg59 = new mcg59_struct();
-        mcg59->engine = &DPNP_RNG_MCG59_ENGINE;
+    else {
+        // MCG59 engine is assumed to provide a better performance on GPU than
+        // MT19937
+        mcg59_struct *mcg59 = new mcg59_struct();
+        mcg59->engine       = &DPNP_RNG_MCG59_ENGINE;
 
-        event_ref = dpnp_rng_normal_c<_DataType>(
-            q_ref, result, mean, stddev, static_cast<int64_t>(size), mcg59, dep_event_vec_ref);
+        event_ref = dpnp_rng_normal_c<_DataType>(q_ref, result, mean, stddev,
+                                                 static_cast<int64_t>(size),
+                                                 mcg59, dep_event_vec_ref);
         DPCTLEvent_WaitAndThrow(event_ref);
         DPCTLEvent_Delete(event_ref);
         delete mcg59;
@@ -1518,23 +1566,24 @@ void dpnp_rng_normal_c(void* result, const _DataType mean, const _DataType stdde
 }
 
 template <typename _DataType>
-void (*dpnp_rng_normal_default_c)(void*,
+void (*dpnp_rng_normal_default_c)(void *,
                                   const _DataType,
                                   const _DataType,
                                   const size_t) = dpnp_rng_normal_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_normal_ext_c)(DPCTLSyclQueueRef,
-                                           void*,
+                                           void *,
                                            const double,
                                            const double,
                                            const int64_t,
-                                           void*,
-                                           const DPCTLEventVectorRef) = dpnp_rng_normal_c<_DataType>;
+                                           void *,
+                                           const DPCTLEventVectorRef) =
+    dpnp_rng_normal_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_rng_pareto_c(DPCTLSyclQueueRef q_ref,
-                                    void* result,
+                                    void *result,
                                     const double alpha,
                                     const size_t size,
                                     const DPCTLEventVectorRef dep_event_vec_ref)
@@ -1544,108 +1593,109 @@ DPCTLSyclEventRef dpnp_rng_pareto_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
     std::vector<sycl::event> no_deps;
 
     const _DataType d_zero = _DataType(0.0);
-    const _DataType d_one = _DataType(1.0);
-    _DataType neg_rec_alp = -1.0 / alpha;
+    const _DataType d_one  = _DataType(1.0);
+    _DataType neg_rec_alp  = -1.0 / alpha;
 
-    _DataType* result1 = reinterpret_cast<_DataType*>(result);
+    _DataType *result1 = reinterpret_cast<_DataType *>(result);
 
     mkl_rng::uniform<_DataType> distribution(d_zero, d_one);
-    auto event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
+    auto event_out =
+        mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
     event_out.wait();
 
-    event_out = mkl_vm::powx(q, size, result1, neg_rec_alp, result1, no_deps, mkl_vm::mode::ha);
+    event_out = mkl_vm::powx(q, size, result1, neg_rec_alp, result1, no_deps,
+                             mkl_vm::mode::ha);
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event_out);
 
     return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType>
-void dpnp_rng_pareto_c(void* result, const double alpha, const size_t size)
+void dpnp_rng_pareto_c(void *result, const double alpha, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_pareto_c<_DataType>(q_ref,
-                                                               result,
-                                                               alpha,
-                                                               size,
-                                                               dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_rng_pareto_c<_DataType>(
+        q_ref, result, alpha, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_pareto_default_c)(void*, const double, const size_t) = dpnp_rng_pareto_c<_DataType>;
+void (*dpnp_rng_pareto_default_c)(void *,
+                                  const double,
+                                  const size_t) = dpnp_rng_pareto_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_pareto_ext_c)(DPCTLSyclQueueRef,
-                                           void*,
+                                           void *,
                                            const double,
                                            const size_t,
-                                           const DPCTLEventVectorRef) = dpnp_rng_pareto_c<_DataType>;
+                                           const DPCTLEventVectorRef) =
+    dpnp_rng_pareto_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_poisson_c(DPCTLSyclQueueRef q_ref,
-                                     void* result,
-                                     const double lambda,
-                                     const size_t size,
-                                     const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_poisson_c(DPCTLSyclQueueRef q_ref,
+                       void *result,
+                       const double lambda,
+                       const size_t size,
+                       const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    _DataType* result1 = reinterpret_cast<_DataType*>(result);
+    _DataType *result1 = reinterpret_cast<_DataType *>(result);
 
     mkl_rng::poisson<_DataType> distribution(lambda);
     // perform generation
-    auto event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
+    auto event_out =
+        mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event_out);
 
     return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType>
-void dpnp_rng_poisson_c(void* result, const double lambda, const size_t size)
+void dpnp_rng_poisson_c(void *result, const double lambda, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_poisson_c<_DataType>(q_ref,
-                                                                result,
-                                                                lambda,
-                                                                size,
-                                                                dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_rng_poisson_c<_DataType>(
+        q_ref, result, lambda, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_poisson_default_c)(void*, const double, const size_t) = dpnp_rng_poisson_c<_DataType>;
+void (*dpnp_rng_poisson_default_c)(void *, const double, const size_t) =
+    dpnp_rng_poisson_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_poisson_ext_c)(DPCTLSyclQueueRef,
-                                            void*,
+                                            void *,
                                             const double,
                                             const size_t,
-                                            const DPCTLEventVectorRef) = dpnp_rng_poisson_c<_DataType>;
+                                            const DPCTLEventVectorRef) =
+    dpnp_rng_poisson_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_rng_power_c(DPCTLSyclQueueRef q_ref,
-                                   void* result,
+                                   void *result,
                                    const double alpha,
                                    const size_t size,
                                    const DPCTLEventVectorRef dep_event_vec_ref)
@@ -1655,178 +1705,183 @@ DPCTLSyclEventRef dpnp_rng_power_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
     std::vector<sycl::event> no_deps;
 
     const _DataType d_zero = _DataType(0.0);
-    const _DataType d_one = _DataType(1.0);
-    _DataType neg_rec_alp = 1.0 / alpha;
+    const _DataType d_one  = _DataType(1.0);
+    _DataType neg_rec_alp  = 1.0 / alpha;
 
-    _DataType* result1 = reinterpret_cast<_DataType*>(result);
+    _DataType *result1 = reinterpret_cast<_DataType *>(result);
 
     mkl_rng::uniform<_DataType> distribution(d_zero, d_one);
-    auto event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
+    auto event_out =
+        mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
     event_out.wait();
 
-    event_out = mkl_vm::powx(q, size, result1, neg_rec_alp, result1, no_deps, mkl_vm::mode::ha);
+    event_out = mkl_vm::powx(q, size, result1, neg_rec_alp, result1, no_deps,
+                             mkl_vm::mode::ha);
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event_out);
 
     return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType>
-void dpnp_rng_power_c(void* result, const double alpha, const size_t size)
+void dpnp_rng_power_c(void *result, const double alpha, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_power_c<_DataType>(q_ref,
-                                                              result,
-                                                              alpha,
-                                                              size,
-                                                              dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_rng_power_c<_DataType>(
+        q_ref, result, alpha, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_power_default_c)(void*, const double, const size_t) = dpnp_rng_power_c<_DataType>;
+void (*dpnp_rng_power_default_c)(void *,
+                                 const double,
+                                 const size_t) = dpnp_rng_power_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_power_ext_c)(DPCTLSyclQueueRef,
-                                          void*,
+                                          void *,
                                           const double,
                                           const size_t,
-                                          const DPCTLEventVectorRef) = dpnp_rng_power_c<_DataType>;
+                                          const DPCTLEventVectorRef) =
+    dpnp_rng_power_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_rayleigh_c(DPCTLSyclQueueRef q_ref,
-                                      void* result,
-                                      const _DataType scale,
-                                      const size_t size,
-                                      const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_rayleigh_c(DPCTLSyclQueueRef q_ref,
+                        void *result,
+                        const _DataType scale,
+                        const size_t size,
+                        const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
     std::vector<sycl::event> no_deps;
 
-    const _DataType a = 0.0;
+    const _DataType a    = 0.0;
     const _DataType beta = 2.0;
 
     DPNPC_ptr_adapter<_DataType> result1_ptr(q_ref, result, size);
-    _DataType* result1 = result1_ptr.get_ptr();
+    _DataType *result1 = result1_ptr.get_ptr();
 
     mkl_rng::exponential<_DataType> distribution(a, beta);
 
-    auto exponential_rng_event = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
-    auto sqrt_event = mkl_vm::sqrt(q, size, result1, result1, {exponential_rng_event}, mkl_vm::mode::ha);
+    auto exponential_rng_event =
+        mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
+    auto sqrt_event = mkl_vm::sqrt(q, size, result1, result1,
+                                   {exponential_rng_event}, mkl_vm::mode::ha);
     auto scal_event = mkl_blas::scal(q, size, scale, result1, 1, {sqrt_event});
-    event_ref = reinterpret_cast<DPCTLSyclEventRef>(&scal_event);
+    event_ref       = reinterpret_cast<DPCTLSyclEventRef>(&scal_event);
 
     return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType>
-void dpnp_rng_rayleigh_c(void* result, const _DataType scale, const size_t size)
+void dpnp_rng_rayleigh_c(void *result, const _DataType scale, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_rayleigh_c<_DataType>(q_ref,
-                                                                 result,
-                                                                 scale,
-                                                                 size,
-                                                                 dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_rng_rayleigh_c<_DataType>(
+        q_ref, result, scale, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_rayleigh_default_c)(void*, const _DataType, const size_t) = dpnp_rng_rayleigh_c<_DataType>;
+void (*dpnp_rng_rayleigh_default_c)(void *, const _DataType, const size_t) =
+    dpnp_rng_rayleigh_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_rayleigh_ext_c)(DPCTLSyclQueueRef,
-                                             void*,
+                                             void *,
                                              const _DataType,
                                              const size_t,
-                                             const DPCTLEventVectorRef) = dpnp_rng_rayleigh_c<_DataType>;
+                                             const DPCTLEventVectorRef) =
+    dpnp_rng_rayleigh_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_shuffle_c(DPCTLSyclQueueRef q_ref,
-                                     void* result,
-                                     const size_t itemsize,
-                                     const size_t ndim,
-                                     const size_t high_dim_size,
-                                     const size_t size,
-                                     const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_shuffle_c(DPCTLSyclQueueRef q_ref,
+                       void *result,
+                       const size_t itemsize,
+                       const size_t ndim,
+                       const size_t high_dim_size,
+                       const size_t size,
+                       const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!result)
-    {
+    if (!result) {
         return event_ref;
     }
 
-    if (!size || !ndim || !(high_dim_size > 1))
-    {
+    if (!size || !ndim || !(high_dim_size > 1)) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    DPNPC_ptr_adapter<char> result1_ptr(q_ref, result, size * itemsize, true, true);
-    char* result1 = result1_ptr.get_ptr();
+    DPNPC_ptr_adapter<char> result1_ptr(q_ref, result, size * itemsize, true,
+                                        true);
+    char *result1 = result1_ptr.get_ptr();
 
     size_t uvec_size = high_dim_size - 1;
-    double* Uvec = reinterpret_cast<double*>(sycl::malloc_shared(uvec_size * sizeof(double), q));
+    double *Uvec     = reinterpret_cast<double *>(
+        sycl::malloc_shared(uvec_size * sizeof(double), q));
     mkl_rng::uniform<double> uniform_distribution(0.0, 1.0);
-    auto uniform_event = mkl_rng::generate(uniform_distribution, DPNP_RNG_ENGINE, uvec_size, Uvec);
+    auto uniform_event = mkl_rng::generate(uniform_distribution,
+                                           DPNP_RNG_ENGINE, uvec_size, Uvec);
     uniform_event.wait();
 
-    if (ndim == 1)
-    {
+    if (ndim == 1) {
         // Fast, statically typed path: shuffle the underlying buffer.
         // Only for non-empty, 1d objects of class ndarray (subclasses such
         // as MaskedArrays may not support this approach).
-        void* buf = sycl::malloc_device(itemsize, q);
-        for (size_t i = uvec_size; i > 0; i--)
-        {
+        void *buf = sycl::malloc_device(itemsize, q);
+        for (size_t i = uvec_size; i > 0; i--) {
             size_t j = (size_t)(floor((i + 1) * Uvec[i - 1]));
-            if (i != j)
-            {
+            if (i != j) {
                 auto memcpy1 = q.memcpy(buf, result1 + j * itemsize, itemsize);
-                auto memcpy2 = q.memcpy(result1 + j * itemsize, result1 + i * itemsize, itemsize, memcpy1);
+                auto memcpy2 =
+                    q.memcpy(result1 + j * itemsize, result1 + i * itemsize,
+                             itemsize, memcpy1);
                 q.memcpy(result1 + i * itemsize, buf, itemsize, memcpy2).wait();
             }
         }
         sycl::free(buf, q);
     }
-    else
-    {
+    else {
         // Multidimensional ndarrays require a bounce buffer.
-        size_t step_size = (size / high_dim_size) * itemsize; // size in bytes for x[i] element
-        void* buf = sycl::malloc_device(step_size, q);
-        for (size_t i = uvec_size; i > 0; i--)
-        {
+        size_t step_size =
+            (size / high_dim_size) * itemsize; // size in bytes for x[i] element
+        void *buf = sycl::malloc_device(step_size, q);
+        for (size_t i = uvec_size; i > 0; i--) {
             size_t j = (size_t)(floor((i + 1) * Uvec[i - 1]));
-            if (j < i)
-            {
-                auto memcpy1 = q.memcpy(buf, result1 + j * step_size, step_size);
-                auto memcpy2 = q.memcpy(result1 + j * step_size, result1 + i * step_size, step_size, memcpy1);
-                q.memcpy(result1 + i * step_size, buf, step_size, memcpy2).wait();
+            if (j < i) {
+                auto memcpy1 =
+                    q.memcpy(buf, result1 + j * step_size, step_size);
+                auto memcpy2 =
+                    q.memcpy(result1 + j * step_size, result1 + i * step_size,
+                             step_size, memcpy1);
+                q.memcpy(result1 + i * step_size, buf, step_size, memcpy2)
+                    .wait();
             }
         }
         sycl::free(buf, q);
@@ -1838,56 +1893,56 @@ DPCTLSyclEventRef dpnp_rng_shuffle_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_rng_shuffle_c(
-    void* result, const size_t itemsize, const size_t ndim, const size_t high_dim_size, const size_t size)
+void dpnp_rng_shuffle_c(void *result,
+                        const size_t itemsize,
+                        const size_t ndim,
+                        const size_t high_dim_size,
+                        const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_shuffle_c<_DataType>(q_ref,
-                                                                result,
-                                                                itemsize,
-                                                                ndim,
-                                                                high_dim_size,
-                                                                size,
-                                                                dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_rng_shuffle_c<_DataType>(
+        q_ref, result, itemsize, ndim, high_dim_size, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_shuffle_default_c)(void*,
+void (*dpnp_rng_shuffle_default_c)(void *,
                                    const size_t,
                                    const size_t,
                                    const size_t,
-                                   const size_t) = dpnp_rng_shuffle_c<_DataType>;
+                                   const size_t) =
+    dpnp_rng_shuffle_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_shuffle_ext_c)(DPCTLSyclQueueRef,
-                                            void*,
+                                            void *,
                                             const size_t,
                                             const size_t,
                                             const size_t,
                                             const size_t,
-                                            const DPCTLEventVectorRef) = dpnp_rng_shuffle_c<_DataType>;
+                                            const DPCTLEventVectorRef) =
+    dpnp_rng_shuffle_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_standard_cauchy_c(DPCTLSyclQueueRef q_ref,
-                                             void* result,
-                                             const size_t size,
-                                             const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_standard_cauchy_c(DPCTLSyclQueueRef q_ref,
+                               void *result,
+                               const size_t size,
+                               const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    _DataType* result1 = reinterpret_cast<_DataType*>(result);
+    _DataType *result1 = reinterpret_cast<_DataType *>(result);
 
     const _DataType displacement = _DataType(0.0);
 
@@ -1895,175 +1950,186 @@ DPCTLSyclEventRef dpnp_rng_standard_cauchy_c(DPCTLSyclQueueRef q_ref,
 
     mkl_rng::cauchy<_DataType> distribution(displacement, scalefactor);
     // perform generation
-    auto event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
+    auto event_out =
+        mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event_out);
 
     return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType>
-void dpnp_rng_standard_cauchy_c(void* result, const size_t size)
+void dpnp_rng_standard_cauchy_c(void *result, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_standard_cauchy_c<_DataType>(q_ref,
-                                                                        result,
-                                                                        size,
-                                                                        dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref = dpnp_rng_standard_cauchy_c<_DataType>(
+        q_ref, result, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_standard_cauchy_default_c)(void*, const size_t) = dpnp_rng_standard_cauchy_c<_DataType>;
+void (*dpnp_rng_standard_cauchy_default_c)(void *, const size_t) =
+    dpnp_rng_standard_cauchy_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_standard_cauchy_ext_c)(DPCTLSyclQueueRef,
-                                                    void*,
+                                                    void *,
                                                     const size_t,
-                                                    const DPCTLEventVectorRef) = dpnp_rng_standard_cauchy_c<_DataType>;
+                                                    const DPCTLEventVectorRef) =
+    dpnp_rng_standard_cauchy_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_standard_exponential_c(DPCTLSyclQueueRef q_ref,
-                                                  void* result,
-                                                  const size_t size,
-                                                  const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_standard_exponential_c(DPCTLSyclQueueRef q_ref,
+                                    void *result,
+                                    const size_t size,
+                                    const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     // set displacement a
     const _DataType beta = (_DataType(1.0));
 
-    event_ref = dpnp_rng_exponential_c(q_ref, result, beta, size, dep_event_vec_ref);
+    event_ref =
+        dpnp_rng_exponential_c(q_ref, result, beta, size, dep_event_vec_ref);
 
     return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType>
-void dpnp_rng_standard_exponential_c(void* result, const size_t size)
+void dpnp_rng_standard_exponential_c(void *result, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_standard_exponential_c<_DataType>(q_ref,
-                                                                             result,
-                                                                             size,
-                                                                             dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref = dpnp_rng_standard_exponential_c<_DataType>(
+        q_ref, result, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_standard_exponential_default_c)(void*, const size_t) = dpnp_rng_standard_exponential_c<_DataType>;
+void (*dpnp_rng_standard_exponential_default_c)(void *, const size_t) =
+    dpnp_rng_standard_exponential_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_standard_exponential_ext_c)(
     DPCTLSyclQueueRef,
-    void*,
+    void *,
     const size_t,
     const DPCTLEventVectorRef) = dpnp_rng_standard_exponential_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_standard_gamma_c(DPCTLSyclQueueRef q_ref,
-                                            void* result,
-                                            const _DataType shape,
-                                            const size_t size,
-                                            const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_standard_gamma_c(DPCTLSyclQueueRef q_ref,
+                              void *result,
+                              const _DataType shape,
+                              const size_t size,
+                              const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     const _DataType scale = _DataType(1.0);
 
-    event_ref = dpnp_rng_gamma_c(q_ref, result, shape, scale, size, dep_event_vec_ref);
+    event_ref =
+        dpnp_rng_gamma_c(q_ref, result, shape, scale, size, dep_event_vec_ref);
 
     return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType>
-void dpnp_rng_standard_gamma_c(void* result, const _DataType shape, const size_t size)
+void dpnp_rng_standard_gamma_c(void *result,
+                               const _DataType shape,
+                               const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_standard_gamma_c<_DataType>(q_ref,
-                                                                       result,
-                                                                       shape,
-                                                                       size,
-                                                                       dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref = dpnp_rng_standard_gamma_c<_DataType>(
+        q_ref, result, shape, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_standard_gamma_default_c)(void*, const _DataType, const size_t) = dpnp_rng_standard_gamma_c<_DataType>;
+void (*dpnp_rng_standard_gamma_default_c)(void *,
+                                          const _DataType,
+                                          const size_t) =
+    dpnp_rng_standard_gamma_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_standard_gamma_ext_c)(DPCTLSyclQueueRef,
-                                                   void*,
+                                                   void *,
                                                    const _DataType,
                                                    const size_t,
-                                                   const DPCTLEventVectorRef) = dpnp_rng_standard_gamma_c<_DataType>;
+                                                   const DPCTLEventVectorRef) =
+    dpnp_rng_standard_gamma_c<_DataType>;
 
 template <typename _DataType>
-void dpnp_rng_standard_normal_c(void* result, size_t size)
+void dpnp_rng_standard_normal_c(void *result, size_t size)
 {
     dpnp_rng_normal_c(result, _DataType(0.0), _DataType(1.0), size);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_standard_normal_default_c)(void*, const size_t) = dpnp_rng_standard_normal_c<_DataType>;
+void (*dpnp_rng_standard_normal_default_c)(void *, const size_t) =
+    dpnp_rng_standard_normal_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_standard_t_c(DPCTLSyclQueueRef q_ref,
-                                        void* result,
-                                        const _DataType df,
-                                        const size_t size,
-                                        const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_standard_t_c(DPCTLSyclQueueRef q_ref,
+                          void *result,
+                          const _DataType df,
+                          const size_t size,
+                          const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size || !result)
-    {
+    if (!size || !result) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    _DataType* result1 = reinterpret_cast<_DataType*>(result);
+    _DataType *result1     = reinterpret_cast<_DataType *>(result);
     const _DataType d_zero = 0.0, d_one = 1.0;
     _DataType shape = df / 2;
-    _DataType* sn = nullptr;
+    _DataType *sn   = nullptr;
 
     mkl_rng::gamma<_DataType> gamma_distribution(shape, d_zero, 1.0 / shape);
-    auto gamma_distr_event = mkl_rng::generate(gamma_distribution, DPNP_RNG_ENGINE, size, result1);
+    auto gamma_distr_event =
+        mkl_rng::generate(gamma_distribution, DPNP_RNG_ENGINE, size, result1);
 
-    auto invsqrt_event = mkl_vm::invsqrt(q, size, result1, result1, {gamma_distr_event}, mkl_vm::mode::ha);
+    auto invsqrt_event = mkl_vm::invsqrt(q, size, result1, result1,
+                                         {gamma_distr_event}, mkl_vm::mode::ha);
 
-    sn = reinterpret_cast<_DataType*>(sycl::malloc_shared(size * sizeof(_DataType), q));
+    sn = reinterpret_cast<_DataType *>(
+        sycl::malloc_shared(size * sizeof(_DataType), q));
 
     mkl_rng::gaussian<_DataType> gaussian_distribution(d_zero, d_one);
-    auto gaussian_distr_event = mkl_rng::generate(gaussian_distribution, DPNP_RNG_ENGINE, size, sn);
+    auto gaussian_distr_event =
+        mkl_rng::generate(gaussian_distribution, DPNP_RNG_ENGINE, size, sn);
 
     auto event_out =
-        mkl_vm::mul(q, size, result1, sn, result1, {invsqrt_event, gaussian_distr_event}, mkl_vm::mode::ha);
+        mkl_vm::mul(q, size, result1, sn, result1,
+                    {invsqrt_event, gaussian_distr_event}, mkl_vm::mode::ha);
     event_out.wait();
 
     sycl::free(sn, q);
@@ -2072,106 +2138,102 @@ DPCTLSyclEventRef dpnp_rng_standard_t_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_rng_standard_t_c(void* result, const _DataType df, const size_t size)
+void dpnp_rng_standard_t_c(void *result, const _DataType df, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_standard_t_c<_DataType>(q_ref,
-                                                                   result,
-                                                                   df,
-                                                                   size,
-                                                                   dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_rng_standard_t_c<_DataType>(
+        q_ref, result, df, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_standard_t_default_c)(void*, const _DataType, const size_t) = dpnp_rng_standard_t_c<_DataType>;
+void (*dpnp_rng_standard_t_default_c)(void *, const _DataType, const size_t) =
+    dpnp_rng_standard_t_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_standard_t_ext_c)(DPCTLSyclQueueRef,
-                                               void*,
+                                               void *,
                                                const _DataType,
                                                const size_t,
-                                               const DPCTLEventVectorRef) = dpnp_rng_standard_t_c<_DataType>;
+                                               const DPCTLEventVectorRef) =
+    dpnp_rng_standard_t_c<_DataType>;
 
 template <typename _KernelNameSpecialization>
 class dpnp_rng_triangular_ration_acceptance_c_kernel;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_triangular_c(DPCTLSyclQueueRef q_ref,
-                                        void* result,
-                                        const _DataType x_min,
-                                        const _DataType x_mode,
-                                        const _DataType x_max,
-                                        const size_t size,
-                                        const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_triangular_c(DPCTLSyclQueueRef q_ref,
+                          void *result,
+                          const _DataType x_min,
+                          const _DataType x_mode,
+                          const _DataType x_max,
+                          const size_t size,
+                          const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    _DataType* result1 = reinterpret_cast<_DataType*>(result);
+    _DataType *result1     = reinterpret_cast<_DataType *>(result);
     const _DataType d_zero = (_DataType(0));
-    const _DataType d_one = (_DataType(1));
+    const _DataType d_one  = (_DataType(1));
 
     _DataType ratio, lpr, rpr;
 
     mkl_rng::uniform<_DataType> uniform_distribution(d_zero, d_one);
-    auto event_uniform = mkl_rng::generate(uniform_distribution, DPNP_RNG_ENGINE, size, result1);
+    auto event_uniform =
+        mkl_rng::generate(uniform_distribution, DPNP_RNG_ENGINE, size, result1);
 
     {
         _DataType wtot, wl, wr;
 
         wtot = x_max - x_min;
-        wl = x_mode - x_min;
-        wr = x_max - x_mode;
+        wl   = x_mode - x_min;
+        wr   = x_max - x_mode;
 
         ratio = wl / wtot;
-        lpr = wl * wtot;
-        rpr = wr * wtot;
+        lpr   = wl * wtot;
+        rpr   = wr * wtot;
     }
 
-    if (!(0 <= ratio && ratio <= 1))
-    {
-        throw std::runtime_error("DPNP RNG Error: dpnp_rng_triangular_c() failed.");
+    if (!(0 <= ratio && ratio <= 1)) {
+        throw std::runtime_error(
+            "DPNP RNG Error: dpnp_rng_triangular_c() failed.");
     }
 
     sycl::range<1> gws(size);
     auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
         size_t i = global_id[0];
-        if (ratio <= 0)
-        {
+        if (ratio <= 0) {
             result1[i] = x_max - sycl::sqrt(result1[i] * rpr);
         }
-        else if (ratio >= 1)
-        {
+        else if (ratio >= 1) {
             result1[i] = x_min + sycl::sqrt(result1[i] * lpr);
         }
-        else
-        {
+        else {
             _DataType ui = result1[i];
-            if (ui > ratio)
-            {
+            if (ui > ratio) {
                 result1[i] = x_max - sycl::sqrt((1.0 - ui) * rpr);
             }
-            else
-            {
+            else {
                 result1[i] = x_min + sycl::sqrt(ui * lpr);
             }
         }
     };
-    auto kernel_func = [&](sycl::handler& cgh) {
+    auto kernel_func = [&](sycl::handler &cgh) {
         cgh.depends_on({event_uniform});
-        cgh.parallel_for<class dpnp_rng_triangular_ration_acceptance_c_kernel<_DataType>>(gws,
-                                                                                          kernel_parallel_for_func);
+        cgh.parallel_for<
+            class dpnp_rng_triangular_ration_acceptance_c_kernel<_DataType>>(
+            gws, kernel_parallel_for_func);
     };
     auto event_ration_acceptance = q.submit(kernel_func);
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event_ration_acceptance);
@@ -2180,76 +2242,78 @@ DPCTLSyclEventRef dpnp_rng_triangular_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_rng_triangular_c(
-    void* result, const _DataType x_min, const _DataType x_mode, const _DataType x_max, const size_t size)
+void dpnp_rng_triangular_c(void *result,
+                           const _DataType x_min,
+                           const _DataType x_mode,
+                           const _DataType x_max,
+                           const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_triangular_c<_DataType>(q_ref,
-                                                                   result,
-                                                                   x_min,
-                                                                   x_mode,
-                                                                   x_max,
-                                                                   size,
-                                                                   dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_rng_triangular_c<_DataType>(
+        q_ref, result, x_min, x_mode, x_max, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_triangular_default_c)(void*,
+void (*dpnp_rng_triangular_default_c)(void *,
                                       const _DataType,
                                       const _DataType,
                                       const _DataType,
-                                      const size_t) = dpnp_rng_triangular_c<_DataType>;
+                                      const size_t) =
+    dpnp_rng_triangular_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_triangular_ext_c)(DPCTLSyclQueueRef,
-                                               void*,
+                                               void *,
                                                const _DataType,
                                                const _DataType,
                                                const _DataType,
                                                const size_t,
-                                               const DPCTLEventVectorRef) = dpnp_rng_triangular_c<_DataType>;
+                                               const DPCTLEventVectorRef) =
+    dpnp_rng_triangular_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_uniform_c(DPCTLSyclQueueRef q_ref,
-                                     void* result_out,
-                                     const double low,
-                                     const double high,
-                                     const int64_t size,
-                                     void* random_state_in,
-                                     const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_uniform_c(DPCTLSyclQueueRef q_ref,
+                       void *result_out,
+                       const double low,
+                       const double high,
+                       const int64_t size,
+                       void *random_state_in,
+                       const DPCTLEventVectorRef dep_event_vec_ref)
 {
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue* q = reinterpret_cast<sycl::queue*>(q_ref);
+    sycl::queue *q = reinterpret_cast<sycl::queue *>(q_ref);
 
-    _DataType* result = static_cast<_DataType*>(result_out);
+    _DataType *result = static_cast<_DataType *>(result_out);
 
     // set left bound of distribution
     const _DataType a = static_cast<_DataType>(low);
     // set right bound of distribution
     const _DataType b = static_cast<_DataType>(high);
 
-    if (q->get_device().is_cpu())
-    {
-        mt19937_struct* random_state = static_cast<mt19937_struct*>(random_state_in);
-        mkl_rng::mt19937* engine = static_cast<mkl_rng::mt19937*>(random_state->engine);
+    if (q->get_device().is_cpu()) {
+        mt19937_struct *random_state =
+            static_cast<mt19937_struct *>(random_state_in);
+        mkl_rng::mt19937 *engine =
+            static_cast<mkl_rng::mt19937 *>(random_state->engine);
 
         // perform generation with MT19937 engine
         event_ref = dpnp_rng_generate_uniform(*engine, q, a, b, size, result);
     }
-    else
-    {
-        mcg59_struct* random_state = static_cast<mcg59_struct*>(random_state_in);
-        mkl_rng::mcg59* engine = static_cast<mkl_rng::mcg59*>(random_state->engine);
+    else {
+        mcg59_struct *random_state =
+            static_cast<mcg59_struct *>(random_state_in);
+        mkl_rng::mcg59 *engine =
+            static_cast<mkl_rng::mcg59 *>(random_state->engine);
 
         // perform generation with MCG59 engine
         event_ref = dpnp_rng_generate_uniform(*engine, q, a, b, size, result);
@@ -2258,42 +2322,36 @@ DPCTLSyclEventRef dpnp_rng_uniform_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_rng_uniform_c(void* result, const long low, const long high, const size_t size)
+void dpnp_rng_uniform_c(void *result,
+                        const long low,
+                        const long high,
+                        const size_t size)
 {
-    sycl::queue* q = &DPNP_QUEUE;
+    sycl::queue *q          = &DPNP_QUEUE;
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(q);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = nullptr;
+    DPCTLSyclEventRef event_ref           = nullptr;
 
-    if (q->get_device().is_cpu())
-    {
-        mt19937_struct* mt19937 = new mt19937_struct();
-        mt19937->engine = &DPNP_RNG_ENGINE;
+    if (q->get_device().is_cpu()) {
+        mt19937_struct *mt19937 = new mt19937_struct();
+        mt19937->engine         = &DPNP_RNG_ENGINE;
 
-        event_ref = dpnp_rng_uniform_c<_DataType>(q_ref,
-                                                  result,
-                                                  static_cast<double>(low),
-                                                  static_cast<double>(high),
-                                                  static_cast<int64_t>(size),
-                                                  mt19937,
-                                                  dep_event_vec_ref);
+        event_ref = dpnp_rng_uniform_c<_DataType>(
+            q_ref, result, static_cast<double>(low), static_cast<double>(high),
+            static_cast<int64_t>(size), mt19937, dep_event_vec_ref);
         DPCTLEvent_WaitAndThrow(event_ref);
         DPCTLEvent_Delete(event_ref);
         delete mt19937;
     }
-    else
-    {
-        // MCG59 engine is assumed to provide a better performance on GPU than MT19937
-        mcg59_struct* mcg59 = new mcg59_struct();
-        mcg59->engine = &DPNP_RNG_MCG59_ENGINE;
+    else {
+        // MCG59 engine is assumed to provide a better performance on GPU than
+        // MT19937
+        mcg59_struct *mcg59 = new mcg59_struct();
+        mcg59->engine       = &DPNP_RNG_MCG59_ENGINE;
 
-        event_ref = dpnp_rng_uniform_c<_DataType>(q_ref,
-                                                  result,
-                                                  static_cast<double>(low),
-                                                  static_cast<double>(high),
-                                                  static_cast<int64_t>(size),
-                                                  mcg59,
-                                                  dep_event_vec_ref);
+        event_ref = dpnp_rng_uniform_c<_DataType>(
+            q_ref, result, static_cast<double>(low), static_cast<double>(high),
+            static_cast<int64_t>(size), mcg59, dep_event_vec_ref);
         DPCTLEvent_WaitAndThrow(event_ref);
         DPCTLEvent_Delete(event_ref);
         delete mcg59;
@@ -2301,16 +2359,21 @@ void dpnp_rng_uniform_c(void* result, const long low, const long high, const siz
 }
 
 template <typename _DataType>
-void (*dpnp_rng_uniform_default_c)(void*, const long, const long, const size_t) = dpnp_rng_uniform_c<_DataType>;
+void (*dpnp_rng_uniform_default_c)(void *,
+                                   const long,
+                                   const long,
+                                   const size_t) =
+    dpnp_rng_uniform_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_uniform_ext_c)(DPCTLSyclQueueRef,
-                                            void*,
+                                            void *,
                                             const double,
                                             const double,
                                             const int64_t,
-                                            void*,
-                                            const DPCTLEventVectorRef) = dpnp_rng_uniform_c<_DataType>;
+                                            void *,
+                                            const DPCTLEventVectorRef) =
+    dpnp_rng_uniform_c<_DataType>;
 
 #ifndef M_PI
 /*  128-bits worth of pi */
@@ -2318,32 +2381,32 @@ DPCTLSyclEventRef (*dpnp_rng_uniform_ext_c)(DPCTLSyclQueueRef,
 #endif
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_vonmises_large_kappa_c(DPCTLSyclQueueRef q_ref,
-                                                  void* result,
-                                                  const _DataType mu,
-                                                  const _DataType kappa,
-                                                  const size_t size,
-                                                  const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_vonmises_large_kappa_c(DPCTLSyclQueueRef q_ref,
+                                    void *result,
+                                    const _DataType mu,
+                                    const _DataType kappa,
+                                    const size_t size,
+                                    const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size || !result)
-    {
+    if (!size || !result) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_DataType> result1_ptr(q_ref, result, size, true, true);
-    _DataType* result1 = result1_ptr.get_ptr();
+    _DataType *result1 = result1_ptr.get_ptr();
 
     _DataType r_over_two_kappa, recip_two_kappa;
     _DataType s_minus_one, hpt, r_over_two_kappa_minus_one, rho_minus_one;
-    _DataType* Uvec = nullptr;
-    _DataType* Vvec = nullptr;
+    _DataType *Uvec        = nullptr;
+    _DataType *Vvec        = nullptr;
     const _DataType d_zero = 0.0, d_one = 1.0;
 
     assert(kappa > 1.0);
@@ -2352,44 +2415,47 @@ DPCTLSyclEventRef dpnp_rng_vonmises_large_kappa_c(DPCTLSyclQueueRef q_ref,
 
     /* variables here are dwindling to zero as kappa grows */
     hpt = sqrt(1 + recip_two_kappa * recip_two_kappa);
-    r_over_two_kappa_minus_one = recip_two_kappa * (1 + recip_two_kappa / (1 + hpt));
+    r_over_two_kappa_minus_one =
+        recip_two_kappa * (1 + recip_two_kappa / (1 + hpt));
     r_over_two_kappa = 1 + r_over_two_kappa_minus_one;
-    rho_minus_one = r_over_two_kappa_minus_one - sqrt(2 * r_over_two_kappa * recip_two_kappa);
+    rho_minus_one    = r_over_two_kappa_minus_one -
+                    sqrt(2 * r_over_two_kappa * recip_two_kappa);
     s_minus_one = rho_minus_one * (0.5 * rho_minus_one / (1 + rho_minus_one));
 
-    Uvec = reinterpret_cast<_DataType*>(sycl::malloc_shared(size * sizeof(_DataType), q));
-    Vvec = reinterpret_cast<_DataType*>(sycl::malloc_shared(size * sizeof(_DataType), q));
+    Uvec = reinterpret_cast<_DataType *>(
+        sycl::malloc_shared(size * sizeof(_DataType), q));
+    Vvec = reinterpret_cast<_DataType *>(
+        sycl::malloc_shared(size * sizeof(_DataType), q));
 
-    for (size_t n = 0; n < size;)
-    {
+    for (size_t n = 0; n < size;) {
         size_t diff_size = size - n;
         mkl_rng::uniform<_DataType> uniform_distribution_u(d_zero, 0.5 * M_PI);
-        auto event_out = mkl_rng::generate(uniform_distribution_u, DPNP_RNG_ENGINE, diff_size, Uvec);
+        auto event_out = mkl_rng::generate(uniform_distribution_u,
+                                           DPNP_RNG_ENGINE, diff_size, Uvec);
         event_out.wait();
         // TODO
         // use deps case
         mkl_rng::uniform<_DataType> uniform_distribution_v(d_zero, d_one);
-        event_out = mkl_rng::generate(uniform_distribution_v, DPNP_RNG_ENGINE, diff_size, Vvec);
+        event_out = mkl_rng::generate(uniform_distribution_v, DPNP_RNG_ENGINE,
+                                      diff_size, Vvec);
         event_out.wait();
 
         // TODO
         // kernel
-        for (size_t i = 0; i < diff_size; i++)
-        {
+        for (size_t i = 0; i < diff_size; i++) {
             _DataType sn, cn, sn2, cn2;
             _DataType neg_W_minus_one, V, Y;
 
-            sn = sin(Uvec[i]);
-            cn = cos(Uvec[i]);
-            V = Vvec[i];
+            sn  = sin(Uvec[i]);
+            cn  = cos(Uvec[i]);
+            V   = Vvec[i];
             sn2 = sn * sn;
             cn2 = cn * cn;
 
             neg_W_minus_one = s_minus_one * sn2 / (0.5 * s_minus_one + cn2);
-            Y = kappa * (s_minus_one + neg_W_minus_one);
+            Y               = kappa * (s_minus_one + neg_W_minus_one);
 
-            if ((Y * (2 - Y) >= V) || (log(Y / V) + 1 >= Y))
-            {
+            if ((Y * (2 - Y) >= V) || (log(Y / V) + 1 >= Y)) {
                 Y = neg_W_minus_one * (2 - neg_W_minus_one);
                 if (Y < 0)
                     Y = 0.0;
@@ -2404,18 +2470,19 @@ DPCTLSyclEventRef dpnp_rng_vonmises_large_kappa_c(DPCTLSyclQueueRef q_ref,
     sycl::free(Uvec, q);
 
     mkl_rng::uniform<_DataType> uniform_distribution(d_zero, d_one);
-    auto uniform_distr_event = mkl_rng::generate(uniform_distribution, DPNP_RNG_ENGINE, size, Vvec);
+    auto uniform_distr_event =
+        mkl_rng::generate(uniform_distribution, DPNP_RNG_ENGINE, size, Vvec);
 
     sycl::range<1> gws(size);
 
-    auto paral_kernel_acceptance = [&](sycl::handler& cgh) {
+    auto paral_kernel_acceptance = [&](sycl::handler &cgh) {
         cgh.depends_on({uniform_distr_event});
         cgh.parallel_for(gws, [=](sycl::id<1> global_id) {
             size_t i = global_id[0];
             double mod, resi;
-            resi = (Vvec[i] < 0.5) ? mu - result1[i] : mu + result1[i];
-            mod = sycl::fabs(resi);
-            mod = (sycl::fmod(mod + M_PI, 2 * M_PI) - M_PI);
+            resi       = (Vvec[i] < 0.5) ? mu - result1[i] : mu + result1[i];
+            mod        = sycl::fabs(resi);
+            mod        = (sycl::fmod(mod + M_PI, 2 * M_PI) - M_PI);
             result1[i] = (resi < 0) ? -mod : mod;
         });
     };
@@ -2427,98 +2494,99 @@ DPCTLSyclEventRef dpnp_rng_vonmises_large_kappa_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_rng_vonmises_large_kappa_c(void* result, const _DataType mu, const _DataType kappa, const size_t size)
+void dpnp_rng_vonmises_large_kappa_c(void *result,
+                                     const _DataType mu,
+                                     const _DataType kappa,
+                                     const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_vonmises_large_kappa_c<_DataType>(q_ref,
-                                                                             result,
-                                                                             mu,
-                                                                             kappa,
-                                                                             size,
-                                                                             dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref = dpnp_rng_vonmises_large_kappa_c<_DataType>(
+        q_ref, result, mu, kappa, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_vonmises_large_kappa_default_c)(void*,
+void (*dpnp_rng_vonmises_large_kappa_default_c)(void *,
                                                 const _DataType,
                                                 const _DataType,
-                                                const size_t) = dpnp_rng_vonmises_large_kappa_c<_DataType>;
+                                                const size_t) =
+    dpnp_rng_vonmises_large_kappa_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_vonmises_large_kappa_ext_c)(
     DPCTLSyclQueueRef,
-    void*,
+    void *,
     const _DataType,
     const _DataType,
     const size_t,
     const DPCTLEventVectorRef) = dpnp_rng_vonmises_large_kappa_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_vonmises_small_kappa_c(DPCTLSyclQueueRef q_ref,
-                                                  void* result,
-                                                  const _DataType mu,
-                                                  const _DataType kappa,
-                                                  const size_t size,
-                                                  const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_vonmises_small_kappa_c(DPCTLSyclQueueRef q_ref,
+                                    void *result,
+                                    const _DataType mu,
+                                    const _DataType kappa,
+                                    const size_t size,
+                                    const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size || !result)
-    {
+    if (!size || !result) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_DataType> result1_ptr(q_ref, result, size, true, true);
-    _DataType* result1 = result1_ptr.get_ptr();
+    _DataType *result1 = result1_ptr.get_ptr();
 
     _DataType rho_over_kappa, rho, r, s_kappa;
-    _DataType* Uvec = nullptr;
-    _DataType* Vvec = nullptr;
+    _DataType *Uvec = nullptr;
+    _DataType *Vvec = nullptr;
 
     const _DataType d_zero = 0.0, d_one = 1.0;
 
     assert(0. < kappa <= 1.0);
 
-    r = 1 + sqrt(1 + 4 * kappa * kappa);
+    r              = 1 + sqrt(1 + 4 * kappa * kappa);
     rho_over_kappa = (2) / (r + sqrt(2 * r));
-    rho = rho_over_kappa * kappa;
+    rho            = rho_over_kappa * kappa;
 
     /* s times kappa */
     s_kappa = (1 + rho * rho) / (2 * rho_over_kappa);
 
-    Uvec = reinterpret_cast<_DataType*>(sycl::malloc_shared(size * sizeof(_DataType), q));
-    Vvec = reinterpret_cast<_DataType*>(sycl::malloc_shared(size * sizeof(_DataType), q));
+    Uvec = reinterpret_cast<_DataType *>(
+        sycl::malloc_shared(size * sizeof(_DataType), q));
+    Vvec = reinterpret_cast<_DataType *>(
+        sycl::malloc_shared(size * sizeof(_DataType), q));
 
-    for (size_t n = 0; n < size;)
-    {
+    for (size_t n = 0; n < size;) {
         size_t diff_size = size - n;
         mkl_rng::uniform<_DataType> uniform_distribution_u(d_zero, M_PI);
-        auto event_out = mkl_rng::generate(uniform_distribution_u, DPNP_RNG_ENGINE, diff_size, Uvec);
+        auto event_out = mkl_rng::generate(uniform_distribution_u,
+                                           DPNP_RNG_ENGINE, diff_size, Uvec);
         event_out.wait();
         // TODO
         // use deps case
         mkl_rng::uniform<_DataType> uniform_distribution_v(d_zero, d_one);
-        event_out = mkl_rng::generate(uniform_distribution_v, DPNP_RNG_ENGINE, diff_size, Vvec);
+        event_out = mkl_rng::generate(uniform_distribution_v, DPNP_RNG_ENGINE,
+                                      diff_size, Vvec);
         event_out.wait();
 
         // TODO
         // kernel
-        for (size_t i = 0; i < diff_size; i++)
-        {
+        for (size_t i = 0; i < diff_size; i++) {
             _DataType Z, W, Y, V;
             Z = cos(Uvec[i]);
             V = Vvec[i];
             W = (kappa + s_kappa * Z) / (s_kappa + kappa * Z);
             Y = s_kappa - kappa * W;
-            if ((Y * (2 - Y) >= V) || (log(Y / V) + 1 >= Y))
-            {
+            if ((Y * (2 - Y) >= V) || (log(Y / V) + 1 >= Y)) {
                 result1[n++] = acos(W);
             }
         }
@@ -2527,17 +2595,18 @@ DPCTLSyclEventRef dpnp_rng_vonmises_small_kappa_c(DPCTLSyclQueueRef q_ref,
     sycl::free(Uvec, q);
 
     mkl_rng::uniform<_DataType> uniform_distribution(d_zero, d_one);
-    auto uniform_distr_event = mkl_rng::generate(uniform_distribution, DPNP_RNG_ENGINE, size, Vvec);
+    auto uniform_distr_event =
+        mkl_rng::generate(uniform_distribution, DPNP_RNG_ENGINE, size, Vvec);
 
     sycl::range<1> gws(size);
-    auto paral_kernel_acceptance = [&](sycl::handler& cgh) {
+    auto paral_kernel_acceptance = [&](sycl::handler &cgh) {
         cgh.depends_on({uniform_distr_event});
         cgh.parallel_for(gws, [=](sycl::id<1> global_id) {
             size_t i = global_id[0];
             double mod, resi;
-            resi = (Vvec[i] < 0.5) ? mu - result1[i] : mu + result1[i];
-            mod = sycl::fabs(resi);
-            mod = (sycl::fmod(mod + M_PI, 2 * M_PI) - M_PI);
+            resi       = (Vvec[i] < 0.5) ? mu - result1[i] : mu + result1[i];
+            mod        = sycl::fabs(resi);
+            mod        = (sycl::fmod(mod + M_PI, 2 * M_PI) - M_PI);
             result1[i] = (resi < 0) ? -mod : mod;
         });
     };
@@ -2549,29 +2618,29 @@ DPCTLSyclEventRef dpnp_rng_vonmises_small_kappa_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_rng_vonmises_small_kappa_c(void* result, const _DataType mu, const _DataType kappa, const size_t size)
+void dpnp_rng_vonmises_small_kappa_c(void *result,
+                                     const _DataType mu,
+                                     const _DataType kappa,
+                                     const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_vonmises_small_kappa_c<_DataType>(q_ref,
-                                                                             result,
-                                                                             mu,
-                                                                             kappa,
-                                                                             size,
-                                                                             dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref = dpnp_rng_vonmises_small_kappa_c<_DataType>(
+        q_ref, result, mu, kappa, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_vonmises_small_kappa_default_c)(void*,
+void (*dpnp_rng_vonmises_small_kappa_default_c)(void *,
                                                 const _DataType,
                                                 const _DataType,
-                                                const size_t) = dpnp_rng_vonmises_small_kappa_c<_DataType>;
+                                                const size_t) =
+    dpnp_rng_vonmises_small_kappa_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_vonmises_small_kappa_ext_c)(
     DPCTLSyclQueueRef,
-    void*,
+    void *,
     const _DataType,
     const _DataType,
     const size_t,
@@ -2584,19 +2653,20 @@ DPCTLSyclEventRef (*dpnp_rng_vonmises_small_kappa_ext_c)(
    (but corrected to match the algorithm in R and Python)
 */
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_vonmises_c(DPCTLSyclQueueRef q_ref,
-                                      void* result,
-                                      const _DataType mu,
-                                      const _DataType kappa,
-                                      const size_t size,
-                                      const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_vonmises_c(DPCTLSyclQueueRef q_ref,
+                        void *result,
+                        const _DataType mu,
+                        const _DataType kappa,
+                        const size_t size,
+                        const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     if (kappa > 1.0)
         dpnp_rng_vonmises_large_kappa_c<_DataType>(result, mu, kappa, size);
@@ -2607,32 +2677,33 @@ DPCTLSyclEventRef dpnp_rng_vonmises_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_rng_vonmises_c(void* result, const _DataType mu, const _DataType kappa, const size_t size)
+void dpnp_rng_vonmises_c(void *result,
+                         const _DataType mu,
+                         const _DataType kappa,
+                         const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_vonmises_c<_DataType>(q_ref,
-                                                                 result,
-                                                                 mu,
-                                                                 kappa,
-                                                                 size,
-                                                                 dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_rng_vonmises_c<_DataType>(
+        q_ref, result, mu, kappa, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_vonmises_default_c)(void*,
+void (*dpnp_rng_vonmises_default_c)(void *,
                                     const _DataType,
                                     const _DataType,
-                                    const size_t) = dpnp_rng_vonmises_c<_DataType>;
+                                    const size_t) =
+    dpnp_rng_vonmises_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_vonmises_ext_c)(DPCTLSyclQueueRef,
-                                             void*,
+                                             void *,
                                              const _DataType,
                                              const _DataType,
                                              const size_t,
-                                             const DPCTLEventVectorRef) = dpnp_rng_vonmises_c<_DataType>;
+                                             const DPCTLEventVectorRef) =
+    dpnp_rng_vonmises_c<_DataType>;
 
 template <typename _KernelNameSpecialization>
 class dpnp_rng_wald_acceptance_kernel1;
@@ -2642,7 +2713,7 @@ class dpnp_rng_wald_acceptance_kernel2;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_rng_wald_c(DPCTLSyclQueueRef q_ref,
-                                  void* result,
+                                  void *result,
                                   const _DataType mean,
                                   const _DataType scale,
                                   const size_t size,
@@ -2653,49 +2724,53 @@ DPCTLSyclEventRef dpnp_rng_wald_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    _DataType* result1 = reinterpret_cast<_DataType*>(result);
-    _DataType* uvec = nullptr;
+    _DataType *result1 = reinterpret_cast<_DataType *>(result);
+    _DataType *uvec    = nullptr;
 
     const _DataType d_zero = _DataType(0.0);
-    const _DataType d_one = _DataType(1.0);
-    _DataType gsc = sqrt(0.5 * mean / scale);
+    const _DataType d_one  = _DataType(1.0);
+    _DataType gsc          = sqrt(0.5 * mean / scale);
 
     mkl_rng::gaussian<_DataType> gaussian_distribution(d_zero, gsc);
 
-    auto gaussian_dstr_event = mkl_rng::generate(gaussian_distribution, DPNP_RNG_ENGINE, size, result1);
+    auto gaussian_dstr_event = mkl_rng::generate(
+        gaussian_distribution, DPNP_RNG_ENGINE, size, result1);
 
     /* Y = mean/(2 scale) * Z^2 */
-    auto sqr_event = mkl_vm::sqr(q, size, result1, result1, {gaussian_dstr_event}, mkl_vm::mode::ha);
+    auto sqr_event = mkl_vm::sqr(q, size, result1, result1,
+                                 {gaussian_dstr_event}, mkl_vm::mode::ha);
 
     sycl::range<1> gws(size);
     auto acceptance_kernel1 = [=](sycl::id<1> global_id) {
         size_t i = global_id[0];
-        if (result1[i] <= 2.0)
-        {
-            result1[i] = 1.0 + result1[i] + sycl::sqrt(result1[i] * (result1[i] + 2.0));
+        if (result1[i] <= 2.0) {
+            result1[i] =
+                1.0 + result1[i] + sycl::sqrt(result1[i] * (result1[i] + 2.0));
         }
-        else
-        {
-            result1[i] = 1.0 + result1[i] * (1.0 + sycl::sqrt(1.0 + 2.0 / result1[i]));
+        else {
+            result1[i] =
+                1.0 + result1[i] * (1.0 + sycl::sqrt(1.0 + 2.0 / result1[i]));
         }
     };
-    auto parallel_for_acceptance1 = [&](sycl::handler& cgh) {
+    auto parallel_for_acceptance1 = [&](sycl::handler &cgh) {
         cgh.depends_on({sqr_event});
-        cgh.parallel_for<class dpnp_rng_wald_acceptance_kernel1<_DataType>>(gws, acceptance_kernel1);
+        cgh.parallel_for<class dpnp_rng_wald_acceptance_kernel1<_DataType>>(
+            gws, acceptance_kernel1);
     };
     auto event_ration_acceptance = q.submit(parallel_for_acceptance1);
 
-    uvec = reinterpret_cast<_DataType*>(sycl::malloc_shared(size * sizeof(_DataType), q));
+    uvec = reinterpret_cast<_DataType *>(
+        sycl::malloc_shared(size * sizeof(_DataType), q));
 
     mkl_rng::uniform<_DataType> uniform_distribution(d_zero, d_one);
-    auto uniform_distr_event = mkl_rng::generate(uniform_distribution, DPNP_RNG_ENGINE, size, uvec);
+    auto uniform_distr_event =
+        mkl_rng::generate(uniform_distribution, DPNP_RNG_ENGINE, size, uvec);
 
     auto acceptance_kernel2 = [=](sycl::id<1> global_id) {
         size_t i = global_id[0];
@@ -2704,9 +2779,10 @@ DPCTLSyclEventRef dpnp_rng_wald_c(DPCTLSyclQueueRef q_ref,
         else
             result1[i] = mean * result1[i];
     };
-    auto parallel_for_acceptance2 = [&](sycl::handler& cgh) {
+    auto parallel_for_acceptance2 = [&](sycl::handler &cgh) {
         cgh.depends_on({event_ration_acceptance, uniform_distr_event});
-        cgh.parallel_for<class dpnp_rng_wald_acceptance_kernel2<_DataType>>(gws, acceptance_kernel2);
+        cgh.parallel_for<class dpnp_rng_wald_acceptance_kernel2<_DataType>>(
+            gws, acceptance_kernel2);
     };
     auto event_out = q.submit(parallel_for_acceptance2);
     event_out.wait();
@@ -2717,37 +2793,40 @@ DPCTLSyclEventRef dpnp_rng_wald_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_rng_wald_c(void* result, const _DataType mean, const _DataType scale, const size_t size)
+void dpnp_rng_wald_c(void *result,
+                     const _DataType mean,
+                     const _DataType scale,
+                     const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_wald_c<_DataType>(q_ref,
-                                                             result,
-                                                             mean,
-                                                             scale,
-                                                             size,
-                                                             dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_rng_wald_c<_DataType>(
+        q_ref, result, mean, scale, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
-
 template <typename _DataType>
-void (*dpnp_rng_wald_default_c)(void*, const _DataType, const _DataType, const size_t) = dpnp_rng_wald_c<_DataType>;
+void (*dpnp_rng_wald_default_c)(void *,
+                                const _DataType,
+                                const _DataType,
+                                const size_t) = dpnp_rng_wald_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_wald_ext_c)(DPCTLSyclQueueRef,
-                                         void*,
+                                         void *,
                                          const _DataType,
                                          const _DataType,
                                          const size_t,
-                                         const DPCTLEventVectorRef) = dpnp_rng_wald_c<_DataType>;
+                                         const DPCTLEventVectorRef) =
+    dpnp_rng_wald_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef dpnp_rng_weibull_c(DPCTLSyclQueueRef q_ref,
-                                     void* result,
-                                     const double alpha,
-                                     const size_t size,
-                                     const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_rng_weibull_c(DPCTLSyclQueueRef q_ref,
+                       void *result,
+                       const double alpha,
+                       const size_t size,
+                       const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
@@ -2755,56 +2834,54 @@ DPCTLSyclEventRef dpnp_rng_weibull_c(DPCTLSyclQueueRef q_ref,
     DPCTLSyclEventRef event_ref = nullptr;
     sycl::event event_out;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    if (alpha == 0)
-    {
-        event_ref = dpnp_zeros_c<_DataType>(q_ref, result, size, dep_event_vec_ref);
+    if (alpha == 0) {
+        event_ref =
+            dpnp_zeros_c<_DataType>(q_ref, result, size, dep_event_vec_ref);
     }
-    else
-    {
-        _DataType* result1 = reinterpret_cast<_DataType*>(result);
-        const _DataType a = (_DataType(0.0));
+    else {
+        _DataType *result1   = reinterpret_cast<_DataType *>(result);
+        const _DataType a    = (_DataType(0.0));
         const _DataType beta = (_DataType(1.0));
 
         mkl_rng::weibull<_DataType> distribution(alpha, a, beta);
-        event_out = mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
+        event_out =
+            mkl_rng::generate(distribution, DPNP_RNG_ENGINE, size, result1);
         event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event_out);
     }
     return DPCTLEvent_Copy(event_ref);
 }
 
 template <typename _DataType>
-void dpnp_rng_weibull_c(void* result, const double alpha, const size_t size)
+void dpnp_rng_weibull_c(void *result, const double alpha, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_weibull_c<_DataType>(q_ref,
-                                                                result,
-                                                                alpha,
-                                                                size,
-                                                                dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_rng_weibull_c<_DataType>(
+        q_ref, result, alpha, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_weibull_default_c)(void*, const double, const size_t) = dpnp_rng_weibull_c<_DataType>;
+void (*dpnp_rng_weibull_default_c)(void *, const double, const size_t) =
+    dpnp_rng_weibull_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_weibull_ext_c)(DPCTLSyclQueueRef,
-                                            void*,
+                                            void *,
                                             const double,
                                             const size_t,
-                                            const DPCTLEventVectorRef) = dpnp_rng_weibull_c<_DataType>;
+                                            const DPCTLEventVectorRef) =
+    dpnp_rng_weibull_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_rng_zipf_c(DPCTLSyclQueueRef q_ref,
-                                  void* result,
+                                  void *result,
                                   const _DataType a,
                                   const size_t size,
                                   const DPCTLEventVectorRef dep_event_vec_ref)
@@ -2814,12 +2891,11 @@ DPCTLSyclEventRef dpnp_rng_zipf_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!size)
-    {
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
     sycl::event event_out;
 
     size_t i, n_accepted, batch_size;
@@ -2827,42 +2903,42 @@ DPCTLSyclEventRef dpnp_rng_zipf_c(DPCTLSyclQueueRef q_ref,
     _DataType *Uvec = nullptr, *Vvec = nullptr;
     long X;
     const _DataType d_zero = 0.0;
-    const _DataType d_one = 1.0;
+    const _DataType d_one  = 1.0;
 
     DPNPC_ptr_adapter<_DataType> result1_ptr(q_ref, result, size, true, true);
-    _DataType* result1 = result1_ptr.get_ptr();
+    _DataType *result1 = result1_ptr.get_ptr();
 
     am1 = a - d_one;
-    b = pow(2.0, am1);
+    b   = pow(2.0, am1);
 
-    Uvec = reinterpret_cast<_DataType*>(sycl::malloc_shared(size * 2 * sizeof(_DataType), q));
+    Uvec = reinterpret_cast<_DataType *>(
+        sycl::malloc_shared(size * 2 * sizeof(_DataType), q));
     Vvec = Uvec + size;
 
     // TODO
     // kernel for acceptance
-    for (n_accepted = 0; n_accepted < size;)
-    {
+    for (n_accepted = 0; n_accepted < size;) {
         batch_size = size - n_accepted;
 
         mkl_rng::uniform<_DataType> uniform_distribution(d_zero, d_one);
-        event_out = mkl_rng::generate(uniform_distribution, DPNP_RNG_ENGINE, batch_size, Uvec);
+        event_out = mkl_rng::generate(uniform_distribution, DPNP_RNG_ENGINE,
+                                      batch_size, Uvec);
         event_out.wait();
-        event_out = mkl_rng::generate(uniform_distribution, DPNP_RNG_ENGINE, batch_size, Vvec);
+        event_out = mkl_rng::generate(uniform_distribution, DPNP_RNG_ENGINE,
+                                      batch_size, Vvec);
         event_out.wait();
-        for (i = 0; i < batch_size; i++)
-        {
+        for (i = 0; i < batch_size; i++) {
             U = d_one - Uvec[i];
             V = Vvec[i];
             X = (long)floor(pow(U, (-1.0) / am1));
             /* The real result may be above what can be represented in a signed
              * long. It will get casted to -sys.maxint-1. Since this is
-             * a straightforward rejection algorithm, we can just reject this value
-             * in the rejection condition below. This function then models a Zipf
-             * distribution truncated to sys.maxint.
+             * a straightforward rejection algorithm, we can just reject this
+             * value in the rejection condition below. This function then models
+             * a Zipf distribution truncated to sys.maxint.
              */
             T = pow(d_one + d_one / X, am1);
-            if ((X > 0) && ((V * X) * (T - d_one) / (b - d_one) <= T / b))
-            {
+            if ((X > 0) && ((V * X) * (T - d_one) / (b - d_one) <= T / b)) {
                 result1[n_accepted++] = X;
             }
         }
@@ -2874,212 +2950,260 @@ DPCTLSyclEventRef dpnp_rng_zipf_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_rng_zipf_c(void* result, const _DataType a, const size_t size)
+void dpnp_rng_zipf_c(void *result, const _DataType a, const size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_rng_zipf_c<_DataType>(q_ref,
-                                                             result,
-                                                             a,
-                                                             size,
-                                                             dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_rng_zipf_c<_DataType>(q_ref, result, a, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_rng_zipf_default_c)(void*, const _DataType, const size_t) = dpnp_rng_zipf_c<_DataType>;
+void (*dpnp_rng_zipf_default_c)(void *,
+                                const _DataType,
+                                const size_t) = dpnp_rng_zipf_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_rng_zipf_ext_c)(DPCTLSyclQueueRef,
-                                         void*,
+                                         void *,
                                          const _DataType,
                                          const size_t,
-                                         const DPCTLEventVectorRef) = dpnp_rng_zipf_c<_DataType>;
+                                         const DPCTLEventVectorRef) =
+    dpnp_rng_zipf_c<_DataType>;
 
-void func_map_init_random(func_map_t& fmap)
+void func_map_init_random(func_map_t &fmap)
 {
-    fmap[DPNPFuncName::DPNP_FN_RNG_BETA][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_beta_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_BETA][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_beta_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_BETA_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_beta_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_BETA_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_beta_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_BINOMIAL][eft_INT][eft_INT] = {eft_INT,
-                                                                  (void*)dpnp_rng_binomial_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_BINOMIAL][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_rng_binomial_default_c<int32_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_BINOMIAL_EXT][eft_INT][eft_INT] = {eft_INT,
-                                                                      (void*)dpnp_rng_binomial_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_BINOMIAL_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_rng_binomial_ext_c<int32_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_CHISQUARE][eft_DBL][eft_DBL] = {eft_DBL,
-                                                                   (void*)dpnp_rng_chisquare_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_CHISQUARE][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_chisquare_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_CHISQUARE_EXT][eft_DBL][eft_DBL] = {eft_DBL,
-                                                                       (void*)dpnp_rng_chisquare_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_CHISQUARE_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_chisquare_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_EXPONENTIAL][eft_DBL][eft_DBL] = {eft_DBL,
-                                                                     (void*)dpnp_rng_exponential_default_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_RNG_EXPONENTIAL][eft_FLT][eft_FLT] = {eft_FLT,
-                                                                     (void*)dpnp_rng_exponential_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_EXPONENTIAL][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_exponential_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_EXPONENTIAL][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_rng_exponential_default_c<float>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_EXPONENTIAL_EXT][eft_DBL][eft_DBL] = {eft_DBL,
-                                                                         (void*)dpnp_rng_exponential_ext_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_RNG_EXPONENTIAL_EXT][eft_FLT][eft_FLT] = {eft_FLT,
-                                                                         (void*)dpnp_rng_exponential_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_EXPONENTIAL_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_exponential_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_EXPONENTIAL_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_rng_exponential_ext_c<float>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_F][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_f_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_F][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_f_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_F_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_f_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_F_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_f_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_GAMMA][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_gamma_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_GAMMA][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_gamma_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_GAMMA_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_gamma_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_GAMMA_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_gamma_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_GAUSSIAN][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_gaussian_default_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_RNG_GAUSSIAN][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_rng_gaussian_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_GAUSSIAN][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_gaussian_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_GAUSSIAN][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_rng_gaussian_default_c<float>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_GAUSSIAN_EXT][eft_DBL][eft_DBL] = {eft_DBL,
-                                                                      (void*)dpnp_rng_gaussian_ext_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_RNG_GAUSSIAN_EXT][eft_FLT][eft_FLT] = {eft_FLT,
-                                                                      (void*)dpnp_rng_gaussian_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_GAUSSIAN_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_gaussian_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_GAUSSIAN_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_rng_gaussian_ext_c<float>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_GEOMETRIC][eft_INT][eft_INT] = {eft_INT,
-                                                                   (void*)dpnp_rng_geometric_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_GEOMETRIC][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_rng_geometric_default_c<int32_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_GEOMETRIC_EXT][eft_INT][eft_INT] = {eft_INT,
-                                                                   (void*)dpnp_rng_geometric_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_GEOMETRIC_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_rng_geometric_ext_c<int32_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_GUMBEL][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_gumbel_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_GUMBEL][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_gumbel_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_GUMBEL_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_gumbel_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_GUMBEL_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_gumbel_ext_c<double>};
 
     fmap[DPNPFuncName::DPNP_FN_RNG_HYPERGEOMETRIC][eft_INT][eft_INT] = {
-        eft_INT, (void*)dpnp_rng_hypergeometric_default_c<int32_t>};
+        eft_INT, (void *)dpnp_rng_hypergeometric_default_c<int32_t>};
 
     fmap[DPNPFuncName::DPNP_FN_RNG_HYPERGEOMETRIC_EXT][eft_INT][eft_INT] = {
-        eft_INT, (void*)dpnp_rng_hypergeometric_ext_c<int32_t>};
+        eft_INT, (void *)dpnp_rng_hypergeometric_ext_c<int32_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_LAPLACE][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_laplace_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_LAPLACE][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_laplace_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_LAPLACE_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_laplace_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_LAPLACE_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_laplace_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_LOGISTIC][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_logistic_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_LOGISTIC][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_logistic_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_LOGISTIC_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_logistic_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_LOGISTIC_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_logistic_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_LOGNORMAL][eft_DBL][eft_DBL] = {eft_DBL,
-                                                                   (void*)dpnp_rng_lognormal_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_LOGNORMAL][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_lognormal_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_LOGNORMAL_EXT][eft_DBL][eft_DBL] = {eft_DBL,
-                                                                       (void*)dpnp_rng_lognormal_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_LOGNORMAL_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_lognormal_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_MULTINOMIAL][eft_INT][eft_INT] = {eft_INT,
-                                                                     (void*)dpnp_rng_multinomial_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_MULTINOMIAL][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_rng_multinomial_default_c<int32_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_MULTINOMIAL_EXT][eft_INT][eft_INT] = {eft_INT,
-                                                                         (void*)dpnp_rng_multinomial_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_MULTINOMIAL_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_rng_multinomial_ext_c<int32_t>};
 
     fmap[DPNPFuncName::DPNP_FN_RNG_MULTIVARIATE_NORMAL][eft_DBL][eft_DBL] = {
-        eft_DBL, (void*)dpnp_rng_multivariate_normal_default_c<double>};
+        eft_DBL, (void *)dpnp_rng_multivariate_normal_default_c<double>};
 
     fmap[DPNPFuncName::DPNP_FN_RNG_NEGATIVE_BINOMIAL][eft_INT][eft_INT] = {
-        eft_INT, (void*)dpnp_rng_negative_binomial_default_c<int32_t>};
+        eft_INT, (void *)dpnp_rng_negative_binomial_default_c<int32_t>};
 
     fmap[DPNPFuncName::DPNP_FN_RNG_NEGATIVE_BINOMIAL_EXT][eft_INT][eft_INT] = {
-        eft_INT, (void*)dpnp_rng_negative_binomial_ext_c<int32_t>};
+        eft_INT, (void *)dpnp_rng_negative_binomial_ext_c<int32_t>};
 
     fmap[DPNPFuncName::DPNP_FN_RNG_NONCENTRAL_CHISQUARE][eft_DBL][eft_DBL] = {
-        eft_DBL, (void*)dpnp_rng_noncentral_chisquare_default_c<double>};
+        eft_DBL, (void *)dpnp_rng_noncentral_chisquare_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_NONCENTRAL_CHISQUARE_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void*)dpnp_rng_noncentral_chisquare_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_NONCENTRAL_CHISQUARE_EXT][eft_DBL][eft_DBL] =
+        {eft_DBL, (void *)dpnp_rng_noncentral_chisquare_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_NORMAL][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_normal_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_NORMAL][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_normal_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_NORMAL_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_normal_ext_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_RNG_NORMAL_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_rng_normal_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_NORMAL_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_normal_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_NORMAL_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_rng_normal_ext_c<float>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_PARETO][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_pareto_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_PARETO][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_pareto_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_PARETO_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_pareto_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_PARETO_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_pareto_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_POISSON][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_rng_poisson_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_POISSON][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_rng_poisson_default_c<int32_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_POISSON_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_rng_poisson_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_POISSON_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_rng_poisson_ext_c<int32_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_POWER][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_power_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_POWER][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_power_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_POWER_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_power_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_POWER_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_power_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_RAYLEIGH][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_rayleigh_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_RAYLEIGH][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_rayleigh_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_RAYLEIGH_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_rayleigh_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_RAYLEIGH_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_rayleigh_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_SHUFFLE][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_shuffle_default_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_RNG_SHUFFLE][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_rng_shuffle_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_RNG_SHUFFLE][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_rng_shuffle_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_RNG_SHUFFLE][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_rng_shuffle_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_SHUFFLE][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_shuffle_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_SHUFFLE][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_rng_shuffle_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_SHUFFLE][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_rng_shuffle_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_SHUFFLE][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_rng_shuffle_default_c<int64_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_SHUFFLE_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_shuffle_ext_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_RNG_SHUFFLE_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_rng_shuffle_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_RNG_SHUFFLE_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_rng_shuffle_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_RNG_SHUFFLE_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_rng_shuffle_ext_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_SHUFFLE_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_shuffle_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_SHUFFLE_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_rng_shuffle_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_SHUFFLE_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_rng_shuffle_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_SHUFFLE_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_rng_shuffle_ext_c<int64_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_SRAND][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_srand_c};
+    fmap[DPNPFuncName::DPNP_FN_RNG_SRAND][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_srand_c};
 
     fmap[DPNPFuncName::DPNP_FN_RNG_STANDARD_CAUCHY][eft_DBL][eft_DBL] = {
-        eft_DBL, (void*)dpnp_rng_standard_cauchy_default_c<double>};
+        eft_DBL, (void *)dpnp_rng_standard_cauchy_default_c<double>};
 
     fmap[DPNPFuncName::DPNP_FN_RNG_STANDARD_CAUCHY_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void*)dpnp_rng_standard_cauchy_ext_c<double>};
+        eft_DBL, (void *)dpnp_rng_standard_cauchy_ext_c<double>};
 
     fmap[DPNPFuncName::DPNP_FN_RNG_STANDARD_EXPONENTIAL][eft_DBL][eft_DBL] = {
-        eft_DBL, (void*)dpnp_rng_standard_exponential_default_c<double>};
+        eft_DBL, (void *)dpnp_rng_standard_exponential_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_STANDARD_EXPONENTIAL_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void*)dpnp_rng_standard_exponential_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_STANDARD_EXPONENTIAL_EXT][eft_DBL][eft_DBL] =
+        {eft_DBL, (void *)dpnp_rng_standard_exponential_ext_c<double>};
 
     fmap[DPNPFuncName::DPNP_FN_RNG_STANDARD_GAMMA][eft_DBL][eft_DBL] = {
-        eft_DBL, (void*)dpnp_rng_standard_gamma_default_c<double>};
+        eft_DBL, (void *)dpnp_rng_standard_gamma_default_c<double>};
 
     fmap[DPNPFuncName::DPNP_FN_RNG_STANDARD_GAMMA_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void*)dpnp_rng_standard_gamma_ext_c<double>};
+        eft_DBL, (void *)dpnp_rng_standard_gamma_ext_c<double>};
 
     fmap[DPNPFuncName::DPNP_FN_RNG_STANDARD_NORMAL][eft_DBL][eft_DBL] = {
-        eft_DBL, (void*)dpnp_rng_standard_normal_default_c<double>};
+        eft_DBL, (void *)dpnp_rng_standard_normal_default_c<double>};
 
     fmap[DPNPFuncName::DPNP_FN_RNG_STANDARD_T][eft_DBL][eft_DBL] = {
-        eft_DBL, (void*)dpnp_rng_standard_t_default_c<double>};
+        eft_DBL, (void *)dpnp_rng_standard_t_default_c<double>};
 
     fmap[DPNPFuncName::DPNP_FN_RNG_STANDARD_T_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void*)dpnp_rng_standard_t_ext_c<double>};
+        eft_DBL, (void *)dpnp_rng_standard_t_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_TRIANGULAR][eft_DBL][eft_DBL] = {eft_DBL,
-                                                                    (void*)dpnp_rng_triangular_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_TRIANGULAR][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_triangular_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_TRIANGULAR_EXT][eft_DBL][eft_DBL] = {eft_DBL,
-                                                                    (void*)dpnp_rng_triangular_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_TRIANGULAR_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_triangular_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_UNIFORM][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_uniform_default_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_RNG_UNIFORM][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_rng_uniform_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_RNG_UNIFORM][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_rng_uniform_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_UNIFORM][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_uniform_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_UNIFORM][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_rng_uniform_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_UNIFORM][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_rng_uniform_default_c<int32_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_UNIFORM_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_uniform_ext_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_RNG_UNIFORM_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_rng_uniform_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_RNG_UNIFORM_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_rng_uniform_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_UNIFORM_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_uniform_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_UNIFORM_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_rng_uniform_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_UNIFORM_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_rng_uniform_ext_c<int32_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_VONMISES][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_vonmises_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_VONMISES][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_vonmises_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_VONMISES_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_vonmises_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_VONMISES_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_vonmises_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_WALD][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_wald_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_WALD][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_wald_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_WALD_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_wald_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_WALD_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_wald_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_WEIBULL][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_weibull_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_WEIBULL][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_weibull_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_WEIBULL_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_weibull_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_WEIBULL_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_weibull_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_ZIPF][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_zipf_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_ZIPF][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_zipf_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RNG_ZIPF_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_rng_zipf_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_RNG_ZIPF_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_rng_zipf_ext_c<double>};
 
     return;
 }

--- a/dpnp/backend/kernels/dpnp_krnl_reduction.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_reduction.cpp
@@ -39,7 +39,7 @@ template <typename _DataType>
 _DataType *get_array_ptr(const void *__array)
 {
     void *const_ptr = const_cast<void *>(__array);
-    _DataType *ptr  = reinterpret_cast<_DataType *>(const_ptr);
+    _DataType *ptr = reinterpret_cast<_DataType *>(const_ptr);
 
     return ptr;
 }
@@ -93,12 +93,12 @@ DPCTLSyclEventRef
 
     DPNPC_ptr_adapter<_DataType_input> input1_ptr(q_ref, input_in, input_size,
                                                   true);
-    _DataType_input *input   = input1_ptr.get_ptr();
+    _DataType_input *input = input1_ptr.get_ptr();
     _DataType_output *result = get_array_ptr<_DataType_output>(result_out);
 
     if (!input_shape && !input_shape_ndim) { // it is a scalar
         // result[0] = input[0];
-        _DataType_input input_elem   = 0;
+        _DataType_input input_elem = 0;
         _DataType_output result_elem = 0;
         q.memcpy(&input_elem, input, sizeof(_DataType_input)).wait();
         result_elem = input_elem;
@@ -131,7 +131,7 @@ DPCTLSyclEventRef
     input_it.set_axes(axes, axes_ndim);
 
     const size_t output_size = input_it.get_output_size();
-    auto policy              = oneapi::dpl::execution::make_device_policy<
+    auto policy = oneapi::dpl::execution::make_device_policy<
         dpnp_sum_c_kernel<_DataType_output, _DataType_input>>(q);
     for (size_t output_id = 0; output_id < output_size; ++output_id) {
         // type of "init" determine internal algorithm accumulator type
@@ -228,12 +228,12 @@ DPCTLSyclEventRef
 
     DPNPC_ptr_adapter<_DataType_input> input1_ptr(q_ref, input_in, input_size,
                                                   true);
-    _DataType_input *input   = input1_ptr.get_ptr();
+    _DataType_input *input = input1_ptr.get_ptr();
     _DataType_output *result = get_array_ptr<_DataType_output>(result_out);
 
     if (!input_shape && !input_shape_ndim) { // it is a scalar
         // result[0] = input[0];
-        _DataType_input input_elem   = 0;
+        _DataType_input input_elem = 0;
         _DataType_output result_elem = 0;
         q.memcpy(&input_elem, input, sizeof(_DataType_input)).wait();
         result_elem = input_elem;
@@ -247,7 +247,7 @@ DPCTLSyclEventRef
     input_it.set_axes(axes, axes_ndim);
 
     const size_t output_size = input_it.get_output_size();
-    auto policy              = oneapi::dpl::execution::make_device_policy<
+    auto policy = oneapi::dpl::execution::make_device_policy<
         dpnp_prod_c_kernel<_DataType_output, _DataType_input>>(q);
     for (size_t output_id = 0; output_id < output_size; ++output_id) {
         // type of "init" determine internal algorithm accumulator type

--- a/dpnp/backend/kernels/dpnp_krnl_reduction.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_reduction.cpp
@@ -26,47 +26,51 @@
 #include <cmath>
 #include <iostream>
 
-#include <dpnp_iface.hpp>
 #include "dpnp_fptr.hpp"
 #include "dpnp_iterator.hpp"
 #include "dpnp_utils.hpp"
 #include "dpnpc_memory_adapter.hpp"
 #include "queue_sycl.hpp"
+#include <dpnp_iface.hpp>
 
 namespace mkl_stats = oneapi::mkl::stats;
 
 template <typename _DataType>
-_DataType* get_array_ptr(const void* __array)
+_DataType *get_array_ptr(const void *__array)
 {
-    void* const_ptr = const_cast<void*>(__array);
-    _DataType* ptr = reinterpret_cast<_DataType*>(const_ptr);
+    void *const_ptr = const_cast<void *>(__array);
+    _DataType *ptr  = reinterpret_cast<_DataType *>(const_ptr);
 
     return ptr;
 }
 
 template <typename _DataType>
-_DataType get_initial_value(const void* __initial, _DataType default_val)
+_DataType get_initial_value(const void *__initial, _DataType default_val)
 {
-    const _DataType* initial_ptr = reinterpret_cast<const _DataType*>(__initial);
-    const _DataType init_val = (initial_ptr == nullptr) ? default_val : *initial_ptr;
+    const _DataType *initial_ptr =
+        reinterpret_cast<const _DataType *>(__initial);
+    const _DataType init_val =
+        (initial_ptr == nullptr) ? default_val : *initial_ptr;
 
     return init_val;
 }
 
-template <typename _KernelNameSpecialization1, typename _KernelNameSpecialization2>
+template <typename _KernelNameSpecialization1,
+          typename _KernelNameSpecialization2>
 class dpnp_sum_c_kernel;
 
 template <typename _DataType_output, typename _DataType_input>
-DPCTLSyclEventRef dpnp_sum_c(DPCTLSyclQueueRef q_ref,
-                             void* result_out,
-                             const void* input_in,
-                             const shape_elem_type* input_shape,
-                             const size_t input_shape_ndim,
-                             const shape_elem_type* axes,
-                             const size_t axes_ndim,
-                             const void* initial, // type must be _DataType_output
-                             const long* where,
-                             const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_sum_c(DPCTLSyclQueueRef q_ref,
+               void *result_out,
+               const void *input_in,
+               const shape_elem_type *input_shape,
+               const size_t input_shape_ndim,
+               const shape_elem_type *axes,
+               const size_t axes_ndim,
+               const void *initial, // type must be _DataType_output
+               const long *where,
+               const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)where;
@@ -74,26 +78,27 @@ DPCTLSyclEventRef dpnp_sum_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if ((input_in == nullptr) || (result_out == nullptr))
-    {
+    if ((input_in == nullptr) || (result_out == nullptr)) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    const _DataType_output init = get_initial_value<_DataType_output>(initial, 0);
+    const _DataType_output init =
+        get_initial_value<_DataType_output>(initial, 0);
 
     const size_t input_size =
-        std::accumulate(input_shape, input_shape + input_shape_ndim, 1, std::multiplies<shape_elem_type>());
+        std::accumulate(input_shape, input_shape + input_shape_ndim, 1,
+                        std::multiplies<shape_elem_type>());
 
-    DPNPC_ptr_adapter<_DataType_input> input1_ptr(q_ref, input_in, input_size, true);
-    _DataType_input* input = input1_ptr.get_ptr();
-    _DataType_output* result = get_array_ptr<_DataType_output>(result_out);
+    DPNPC_ptr_adapter<_DataType_input> input1_ptr(q_ref, input_in, input_size,
+                                                  true);
+    _DataType_input *input   = input1_ptr.get_ptr();
+    _DataType_output *result = get_array_ptr<_DataType_output>(result_out);
 
-    if (!input_shape && !input_shape_ndim)
-    { // it is a scalar
-        //result[0] = input[0];
-        _DataType_input input_elem = 0;
+    if (!input_shape && !input_shape_ndim) { // it is a scalar
+        // result[0] = input[0];
+        _DataType_input input_elem   = 0;
         _DataType_output result_elem = 0;
         q.memcpy(&input_elem, input, sizeof(_DataType_input)).wait();
         result_elem = input_elem;
@@ -102,16 +107,18 @@ DPCTLSyclEventRef dpnp_sum_c(DPCTLSyclQueueRef q_ref,
         return event_ref;
     }
 
-    if constexpr ((std::is_same<_DataType_input, double>::value || std::is_same<_DataType_input, float>::value) &&
+    if constexpr ((std::is_same<_DataType_input, double>::value ||
+                   std::is_same<_DataType_input, float>::value) &&
                   std::is_same<_DataType_input, _DataType_output>::value)
     {
         // Support is limited by
         // - 1D array (no axes)
         // - same types for input and output
         // - float64 and float32 types only
-        if (axes_ndim < 1)
-        {
-            auto dataset = mkl_stats::make_dataset<mkl_stats::layout::row_major>(1, input_size, input);
+        if (axes_ndim < 1) {
+            auto dataset =
+                mkl_stats::make_dataset<mkl_stats::layout::row_major>(
+                    1, input_size, input);
             sycl::event event = mkl_stats::raw_sum(q, dataset, result);
             event.wait();
 
@@ -119,88 +126,86 @@ DPCTLSyclEventRef dpnp_sum_c(DPCTLSyclQueueRef q_ref,
         }
     }
 
-    DPNPC_id<_DataType_input> input_it(q_ref, input, input_shape, input_shape_ndim);
+    DPNPC_id<_DataType_input> input_it(q_ref, input, input_shape,
+                                       input_shape_ndim);
     input_it.set_axes(axes, axes_ndim);
 
     const size_t output_size = input_it.get_output_size();
-    auto policy =
-        oneapi::dpl::execution::make_device_policy<dpnp_sum_c_kernel<_DataType_output, _DataType_input>>(q);
-    for (size_t output_id = 0; output_id < output_size; ++output_id)
-    {
+    auto policy              = oneapi::dpl::execution::make_device_policy<
+        dpnp_sum_c_kernel<_DataType_output, _DataType_input>>(q);
+    for (size_t output_id = 0; output_id < output_size; ++output_id) {
         // type of "init" determine internal algorithm accumulator type
         _DataType_output accumulator = std::reduce(
-            policy, input_it.begin(output_id), input_it.end(output_id), init, std::plus<_DataType_output>());
+            policy, input_it.begin(output_id), input_it.end(output_id), init,
+            std::plus<_DataType_output>());
         policy.queue().wait(); // TODO move out of the loop
 
-        q.memcpy(
-            result + output_id, &accumulator, sizeof(_DataType_output)).wait(); // result[output_id] = accumulator;
+        q.memcpy(result + output_id, &accumulator, sizeof(_DataType_output))
+            .wait(); // result[output_id] = accumulator;
     }
 
     return event_ref;
 }
 
 template <typename _DataType_output, typename _DataType_input>
-void dpnp_sum_c(void* result_out,
-                const void* input_in,
-                const shape_elem_type* input_shape,
+void dpnp_sum_c(void *result_out,
+                const void *input_in,
+                const shape_elem_type *input_shape,
                 const size_t input_shape_ndim,
-                const shape_elem_type* axes,
+                const shape_elem_type *axes,
                 const size_t axes_ndim,
-                const void* initial, // type must be _DataType_output
-                const long* where)
+                const void *initial, // type must be _DataType_output
+                const long *where)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_sum_c<_DataType_output, _DataType_input>(q_ref,
-                                                                                result_out,
-                                                                                input_in,
-                                                                                input_shape,
-                                                                                input_shape_ndim,
-                                                                                axes,
-                                                                                axes_ndim,
-                                                                                initial,
-                                                                                where,
-                                                                                dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref = dpnp_sum_c<_DataType_output, _DataType_input>(
+        q_ref, result_out, input_in, input_shape, input_shape_ndim, axes,
+        axes_ndim, initial, where, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType_output, typename _DataType_input>
-void (*dpnp_sum_default_c)(void*,
-                           const void*,
-                           const shape_elem_type*,
+void (*dpnp_sum_default_c)(void *,
+                           const void *,
+                           const shape_elem_type *,
                            const size_t,
-                           const shape_elem_type*,
+                           const shape_elem_type *,
                            const size_t,
-                           const void*,
-                           const long*) = dpnp_sum_c<_DataType_output, _DataType_input>;
+                           const void *,
+                           const long *) =
+    dpnp_sum_c<_DataType_output, _DataType_input>;
 
 template <typename _DataType_output, typename _DataType_input>
 DPCTLSyclEventRef (*dpnp_sum_ext_c)(DPCTLSyclQueueRef,
-                                    void*,
-                                    const void*,
-                                    const shape_elem_type*,
+                                    void *,
+                                    const void *,
+                                    const shape_elem_type *,
                                     const size_t,
-                                    const shape_elem_type*,
+                                    const shape_elem_type *,
                                     const size_t,
-                                    const void*,
-                                    const long*,
-                                    const DPCTLEventVectorRef) = dpnp_sum_c<_DataType_output, _DataType_input>;
+                                    const void *,
+                                    const long *,
+                                    const DPCTLEventVectorRef) =
+    dpnp_sum_c<_DataType_output, _DataType_input>;
 
-template <typename _KernelNameSpecialization1, typename _KernelNameSpecialization2>
+template <typename _KernelNameSpecialization1,
+          typename _KernelNameSpecialization2>
 class dpnp_prod_c_kernel;
 
 template <typename _DataType_output, typename _DataType_input>
-DPCTLSyclEventRef dpnp_prod_c(DPCTLSyclQueueRef q_ref,
-                              void* result_out,
-                              const void* input_in,
-                              const shape_elem_type* input_shape,
-                              const size_t input_shape_ndim,
-                              const shape_elem_type* axes,
-                              const size_t axes_ndim,
-                              const void* initial, // type must be _DataType_output
-                              const long* where,
-                              const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_prod_c(DPCTLSyclQueueRef q_ref,
+                void *result_out,
+                const void *input_in,
+                const shape_elem_type *input_shape,
+                const size_t input_shape_ndim,
+                const shape_elem_type *axes,
+                const size_t axes_ndim,
+                const void *initial, // type must be _DataType_output
+                const long *where,
+                const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)where;
@@ -208,26 +213,27 @@ DPCTLSyclEventRef dpnp_prod_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if ((input_in == nullptr) || (result_out == nullptr))
-    {
+    if ((input_in == nullptr) || (result_out == nullptr)) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    const _DataType_output init = get_initial_value<_DataType_output>(initial, 1);
+    const _DataType_output init =
+        get_initial_value<_DataType_output>(initial, 1);
 
     const size_t input_size =
-        std::accumulate(input_shape, input_shape + input_shape_ndim, 1, std::multiplies<shape_elem_type>());
+        std::accumulate(input_shape, input_shape + input_shape_ndim, 1,
+                        std::multiplies<shape_elem_type>());
 
-    DPNPC_ptr_adapter<_DataType_input> input1_ptr(q_ref, input_in, input_size, true);
-    _DataType_input* input = input1_ptr.get_ptr();
-    _DataType_output* result = get_array_ptr<_DataType_output>(result_out);
+    DPNPC_ptr_adapter<_DataType_input> input1_ptr(q_ref, input_in, input_size,
+                                                  true);
+    _DataType_input *input   = input1_ptr.get_ptr();
+    _DataType_output *result = get_array_ptr<_DataType_output>(result_out);
 
-    if (!input_shape && !input_shape_ndim)
-    { // it is a scalar
+    if (!input_shape && !input_shape_ndim) { // it is a scalar
         // result[0] = input[0];
-        _DataType_input input_elem = 0;
+        _DataType_input input_elem   = 0;
         _DataType_output result_elem = 0;
         q.memcpy(&input_elem, input, sizeof(_DataType_input)).wait();
         result_elem = input_elem;
@@ -236,158 +242,220 @@ DPCTLSyclEventRef dpnp_prod_c(DPCTLSyclQueueRef q_ref,
         return event_ref;
     }
 
-    DPNPC_id<_DataType_input> input_it(q_ref, input, input_shape, input_shape_ndim);
+    DPNPC_id<_DataType_input> input_it(q_ref, input, input_shape,
+                                       input_shape_ndim);
     input_it.set_axes(axes, axes_ndim);
 
     const size_t output_size = input_it.get_output_size();
-    auto policy =
-        oneapi::dpl::execution::make_device_policy<dpnp_prod_c_kernel<_DataType_output, _DataType_input>>(q);
-    for (size_t output_id = 0; output_id < output_size; ++output_id)
-    {
+    auto policy              = oneapi::dpl::execution::make_device_policy<
+        dpnp_prod_c_kernel<_DataType_output, _DataType_input>>(q);
+    for (size_t output_id = 0; output_id < output_size; ++output_id) {
         // type of "init" determine internal algorithm accumulator type
         _DataType_output accumulator = std::reduce(
-            policy, input_it.begin(output_id), input_it.end(output_id), init, std::multiplies<_DataType_output>());
+            policy, input_it.begin(output_id), input_it.end(output_id), init,
+            std::multiplies<_DataType_output>());
         policy.queue().wait(); // TODO move out of the loop
 
-        q.memcpy(
-            result + output_id, &accumulator, sizeof(_DataType_output)).wait(); // result[output_id] = accumulator;
+        q.memcpy(result + output_id, &accumulator, sizeof(_DataType_output))
+            .wait(); // result[output_id] = accumulator;
     }
 
     return event_ref;
 }
 
 template <typename _DataType_output, typename _DataType_input>
-void dpnp_prod_c(void* result_out,
-                 const void* input_in,
-                 const shape_elem_type* input_shape,
+void dpnp_prod_c(void *result_out,
+                 const void *input_in,
+                 const shape_elem_type *input_shape,
                  const size_t input_shape_ndim,
-                 const shape_elem_type* axes,
+                 const shape_elem_type *axes,
                  const size_t axes_ndim,
-                 const void* initial, // type must be _DataType_output
-                 const long* where)
+                 const void *initial, // type must be _DataType_output
+                 const long *where)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_prod_c<_DataType_output, _DataType_input>(q_ref,
-                                                                                 result_out,
-                                                                                 input_in,
-                                                                                 input_shape,
-                                                                                 input_shape_ndim,
-                                                                                 axes,
-                                                                                 axes_ndim,
-                                                                                 initial,
-                                                                                 where,
-                                                                                 dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_prod_c<_DataType_output, _DataType_input>(
+            q_ref, result_out, input_in, input_shape, input_shape_ndim, axes,
+            axes_ndim, initial, where, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType_output, typename _DataType_input>
-void (*dpnp_prod_default_c)(void*,
-                            const void*,
-                            const shape_elem_type*,
+void (*dpnp_prod_default_c)(void *,
+                            const void *,
+                            const shape_elem_type *,
                             const size_t,
-                            const shape_elem_type*,
+                            const shape_elem_type *,
                             const size_t,
-                            const void*,
-                            const long*) = dpnp_prod_c<_DataType_output, _DataType_input>;
+                            const void *,
+                            const long *) =
+    dpnp_prod_c<_DataType_output, _DataType_input>;
 
 template <typename _DataType_output, typename _DataType_input>
 DPCTLSyclEventRef (*dpnp_prod_ext_c)(DPCTLSyclQueueRef,
-                                     void*,
-                                     const void*,
-                                     const shape_elem_type*,
+                                     void *,
+                                     const void *,
+                                     const shape_elem_type *,
                                      const size_t,
-                                     const shape_elem_type*,
+                                     const shape_elem_type *,
                                      const size_t,
-                                     const void*,
-                                     const long*,
-                                     const DPCTLEventVectorRef) = dpnp_prod_c<_DataType_output, _DataType_input>;
+                                     const void *,
+                                     const long *,
+                                     const DPCTLEventVectorRef) =
+    dpnp_prod_c<_DataType_output, _DataType_input>;
 
-void func_map_init_reduction(func_map_t& fmap)
+void func_map_init_reduction(func_map_t &fmap)
 {
-    // WARNING. The meaning of the fmap is changed. Second argument represents RESULT_TYPE for this function
-    // handle "out" and "type" parameters require user selection of return type
+    // WARNING. The meaning of the fmap is changed. Second argument represents
+    // RESULT_TYPE for this function handle "out" and "type" parameters require
+    // user selection of return type
     // TODO. required refactoring of fmap to some kernelSelector
-    fmap[DPNPFuncName::DPNP_FN_PROD][eft_INT][eft_INT] = {eft_LNG, (void*)dpnp_prod_default_c<int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_PROD][eft_INT][eft_LNG] = {eft_LNG, (void*)dpnp_prod_default_c<int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_PROD][eft_INT][eft_FLT] = {eft_FLT, (void*)dpnp_prod_default_c<float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_PROD][eft_INT][eft_DBL] = {eft_DBL, (void*)dpnp_prod_default_c<double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_PROD][eft_INT][eft_INT] = {
+        eft_LNG, (void *)dpnp_prod_default_c<int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_PROD][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_prod_default_c<int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_PROD][eft_INT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_prod_default_c<float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_PROD][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_prod_default_c<double, int32_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_PROD][eft_LNG][eft_INT] = {eft_INT, (void*)dpnp_prod_default_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_PROD][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_prod_default_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_PROD][eft_LNG][eft_FLT] = {eft_FLT, (void*)dpnp_prod_default_c<float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_PROD][eft_LNG][eft_DBL] = {eft_DBL, (void*)dpnp_prod_default_c<double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_PROD][eft_LNG][eft_INT] = {
+        eft_INT, (void *)dpnp_prod_default_c<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_PROD][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_prod_default_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_PROD][eft_LNG][eft_FLT] = {
+        eft_FLT, (void *)dpnp_prod_default_c<float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_PROD][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_prod_default_c<double, int64_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_PROD][eft_FLT][eft_INT] = {eft_INT, (void*)dpnp_prod_default_c<int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_PROD][eft_FLT][eft_LNG] = {eft_LNG, (void*)dpnp_prod_default_c<int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_PROD][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_prod_default_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_PROD][eft_FLT][eft_DBL] = {eft_DBL, (void*)dpnp_prod_default_c<double, float>};
+    fmap[DPNPFuncName::DPNP_FN_PROD][eft_FLT][eft_INT] = {
+        eft_INT, (void *)dpnp_prod_default_c<int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_PROD][eft_FLT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_prod_default_c<int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_PROD][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_prod_default_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_PROD][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_prod_default_c<double, float>};
 
-    fmap[DPNPFuncName::DPNP_FN_PROD][eft_DBL][eft_INT] = {eft_INT, (void*)dpnp_prod_default_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_PROD][eft_DBL][eft_LNG] = {eft_LNG, (void*)dpnp_prod_default_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_PROD][eft_DBL][eft_FLT] = {eft_FLT, (void*)dpnp_prod_default_c<float, double>};
-    fmap[DPNPFuncName::DPNP_FN_PROD][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_prod_default_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_PROD][eft_DBL][eft_INT] = {
+        eft_INT, (void *)dpnp_prod_default_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_PROD][eft_DBL][eft_LNG] = {
+        eft_LNG, (void *)dpnp_prod_default_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_PROD][eft_DBL][eft_FLT] = {
+        eft_FLT, (void *)dpnp_prod_default_c<float, double>};
+    fmap[DPNPFuncName::DPNP_FN_PROD][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_prod_default_c<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_INT][eft_INT] = {eft_LNG, (void*)dpnp_prod_ext_c<int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_INT][eft_LNG] = {eft_LNG, (void*)dpnp_prod_ext_c<int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_INT][eft_FLT] = {eft_FLT, (void*)dpnp_prod_ext_c<float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_INT][eft_DBL] = {eft_DBL, (void*)dpnp_prod_ext_c<double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_INT][eft_INT] = {
+        eft_LNG, (void *)dpnp_prod_ext_c<int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_prod_ext_c<int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_INT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_prod_ext_c<float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_prod_ext_c<double, int32_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_LNG][eft_INT] = {eft_INT, (void*)dpnp_prod_ext_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_prod_ext_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_LNG][eft_FLT] = {eft_FLT, (void*)dpnp_prod_ext_c<float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_LNG][eft_DBL] = {eft_DBL, (void*)dpnp_prod_ext_c<double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_LNG][eft_INT] = {
+        eft_INT, (void *)dpnp_prod_ext_c<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_prod_ext_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_LNG][eft_FLT] = {
+        eft_FLT, (void *)dpnp_prod_ext_c<float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_prod_ext_c<double, int64_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_FLT][eft_INT] = {eft_INT, (void*)dpnp_prod_ext_c<int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_FLT][eft_LNG] = {eft_LNG, (void*)dpnp_prod_ext_c<int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_prod_ext_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_FLT][eft_DBL] = {eft_DBL, (void*)dpnp_prod_ext_c<double, float>};
+    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_FLT][eft_INT] = {
+        eft_INT, (void *)dpnp_prod_ext_c<int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_FLT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_prod_ext_c<int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_prod_ext_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_prod_ext_c<double, float>};
 
-    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_DBL][eft_INT] = {eft_INT, (void*)dpnp_prod_ext_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_DBL][eft_LNG] = {eft_LNG, (void*)dpnp_prod_ext_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_DBL][eft_FLT] = {eft_FLT, (void*)dpnp_prod_ext_c<float, double>};
-    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_prod_ext_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_DBL][eft_INT] = {
+        eft_INT, (void *)dpnp_prod_ext_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_DBL][eft_LNG] = {
+        eft_LNG, (void *)dpnp_prod_ext_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_DBL][eft_FLT] = {
+        eft_FLT, (void *)dpnp_prod_ext_c<float, double>};
+    fmap[DPNPFuncName::DPNP_FN_PROD_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_prod_ext_c<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_SUM][eft_INT][eft_INT] = {eft_LNG, (void*)dpnp_sum_default_c<int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_SUM][eft_INT][eft_LNG] = {eft_LNG, (void*)dpnp_sum_default_c<int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_SUM][eft_INT][eft_FLT] = {eft_FLT, (void*)dpnp_sum_default_c<float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_SUM][eft_INT][eft_DBL] = {eft_DBL, (void*)dpnp_sum_default_c<double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_SUM][eft_INT][eft_INT] = {
+        eft_LNG, (void *)dpnp_sum_default_c<int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_SUM][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_sum_default_c<int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_SUM][eft_INT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_sum_default_c<float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_SUM][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_sum_default_c<double, int32_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_SUM][eft_LNG][eft_INT] = {eft_INT, (void*)dpnp_sum_default_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_SUM][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_sum_default_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_SUM][eft_LNG][eft_FLT] = {eft_FLT, (void*)dpnp_sum_default_c<float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_SUM][eft_LNG][eft_DBL] = {eft_DBL, (void*)dpnp_sum_default_c<double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_SUM][eft_LNG][eft_INT] = {
+        eft_INT, (void *)dpnp_sum_default_c<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_SUM][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_sum_default_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_SUM][eft_LNG][eft_FLT] = {
+        eft_FLT, (void *)dpnp_sum_default_c<float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_SUM][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_sum_default_c<double, int64_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_SUM][eft_FLT][eft_INT] = {eft_INT, (void*)dpnp_sum_default_c<int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_SUM][eft_FLT][eft_LNG] = {eft_LNG, (void*)dpnp_sum_default_c<int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_SUM][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_sum_default_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_SUM][eft_FLT][eft_DBL] = {eft_DBL, (void*)dpnp_sum_default_c<double, float>};
+    fmap[DPNPFuncName::DPNP_FN_SUM][eft_FLT][eft_INT] = {
+        eft_INT, (void *)dpnp_sum_default_c<int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_SUM][eft_FLT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_sum_default_c<int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_SUM][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_sum_default_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_SUM][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_sum_default_c<double, float>};
 
-    fmap[DPNPFuncName::DPNP_FN_SUM][eft_DBL][eft_INT] = {eft_INT, (void*)dpnp_sum_default_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_SUM][eft_DBL][eft_LNG] = {eft_LNG, (void*)dpnp_sum_default_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_SUM][eft_DBL][eft_FLT] = {eft_FLT, (void*)dpnp_sum_default_c<float, double>};
-    fmap[DPNPFuncName::DPNP_FN_SUM][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_sum_default_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_SUM][eft_DBL][eft_INT] = {
+        eft_INT, (void *)dpnp_sum_default_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_SUM][eft_DBL][eft_LNG] = {
+        eft_LNG, (void *)dpnp_sum_default_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_SUM][eft_DBL][eft_FLT] = {
+        eft_FLT, (void *)dpnp_sum_default_c<float, double>};
+    fmap[DPNPFuncName::DPNP_FN_SUM][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_sum_default_c<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_INT][eft_INT] = {eft_LNG, (void*)dpnp_sum_ext_c<int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_INT][eft_LNG] = {eft_LNG, (void*)dpnp_sum_ext_c<int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_INT][eft_FLT] = {eft_FLT, (void*)dpnp_sum_ext_c<float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_INT][eft_DBL] = {eft_DBL, (void*)dpnp_sum_ext_c<double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_INT][eft_INT] = {
+        eft_LNG, (void *)dpnp_sum_ext_c<int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_sum_ext_c<int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_INT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_sum_ext_c<float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_INT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_sum_ext_c<double, int32_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_LNG][eft_INT] = {eft_INT, (void*)dpnp_sum_ext_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_sum_ext_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_LNG][eft_FLT] = {eft_FLT, (void*)dpnp_sum_ext_c<float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_LNG][eft_DBL] = {eft_DBL, (void*)dpnp_sum_ext_c<double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_LNG][eft_INT] = {
+        eft_INT, (void *)dpnp_sum_ext_c<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_sum_ext_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_LNG][eft_FLT] = {
+        eft_FLT, (void *)dpnp_sum_ext_c<float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_LNG][eft_DBL] = {
+        eft_DBL, (void *)dpnp_sum_ext_c<double, int64_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_FLT][eft_INT] = {eft_INT, (void*)dpnp_sum_ext_c<int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_FLT][eft_LNG] = {eft_LNG, (void*)dpnp_sum_ext_c<int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_sum_ext_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_FLT][eft_DBL] = {eft_DBL, (void*)dpnp_sum_ext_c<double, float>};
+    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_FLT][eft_INT] = {
+        eft_INT, (void *)dpnp_sum_ext_c<int32_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_FLT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_sum_ext_c<int64_t, float>};
+    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_sum_ext_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_FLT][eft_DBL] = {
+        eft_DBL, (void *)dpnp_sum_ext_c<double, float>};
 
-    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_DBL][eft_INT] = {eft_INT, (void*)dpnp_sum_ext_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_DBL][eft_LNG] = {eft_LNG, (void*)dpnp_sum_ext_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_DBL][eft_FLT] = {eft_FLT, (void*)dpnp_sum_ext_c<float, double>};
-    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_sum_ext_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_DBL][eft_INT] = {
+        eft_INT, (void *)dpnp_sum_ext_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_DBL][eft_LNG] = {
+        eft_LNG, (void *)dpnp_sum_ext_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_DBL][eft_FLT] = {
+        eft_FLT, (void *)dpnp_sum_ext_c<float, double>};
+    fmap[DPNPFuncName::DPNP_FN_SUM_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_sum_ext_c<double, double>};
 
     return;
 }

--- a/dpnp/backend/kernels/dpnp_krnl_searching.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_searching.cpp
@@ -25,18 +25,18 @@
 
 #include <iostream>
 
-#include <dpnp_iface.hpp>
 #include "dpnp_fptr.hpp"
 #include "dpnpc_memory_adapter.hpp"
 #include "queue_sycl.hpp"
+#include <dpnp_iface.hpp>
 
 template <typename _DataType, typename _idx_DataType>
 class dpnp_argmax_c_kernel;
 
 template <typename _DataType, typename _idx_DataType>
 DPCTLSyclEventRef dpnp_argmax_c(DPCTLSyclQueueRef q_ref,
-                                void* array1_in,
-                                void* result1,
+                                void *array1_in,
+                                void *result1,
                                 size_t size,
                                 const DPCTLEventVectorRef dep_event_vec_ref)
 {
@@ -44,54 +44,55 @@ DPCTLSyclEventRef dpnp_argmax_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, size);
-    _DataType* array_1 = input1_ptr.get_ptr();
-    _idx_DataType* result = reinterpret_cast<_idx_DataType*>(result1);
+    _DataType *array_1    = input1_ptr.get_ptr();
+    _idx_DataType *result = reinterpret_cast<_idx_DataType *>(result1);
 
-    auto policy =
-        oneapi::dpl::execution::make_device_policy<class dpnp_argmax_c_kernel<_DataType, _idx_DataType>>(q);
+    auto policy = oneapi::dpl::execution::make_device_policy<
+        class dpnp_argmax_c_kernel<_DataType, _idx_DataType>>(q);
 
-    _DataType* res = std::max_element(policy, array_1, array_1 + size);
+    _DataType *res = std::max_element(policy, array_1, array_1 + size);
     policy.queue().wait();
 
     _idx_DataType result_val = std::distance(array_1, res);
-    q.memcpy(result, &result_val, sizeof(_idx_DataType)).wait(); // result[0] = std::distance(array_1, res);
+    q.memcpy(result, &result_val, sizeof(_idx_DataType))
+        .wait(); // result[0] = std::distance(array_1, res);
 
     return event_ref;
 }
 
 template <typename _DataType, typename _idx_DataType>
-void dpnp_argmax_c(void* array1_in, void* result1, size_t size)
+void dpnp_argmax_c(void *array1_in, void *result1, size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_argmax_c<_DataType, _idx_DataType>(q_ref,
-                                                                          array1_in,
-                                                                          result1,
-                                                                          size,
-                                                                          dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref = dpnp_argmax_c<_DataType, _idx_DataType>(
+        q_ref, array1_in, result1, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType, typename _idx_DataType>
-void (*dpnp_argmax_default_c)(void*, void*, size_t) = dpnp_argmax_c<_DataType, _idx_DataType>;
+void (*dpnp_argmax_default_c)(void *,
+                              void *,
+                              size_t) = dpnp_argmax_c<_DataType, _idx_DataType>;
 
 template <typename _DataType, typename _idx_DataType>
 DPCTLSyclEventRef (*dpnp_argmax_ext_c)(DPCTLSyclQueueRef,
-                                       void*,
-                                       void*,
+                                       void *,
+                                       void *,
                                        size_t,
-                                       const DPCTLEventVectorRef) = dpnp_argmax_c<_DataType, _idx_DataType>;
+                                       const DPCTLEventVectorRef) =
+    dpnp_argmax_c<_DataType, _idx_DataType>;
 
 template <typename _DataType, typename _idx_DataType>
 class dpnp_argmin_c_kernel;
 
 template <typename _DataType, typename _idx_DataType>
 DPCTLSyclEventRef dpnp_argmin_c(DPCTLSyclQueueRef q_ref,
-                                void* array1_in,
-                                void* result1,
+                                void *array1_in,
+                                void *result1,
                                 size_t size,
                                 const DPCTLEventVectorRef dep_event_vec_ref)
 {
@@ -99,83 +100,116 @@ DPCTLSyclEventRef dpnp_argmin_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, size);
-    _DataType* array_1 = input1_ptr.get_ptr();
-    _idx_DataType* result = reinterpret_cast<_idx_DataType*>(result1);
+    _DataType *array_1    = input1_ptr.get_ptr();
+    _idx_DataType *result = reinterpret_cast<_idx_DataType *>(result1);
 
-    auto policy =
-        oneapi::dpl::execution::make_device_policy<class dpnp_argmin_c_kernel<_DataType, _idx_DataType>>(q);
+    auto policy = oneapi::dpl::execution::make_device_policy<
+        class dpnp_argmin_c_kernel<_DataType, _idx_DataType>>(q);
 
-    _DataType* res = std::min_element(policy, array_1, array_1 + size);
+    _DataType *res = std::min_element(policy, array_1, array_1 + size);
     policy.queue().wait();
 
     _idx_DataType result_val = std::distance(array_1, res);
-    q.memcpy(result, &result_val, sizeof(_idx_DataType)).wait(); // result[0] = std::distance(array_1, res);
+    q.memcpy(result, &result_val, sizeof(_idx_DataType))
+        .wait(); // result[0] = std::distance(array_1, res);
 
     return event_ref;
 }
 
 template <typename _DataType, typename _idx_DataType>
-void dpnp_argmin_c(void* array1_in, void* result1, size_t size)
+void dpnp_argmin_c(void *array1_in, void *result1, size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_argmin_c<_DataType, _idx_DataType>(q_ref,
-                                                                          array1_in,
-                                                                          result1,
-                                                                          size,
-                                                                          dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref = dpnp_argmin_c<_DataType, _idx_DataType>(
+        q_ref, array1_in, result1, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType, typename _idx_DataType>
-void (*dpnp_argmin_default_c)(void*, void*, size_t) = dpnp_argmin_c<_DataType, _idx_DataType>;
+void (*dpnp_argmin_default_c)(void *,
+                              void *,
+                              size_t) = dpnp_argmin_c<_DataType, _idx_DataType>;
 
 template <typename _DataType, typename _idx_DataType>
 DPCTLSyclEventRef (*dpnp_argmin_ext_c)(DPCTLSyclQueueRef,
-                                       void*,
-                                       void*,
+                                       void *,
+                                       void *,
                                        size_t,
-                                       const DPCTLEventVectorRef) = dpnp_argmin_c<_DataType, _idx_DataType>;
+                                       const DPCTLEventVectorRef) =
+    dpnp_argmin_c<_DataType, _idx_DataType>;
 
-void func_map_init_searching(func_map_t& fmap)
+void func_map_init_searching(func_map_t &fmap)
 {
-    fmap[DPNPFuncName::DPNP_FN_ARGMAX][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_argmax_default_c<int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMAX][eft_INT][eft_LNG] = {eft_LNG, (void*)dpnp_argmax_default_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMAX][eft_LNG][eft_INT] = {eft_INT, (void*)dpnp_argmax_default_c<int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMAX][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_argmax_default_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMAX][eft_FLT][eft_INT] = {eft_INT, (void*)dpnp_argmax_default_c<float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMAX][eft_FLT][eft_LNG] = {eft_LNG, (void*)dpnp_argmax_default_c<float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMAX][eft_DBL][eft_INT] = {eft_INT, (void*)dpnp_argmax_default_c<double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMAX][eft_DBL][eft_LNG] = {eft_LNG, (void*)dpnp_argmax_default_c<double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMAX][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_argmax_default_c<int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMAX][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_argmax_default_c<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMAX][eft_LNG][eft_INT] = {
+        eft_INT, (void *)dpnp_argmax_default_c<int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMAX][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_argmax_default_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMAX][eft_FLT][eft_INT] = {
+        eft_INT, (void *)dpnp_argmax_default_c<float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMAX][eft_FLT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_argmax_default_c<float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMAX][eft_DBL][eft_INT] = {
+        eft_INT, (void *)dpnp_argmax_default_c<double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMAX][eft_DBL][eft_LNG] = {
+        eft_LNG, (void *)dpnp_argmax_default_c<double, int64_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_ARGMAX_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_argmax_ext_c<int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMAX_EXT][eft_INT][eft_LNG] = {eft_LNG, (void*)dpnp_argmax_ext_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMAX_EXT][eft_LNG][eft_INT] = {eft_INT, (void*)dpnp_argmax_ext_c<int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMAX_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_argmax_ext_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMAX_EXT][eft_FLT][eft_INT] = {eft_INT, (void*)dpnp_argmax_ext_c<float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMAX_EXT][eft_FLT][eft_LNG] = {eft_LNG, (void*)dpnp_argmax_ext_c<float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMAX_EXT][eft_DBL][eft_INT] = {eft_INT, (void*)dpnp_argmax_ext_c<double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMAX_EXT][eft_DBL][eft_LNG] = {eft_LNG, (void*)dpnp_argmax_ext_c<double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMAX_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_argmax_ext_c<int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMAX_EXT][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_argmax_ext_c<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMAX_EXT][eft_LNG][eft_INT] = {
+        eft_INT, (void *)dpnp_argmax_ext_c<int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMAX_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_argmax_ext_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMAX_EXT][eft_FLT][eft_INT] = {
+        eft_INT, (void *)dpnp_argmax_ext_c<float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMAX_EXT][eft_FLT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_argmax_ext_c<float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMAX_EXT][eft_DBL][eft_INT] = {
+        eft_INT, (void *)dpnp_argmax_ext_c<double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMAX_EXT][eft_DBL][eft_LNG] = {
+        eft_LNG, (void *)dpnp_argmax_ext_c<double, int64_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_ARGMIN][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_argmin_default_c<int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMIN][eft_INT][eft_LNG] = {eft_LNG, (void*)dpnp_argmin_default_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMIN][eft_LNG][eft_INT] = {eft_INT, (void*)dpnp_argmin_default_c<int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMIN][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_argmin_default_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMIN][eft_FLT][eft_INT] = {eft_INT, (void*)dpnp_argmin_default_c<float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMIN][eft_FLT][eft_LNG] = {eft_LNG, (void*)dpnp_argmin_default_c<float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMIN][eft_DBL][eft_INT] = {eft_INT, (void*)dpnp_argmin_default_c<double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMIN][eft_DBL][eft_LNG] = {eft_LNG, (void*)dpnp_argmin_default_c<double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMIN][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_argmin_default_c<int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMIN][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_argmin_default_c<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMIN][eft_LNG][eft_INT] = {
+        eft_INT, (void *)dpnp_argmin_default_c<int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMIN][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_argmin_default_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMIN][eft_FLT][eft_INT] = {
+        eft_INT, (void *)dpnp_argmin_default_c<float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMIN][eft_FLT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_argmin_default_c<float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMIN][eft_DBL][eft_INT] = {
+        eft_INT, (void *)dpnp_argmin_default_c<double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMIN][eft_DBL][eft_LNG] = {
+        eft_LNG, (void *)dpnp_argmin_default_c<double, int64_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_ARGMIN_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_argmin_ext_c<int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMIN_EXT][eft_INT][eft_LNG] = {eft_LNG, (void*)dpnp_argmin_ext_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMIN_EXT][eft_LNG][eft_INT] = {eft_INT, (void*)dpnp_argmin_ext_c<int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMIN_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_argmin_ext_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMIN_EXT][eft_FLT][eft_INT] = {eft_INT, (void*)dpnp_argmin_ext_c<float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMIN_EXT][eft_FLT][eft_LNG] = {eft_LNG, (void*)dpnp_argmin_ext_c<float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMIN_EXT][eft_DBL][eft_INT] = {eft_INT, (void*)dpnp_argmin_ext_c<double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGMIN_EXT][eft_DBL][eft_LNG] = {eft_LNG, (void*)dpnp_argmin_ext_c<double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMIN_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_argmin_ext_c<int32_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMIN_EXT][eft_INT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_argmin_ext_c<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMIN_EXT][eft_LNG][eft_INT] = {
+        eft_INT, (void *)dpnp_argmin_ext_c<int64_t, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMIN_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_argmin_ext_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMIN_EXT][eft_FLT][eft_INT] = {
+        eft_INT, (void *)dpnp_argmin_ext_c<float, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMIN_EXT][eft_FLT][eft_LNG] = {
+        eft_LNG, (void *)dpnp_argmin_ext_c<float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMIN_EXT][eft_DBL][eft_INT] = {
+        eft_INT, (void *)dpnp_argmin_ext_c<double, int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGMIN_EXT][eft_DBL][eft_LNG] = {
+        eft_LNG, (void *)dpnp_argmin_ext_c<double, int64_t>};
 
     return;
 }

--- a/dpnp/backend/kernels/dpnp_krnl_searching.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_searching.cpp
@@ -44,10 +44,10 @@ DPCTLSyclEventRef dpnp_argmax_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, size);
-    _DataType *array_1    = input1_ptr.get_ptr();
+    _DataType *array_1 = input1_ptr.get_ptr();
     _idx_DataType *result = reinterpret_cast<_idx_DataType *>(result1);
 
     auto policy = oneapi::dpl::execution::make_device_policy<
@@ -100,9 +100,9 @@ DPCTLSyclEventRef dpnp_argmin_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, size);
-    _DataType *array_1    = input1_ptr.get_ptr();
+    _DataType *array_1 = input1_ptr.get_ptr();
     _idx_DataType *result = reinterpret_cast<_idx_DataType *>(result1);
 
     auto policy = oneapi::dpl::execution::make_device_policy<

--- a/dpnp/backend/kernels/dpnp_krnl_sorting.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_sorting.cpp
@@ -25,26 +25,26 @@
 
 #include <iostream>
 
-#include <dpnp_iface.hpp>
 #include "dpnp_fptr.hpp"
 #include "dpnpc_memory_adapter.hpp"
 #include "queue_sycl.hpp"
+#include <dpnp_iface.hpp>
 
 template <typename _DataType, typename _idx_DataType>
 struct _argsort_less
 {
-    _argsort_less(_DataType* data_ptr)
+    _argsort_less(_DataType *data_ptr)
     {
         _data_ptr = data_ptr;
     }
 
-    inline bool operator()(const _idx_DataType& idx1, const _idx_DataType& idx2)
+    inline bool operator()(const _idx_DataType &idx1, const _idx_DataType &idx2)
     {
         return (_data_ptr[idx1] < _data_ptr[idx2]);
     }
 
 private:
-    _DataType* _data_ptr = nullptr;
+    _DataType *_data_ptr = nullptr;
 };
 
 template <typename _DataType, typename _idx_DataType>
@@ -52,8 +52,8 @@ class dpnp_argsort_c_kernel;
 
 template <typename _DataType, typename _idx_DataType>
 DPCTLSyclEventRef dpnp_argsort_c(DPCTLSyclQueueRef q_ref,
-                                 void* array1_in,
-                                 void* result1,
+                                 void *array1_in,
+                                 void *result1,
                                  size_t size,
                                  const DPCTLEventVectorRef dep_event_vec_ref)
 {
@@ -61,19 +61,21 @@ DPCTLSyclEventRef dpnp_argsort_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, size, true);
-    DPNPC_ptr_adapter<_idx_DataType> result1_ptr(q_ref, result1, size, true, true);
-    _DataType* array_1 = input1_ptr.get_ptr();
-    _idx_DataType* result = result1_ptr.get_ptr();
+    DPNPC_ptr_adapter<_idx_DataType> result1_ptr(q_ref, result1, size, true,
+                                                 true);
+    _DataType *array_1    = input1_ptr.get_ptr();
+    _idx_DataType *result = result1_ptr.get_ptr();
 
     std::iota(result, result + size, 0);
 
-    auto policy =
-        oneapi::dpl::execution::make_device_policy<class dpnp_argsort_c_kernel<_DataType, _idx_DataType>>(q);
+    auto policy = oneapi::dpl::execution::make_device_policy<
+        class dpnp_argsort_c_kernel<_DataType, _idx_DataType>>(q);
 
-    std::sort(policy, result, result + size, _argsort_less<_DataType, _idx_DataType>(array_1));
+    std::sort(policy, result, result + size,
+              _argsort_less<_DataType, _idx_DataType>(array_1));
 
     policy.queue().wait();
 
@@ -81,42 +83,43 @@ DPCTLSyclEventRef dpnp_argsort_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType, typename _idx_DataType>
-void dpnp_argsort_c(void* array1_in, void* result1, size_t size)
+void dpnp_argsort_c(void *array1_in, void *result1, size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_argsort_c<_DataType, _idx_DataType>(q_ref,
-                                                                           array1_in,
-                                                                           result1,
-                                                                           size,
-                                                                           dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref = dpnp_argsort_c<_DataType, _idx_DataType>(
+        q_ref, array1_in, result1, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType, typename _idx_DataType>
-void (*dpnp_argsort_default_c)(void*, void*, size_t) = dpnp_argsort_c<_DataType, _idx_DataType>;
+void (*dpnp_argsort_default_c)(void *, void *, size_t) =
+    dpnp_argsort_c<_DataType, _idx_DataType>;
 
 template <typename _DataType, typename _idx_DataType>
 DPCTLSyclEventRef (*dpnp_argsort_ext_c)(DPCTLSyclQueueRef,
-                                        void*,
-                                        void*,
+                                        void *,
+                                        void *,
                                         size_t,
-                                        const DPCTLEventVectorRef) = dpnp_argsort_c<_DataType, _idx_DataType>;
+                                        const DPCTLEventVectorRef) =
+    dpnp_argsort_c<_DataType, _idx_DataType>;
 
-// template void dpnp_argsort_c<double, long>(void* array1_in, void* result1, size_t size);
-// template void dpnp_argsort_c<float, long>(void* array1_in, void* result1, size_t size);
-// template void dpnp_argsort_c<long, long>(void* array1_in, void* result1, size_t size);
-// template void dpnp_argsort_c<int, long>(void* array1_in, void* result1, size_t size);
-// template void dpnp_argsort_c<double, int>(void* array1_in, void* result1, size_t size);
-// template void dpnp_argsort_c<float, int>(void* array1_in, void* result1, size_t size);
-// template void dpnp_argsort_c<long, int>(void* array1_in, void* result1, size_t size);
-// template void dpnp_argsort_c<int, int>(void* array1_in, void* result1, size_t size);
+// template void dpnp_argsort_c<double, long>(void* array1_in, void* result1,
+// size_t size); template void dpnp_argsort_c<float, long>(void* array1_in,
+// void* result1, size_t size); template void dpnp_argsort_c<long, long>(void*
+// array1_in, void* result1, size_t size); template void dpnp_argsort_c<int,
+// long>(void* array1_in, void* result1, size_t size); template void
+// dpnp_argsort_c<double, int>(void* array1_in, void* result1, size_t size);
+// template void dpnp_argsort_c<float, int>(void* array1_in, void* result1,
+// size_t size); template void dpnp_argsort_c<long, int>(void* array1_in, void*
+// result1, size_t size); template void dpnp_argsort_c<int, int>(void*
+// array1_in, void* result1, size_t size);
 
 template <typename _DataType>
 struct _sort_less
 {
-    inline bool operator()(const _DataType& val1, const _DataType& val2)
+    inline bool operator()(const _DataType &val1, const _DataType &val2)
     {
         return (val1 < val2);
     }
@@ -127,11 +130,11 @@ class dpnp_partition_c_kernel;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_partition_c(DPCTLSyclQueueRef q_ref,
-                                   void* array1_in,
-                                   void* array2_in,
-                                   void* result1,
+                                   void *array1_in,
+                                   void *array2_in,
+                                   void *result1,
                                    const size_t kth,
-                                   const shape_elem_type* shape_,
+                                   const shape_elem_type *shape_,
                                    const size_t ndim,
                                    const DPCTLEventVectorRef dep_event_vec_ref)
 {
@@ -140,32 +143,32 @@ DPCTLSyclEventRef dpnp_partition_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if ((array1_in == nullptr) || (array2_in == nullptr) || (result1 == nullptr))
-    {
+    if ((array1_in == nullptr) || (array2_in == nullptr) ||
+        (result1 == nullptr)) {
         return event_ref;
     }
 
-    if (ndim < 1)
-    {
+    if (ndim < 1) {
         return event_ref;
     }
 
-    const size_t size = std::accumulate(shape_, shape_ + ndim, 1, std::multiplies<shape_elem_type>());
-    size_t size_ = size / shape_[ndim - 1];
+    const size_t size = std::accumulate(shape_, shape_ + ndim, 1,
+                                        std::multiplies<shape_elem_type>());
+    size_t size_      = size / shape_[ndim - 1];
 
-    if (size_ == 0)
-    {
+    if (size_ == 0) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     if (ndim == 1) // 1d array with C-contiguous data
     {
-        _DataType* arr = static_cast<_DataType*>(array1_in);
-        _DataType* result = static_cast<_DataType*>(result1);
+        _DataType *arr    = static_cast<_DataType *>(array1_in);
+        _DataType *result = static_cast<_DataType *>(result1);
 
-        auto policy = oneapi::dpl::execution::make_device_policy<dpnp_partition_c_kernel<_DataType>>(q);
+        auto policy = oneapi::dpl::execution::make_device_policy<
+            dpnp_partition_c_kernel<_DataType>>(q);
 
         // fill the result array with data from input one
         q.memcpy(result, arr, size * sizeof(_DataType)).wait();
@@ -174,41 +177,40 @@ DPCTLSyclEventRef dpnp_partition_c(DPCTLSyclQueueRef q_ref,
         // 1. result[0 <= i < kth]    <= result[kth]
         // 2. result[kth <= i < size] >= result[kth]
         // event-blocking call, no need for wait()
-        std::nth_element(policy, result, result + kth, result + size, dpnp_less_comp());
+        std::nth_element(policy, result, result + kth, result + size,
+                         dpnp_less_comp());
         return event_ref;
     }
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, size, true);
     DPNPC_ptr_adapter<_DataType> input2_ptr(q_ref, array2_in, size, true);
     DPNPC_ptr_adapter<_DataType> result1_ptr(q_ref, result1, size, true, true);
-    _DataType* arr = input1_ptr.get_ptr();
-    _DataType* arr2 = input2_ptr.get_ptr();
-    _DataType* result = result1_ptr.get_ptr();
+    _DataType *arr    = input1_ptr.get_ptr();
+    _DataType *arr2   = input2_ptr.get_ptr();
+    _DataType *result = result1_ptr.get_ptr();
 
     auto arr_to_result_event = q.memcpy(result, arr, size * sizeof(_DataType));
     arr_to_result_event.wait();
 
-    for (size_t i = 0; i < size_; ++i)
-    {
+    for (size_t i = 0; i < size_; ++i) {
         size_t ind_begin = i * shape_[ndim - 1];
-        size_t ind_end = (i + 1) * shape_[ndim - 1] - 1;
+        size_t ind_end   = (i + 1) * shape_[ndim - 1] - 1;
 
         _DataType matrix[shape_[ndim - 1]];
-        for (size_t j = ind_begin; j < ind_end + 1; ++j)
-        {
-            size_t ind = j - ind_begin;
+        for (size_t j = ind_begin; j < ind_end + 1; ++j) {
+            size_t ind  = j - ind_begin;
             matrix[ind] = arr2[j];
         }
-        std::partial_sort(matrix, matrix + shape_[ndim - 1], matrix + shape_[ndim - 1], dpnp_less_comp());
-        for (size_t j = ind_begin; j < ind_end + 1; ++j)
-        {
+        std::partial_sort(matrix, matrix + shape_[ndim - 1],
+                          matrix + shape_[ndim - 1], dpnp_less_comp());
+        for (size_t j = ind_begin; j < ind_end + 1; ++j) {
             size_t ind = j - ind_begin;
-            arr2[j] = matrix[ind];
+            arr2[j]    = matrix[ind];
         }
     }
 
-    shape_elem_type* shape = reinterpret_cast<shape_elem_type*>(sycl::malloc_shared(ndim * sizeof(shape_elem_type),
-                                                                                    q));
+    shape_elem_type *shape = reinterpret_cast<shape_elem_type *>(
+        sycl::malloc_shared(ndim * sizeof(shape_elem_type), q));
     auto memcpy_event = q.memcpy(shape, shape_, ndim * sizeof(shape_elem_type));
 
     memcpy_event.wait();
@@ -220,10 +222,8 @@ DPCTLSyclEventRef dpnp_partition_c(DPCTLSyclQueueRef q_ref,
 
         _DataType val = arr2[j * shape[ndim - 1] + k];
 
-        for (size_t i = 0; i < static_cast<size_t>(shape[ndim - 1]); ++i)
-        {
-            if (result[j * shape[ndim - 1] + i] == val)
-            {
+        for (size_t i = 0; i < static_cast<size_t>(shape[ndim - 1]); ++i) {
+            if (result[j * shape[ndim - 1] + i] == val) {
                 _DataType change_val1 = result[j * shape[ndim - 1] + i];
                 _DataType change_val2 = result[j * shape[ndim - 1] + k];
                 result[j * shape[ndim - 1] + k] = change_val1;
@@ -232,9 +232,10 @@ DPCTLSyclEventRef dpnp_partition_c(DPCTLSyclQueueRef q_ref,
         }
     };
 
-    auto kernel_func = [&](sycl::handler& cgh) {
+    auto kernel_func = [&](sycl::handler &cgh) {
         cgh.depends_on({memcpy_event});
-        cgh.parallel_for<class dpnp_partition_c_kernel<_DataType>>(gws, kernel_parallel_for_func);
+        cgh.parallel_for<class dpnp_partition_c_kernel<_DataType>>(
+            gws, kernel_parallel_for_func);
     };
 
     auto event = q.submit(kernel_func);
@@ -247,140 +248,121 @@ DPCTLSyclEventRef dpnp_partition_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_partition_c(
-    void* array1_in, void* array2_in, void* result1, const size_t kth, const shape_elem_type* shape_, const size_t ndim)
+void dpnp_partition_c(void *array1_in,
+                      void *array2_in,
+                      void *result1,
+                      const size_t kth,
+                      const shape_elem_type *shape_,
+                      const size_t ndim)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_partition_c<_DataType>(q_ref,
-                                                              array1_in,
-                                                              array2_in,
-                                                              result1,
-                                                              kth,
-                                                              shape_,
-                                                              ndim,
-                                                              dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_partition_c<_DataType>(q_ref, array1_in, array2_in, result1, kth,
+                                    shape_, ndim, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_partition_default_c)(void*,
-                                 void*,
-                                 void*,
+void (*dpnp_partition_default_c)(void *,
+                                 void *,
+                                 void *,
                                  const size_t,
-                                 const shape_elem_type*,
+                                 const shape_elem_type *,
                                  const size_t) = dpnp_partition_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_partition_ext_c)(DPCTLSyclQueueRef,
-                                         void*,
-                                         void*,
-                                         void*,
-                                         const size_t,
-                                         const shape_elem_type*,
-                                         const size_t,
-                                         const DPCTLEventVectorRef) = dpnp_partition_c<_DataType>;
+                                          void *,
+                                          void *,
+                                          void *,
+                                          const size_t,
+                                          const shape_elem_type *,
+                                          const size_t,
+                                          const DPCTLEventVectorRef) =
+    dpnp_partition_c<_DataType>;
 
 template <typename _DataType, typename _IndexingType>
 class dpnp_searchsorted_c_kernel;
 
 template <typename _DataType, typename _IndexingType>
-DPCTLSyclEventRef dpnp_searchsorted_c(DPCTLSyclQueueRef q_ref,
-                                      void* result1,
-                                      const void* array1_in,
-                                      const void* v1_in,
-                                      bool side,
-                                      const size_t arr_size,
-                                      const size_t v_size,
-                                      const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_searchsorted_c(DPCTLSyclQueueRef q_ref,
+                        void *result1,
+                        const void *array1_in,
+                        const void *v1_in,
+                        bool side,
+                        const size_t arr_size,
+                        const size_t v_size,
+                        const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if ((array1_in == nullptr) || (v1_in == nullptr) || (result1 == nullptr))
-    {
+    if ((array1_in == nullptr) || (v1_in == nullptr) || (result1 == nullptr)) {
         return event_ref;
     }
 
-    if (arr_size == 0)
-    {
+    if (arr_size == 0) {
         return event_ref;
     }
 
-    if (v_size == 0)
-    {
+    if (v_size == 0) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, arr_size);
     DPNPC_ptr_adapter<_DataType> input2_ptr(q_ref, v1_in, v_size);
-    const _DataType* arr = input1_ptr.get_ptr();
-    const _DataType* v = input2_ptr.get_ptr();
-    _IndexingType* result = reinterpret_cast<_IndexingType*>(result1);
+    const _DataType *arr  = input1_ptr.get_ptr();
+    const _DataType *v    = input2_ptr.get_ptr();
+    _IndexingType *result = reinterpret_cast<_IndexingType *>(result1);
 
     sycl::range<2> gws(v_size, arr_size);
     auto kernel_parallel_for_func = [=](sycl::id<2> global_id) {
         size_t i = global_id[0];
         size_t j = global_id[1];
 
-        if (j != 0)
-        {
-            if (side)
-            {
-                if (j == arr_size - 1)
-                {
-                    if (v[i] == arr[j])
-                    {
+        if (j != 0) {
+            if (side) {
+                if (j == arr_size - 1) {
+                    if (v[i] == arr[j]) {
                         result[i] = arr_size - 1;
                     }
-                    else
-                    {
-                        if (v[i] > arr[j])
-                        {
+                    else {
+                        if (v[i] > arr[j]) {
                             result[i] = arr_size;
                         }
                     }
                 }
-                else
-                {
-                    if ((arr[j - 1] < v[i]) && (v[i] <= arr[j]))
-                    {
+                else {
+                    if ((arr[j - 1] < v[i]) && (v[i] <= arr[j])) {
                         result[i] = j;
                     }
                 }
             }
-            else
-            {
-                if (j == arr_size - 1)
-                {
-                    if ((arr[j - 1] <= v[i]) && (v[i] < arr[j]))
-                    {
+            else {
+                if (j == arr_size - 1) {
+                    if ((arr[j - 1] <= v[i]) && (v[i] < arr[j])) {
                         result[i] = arr_size - 1;
                     }
-                    else
-                    {
-                        if (v[i] == arr[j])
-                        {
+                    else {
+                        if (v[i] == arr[j]) {
                             result[i] = arr_size;
                         }
-                        else
-                        {
-                            if (v[i] > arr[j])
-                            {
+                        else {
+                            if (v[i] > arr[j]) {
                                 result[i] = arr_size;
                             }
                         }
                     }
                 }
-                else
-                {
-                    if ((arr[j - 1] <= v[i]) && (v[i] < arr[j]))
-                    {
+                else {
+                    if ((arr[j - 1] <= v[i]) && (v[i] < arr[j])) {
                         result[i] = j;
                     }
                 }
@@ -388,8 +370,10 @@ DPCTLSyclEventRef dpnp_searchsorted_c(DPCTLSyclQueueRef q_ref,
         }
     };
 
-    auto kernel_func = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class dpnp_searchsorted_c_kernel<_DataType, _IndexingType>>(gws, kernel_parallel_for_func);
+    auto kernel_func = [&](sycl::handler &cgh) {
+        cgh.parallel_for<
+            class dpnp_searchsorted_c_kernel<_DataType, _IndexingType>>(
+            gws, kernel_parallel_for_func);
     };
 
     auto event = q.submit(kernel_func);
@@ -400,48 +384,49 @@ DPCTLSyclEventRef dpnp_searchsorted_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType, typename _IndexingType>
-void dpnp_searchsorted_c(
-    void* result1, const void* array1_in, const void* v1_in, bool side, const size_t arr_size, const size_t v_size)
+void dpnp_searchsorted_c(void *result1,
+                         const void *array1_in,
+                         const void *v1_in,
+                         bool side,
+                         const size_t arr_size,
+                         const size_t v_size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_searchsorted_c<_DataType, _IndexingType>(q_ref,
-                                                                                result1,
-                                                                                array1_in,
-                                                                                v1_in,
-                                                                                side,
-                                                                                arr_size,
-                                                                                v_size,
-                                                                                dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref = dpnp_searchsorted_c<_DataType, _IndexingType>(
+        q_ref, result1, array1_in, v1_in, side, arr_size, v_size,
+        dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType, typename _IndexingType>
-void (*dpnp_searchsorted_default_c)(void*,
-                                    const void*,
-                                    const void*,
+void (*dpnp_searchsorted_default_c)(void *,
+                                    const void *,
+                                    const void *,
                                     bool,
                                     const size_t,
-                                    const size_t) = dpnp_searchsorted_c<_DataType, _IndexingType>;
+                                    const size_t) =
+    dpnp_searchsorted_c<_DataType, _IndexingType>;
 
 template <typename _DataType, typename _IndexingType>
 DPCTLSyclEventRef (*dpnp_searchsorted_ext_c)(DPCTLSyclQueueRef,
-                                             void*,
-                                             const void*,
-                                             const void*,
+                                             void *,
+                                             const void *,
+                                             const void *,
                                              bool,
                                              const size_t,
                                              const size_t,
-                                             const DPCTLEventVectorRef) = dpnp_searchsorted_c<_DataType, _IndexingType>;
+                                             const DPCTLEventVectorRef) =
+    dpnp_searchsorted_c<_DataType, _IndexingType>;
 
 template <typename _DataType>
 class dpnp_sort_c_kernel;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_sort_c(DPCTLSyclQueueRef q_ref,
-                              void* array1_in,
-                              void* result1,
+                              void *array1_in,
+                              void *result1,
                               size_t size,
                               const DPCTLEventVectorRef dep_event_vec_ref)
 {
@@ -449,19 +434,20 @@ DPCTLSyclEventRef dpnp_sort_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, size, true);
     DPNPC_ptr_adapter<_DataType> result1_ptr(q_ref, result1, size, true, true);
-    _DataType* array_1 = input1_ptr.get_ptr();
-    _DataType* result = result1_ptr.get_ptr();
+    _DataType *array_1 = input1_ptr.get_ptr();
+    _DataType *result  = result1_ptr.get_ptr();
 
     std::copy(array_1, array_1 + size, result);
 
-    auto policy = oneapi::dpl::execution::make_device_policy<class dpnp_sort_c_kernel<_DataType>>(q);
+    auto policy = oneapi::dpl::execution::make_device_policy<
+        class dpnp_sort_c_kernel<_DataType>>(q);
 
-    // fails without explicitly specifying of comparator or with std::less during kernels compilation
-    // affects other kernels
+    // fails without explicitly specifying of comparator or with std::less
+    // during kernels compilation affects other kernels
     std::sort(policy, result, result + size, _sort_less<_DataType>());
 
     policy.queue().wait();
@@ -470,81 +456,106 @@ DPCTLSyclEventRef dpnp_sort_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_sort_c(void* array1_in, void* result1, size_t size)
+void dpnp_sort_c(void *array1_in, void *result1, size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_sort_c<_DataType>(q_ref,
-                                                         array1_in,
-                                                         result1,
-                                                         size,
-                                                         dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_sort_c<_DataType>(
+        q_ref, array1_in, result1, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_sort_default_c)(void*, void*, size_t) = dpnp_sort_c<_DataType>;
+void (*dpnp_sort_default_c)(void *, void *, size_t) = dpnp_sort_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_sort_ext_c)(DPCTLSyclQueueRef,
-                                     void*,
-                                     void*,
+                                     void *,
+                                     void *,
                                      size_t,
-                                     const DPCTLEventVectorRef) = dpnp_sort_c<_DataType>;
+                                     const DPCTLEventVectorRef) =
+    dpnp_sort_c<_DataType>;
 
-void func_map_init_sorting(func_map_t& fmap)
+void func_map_init_sorting(func_map_t &fmap)
 {
-    fmap[DPNPFuncName::DPNP_FN_ARGSORT][eft_INT][eft_INT] = {eft_LNG, (void*)dpnp_argsort_default_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGSORT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_argsort_default_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGSORT][eft_FLT][eft_FLT] = {eft_LNG, (void*)dpnp_argsort_default_c<float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGSORT][eft_DBL][eft_DBL] = {eft_LNG, (void*)dpnp_argsort_default_c<double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGSORT][eft_INT][eft_INT] = {
+        eft_LNG, (void *)dpnp_argsort_default_c<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGSORT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_argsort_default_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGSORT][eft_FLT][eft_FLT] = {
+        eft_LNG, (void *)dpnp_argsort_default_c<float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGSORT][eft_DBL][eft_DBL] = {
+        eft_LNG, (void *)dpnp_argsort_default_c<double, int64_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_ARGSORT_EXT][eft_INT][eft_INT] = {eft_LNG, (void*)dpnp_argsort_ext_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGSORT_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_argsort_ext_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGSORT_EXT][eft_FLT][eft_FLT] = {eft_LNG, (void*)dpnp_argsort_ext_c<float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ARGSORT_EXT][eft_DBL][eft_DBL] = {eft_LNG, (void*)dpnp_argsort_ext_c<double, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGSORT_EXT][eft_INT][eft_INT] = {
+        eft_LNG, (void *)dpnp_argsort_ext_c<int32_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGSORT_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_argsort_ext_c<int64_t, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGSORT_EXT][eft_FLT][eft_FLT] = {
+        eft_LNG, (void *)dpnp_argsort_ext_c<float, int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_ARGSORT_EXT][eft_DBL][eft_DBL] = {
+        eft_LNG, (void *)dpnp_argsort_ext_c<double, int64_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_PARTITION][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_partition_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_PARTITION][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_partition_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_PARTITION][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_partition_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_PARTITION][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_partition_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_PARTITION][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_partition_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_PARTITION][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_partition_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_PARTITION][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_partition_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_PARTITION][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_partition_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_PARTITION_EXT][eft_BLN][eft_BLN] = {eft_BLN, (void*)dpnp_partition_ext_c<bool>};
-    fmap[DPNPFuncName::DPNP_FN_PARTITION_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_partition_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_PARTITION_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_partition_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_PARTITION_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_partition_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_PARTITION_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_partition_ext_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_PARTITION_EXT][eft_C64][eft_C64] = {eft_C64, (void*)dpnp_partition_ext_c<std::complex<float>>};
-    fmap[DPNPFuncName::DPNP_FN_PARTITION_EXT][eft_C128][eft_C128] = {eft_C128, (void*)dpnp_partition_ext_c<std::complex<double>>};
+    fmap[DPNPFuncName::DPNP_FN_PARTITION_EXT][eft_BLN][eft_BLN] = {
+        eft_BLN, (void *)dpnp_partition_ext_c<bool>};
+    fmap[DPNPFuncName::DPNP_FN_PARTITION_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_partition_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_PARTITION_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_partition_ext_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_PARTITION_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_partition_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_PARTITION_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_partition_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_PARTITION_EXT][eft_C64][eft_C64] = {
+        eft_C64, (void *)dpnp_partition_ext_c<std::complex<float>>};
+    fmap[DPNPFuncName::DPNP_FN_PARTITION_EXT][eft_C128][eft_C128] = {
+        eft_C128, (void *)dpnp_partition_ext_c<std::complex<double>>};
 
     fmap[DPNPFuncName::DPNP_FN_SEARCHSORTED][eft_INT][eft_INT] = {
-        eft_INT, (void*)dpnp_searchsorted_default_c<int32_t, int64_t>};
+        eft_INT, (void *)dpnp_searchsorted_default_c<int32_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_SEARCHSORTED][eft_LNG][eft_LNG] = {
-        eft_LNG, (void*)dpnp_searchsorted_default_c<int64_t, int64_t>};
+        eft_LNG, (void *)dpnp_searchsorted_default_c<int64_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_SEARCHSORTED][eft_FLT][eft_FLT] = {
-        eft_FLT, (void*)dpnp_searchsorted_default_c<float, int64_t>};
+        eft_FLT, (void *)dpnp_searchsorted_default_c<float, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_SEARCHSORTED][eft_DBL][eft_DBL] = {
-        eft_DBL, (void*)dpnp_searchsorted_default_c<double, int64_t>};
+        eft_DBL, (void *)dpnp_searchsorted_default_c<double, int64_t>};
 
     fmap[DPNPFuncName::DPNP_FN_SEARCHSORTED_EXT][eft_INT][eft_INT] = {
-        eft_INT, (void*)dpnp_searchsorted_ext_c<int32_t, int64_t>};
+        eft_INT, (void *)dpnp_searchsorted_ext_c<int32_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_SEARCHSORTED_EXT][eft_LNG][eft_LNG] = {
-        eft_LNG, (void*)dpnp_searchsorted_ext_c<int64_t, int64_t>};
+        eft_LNG, (void *)dpnp_searchsorted_ext_c<int64_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_SEARCHSORTED_EXT][eft_FLT][eft_FLT] = {
-        eft_FLT, (void*)dpnp_searchsorted_ext_c<float, int64_t>};
+        eft_FLT, (void *)dpnp_searchsorted_ext_c<float, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_SEARCHSORTED_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void*)dpnp_searchsorted_ext_c<double, int64_t>};
+        eft_DBL, (void *)dpnp_searchsorted_ext_c<double, int64_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_SORT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_sort_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_SORT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_sort_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_SORT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_sort_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_SORT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_sort_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_SORT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_sort_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_SORT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_sort_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_SORT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_sort_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_SORT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_sort_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_SORT_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_sort_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_SORT_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_sort_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_SORT_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_sort_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_SORT_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_sort_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_SORT_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_sort_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_SORT_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_sort_ext_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_SORT_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_sort_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_SORT_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_sort_ext_c<double>};
 
     return;
 }

--- a/dpnp/backend/kernels/dpnp_krnl_sorting.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_sorting.cpp
@@ -61,12 +61,12 @@ DPCTLSyclEventRef dpnp_argsort_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, size, true);
     DPNPC_ptr_adapter<_idx_DataType> result1_ptr(q_ref, result1, size, true,
                                                  true);
-    _DataType *array_1    = input1_ptr.get_ptr();
+    _DataType *array_1 = input1_ptr.get_ptr();
     _idx_DataType *result = result1_ptr.get_ptr();
 
     std::iota(result, result + size, 0);
@@ -154,7 +154,7 @@ DPCTLSyclEventRef dpnp_partition_c(DPCTLSyclQueueRef q_ref,
 
     const size_t size = std::accumulate(shape_, shape_ + ndim, 1,
                                         std::multiplies<shape_elem_type>());
-    size_t size_      = size / shape_[ndim - 1];
+    size_t size_ = size / shape_[ndim - 1];
 
     if (size_ == 0) {
         return event_ref;
@@ -164,7 +164,7 @@ DPCTLSyclEventRef dpnp_partition_c(DPCTLSyclQueueRef q_ref,
 
     if (ndim == 1) // 1d array with C-contiguous data
     {
-        _DataType *arr    = static_cast<_DataType *>(array1_in);
+        _DataType *arr = static_cast<_DataType *>(array1_in);
         _DataType *result = static_cast<_DataType *>(result1);
 
         auto policy = oneapi::dpl::execution::make_device_policy<
@@ -185,8 +185,8 @@ DPCTLSyclEventRef dpnp_partition_c(DPCTLSyclQueueRef q_ref,
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, size, true);
     DPNPC_ptr_adapter<_DataType> input2_ptr(q_ref, array2_in, size, true);
     DPNPC_ptr_adapter<_DataType> result1_ptr(q_ref, result1, size, true, true);
-    _DataType *arr    = input1_ptr.get_ptr();
-    _DataType *arr2   = input2_ptr.get_ptr();
+    _DataType *arr = input1_ptr.get_ptr();
+    _DataType *arr2 = input2_ptr.get_ptr();
     _DataType *result = result1_ptr.get_ptr();
 
     auto arr_to_result_event = q.memcpy(result, arr, size * sizeof(_DataType));
@@ -194,18 +194,18 @@ DPCTLSyclEventRef dpnp_partition_c(DPCTLSyclQueueRef q_ref,
 
     for (size_t i = 0; i < size_; ++i) {
         size_t ind_begin = i * shape_[ndim - 1];
-        size_t ind_end   = (i + 1) * shape_[ndim - 1] - 1;
+        size_t ind_end = (i + 1) * shape_[ndim - 1] - 1;
 
         _DataType matrix[shape_[ndim - 1]];
         for (size_t j = ind_begin; j < ind_end + 1; ++j) {
-            size_t ind  = j - ind_begin;
+            size_t ind = j - ind_begin;
             matrix[ind] = arr2[j];
         }
         std::partial_sort(matrix, matrix + shape_[ndim - 1],
                           matrix + shape_[ndim - 1], dpnp_less_comp());
         for (size_t j = ind_begin; j < ind_end + 1; ++j) {
             size_t ind = j - ind_begin;
-            arr2[j]    = matrix[ind];
+            arr2[j] = matrix[ind];
         }
     }
 
@@ -318,8 +318,8 @@ DPCTLSyclEventRef
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, arr_size);
     DPNPC_ptr_adapter<_DataType> input2_ptr(q_ref, v1_in, v_size);
-    const _DataType *arr  = input1_ptr.get_ptr();
-    const _DataType *v    = input2_ptr.get_ptr();
+    const _DataType *arr = input1_ptr.get_ptr();
+    const _DataType *v = input2_ptr.get_ptr();
     _IndexingType *result = reinterpret_cast<_IndexingType *>(result1);
 
     sycl::range<2> gws(v_size, arr_size);
@@ -434,12 +434,12 @@ DPCTLSyclEventRef dpnp_sort_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, size, true);
     DPNPC_ptr_adapter<_DataType> result1_ptr(q_ref, result1, size, true, true);
     _DataType *array_1 = input1_ptr.get_ptr();
-    _DataType *result  = result1_ptr.get_ptr();
+    _DataType *result = result1_ptr.get_ptr();
 
     std::copy(array_1, array_1 + size, result);
 
@@ -460,7 +460,7 @@ void dpnp_sort_c(void *array1_in, void *result1, size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_sort_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_sort_c<_DataType>(
         q_ref, array1_in, result1, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);

--- a/dpnp/backend/kernels/dpnp_krnl_statistics.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_statistics.cpp
@@ -31,7 +31,7 @@
 #include "queue_sycl.hpp"
 #include <dpnp_iface.hpp>
 
-namespace mkl_blas  = oneapi::mkl::blas::row_major;
+namespace mkl_blas = oneapi::mkl::blas::row_major;
 namespace mkl_stats = oneapi::mkl::stats;
 
 template <typename _KernelNameSpecialization1,
@@ -155,7 +155,7 @@ DPCTLSyclEventRef dpnp_cov_c(DPCTLSyclQueueRef q_ref,
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, nrows * ncols);
     _DataType *array_1 = input1_ptr.get_ptr();
-    _DataType *result  = reinterpret_cast<_DataType *>(result1);
+    _DataType *result = reinterpret_cast<_DataType *>(result1);
 
     auto policy = oneapi::dpl::execution::make_device_policy<
         class dpnp_cov_c_kernel1<_DataType>>(q);
@@ -164,7 +164,7 @@ DPCTLSyclEventRef dpnp_cov_c(DPCTLSyclQueueRef q_ref,
         sycl::malloc_shared(nrows * sizeof(_DataType), q));
     for (size_t i = 0; i < nrows; ++i) {
         _DataType *row_start = array_1 + ncols * i;
-        mean[i]              = std::reduce(policy, row_start, row_start + ncols,
+        mean[i] = std::reduce(policy, row_start, row_start + ncols,
                               _DataType(0), std::plus<_DataType>()) /
                   ncols;
     }
@@ -173,7 +173,7 @@ DPCTLSyclEventRef dpnp_cov_c(DPCTLSyclQueueRef q_ref,
     _DataType *temp = reinterpret_cast<_DataType *>(
         sycl::malloc_shared(nrows * ncols * sizeof(_DataType), q));
     for (size_t i = 0; i < nrows; ++i) {
-        size_t offset        = ncols * i;
+        size_t offset = ncols * i;
         _DataType *row_start = array_1 + offset;
         std::transform(policy, row_start, row_start + ncols, temp + offset,
                        [=](_DataType x) { return x - mean[i]; });
@@ -183,7 +183,7 @@ DPCTLSyclEventRef dpnp_cov_c(DPCTLSyclQueueRef q_ref,
     sycl::event event_syrk;
 
     const _DataType alpha = _DataType(1) / (ncols - 1);
-    const _DataType beta  = _DataType(0);
+    const _DataType beta = _DataType(0);
 
     event_syrk =
         mkl_blas::syrk(q,                                // queue &exec_queue,
@@ -203,7 +203,7 @@ DPCTLSyclEventRef dpnp_cov_c(DPCTLSyclQueueRef q_ref,
     sycl::event event;
     sycl::range<1> gws(nrows * nrows);
     auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
-        const size_t idx     = global_id[0];
+        const size_t idx = global_id[0];
         const size_t row_idx = idx / nrows;
         const size_t col_idx = idx - row_idx * nrows;
         if (col_idx < row_idx) {
@@ -231,7 +231,7 @@ void dpnp_cov_c(void *array1_in, void *result1, size_t nrows, size_t ncols)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_cov_c<_DataType>(
+    DPCTLSyclEventRef event_ref = dpnp_cov_c<_DataType>(
         q_ref, array1_in, result1, nrows, ncols, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
@@ -262,7 +262,7 @@ DPCTLSyclEventRef
     DPNPC_ptr_adapter<_DataType_input> input1_ptr(q_ref, array1_in, size, true);
     DPNPC_ptr_adapter<_DataType_output> result_ptr(q_ref, result1_out, 1, true,
                                                    true);
-    _DataType_input *array1   = input1_ptr.get_ptr();
+    _DataType_input *array1 = input1_ptr.get_ptr();
     _DataType_output *result1 = result_ptr.get_ptr();
 
     result1[0] = 0;
@@ -331,7 +331,7 @@ DPCTLSyclEventRef dpnp_max_c(DPCTLSyclQueueRef q_ref,
     DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, result_size, true,
                                             true);
     _DataType *array_1 = input1_ptr.get_ptr();
-    _DataType *result  = result_ptr.get_ptr();
+    _DataType *result = result_ptr.get_ptr();
 
     if (naxis == 0) {
         __attribute__((unused)) void *tmp = (void *)(axis + naxis);
@@ -411,7 +411,7 @@ DPCTLSyclEventRef dpnp_max_c(DPCTLSyclQueueRef q_ref,
             size_t xyz[res_ndim];
             size_t remainder = result_idx;
             for (size_t i = 0; i < res_ndim; ++i) {
-                xyz[i]    = remainder / output_shape_offsets[i];
+                xyz[i] = remainder / output_shape_offsets[i];
                 remainder = remainder - xyz[i] * output_shape_offsets[i];
             }
 
@@ -447,7 +447,7 @@ DPCTLSyclEventRef dpnp_max_c(DPCTLSyclQueueRef q_ref,
             size_t xyz[ndim];
             size_t remainder = source_idx;
             for (size_t i = 0; i < ndim; ++i) {
-                xyz[i]    = remainder / input_shape_offsets[i];
+                xyz[i] = remainder / input_shape_offsets[i];
                 remainder = remainder - xyz[i] * input_shape_offsets[i];
             }
 
@@ -550,7 +550,7 @@ DPCTLSyclEventRef dpnp_mean_c(DPCTLSyclQueueRef q_ref,
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, size, true);
     DPNPC_ptr_adapter<_ResultType> result_ptr(q_ref, result1, 1, true, true);
-    _DataType *array    = input1_ptr.get_ptr();
+    _DataType *array = input1_ptr.get_ptr();
     _ResultType *result = result_ptr.get_ptr();
 
     if constexpr (std::is_same<_DataType, double>::value ||
@@ -592,7 +592,7 @@ void dpnp_mean_c(void *array1_in,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_mean_c<_DataType, _ResultType>(
+    DPCTLSyclEventRef event_ref = dpnp_mean_c<_DataType, _ResultType>(
         q_ref, array1_in, result1, shape, ndim, axis, naxis, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
@@ -721,7 +721,7 @@ DPCTLSyclEventRef dpnp_min_c(DPCTLSyclQueueRef q_ref,
     DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, result_size, true,
                                             true);
     _DataType *array_1 = input1_ptr.get_ptr();
-    _DataType *result  = result_ptr.get_ptr();
+    _DataType *result = result_ptr.get_ptr();
 
     if (naxis == 0) {
         if constexpr (std::is_same<_DataType, double>::value ||
@@ -795,7 +795,7 @@ DPCTLSyclEventRef dpnp_min_c(DPCTLSyclQueueRef q_ref,
             size_t xyz[res_ndim];
             size_t remainder = result_idx;
             for (size_t i = 0; i < res_ndim; ++i) {
-                xyz[i]    = remainder / output_shape_offsets[i];
+                xyz[i] = remainder / output_shape_offsets[i];
                 remainder = remainder - xyz[i] * output_shape_offsets[i];
             }
 
@@ -831,7 +831,7 @@ DPCTLSyclEventRef dpnp_min_c(DPCTLSyclQueueRef q_ref,
             size_t xyz[ndim];
             size_t remainder = source_idx;
             for (size_t i = 0; i < ndim; ++i) {
-                xyz[i]    = remainder / input_shape_offsets[i];
+                xyz[i] = remainder / input_shape_offsets[i];
                 remainder = remainder - xyz[i] * input_shape_offsets[i];
             }
 
@@ -937,7 +937,7 @@ DPCTLSyclEventRef dpnp_nanvar_c(DPCTLSyclQueueRef q_ref,
     DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, result_size, true,
                                             true);
     _DataType *array1 = input1_ptr.get_ptr();
-    bool *mask_arr    = input2_ptr.get_ptr();
+    bool *mask_arr = input2_ptr.get_ptr();
     _DataType *result = result_ptr.get_ptr();
 
     size_t ind = 0;
@@ -996,7 +996,7 @@ DPCTLSyclEventRef dpnp_std_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     _ResultType *var = reinterpret_cast<_ResultType *>(
         sycl::malloc_shared(1 * sizeof(_ResultType), q));
@@ -1012,18 +1012,18 @@ DPCTLSyclEventRef dpnp_std_c(DPCTLSyclQueueRef q_ref,
         result1_ndim * sizeof(shape_elem_type);
     shape_elem_type *result1_shape = reinterpret_cast<shape_elem_type *>(
         sycl::malloc_shared(result1_shape_size_in_bytes, q));
-    *result1_shape                   = 1;
+    *result1_shape = 1;
     shape_elem_type *result1_strides = reinterpret_cast<shape_elem_type *>(
         sycl::malloc_shared(result1_strides_size_in_bytes, q));
     *result1_strides = 1;
 
-    const size_t var_size                  = 1;
-    const size_t var_ndim                  = 1;
-    const size_t var_shape_size_in_bytes   = var_ndim * sizeof(shape_elem_type);
+    const size_t var_size = 1;
+    const size_t var_ndim = 1;
+    const size_t var_shape_size_in_bytes = var_ndim * sizeof(shape_elem_type);
     const size_t var_strides_size_in_bytes = var_ndim * sizeof(shape_elem_type);
     shape_elem_type *var_shape = reinterpret_cast<shape_elem_type *>(
         sycl::malloc_shared(var_shape_size_in_bytes, q));
-    *var_shape                   = 1;
+    *var_shape = 1;
     shape_elem_type *var_strides = reinterpret_cast<shape_elem_type *>(
         sycl::malloc_shared(var_strides_size_in_bytes, q));
     *var_strides = 1;
@@ -1055,7 +1055,7 @@ void dpnp_std_c(void *array1_in,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_std_c<_DataType, _ResultType>(
+    DPCTLSyclEventRef event_ref = dpnp_std_c<_DataType, _ResultType>(
         q_ref, array1_in, result1, shape, ndim, axis, naxis, ddof,
         dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
@@ -1113,7 +1113,7 @@ DPCTLSyclEventRef dpnp_var_c(DPCTLSyclQueueRef q_ref,
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, size);
     DPNPC_ptr_adapter<_ResultType> result_ptr(q_ref, result1, 1, true, true);
-    _DataType *array1   = input1_ptr.get_ptr();
+    _DataType *array1 = input1_ptr.get_ptr();
     _ResultType *result = result_ptr.get_ptr();
 
     _ResultType *mean = reinterpret_cast<_ResultType *>(
@@ -1166,7 +1166,7 @@ void dpnp_var_c(void *array1_in,
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref           = dpnp_var_c<_DataType, _ResultType>(
+    DPCTLSyclEventRef event_ref = dpnp_var_c<_DataType, _ResultType>(
         q_ref, array1_in, result1, shape, ndim, axis, naxis, ddof,
         dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);

--- a/dpnp/backend/kernels/dpnp_krnl_statistics.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_statistics.cpp
@@ -25,112 +25,108 @@
 
 #include <iostream>
 
-#include <dpnp_iface.hpp>
 #include "dpnp_fptr.hpp"
 #include "dpnp_utils.hpp"
 #include "dpnpc_memory_adapter.hpp"
 #include "queue_sycl.hpp"
+#include <dpnp_iface.hpp>
 
-namespace mkl_blas = oneapi::mkl::blas::row_major;
+namespace mkl_blas  = oneapi::mkl::blas::row_major;
 namespace mkl_stats = oneapi::mkl::stats;
 
-template <typename _KernelNameSpecialization1, typename _KernelNameSpecialization2, typename _KernelNameSpecialization3>
+template <typename _KernelNameSpecialization1,
+          typename _KernelNameSpecialization2,
+          typename _KernelNameSpecialization3>
 class dpnp_correlate_c_kernel;
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
 DPCTLSyclEventRef dpnp_correlate_c(DPCTLSyclQueueRef q_ref,
-                                   void* result_out,
-                                   const void* input1_in,
+                                   void *result_out,
+                                   const void *input1_in,
                                    const size_t input1_size,
-                                   const shape_elem_type* input1_shape,
+                                   const shape_elem_type *input1_shape,
                                    const size_t input1_shape_ndim,
-                                   const void* input2_in,
+                                   const void *input2_in,
                                    const size_t input2_size,
-                                   const shape_elem_type* input2_shape,
+                                   const shape_elem_type *input2_shape,
                                    const size_t input2_shape_ndim,
-                                   const size_t* where,
+                                   const size_t *where,
                                    const DPCTLEventVectorRef dep_event_vec_ref)
 {
     (void)where;
 
     shape_elem_type dummy[] = {1};
-    return dpnp_dot_c<_DataType_output, _DataType_input1, _DataType_input2>(q_ref,
-                                                                            result_out,
-                                                                            42,   // dummy result_size
-                                                                            42,   // dummy result_ndim
-                                                                            NULL, // dummy result_shape
-                                                                            NULL, // dummy result_strides
-                                                                            input1_in,
-                                                                            input1_size,
-                                                                            input1_shape_ndim,
-                                                                            input1_shape,
-                                                                            dummy, // dummy input1_strides
-                                                                            input2_in,
-                                                                            input2_size,
-                                                                            input2_shape_ndim,
-                                                                            input2_shape,
-                                                                            dummy, // dummy input2_strides
-                                                                            dep_event_vec_ref);
+    return dpnp_dot_c<_DataType_output, _DataType_input1, _DataType_input2>(
+        q_ref, result_out,
+        42,   // dummy result_size
+        42,   // dummy result_ndim
+        NULL, // dummy result_shape
+        NULL, // dummy result_strides
+        input1_in, input1_size, input1_shape_ndim, input1_shape,
+        dummy, // dummy input1_strides
+        input2_in, input2_size, input2_shape_ndim, input2_shape,
+        dummy, // dummy input2_strides
+        dep_event_vec_ref);
 }
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
-void dpnp_correlate_c(void* result_out,
-                      const void* input1_in,
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
+void dpnp_correlate_c(void *result_out,
+                      const void *input1_in,
                       const size_t input1_size,
-                      const shape_elem_type* input1_shape,
+                      const shape_elem_type *input1_shape,
                       const size_t input1_shape_ndim,
-                      const void* input2_in,
+                      const void *input2_in,
                       const size_t input2_size,
-                      const shape_elem_type* input2_shape,
+                      const shape_elem_type *input2_shape,
                       const size_t input2_shape_ndim,
-                      const size_t* where)
+                      const size_t *where)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_correlate_c<_DataType_output, _DataType_input1, _DataType_input2>(
-        q_ref,
-        result_out,
-        input1_in,
-        input1_size,
-        input1_shape,
-        input1_shape_ndim,
-        input2_in,
-        input2_size,
-        input2_shape,
-        input2_shape_ndim,
-        where,
-        dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_correlate_c<_DataType_output, _DataType_input1, _DataType_input2>(
+            q_ref, result_out, input1_in, input1_size, input1_shape,
+            input1_shape_ndim, input2_in, input2_size, input2_shape,
+            input2_shape_ndim, where, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
-void (*dpnp_correlate_default_c)(
-    void*,
-    const void*,
-    const size_t,
-    const shape_elem_type*,
-    const size_t,
-    const void*,
-    const size_t,
-    const shape_elem_type*,
-    const size_t,
-    const size_t*) = dpnp_correlate_c<_DataType_output, _DataType_input1, _DataType_input2>;
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
+void (*dpnp_correlate_default_c)(void *,
+                                 const void *,
+                                 const size_t,
+                                 const shape_elem_type *,
+                                 const size_t,
+                                 const void *,
+                                 const size_t,
+                                 const shape_elem_type *,
+                                 const size_t,
+                                 const size_t *) =
+    dpnp_correlate_c<_DataType_output, _DataType_input1, _DataType_input2>;
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
-DPCTLSyclEventRef (*dpnp_correlate_ext_c)(
-    DPCTLSyclQueueRef,
-    void*,
-    const void*,
-    const size_t,
-    const shape_elem_type*,
-    const size_t,
-    const void*,
-    const size_t,
-    const shape_elem_type*,
-    const size_t,
-    const size_t*,
-    const DPCTLEventVectorRef) = dpnp_correlate_c<_DataType_output, _DataType_input1, _DataType_input2>;
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
+DPCTLSyclEventRef (*dpnp_correlate_ext_c)(DPCTLSyclQueueRef,
+                                          void *,
+                                          const void *,
+                                          const size_t,
+                                          const shape_elem_type *,
+                                          const size_t,
+                                          const void *,
+                                          const size_t,
+                                          const shape_elem_type *,
+                                          const size_t,
+                                          const size_t *,
+                                          const DPCTLEventVectorRef) =
+    dpnp_correlate_c<_DataType_output, _DataType_input1, _DataType_input2>;
 
 template <typename _DataType>
 class dpnp_cov_c_kernel1;
@@ -140,8 +136,8 @@ class dpnp_cov_c_kernel2;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_cov_c(DPCTLSyclQueueRef q_ref,
-                             void* array1_in,
-                             void* result1,
+                             void *array1_in,
+                             void *result1,
                              size_t nrows,
                              size_t ncols,
                              const DPCTLEventVectorRef dep_event_vec_ref)
@@ -151,69 +147,73 @@ DPCTLSyclEventRef dpnp_cov_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (!nrows || !ncols)
-    {
+    if (!nrows || !ncols) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, nrows * ncols);
-    _DataType* array_1 = input1_ptr.get_ptr();
-    _DataType* result = reinterpret_cast<_DataType*>(result1);
+    _DataType *array_1 = input1_ptr.get_ptr();
+    _DataType *result  = reinterpret_cast<_DataType *>(result1);
 
-    auto policy = oneapi::dpl::execution::make_device_policy<class dpnp_cov_c_kernel1<_DataType>>(q);
+    auto policy = oneapi::dpl::execution::make_device_policy<
+        class dpnp_cov_c_kernel1<_DataType>>(q);
 
-    _DataType* mean = reinterpret_cast<_DataType*>(sycl::malloc_shared(nrows * sizeof(_DataType), q));
-    for (size_t i = 0; i < nrows; ++i)
-    {
-        _DataType* row_start = array_1 + ncols * i;
-        mean[i] = std::reduce(policy, row_start, row_start + ncols, _DataType(0), std::plus<_DataType>()) / ncols;
+    _DataType *mean = reinterpret_cast<_DataType *>(
+        sycl::malloc_shared(nrows * sizeof(_DataType), q));
+    for (size_t i = 0; i < nrows; ++i) {
+        _DataType *row_start = array_1 + ncols * i;
+        mean[i]              = std::reduce(policy, row_start, row_start + ncols,
+                              _DataType(0), std::plus<_DataType>()) /
+                  ncols;
     }
     policy.queue().wait();
 
-    _DataType* temp = reinterpret_cast<_DataType*>(sycl::malloc_shared(nrows * ncols * sizeof(_DataType), q));
-    for (size_t i = 0; i < nrows; ++i)
-    {
-        size_t offset = ncols * i;
-        _DataType* row_start = array_1 + offset;
-        std::transform(policy, row_start, row_start + ncols, temp + offset, [=](_DataType x) { return x - mean[i]; });
+    _DataType *temp = reinterpret_cast<_DataType *>(
+        sycl::malloc_shared(nrows * ncols * sizeof(_DataType), q));
+    for (size_t i = 0; i < nrows; ++i) {
+        size_t offset        = ncols * i;
+        _DataType *row_start = array_1 + offset;
+        std::transform(policy, row_start, row_start + ncols, temp + offset,
+                       [=](_DataType x) { return x - mean[i]; });
     }
     policy.queue().wait();
 
     sycl::event event_syrk;
 
     const _DataType alpha = _DataType(1) / (ncols - 1);
-    const _DataType beta = _DataType(0);
+    const _DataType beta  = _DataType(0);
 
-    event_syrk = mkl_blas::syrk(q,                       // queue &exec_queue,
-                                oneapi::mkl::uplo::upper,         // uplo upper_lower,
-                                oneapi::mkl::transpose::nontrans, // transpose trans,
-                                nrows,                            // std::int64_t n,
-                                ncols,                            // std::int64_t k,
-                                alpha,                            // T alpha,
-                                temp,                             // const T* a,
-                                ncols,                            // std::int64_t lda,
-                                beta,                             // T beta,
-                                result,                           // T* c,
-                                nrows);                           // std::int64_t ldc);
+    event_syrk =
+        mkl_blas::syrk(q,                                // queue &exec_queue,
+                       oneapi::mkl::uplo::upper,         // uplo upper_lower,
+                       oneapi::mkl::transpose::nontrans, // transpose trans,
+                       nrows,                            // std::int64_t n,
+                       ncols,                            // std::int64_t k,
+                       alpha,                            // T alpha,
+                       temp,                             // const T* a,
+                       ncols,                            // std::int64_t lda,
+                       beta,                             // T beta,
+                       result,                           // T* c,
+                       nrows);                           // std::int64_t ldc);
     event_syrk.wait();
 
     // fill lower elements
     sycl::event event;
     sycl::range<1> gws(nrows * nrows);
     auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
-        const size_t idx = global_id[0];
+        const size_t idx     = global_id[0];
         const size_t row_idx = idx / nrows;
         const size_t col_idx = idx - row_idx * nrows;
-        if (col_idx < row_idx)
-        {
+        if (col_idx < row_idx) {
             result[idx] = result[col_idx * nrows + row_idx];
         }
     };
 
-    auto kernel_func = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class dpnp_cov_c_kernel2<_DataType>>(gws, kernel_parallel_for_func);
+    auto kernel_func = [&](sycl::handler &cgh) {
+        cgh.parallel_for<class dpnp_cov_c_kernel2<_DataType>>(
+            gws, kernel_parallel_for_func);
     };
 
     event = q.submit(kernel_func);
@@ -227,52 +227,48 @@ DPCTLSyclEventRef dpnp_cov_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_cov_c(void* array1_in, void* result1, size_t nrows, size_t ncols)
+void dpnp_cov_c(void *array1_in, void *result1, size_t nrows, size_t ncols)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_cov_c<_DataType>(q_ref,
-                                                        array1_in,
-                                                        result1,
-                                                        nrows,
-                                                        ncols,
-                                                        dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_cov_c<_DataType>(
+        q_ref, array1_in, result1, nrows, ncols, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_cov_default_c)(void*, void*, size_t, size_t) = dpnp_cov_c<_DataType>;
+void (*dpnp_cov_default_c)(void *, void *, size_t, size_t) =
+    dpnp_cov_c<_DataType>;
 
 template <typename _DataType_input, typename _DataType_output>
-DPCTLSyclEventRef dpnp_count_nonzero_c(DPCTLSyclQueueRef q_ref,
-                                       void* array1_in,
-                                       void* result1_out,
-                                       size_t size,
-                                       const DPCTLEventVectorRef dep_event_vec_ref)
+DPCTLSyclEventRef
+    dpnp_count_nonzero_c(DPCTLSyclQueueRef q_ref,
+                         void *array1_in,
+                         void *result1_out,
+                         size_t size,
+                         const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if (array1_in == nullptr)
-    {
+    if (array1_in == nullptr) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_DataType_input> input1_ptr(q_ref, array1_in, size, true);
-    DPNPC_ptr_adapter<_DataType_output> result_ptr(q_ref, result1_out, 1, true, true);
-    _DataType_input* array1 = input1_ptr.get_ptr();
-    _DataType_output* result1 = result_ptr.get_ptr();
+    DPNPC_ptr_adapter<_DataType_output> result_ptr(q_ref, result1_out, 1, true,
+                                                   true);
+    _DataType_input *array1   = input1_ptr.get_ptr();
+    _DataType_output *result1 = result_ptr.get_ptr();
 
     result1[0] = 0;
 
-    for (size_t i = 0; i < size; ++i)
-    {
-        if (array1[i] != 0)
-        {
+    for (size_t i = 0; i < size; ++i) {
+        if (array1[i] != 0) {
             result1[0] += 1;
         }
     }
@@ -281,41 +277,40 @@ DPCTLSyclEventRef dpnp_count_nonzero_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType_input, typename _DataType_output>
-void dpnp_count_nonzero_c(void* array1_in, void* result1_out, size_t size)
+void dpnp_count_nonzero_c(void *array1_in, void *result1_out, size_t size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_count_nonzero_c<_DataType_input, _DataType_output>(q_ref,
-                                                                                          array1_in,
-                                                                                          result1_out,
-                                                                                          size,
-                                                                                          dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_count_nonzero_c<_DataType_input, _DataType_output>(
+            q_ref, array1_in, result1_out, size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType_input, typename _DataType_output>
-void (*dpnp_count_nonzero_default_c)(void*, void*, size_t) = dpnp_count_nonzero_c<_DataType_input, _DataType_output>;
+void (*dpnp_count_nonzero_default_c)(void *, void *, size_t) =
+    dpnp_count_nonzero_c<_DataType_input, _DataType_output>;
 
 template <typename _DataType_input, typename _DataType_output>
-DPCTLSyclEventRef (*dpnp_count_nonzero_ext_c)(
-    DPCTLSyclQueueRef,
-    void*,
-    void*,
-    size_t,
-    const DPCTLEventVectorRef) = dpnp_count_nonzero_c<_DataType_input, _DataType_output>;
+DPCTLSyclEventRef (*dpnp_count_nonzero_ext_c)(DPCTLSyclQueueRef,
+                                              void *,
+                                              void *,
+                                              size_t,
+                                              const DPCTLEventVectorRef) =
+    dpnp_count_nonzero_c<_DataType_input, _DataType_output>;
 
 template <typename _DataType>
 class dpnp_max_c_kernel;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_max_c(DPCTLSyclQueueRef q_ref,
-                             void* array1_in,
-                             void* result1,
+                             void *array1_in,
+                             void *result1,
                              const size_t result_size,
-                             const shape_elem_type* shape,
+                             const shape_elem_type *shape,
                              size_t ndim,
-                             const shape_elem_type* axis,
+                             const shape_elem_type *axis,
                              size_t naxis,
                              const DPCTLEventVectorRef dep_event_vec_ref)
 {
@@ -324,68 +319,65 @@ DPCTLSyclEventRef dpnp_max_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    const size_t size_input = std::accumulate(shape, shape + ndim, 1, std::multiplies<shape_elem_type>());
-    if (!size_input)
-    {
+    const size_t size_input = std::accumulate(
+        shape, shape + ndim, 1, std::multiplies<shape_elem_type>());
+    if (!size_input) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, size_input, true);
-    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, result_size, true, true);
-    _DataType* array_1 = input1_ptr.get_ptr();
-    _DataType* result = result_ptr.get_ptr();
+    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, result_size, true,
+                                            true);
+    _DataType *array_1 = input1_ptr.get_ptr();
+    _DataType *result  = result_ptr.get_ptr();
 
-    if (naxis == 0)
-    {
-        __attribute__((unused)) void* tmp = (void*)(axis + naxis);
+    if (naxis == 0) {
+        __attribute__((unused)) void *tmp = (void *)(axis + naxis);
 
         size_t size = 1;
-        for (size_t i = 0; i < ndim; ++i)
-        {
+        for (size_t i = 0; i < ndim; ++i) {
             size *= shape[i];
         }
 
-        if constexpr (std::is_same<_DataType, double>::value || std::is_same<_DataType, float>::value)
+        if constexpr (std::is_same<_DataType, double>::value ||
+                      std::is_same<_DataType, float>::value)
         {
             // Required initializing the result before call the function
             result[0] = array_1[0];
 
-            auto dataset = mkl_stats::make_dataset<mkl_stats::layout::row_major>(1, size, array_1);
+            auto dataset =
+                mkl_stats::make_dataset<mkl_stats::layout::row_major>(1, size,
+                                                                      array_1);
 
             sycl::event event = mkl_stats::max(q, dataset, result);
 
             event.wait();
         }
-        else
-        {
-            auto policy = oneapi::dpl::execution::make_device_policy<class dpnp_max_c_kernel<_DataType>>(q);
+        else {
+            auto policy = oneapi::dpl::execution::make_device_policy<
+                class dpnp_max_c_kernel<_DataType>>(q);
 
-            _DataType* res = std::max_element(policy, array_1, array_1 + size);
+            _DataType *res = std::max_element(policy, array_1, array_1 + size);
             policy.queue().wait();
 
             result[0] = *res;
         }
     }
-    else
-    {
+    else {
         size_t res_ndim = ndim - naxis;
         size_t res_shape[res_ndim];
         int ind = 0;
-        for (size_t i = 0; i < ndim; ++i)
-        {
+        for (size_t i = 0; i < ndim; ++i) {
             bool found = false;
-            for (size_t j = 0; j < naxis; ++j)
-            {
-                if (static_cast<size_t>(axis[j]) == i)
-                {
+            for (size_t j = 0; j < naxis; ++j) {
+                if (static_cast<size_t>(axis[j]) == i) {
                     found = true;
                     break;
                 }
             }
-            if (!found)
-            {
+            if (!found) {
                 res_shape[ind] = shape[i];
                 ind++;
             }
@@ -393,8 +385,7 @@ DPCTLSyclEventRef dpnp_max_c(DPCTLSyclQueueRef q_ref,
 
         size_t input_shape_offsets[ndim];
         size_t acc = 1;
-        for (size_t i = ndim - 1; i > 0; --i)
-        {
+        for (size_t i = ndim - 1; i > 0; --i) {
             input_shape_offsets[i] = acc;
             acc *= shape[i];
         }
@@ -402,10 +393,8 @@ DPCTLSyclEventRef dpnp_max_c(DPCTLSyclQueueRef q_ref,
 
         size_t output_shape_offsets[res_ndim];
         acc = 1;
-        if (res_ndim > 0)
-        {
-            for (size_t i = res_ndim - 1; i > 0; --i)
-            {
+        if (res_ndim > 0) {
+            for (size_t i = res_ndim - 1; i > 0; --i) {
                 output_shape_offsets[i] = acc;
                 acc *= res_shape[i];
             }
@@ -413,83 +402,68 @@ DPCTLSyclEventRef dpnp_max_c(DPCTLSyclQueueRef q_ref,
         output_shape_offsets[0] = acc;
 
         size_t size_result = 1;
-        for (size_t i = 0; i < res_ndim; ++i)
-        {
+        for (size_t i = 0; i < res_ndim; ++i) {
             size_result *= res_shape[i];
         }
 
-        //init result array
-        for (size_t result_idx = 0; result_idx < size_result; ++result_idx)
-        {
+        // init result array
+        for (size_t result_idx = 0; result_idx < size_result; ++result_idx) {
             size_t xyz[res_ndim];
             size_t remainder = result_idx;
-            for (size_t i = 0; i < res_ndim; ++i)
-            {
-                xyz[i] = remainder / output_shape_offsets[i];
+            for (size_t i = 0; i < res_ndim; ++i) {
+                xyz[i]    = remainder / output_shape_offsets[i];
                 remainder = remainder - xyz[i] * output_shape_offsets[i];
             }
 
             size_t source_axis[ndim];
             size_t result_axis_idx = 0;
-            for (size_t idx = 0; idx < ndim; ++idx)
-            {
+            for (size_t idx = 0; idx < ndim; ++idx) {
                 bool found = false;
-                for (size_t i = 0; i < naxis; ++i)
-                {
-                    if (static_cast<size_t>(axis[i]) == idx)
-                    {
+                for (size_t i = 0; i < naxis; ++i) {
+                    if (static_cast<size_t>(axis[i]) == idx) {
                         found = true;
                         break;
                     }
                 }
-                if (found)
-                {
+                if (found) {
                     source_axis[idx] = 0;
                 }
-                else
-                {
+                else {
                     source_axis[idx] = xyz[result_axis_idx];
                     result_axis_idx++;
                 }
             }
 
             size_t source_idx = 0;
-            for (size_t i = 0; i < ndim; ++i)
-            {
+            for (size_t i = 0; i < ndim; ++i) {
                 source_idx += input_shape_offsets[i] * source_axis[i];
             }
 
             result[result_idx] = array_1[source_idx];
         }
 
-        for (size_t source_idx = 0; source_idx < size_input; ++source_idx)
-        {
+        for (size_t source_idx = 0; source_idx < size_input; ++source_idx) {
             // reconstruct x,y,z from linear source_idx
             size_t xyz[ndim];
             size_t remainder = source_idx;
-            for (size_t i = 0; i < ndim; ++i)
-            {
-                xyz[i] = remainder / input_shape_offsets[i];
+            for (size_t i = 0; i < ndim; ++i) {
+                xyz[i]    = remainder / input_shape_offsets[i];
                 remainder = remainder - xyz[i] * input_shape_offsets[i];
             }
 
             // extract result axis
             size_t result_axis[res_ndim];
             size_t result_idx = 0;
-            for (size_t idx = 0; idx < ndim; ++idx)
-            {
+            for (size_t idx = 0; idx < ndim; ++idx) {
                 // try to find current idx in axis array
                 bool found = false;
-                for (size_t i = 0; i < naxis; ++i)
-                {
-                    if (static_cast<size_t>(axis[i]) == idx)
-                    {
+                for (size_t i = 0; i < naxis; ++i) {
+                    if (static_cast<size_t>(axis[i]) == idx) {
                         found = true;
                         break;
                     }
                 }
-                if (!found)
-                {
+                if (!found) {
                     result_axis[result_idx] = xyz[idx];
                     result_idx++;
                 }
@@ -497,13 +471,11 @@ DPCTLSyclEventRef dpnp_max_c(DPCTLSyclQueueRef q_ref,
 
             // Construct result offset
             size_t result_offset = 0;
-            for (size_t i = 0; i < res_ndim; ++i)
-            {
+            for (size_t i = 0; i < res_ndim; ++i) {
                 result_offset += output_shape_offsets[i] * result_axis[i];
             }
 
-            if (result[result_offset] < array_1[source_idx])
-            {
+            if (result[result_offset] < array_1[source_idx]) {
                 result[result_offset] = array_1[source_idx];
             }
         }
@@ -513,82 +485,79 @@ DPCTLSyclEventRef dpnp_max_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_max_c(void* array1_in,
-                void* result1,
+void dpnp_max_c(void *array1_in,
+                void *result1,
                 const size_t result_size,
-                const shape_elem_type* shape,
+                const shape_elem_type *shape,
                 size_t ndim,
-                const shape_elem_type* axis,
+                const shape_elem_type *axis,
                 size_t naxis)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_max_c<_DataType>(q_ref,
-                                                        array1_in,
-                                                        result1,
-                                                        result_size,
-                                                        shape,
-                                                        ndim,
-                                                        axis,
-                                                        naxis,
-                                                        dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_max_c<_DataType>(q_ref, array1_in, result1, result_size, shape,
+                              ndim, axis, naxis, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_max_default_c)(void*,
-                           void*,
+void (*dpnp_max_default_c)(void *,
+                           void *,
                            const size_t,
-                           const shape_elem_type*,
+                           const shape_elem_type *,
                            size_t,
-                           const shape_elem_type*,
+                           const shape_elem_type *,
                            size_t) = dpnp_max_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_max_ext_c)(DPCTLSyclQueueRef,
-                                    void*,
-                                    void*,
+                                    void *,
+                                    void *,
                                     const size_t,
-                                    const shape_elem_type*,
+                                    const shape_elem_type *,
                                     size_t,
-                                    const shape_elem_type*,
+                                    const shape_elem_type *,
                                     size_t,
-                                    const DPCTLEventVectorRef) = dpnp_max_c<_DataType>;
+                                    const DPCTLEventVectorRef) =
+    dpnp_max_c<_DataType>;
 
 template <typename _DataType, typename _ResultType>
 DPCTLSyclEventRef dpnp_mean_c(DPCTLSyclQueueRef q_ref,
-                              void* array1_in,
-                              void* result1,
-                              const shape_elem_type* shape,
+                              void *array1_in,
+                              void *result1,
+                              const shape_elem_type *shape,
                               size_t ndim,
-                              const shape_elem_type* axis,
+                              const shape_elem_type *axis,
                               size_t naxis,
                               const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
-    __attribute__((unused)) void* tmp = (void*)(axis + naxis);
+    __attribute__((unused)) void *tmp = (void *)(axis + naxis);
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    const size_t size = std::accumulate(shape, shape + ndim, 1, std::multiplies<shape_elem_type>());
-    if (!size)
-    {
+    const size_t size = std::accumulate(shape, shape + ndim, 1,
+                                        std::multiplies<shape_elem_type>());
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, size, true);
     DPNPC_ptr_adapter<_ResultType> result_ptr(q_ref, result1, 1, true, true);
-    _DataType* array = input1_ptr.get_ptr();
-    _ResultType* result = result_ptr.get_ptr();
+    _DataType *array    = input1_ptr.get_ptr();
+    _ResultType *result = result_ptr.get_ptr();
 
-    if constexpr (std::is_same<_DataType, double>::value || std::is_same<_DataType, float>::value)
+    if constexpr (std::is_same<_DataType, double>::value ||
+                  std::is_same<_DataType, float>::value)
     {
-        auto dataset = mkl_stats::make_dataset<mkl_stats::layout::row_major /*, _ResultType*/>(1, size, array);
+        auto dataset = mkl_stats::make_dataset<
+            mkl_stats::layout::row_major /*, _ResultType*/>(1, size, array);
 
         sycl::event event = mkl_stats::mean(q, dataset, result);
 
@@ -598,11 +567,12 @@ DPCTLSyclEventRef dpnp_mean_c(DPCTLSyclQueueRef q_ref,
 
         return DPCTLEvent_Copy(event_ref);
     }
-    else
-    {
-        _ResultType* sum = reinterpret_cast<_ResultType*>(sycl::malloc_shared(1 * sizeof(_ResultType), q));
+    else {
+        _ResultType *sum = reinterpret_cast<_ResultType *>(
+            sycl::malloc_shared(1 * sizeof(_ResultType), q));
 
-        dpnp_sum_c<_ResultType, _DataType>(sum, array, shape, ndim, axis, naxis, nullptr, nullptr);
+        dpnp_sum_c<_ResultType, _DataType>(sum, array, shape, ndim, axis, naxis,
+                                           nullptr, nullptr);
 
         result[0] = sum[0] / static_cast<_ResultType>(size);
 
@@ -613,74 +583,68 @@ DPCTLSyclEventRef dpnp_mean_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType, typename _ResultType>
-void dpnp_mean_c(void* array1_in,
-                 void* result1,
-                 const shape_elem_type* shape,
+void dpnp_mean_c(void *array1_in,
+                 void *result1,
+                 const shape_elem_type *shape,
                  size_t ndim,
-                 const shape_elem_type* axis,
+                 const shape_elem_type *axis,
                  size_t naxis)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_mean_c<_DataType, _ResultType>(q_ref,
-                                                                      array1_in,
-                                                                      result1,
-                                                                      shape,
-                                                                      ndim,
-                                                                      axis,
-                                                                      naxis,
-                                                                      dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_mean_c<_DataType, _ResultType>(
+        q_ref, array1_in, result1, shape, ndim, axis, naxis, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType, typename _ResultType>
-void (*dpnp_mean_default_c)(void*,
-                            void*,
-                            const shape_elem_type*,
+void (*dpnp_mean_default_c)(void *,
+                            void *,
+                            const shape_elem_type *,
                             size_t,
-                            const shape_elem_type*,
+                            const shape_elem_type *,
                             size_t) = dpnp_mean_c<_DataType, _ResultType>;
-
 
 template <typename _DataType, typename _ResultType>
 DPCTLSyclEventRef dpnp_median_c(DPCTLSyclQueueRef q_ref,
-                                void* array1_in,
-                                void* result1,
-                                const shape_elem_type* shape,
+                                void *array1_in,
+                                void *result1,
+                                const shape_elem_type *shape,
                                 size_t ndim,
-                                const shape_elem_type* axis,
+                                const shape_elem_type *axis,
                                 size_t naxis,
                                 const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
-    __attribute__((unused)) void* tmp = (void*)(axis + naxis);
+    __attribute__((unused)) void *tmp = (void *)(axis + naxis);
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    const size_t size = std::accumulate(shape, shape + ndim, 1, std::multiplies<shape_elem_type>());
-    if (!size)
-    {
+    const size_t size = std::accumulate(shape, shape + ndim, 1,
+                                        std::multiplies<shape_elem_type>());
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_ResultType> result_ptr(q_ref, result1, 1, true, true);
-    _ResultType* result = result_ptr.get_ptr();
+    _ResultType *result = result_ptr.get_ptr();
 
-    _DataType* sorted = reinterpret_cast<_DataType*>(sycl::malloc_shared(size * sizeof(_DataType), q));
+    _DataType *sorted = reinterpret_cast<_DataType *>(
+        sycl::malloc_shared(size * sizeof(_DataType), q));
 
     dpnp_sort_c<_DataType>(array1_in, sorted, size);
 
-    if (size % 2 == 0)
-    {
-        result[0] = static_cast<_ResultType>(sorted[size / 2] + sorted[size / 2 - 1]) / 2;
+    if (size % 2 == 0) {
+        result[0] =
+            static_cast<_ResultType>(sorted[size / 2] + sorted[size / 2 - 1]) /
+            2;
     }
-    else
-    {
+    else {
         result[0] = sorted[(size - 1) / 2];
     }
 
@@ -690,120 +654,114 @@ DPCTLSyclEventRef dpnp_median_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType, typename _ResultType>
-void dpnp_median_c(void* array1_in,
-                   void* result1,
-                   const shape_elem_type* shape,
+void dpnp_median_c(void *array1_in,
+                   void *result1,
+                   const shape_elem_type *shape,
                    size_t ndim,
-                   const shape_elem_type* axis,
+                   const shape_elem_type *axis,
                    size_t naxis)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_median_c<_DataType, _ResultType>(q_ref,
-                                                                        array1_in,
-                                                                        result1,
-                                                                        shape,
-                                                                        ndim,
-                                                                        axis,
-                                                                        naxis,
-                                                                        dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref = dpnp_median_c<_DataType, _ResultType>(
+        q_ref, array1_in, result1, shape, ndim, axis, naxis, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType, typename _ResultType>
-void (*dpnp_median_default_c)(void*,
-                              void*,
-                              const shape_elem_type*,
+void (*dpnp_median_default_c)(void *,
+                              void *,
+                              const shape_elem_type *,
                               size_t,
-                              const shape_elem_type*,
+                              const shape_elem_type *,
                               size_t) = dpnp_median_c<_DataType, _ResultType>;
 
 template <typename _DataType, typename _ResultType>
 DPCTLSyclEventRef (*dpnp_median_ext_c)(DPCTLSyclQueueRef,
-                                       void*,
-                                       void*,
-                                       const shape_elem_type*,
+                                       void *,
+                                       void *,
+                                       const shape_elem_type *,
                                        size_t,
-                                       const shape_elem_type*,
+                                       const shape_elem_type *,
                                        size_t,
-                                       const DPCTLEventVectorRef) = dpnp_median_c<_DataType, _ResultType>;
+                                       const DPCTLEventVectorRef) =
+    dpnp_median_c<_DataType, _ResultType>;
 
 template <typename _DataType>
 class dpnp_min_c_kernel;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_min_c(DPCTLSyclQueueRef q_ref,
-                             void* array1_in,
-                             void* result1,
+                             void *array1_in,
+                             void *result1,
                              const size_t result_size,
-                             const shape_elem_type* shape,
+                             const shape_elem_type *shape,
                              size_t ndim,
-                             const shape_elem_type* axis,
+                             const shape_elem_type *axis,
                              size_t naxis,
                              const DPCTLEventVectorRef dep_event_vec_ref)
 {
     // avoid warning unused variable
     (void)dep_event_vec_ref;
 
-    __attribute__((unused)) void* tmp = (void*)(axis + naxis);
+    __attribute__((unused)) void *tmp = (void *)(axis + naxis);
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    const size_t size_input = std::accumulate(shape, shape + ndim, 1, std::multiplies<shape_elem_type>());
-    if (!size_input)
-    {
+    const size_t size_input = std::accumulate(
+        shape, shape + ndim, 1, std::multiplies<shape_elem_type>());
+    if (!size_input) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, size_input, true);
-    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, result_size, true, true);
-    _DataType* array_1 = input1_ptr.get_ptr();
-    _DataType* result = result_ptr.get_ptr();
+    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, result_size, true,
+                                            true);
+    _DataType *array_1 = input1_ptr.get_ptr();
+    _DataType *result  = result_ptr.get_ptr();
 
-    if (naxis == 0)
-    {
-        if constexpr (std::is_same<_DataType, double>::value || std::is_same<_DataType, float>::value)
+    if (naxis == 0) {
+        if constexpr (std::is_same<_DataType, double>::value ||
+                      std::is_same<_DataType, float>::value)
         {
             // Required initializing the result before call the function
             result[0] = array_1[0];
 
-            auto dataset = mkl_stats::make_dataset<mkl_stats::layout::row_major>(1, size_input, array_1);
+            auto dataset =
+                mkl_stats::make_dataset<mkl_stats::layout::row_major>(
+                    1, size_input, array_1);
 
             sycl::event event = mkl_stats::min(q, dataset, result);
 
             event.wait();
         }
-        else
-        {
-            auto policy = oneapi::dpl::execution::make_device_policy<class dpnp_min_c_kernel<_DataType>>(q);
+        else {
+            auto policy = oneapi::dpl::execution::make_device_policy<
+                class dpnp_min_c_kernel<_DataType>>(q);
 
-            _DataType* res = std::min_element(policy, array_1, array_1 + size_input);
+            _DataType *res =
+                std::min_element(policy, array_1, array_1 + size_input);
             policy.queue().wait();
 
             result[0] = *res;
         }
     }
-    else
-    {
+    else {
         size_t res_ndim = ndim - naxis;
         size_t res_shape[res_ndim];
         int ind = 0;
-        for (size_t i = 0; i < ndim; i++)
-        {
+        for (size_t i = 0; i < ndim; i++) {
             bool found = false;
-            for (size_t j = 0; j < naxis; j++)
-            {
-                if (static_cast<size_t>(axis[j]) == i)
-                {
+            for (size_t j = 0; j < naxis; j++) {
+                if (static_cast<size_t>(axis[j]) == i) {
                     found = true;
                     break;
                 }
             }
-            if (!found)
-            {
+            if (!found) {
                 res_shape[ind] = shape[i];
                 ind++;
             }
@@ -811,8 +769,7 @@ DPCTLSyclEventRef dpnp_min_c(DPCTLSyclQueueRef q_ref,
 
         size_t input_shape_offsets[ndim];
         size_t acc = 1;
-        for (size_t i = ndim - 1; i > 0; --i)
-        {
+        for (size_t i = ndim - 1; i > 0; --i) {
             input_shape_offsets[i] = acc;
             acc *= shape[i];
         }
@@ -820,10 +777,8 @@ DPCTLSyclEventRef dpnp_min_c(DPCTLSyclQueueRef q_ref,
 
         size_t output_shape_offsets[res_ndim];
         acc = 1;
-        if (res_ndim > 0)
-        {
-            for (size_t i = res_ndim - 1; i > 0; --i)
-            {
+        if (res_ndim > 0) {
+            for (size_t i = res_ndim - 1; i > 0; --i) {
                 output_shape_offsets[i] = acc;
                 acc *= res_shape[i];
             }
@@ -831,83 +786,68 @@ DPCTLSyclEventRef dpnp_min_c(DPCTLSyclQueueRef q_ref,
         output_shape_offsets[0] = acc;
 
         size_t size_result = 1;
-        for (size_t i = 0; i < res_ndim; ++i)
-        {
+        for (size_t i = 0; i < res_ndim; ++i) {
             size_result *= res_shape[i];
         }
 
-        //init result array
-        for (size_t result_idx = 0; result_idx < size_result; ++result_idx)
-        {
+        // init result array
+        for (size_t result_idx = 0; result_idx < size_result; ++result_idx) {
             size_t xyz[res_ndim];
             size_t remainder = result_idx;
-            for (size_t i = 0; i < res_ndim; ++i)
-            {
-                xyz[i] = remainder / output_shape_offsets[i];
+            for (size_t i = 0; i < res_ndim; ++i) {
+                xyz[i]    = remainder / output_shape_offsets[i];
                 remainder = remainder - xyz[i] * output_shape_offsets[i];
             }
 
             size_t source_axis[ndim];
             size_t result_axis_idx = 0;
-            for (size_t idx = 0; idx < ndim; ++idx)
-            {
+            for (size_t idx = 0; idx < ndim; ++idx) {
                 bool found = false;
-                for (size_t i = 0; i < naxis; ++i)
-                {
-                    if (static_cast<size_t>(axis[i]) == idx)
-                    {
+                for (size_t i = 0; i < naxis; ++i) {
+                    if (static_cast<size_t>(axis[i]) == idx) {
                         found = true;
                         break;
                     }
                 }
-                if (found)
-                {
+                if (found) {
                     source_axis[idx] = 0;
                 }
-                else
-                {
+                else {
                     source_axis[idx] = xyz[result_axis_idx];
                     result_axis_idx++;
                 }
             }
 
             size_t source_idx = 0;
-            for (size_t i = 0; i < ndim; ++i)
-            {
+            for (size_t i = 0; i < ndim; ++i) {
                 source_idx += input_shape_offsets[i] * source_axis[i];
             }
 
             result[result_idx] = array_1[source_idx];
         }
 
-        for (size_t source_idx = 0; source_idx < size_input; ++source_idx)
-        {
+        for (size_t source_idx = 0; source_idx < size_input; ++source_idx) {
             // reconstruct x,y,z from linear source_idx
             size_t xyz[ndim];
             size_t remainder = source_idx;
-            for (size_t i = 0; i < ndim; ++i)
-            {
-                xyz[i] = remainder / input_shape_offsets[i];
+            for (size_t i = 0; i < ndim; ++i) {
+                xyz[i]    = remainder / input_shape_offsets[i];
                 remainder = remainder - xyz[i] * input_shape_offsets[i];
             }
 
             // extract result axis
             size_t result_axis[res_ndim];
             size_t result_idx = 0;
-            for (size_t idx = 0; idx < ndim; ++idx)
-            {
+            for (size_t idx = 0; idx < ndim; ++idx) {
                 // try to find current idx in axis array
                 bool found = false;
-                for (size_t i = 0; i < naxis; ++i)
-                {
-                    if (static_cast<size_t>(axis[i]) == idx)
-                    {
+                for (size_t i = 0; i < naxis; ++i) {
+                    if (static_cast<size_t>(axis[i]) == idx) {
                         found = true;
                         break;
                     }
                 }
-                if (!found)
-                {
+                if (!found) {
                     result_axis[result_idx] = xyz[idx];
                     result_idx++;
                 }
@@ -915,13 +855,11 @@ DPCTLSyclEventRef dpnp_min_c(DPCTLSyclQueueRef q_ref,
 
             // Construct result offset
             size_t result_offset = 0;
-            for (size_t i = 0; i < res_ndim; ++i)
-            {
+            for (size_t i = 0; i < res_ndim; ++i) {
                 result_offset += output_shape_offsets[i] * result_axis[i];
             }
 
-            if (result[result_offset] > array_1[source_idx])
-            {
+            if (result[result_offset] > array_1[source_idx]) {
                 result[result_offset] = array_1[source_idx];
             }
         }
@@ -931,54 +869,49 @@ DPCTLSyclEventRef dpnp_min_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_min_c(void* array1_in,
-                void* result1,
+void dpnp_min_c(void *array1_in,
+                void *result1,
                 const size_t result_size,
-                const shape_elem_type* shape,
+                const shape_elem_type *shape,
                 size_t ndim,
-                const shape_elem_type* axis,
+                const shape_elem_type *axis,
                 size_t naxis)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_min_c<_DataType>(q_ref,
-                                                        array1_in,
-                                                        result1,
-                                                        result_size,
-                                                        shape,
-                                                        ndim,
-                                                        axis,
-                                                        naxis,
-                                                        dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_min_c<_DataType>(q_ref, array1_in, result1, result_size, shape,
+                              ndim, axis, naxis, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_min_default_c)(void*,
-                           void*,
+void (*dpnp_min_default_c)(void *,
+                           void *,
                            const size_t,
-                           const shape_elem_type*,
+                           const shape_elem_type *,
                            size_t,
-                           const shape_elem_type*,
+                           const shape_elem_type *,
                            size_t) = dpnp_min_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_min_ext_c)(DPCTLSyclQueueRef,
-                                    void*,
-                                    void*,
+                                    void *,
+                                    void *,
                                     const size_t,
-                                    const shape_elem_type*,
+                                    const shape_elem_type *,
                                     size_t,
-                                    const shape_elem_type*,
+                                    const shape_elem_type *,
                                     size_t,
-                                    const DPCTLEventVectorRef) = dpnp_min_c<_DataType>;
+                                    const DPCTLEventVectorRef) =
+    dpnp_min_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_nanvar_c(DPCTLSyclQueueRef q_ref,
-                                void* array1_in,
-                                void* mask_arr1,
-                                void* result1,
+                                void *array1_in,
+                                void *mask_arr1,
+                                void *result1,
                                 const size_t result_size,
                                 size_t arr_size,
                                 const DPCTLEventVectorRef dep_event_vec_ref)
@@ -988,30 +921,28 @@ DPCTLSyclEventRef dpnp_nanvar_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    if ((array1_in == nullptr) || (mask_arr1 == nullptr) || (result1 == nullptr))
-    {
+    if ((array1_in == nullptr) || (mask_arr1 == nullptr) ||
+        (result1 == nullptr)) {
         return event_ref;
     }
 
-    if (arr_size == 0)
-    {
+    if (arr_size == 0) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, arr_size, true);
     DPNPC_ptr_adapter<bool> input2_ptr(q_ref, mask_arr1, arr_size, true);
-    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, result_size, true, true);
-    _DataType* array1 = input1_ptr.get_ptr();
-    bool* mask_arr = input2_ptr.get_ptr();
-    _DataType* result = result_ptr.get_ptr();
+    DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result1, result_size, true,
+                                            true);
+    _DataType *array1 = input1_ptr.get_ptr();
+    bool *mask_arr    = input2_ptr.get_ptr();
+    _DataType *result = result_ptr.get_ptr();
 
     size_t ind = 0;
-    for (size_t i = 0; i < arr_size; ++i)
-    {
-        if (!mask_arr[i])
-        {
+    for (size_t i = 0; i < arr_size; ++i) {
+        if (!mask_arr[i]) {
             result[ind] = array1[i];
             ind += 1;
         }
@@ -1021,40 +952,42 @@ DPCTLSyclEventRef dpnp_nanvar_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType>
-void dpnp_nanvar_c(void* array1_in, void* mask_arr1, void* result1, const size_t result_size, size_t arr_size)
+void dpnp_nanvar_c(void *array1_in,
+                   void *mask_arr1,
+                   void *result1,
+                   const size_t result_size,
+                   size_t arr_size)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_nanvar_c<_DataType>(q_ref,
-                                                           array1_in,
-                                                           mask_arr1,
-                                                           result1,
-                                                           result_size,
-                                                           arr_size,
-                                                           dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref =
+        dpnp_nanvar_c<_DataType>(q_ref, array1_in, mask_arr1, result1,
+                                 result_size, arr_size, dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType>
-void (*dpnp_nanvar_default_c)(void*, void*, void*, const size_t, size_t) = dpnp_nanvar_c<_DataType>;
+void (*dpnp_nanvar_default_c)(void *, void *, void *, const size_t, size_t) =
+    dpnp_nanvar_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef (*dpnp_nanvar_ext_c)(DPCTLSyclQueueRef,
-                                       void*,
-                                       void*,
-                                       void*,
+                                       void *,
+                                       void *,
+                                       void *,
                                        const size_t,
                                        size_t,
-                                       const DPCTLEventVectorRef) = dpnp_nanvar_c<_DataType>;
+                                       const DPCTLEventVectorRef) =
+    dpnp_nanvar_c<_DataType>;
 
 template <typename _DataType, typename _ResultType>
 DPCTLSyclEventRef dpnp_std_c(DPCTLSyclQueueRef q_ref,
-                             void* array1_in,
-                             void* result1,
-                             const shape_elem_type* shape,
+                             void *array1_in,
+                             void *result1,
+                             const shape_elem_type *shape,
                              size_t ndim,
-                             const shape_elem_type* axis,
+                             const shape_elem_type *axis,
                              size_t naxis,
                              size_t ddof,
                              const DPCTLEventVectorRef dep_event_vec_ref)
@@ -1063,45 +996,42 @@ DPCTLSyclEventRef dpnp_std_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q               = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    _ResultType* var = reinterpret_cast<_ResultType*>(sycl::malloc_shared(1 * sizeof(_ResultType), q));
+    _ResultType *var = reinterpret_cast<_ResultType *>(
+        sycl::malloc_shared(1 * sizeof(_ResultType), q));
 
-    dpnp_var_c<_DataType, _ResultType>(array1_in, var, shape, ndim, axis, naxis, ddof);
+    dpnp_var_c<_DataType, _ResultType>(array1_in, var, shape, ndim, axis, naxis,
+                                       ddof);
 
     const size_t result1_size = 1;
     const size_t result1_ndim = 1;
-    const size_t result1_shape_size_in_bytes = result1_ndim * sizeof(shape_elem_type);
-    const size_t result1_strides_size_in_bytes = result1_ndim * sizeof(shape_elem_type);
-    shape_elem_type* result1_shape =
-        reinterpret_cast<shape_elem_type*>(sycl::malloc_shared(result1_shape_size_in_bytes, q));
-    *result1_shape = 1;
-    shape_elem_type* result1_strides =
-        reinterpret_cast<shape_elem_type*>(sycl::malloc_shared(result1_strides_size_in_bytes, q));
+    const size_t result1_shape_size_in_bytes =
+        result1_ndim * sizeof(shape_elem_type);
+    const size_t result1_strides_size_in_bytes =
+        result1_ndim * sizeof(shape_elem_type);
+    shape_elem_type *result1_shape = reinterpret_cast<shape_elem_type *>(
+        sycl::malloc_shared(result1_shape_size_in_bytes, q));
+    *result1_shape                   = 1;
+    shape_elem_type *result1_strides = reinterpret_cast<shape_elem_type *>(
+        sycl::malloc_shared(result1_strides_size_in_bytes, q));
     *result1_strides = 1;
 
-    const size_t var_size = 1;
-    const size_t var_ndim = 1;
-    const size_t var_shape_size_in_bytes = var_ndim * sizeof(shape_elem_type);
+    const size_t var_size                  = 1;
+    const size_t var_ndim                  = 1;
+    const size_t var_shape_size_in_bytes   = var_ndim * sizeof(shape_elem_type);
     const size_t var_strides_size_in_bytes = var_ndim * sizeof(shape_elem_type);
-    shape_elem_type* var_shape = reinterpret_cast<shape_elem_type*>(sycl::malloc_shared(var_shape_size_in_bytes, q));
-    *var_shape = 1;
-    shape_elem_type* var_strides = reinterpret_cast<shape_elem_type*>(sycl::malloc_shared(var_strides_size_in_bytes,
-                                                                      q));
+    shape_elem_type *var_shape = reinterpret_cast<shape_elem_type *>(
+        sycl::malloc_shared(var_shape_size_in_bytes, q));
+    *var_shape                   = 1;
+    shape_elem_type *var_strides = reinterpret_cast<shape_elem_type *>(
+        sycl::malloc_shared(var_strides_size_in_bytes, q));
     *var_strides = 1;
 
-    DPCTLSyclEventRef e_sqrt_ref =
-	dpnp_sqrt_c<_ResultType, _ResultType>(q_ref, result1,
-					      result1_size,
-					      result1_ndim,
-					      result1_shape,
-					      result1_strides,
-					      var,
-					      var_size,
-					      var_ndim,
-					      var_shape,
-					      var_strides,
-					      NULL, NULL);
+    DPCTLSyclEventRef e_sqrt_ref = dpnp_sqrt_c<_ResultType, _ResultType>(
+        q_ref, result1, result1_size, result1_ndim, result1_shape,
+        result1_strides, var, var_size, var_ndim, var_shape, var_strides, NULL,
+        NULL);
     DPCTLEvent_WaitAndThrow(e_sqrt_ref);
     DPCTLEvent_Delete(e_sqrt_ref);
 
@@ -1115,59 +1045,54 @@ DPCTLSyclEventRef dpnp_std_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType, typename _ResultType>
-void dpnp_std_c(void* array1_in,
-                void* result1,
-                const shape_elem_type* shape,
+void dpnp_std_c(void *array1_in,
+                void *result1,
+                const shape_elem_type *shape,
                 size_t ndim,
-                const shape_elem_type* axis,
+                const shape_elem_type *axis,
                 size_t naxis,
                 size_t ddof)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_std_c<_DataType, _ResultType>(q_ref,
-                                                                     array1_in,
-                                                                     result1,
-                                                                     shape,
-                                                                     ndim,
-                                                                     axis,
-                                                                     naxis,
-                                                                     ddof,
-                                                                     dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_std_c<_DataType, _ResultType>(
+        q_ref, array1_in, result1, shape, ndim, axis, naxis, ddof,
+        dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType, typename _ResultType>
-void (*dpnp_std_default_c)(void*,
-                           void*,
-                           const shape_elem_type*,
+void (*dpnp_std_default_c)(void *,
+                           void *,
+                           const shape_elem_type *,
                            size_t,
-                           const shape_elem_type*,
+                           const shape_elem_type *,
                            size_t,
                            size_t) = dpnp_std_c<_DataType, _ResultType>;
 
 template <typename _DataType, typename _ResultType>
 DPCTLSyclEventRef (*dpnp_std_ext_c)(DPCTLSyclQueueRef,
-                                    void*,
-                                    void*,
-                                    const shape_elem_type*,
+                                    void *,
+                                    void *,
+                                    const shape_elem_type *,
                                     size_t,
-                                    const shape_elem_type*,
+                                    const shape_elem_type *,
                                     size_t,
                                     size_t,
-                                    const DPCTLEventVectorRef) = dpnp_std_c<_DataType, _ResultType>;
+                                    const DPCTLEventVectorRef) =
+    dpnp_std_c<_DataType, _ResultType>;
 
 template <typename _DataType, typename _ResultType>
 class dpnp_var_c_kernel;
 
 template <typename _DataType, typename _ResultType>
 DPCTLSyclEventRef dpnp_var_c(DPCTLSyclQueueRef q_ref,
-                             void* array1_in,
-                             void* result1,
-                             const shape_elem_type* shape,
+                             void *array1_in,
+                             void *result1,
+                             const shape_elem_type *shape,
                              size_t ndim,
-                             const shape_elem_type* axis,
+                             const shape_elem_type *axis,
                              size_t naxis,
                              size_t ddof,
                              const DPCTLEventVectorRef dep_event_vec_ref)
@@ -1177,45 +1102,49 @@ DPCTLSyclEventRef dpnp_var_c(DPCTLSyclQueueRef q_ref,
 
     DPCTLSyclEventRef event_ref = nullptr;
 
-    const size_t size = std::accumulate(shape, shape + ndim, 1, std::multiplies<shape_elem_type>());
-    if (!size)
-    {
+    const size_t size = std::accumulate(shape, shape + ndim, 1,
+                                        std::multiplies<shape_elem_type>());
+    if (!size) {
         return event_ref;
     }
 
-    sycl::queue q = *(reinterpret_cast<sycl::queue*>(q_ref));
+    sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
     sycl::event event;
 
     DPNPC_ptr_adapter<_DataType> input1_ptr(q_ref, array1_in, size);
     DPNPC_ptr_adapter<_ResultType> result_ptr(q_ref, result1, 1, true, true);
-    _DataType* array1 = input1_ptr.get_ptr();
-    _ResultType* result = result_ptr.get_ptr();
+    _DataType *array1   = input1_ptr.get_ptr();
+    _ResultType *result = result_ptr.get_ptr();
 
-    _ResultType* mean = reinterpret_cast<_ResultType*>(sycl::malloc_shared(1 * sizeof(_ResultType), q));
+    _ResultType *mean = reinterpret_cast<_ResultType *>(
+        sycl::malloc_shared(1 * sizeof(_ResultType), q));
     dpnp_mean_c<_DataType, _ResultType>(array1, mean, shape, ndim, axis, naxis);
     _ResultType mean_val = mean[0];
 
-    _ResultType* squared_deviations = reinterpret_cast<_ResultType*>(sycl::malloc_shared(size * sizeof(_ResultType),
-                                                                     q));
+    _ResultType *squared_deviations = reinterpret_cast<_ResultType *>(
+        sycl::malloc_shared(size * sizeof(_ResultType), q));
 
     sycl::range<1> gws(size);
     auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
         size_t i = global_id[0]; /*for (size_t i = 0; i < size; ++i)*/
         {
-            _ResultType deviation = static_cast<_ResultType>(array1[i]) - mean_val;
+            _ResultType deviation =
+                static_cast<_ResultType>(array1[i]) - mean_val;
             squared_deviations[i] = deviation * deviation;
         }
     };
 
-    auto kernel_func = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class dpnp_var_c_kernel<_DataType, _ResultType>>(gws, kernel_parallel_for_func);
+    auto kernel_func = [&](sycl::handler &cgh) {
+        cgh.parallel_for<class dpnp_var_c_kernel<_DataType, _ResultType>>(
+            gws, kernel_parallel_for_func);
     };
 
     event = q.submit(kernel_func);
 
     event.wait();
 
-    dpnp_mean_c<_ResultType, _ResultType>(squared_deviations, mean, shape, ndim, axis, naxis);
+    dpnp_mean_c<_ResultType, _ResultType>(squared_deviations, mean, shape, ndim,
+                                          axis, naxis);
     mean_val = mean[0];
 
     result[0] = mean_val * size / static_cast<_ResultType>(size - ddof);
@@ -1227,208 +1156,259 @@ DPCTLSyclEventRef dpnp_var_c(DPCTLSyclQueueRef q_ref,
 }
 
 template <typename _DataType, typename _ResultType>
-void dpnp_var_c(void* array1_in,
-                void* result1,
-                const shape_elem_type* shape,
+void dpnp_var_c(void *array1_in,
+                void *result1,
+                const shape_elem_type *shape,
                 size_t ndim,
-                const shape_elem_type* axis,
+                const shape_elem_type *axis,
                 size_t naxis,
                 size_t ddof)
 {
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
     DPCTLEventVectorRef dep_event_vec_ref = nullptr;
-    DPCTLSyclEventRef event_ref = dpnp_var_c<_DataType, _ResultType>(q_ref,
-                                                                     array1_in,
-                                                                     result1,
-                                                                     shape,
-                                                                     ndim,
-                                                                     axis,
-                                                                     naxis,
-                                                                     ddof,
-                                                                     dep_event_vec_ref);
+    DPCTLSyclEventRef event_ref           = dpnp_var_c<_DataType, _ResultType>(
+        q_ref, array1_in, result1, shape, ndim, axis, naxis, ddof,
+        dep_event_vec_ref);
     DPCTLEvent_WaitAndThrow(event_ref);
     DPCTLEvent_Delete(event_ref);
 }
 
 template <typename _DataType, typename _ResultType>
-void (*dpnp_var_default_c)(void*,
-                           void*,
-                           const shape_elem_type*,
+void (*dpnp_var_default_c)(void *,
+                           void *,
+                           const shape_elem_type *,
                            size_t,
-                           const shape_elem_type*,
+                           const shape_elem_type *,
                            size_t,
                            size_t) = dpnp_var_c<_DataType, _ResultType>;
 
 template <typename _DataType, typename _ResultType>
 DPCTLSyclEventRef (*dpnp_var_ext_c)(DPCTLSyclQueueRef,
-                                    void*,
-                                    void*,
-                                    const shape_elem_type*,
+                                    void *,
+                                    void *,
+                                    const shape_elem_type *,
                                     size_t,
-                                    const shape_elem_type*,
+                                    const shape_elem_type *,
                                     size_t,
                                     size_t,
-                                    const DPCTLEventVectorRef) = dpnp_var_c<_DataType, _ResultType>;
+                                    const DPCTLEventVectorRef) =
+    dpnp_var_c<_DataType, _ResultType>;
 
-void func_map_init_statistics(func_map_t& fmap)
+void func_map_init_statistics(func_map_t &fmap)
 {
     fmap[DPNPFuncName::DPNP_FN_CORRELATE][eft_INT][eft_INT] = {
-        eft_INT, (void*)dpnp_correlate_default_c<int32_t, int32_t, int32_t>};
+        eft_INT, (void *)dpnp_correlate_default_c<int32_t, int32_t, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE][eft_INT][eft_LNG] = {
-        eft_LNG, (void*)dpnp_correlate_default_c<int64_t, int32_t, int64_t>};
+        eft_LNG, (void *)dpnp_correlate_default_c<int64_t, int32_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE][eft_INT][eft_FLT] = {
-        eft_DBL, (void*)dpnp_correlate_default_c<double, int32_t, float>};
+        eft_DBL, (void *)dpnp_correlate_default_c<double, int32_t, float>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE][eft_INT][eft_DBL] = {
-        eft_DBL, (void*)dpnp_correlate_default_c<double, int32_t, double>};
+        eft_DBL, (void *)dpnp_correlate_default_c<double, int32_t, double>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE][eft_LNG][eft_INT] = {
-        eft_LNG, (void*)dpnp_correlate_default_c<int64_t, int64_t, int32_t>};
+        eft_LNG, (void *)dpnp_correlate_default_c<int64_t, int64_t, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE][eft_LNG][eft_LNG] = {
-        eft_LNG, (void*)dpnp_correlate_default_c<int64_t, int64_t, int64_t>};
+        eft_LNG, (void *)dpnp_correlate_default_c<int64_t, int64_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE][eft_LNG][eft_FLT] = {
-        eft_DBL, (void*)dpnp_correlate_default_c<double, int64_t, float>};
+        eft_DBL, (void *)dpnp_correlate_default_c<double, int64_t, float>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE][eft_LNG][eft_DBL] = {
-        eft_DBL, (void*)dpnp_correlate_default_c<double, int64_t, double>};
+        eft_DBL, (void *)dpnp_correlate_default_c<double, int64_t, double>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE][eft_FLT][eft_INT] = {
-        eft_DBL, (void*)dpnp_correlate_default_c<double, float, int32_t>};
+        eft_DBL, (void *)dpnp_correlate_default_c<double, float, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE][eft_FLT][eft_LNG] = {
-        eft_DBL, (void*)dpnp_correlate_default_c<double, float, int64_t>};
+        eft_DBL, (void *)dpnp_correlate_default_c<double, float, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE][eft_FLT][eft_FLT] = {
-        eft_FLT, (void*)dpnp_correlate_default_c<float, float, float>};
+        eft_FLT, (void *)dpnp_correlate_default_c<float, float, float>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE][eft_FLT][eft_DBL] = {
-        eft_DBL, (void*)dpnp_correlate_default_c<double, float, double>};
+        eft_DBL, (void *)dpnp_correlate_default_c<double, float, double>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE][eft_DBL][eft_INT] = {
-        eft_DBL, (void*)dpnp_correlate_default_c<double, double, int32_t>};
+        eft_DBL, (void *)dpnp_correlate_default_c<double, double, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE][eft_DBL][eft_LNG] = {
-        eft_DBL, (void*)dpnp_correlate_default_c<double, double, int64_t>};
+        eft_DBL, (void *)dpnp_correlate_default_c<double, double, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE][eft_DBL][eft_FLT] = {
-        eft_DBL, (void*)dpnp_correlate_default_c<double, double, float>};
+        eft_DBL, (void *)dpnp_correlate_default_c<double, double, float>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE][eft_DBL][eft_DBL] = {
-        eft_DBL, (void*)dpnp_correlate_default_c<double, double, double>};
+        eft_DBL, (void *)dpnp_correlate_default_c<double, double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_CORRELATE_EXT][eft_INT][eft_INT] = {
-        eft_INT, (void*)dpnp_correlate_ext_c<int32_t, int32_t, int32_t>};
+        eft_INT, (void *)dpnp_correlate_ext_c<int32_t, int32_t, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE_EXT][eft_INT][eft_LNG] = {
-        eft_LNG, (void*)dpnp_correlate_ext_c<int64_t, int32_t, int64_t>};
+        eft_LNG, (void *)dpnp_correlate_ext_c<int64_t, int32_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE_EXT][eft_INT][eft_FLT] = {
-        eft_DBL, (void*)dpnp_correlate_ext_c<double, int32_t, float>};
+        eft_DBL, (void *)dpnp_correlate_ext_c<double, int32_t, float>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE_EXT][eft_INT][eft_DBL] = {
-        eft_DBL, (void*)dpnp_correlate_ext_c<double, int32_t, double>};
+        eft_DBL, (void *)dpnp_correlate_ext_c<double, int32_t, double>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE_EXT][eft_LNG][eft_INT] = {
-        eft_LNG, (void*)dpnp_correlate_ext_c<int64_t, int64_t, int32_t>};
+        eft_LNG, (void *)dpnp_correlate_ext_c<int64_t, int64_t, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE_EXT][eft_LNG][eft_LNG] = {
-        eft_LNG, (void*)dpnp_correlate_ext_c<int64_t, int64_t, int64_t>};
+        eft_LNG, (void *)dpnp_correlate_ext_c<int64_t, int64_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE_EXT][eft_LNG][eft_FLT] = {
-        eft_DBL, (void*)dpnp_correlate_ext_c<double, int64_t, float>};
+        eft_DBL, (void *)dpnp_correlate_ext_c<double, int64_t, float>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE_EXT][eft_LNG][eft_DBL] = {
-        eft_DBL, (void*)dpnp_correlate_ext_c<double, int64_t, double>};
+        eft_DBL, (void *)dpnp_correlate_ext_c<double, int64_t, double>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE_EXT][eft_FLT][eft_INT] = {
-        eft_DBL, (void*)dpnp_correlate_ext_c<double, float, int32_t>};
+        eft_DBL, (void *)dpnp_correlate_ext_c<double, float, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE_EXT][eft_FLT][eft_LNG] = {
-        eft_DBL, (void*)dpnp_correlate_ext_c<double, float, int64_t>};
+        eft_DBL, (void *)dpnp_correlate_ext_c<double, float, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE_EXT][eft_FLT][eft_FLT] = {
-        eft_FLT, (void*)dpnp_correlate_ext_c<float, float, float>};
+        eft_FLT, (void *)dpnp_correlate_ext_c<float, float, float>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE_EXT][eft_FLT][eft_DBL] = {
-        eft_DBL, (void*)dpnp_correlate_ext_c<double, float, double>};
+        eft_DBL, (void *)dpnp_correlate_ext_c<double, float, double>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE_EXT][eft_DBL][eft_INT] = {
-        eft_DBL, (void*)dpnp_correlate_ext_c<double, double, int32_t>};
+        eft_DBL, (void *)dpnp_correlate_ext_c<double, double, int32_t>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE_EXT][eft_DBL][eft_LNG] = {
-        eft_DBL, (void*)dpnp_correlate_ext_c<double, double, int64_t>};
+        eft_DBL, (void *)dpnp_correlate_ext_c<double, double, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE_EXT][eft_DBL][eft_FLT] = {
-        eft_DBL, (void*)dpnp_correlate_ext_c<double, double, float>};
+        eft_DBL, (void *)dpnp_correlate_ext_c<double, double, float>};
     fmap[DPNPFuncName::DPNP_FN_CORRELATE_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void*)dpnp_correlate_ext_c<double, double, double>};
+        eft_DBL, (void *)dpnp_correlate_ext_c<double, double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_COUNT_NONZERO][eft_BLN][eft_BLN] = {
-        eft_LNG, (void*)dpnp_count_nonzero_default_c<bool, int64_t>};
+        eft_LNG, (void *)dpnp_count_nonzero_default_c<bool, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_COUNT_NONZERO][eft_INT][eft_INT] = {
-        eft_LNG, (void*)dpnp_count_nonzero_default_c<int32_t, int64_t>};
+        eft_LNG, (void *)dpnp_count_nonzero_default_c<int32_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_COUNT_NONZERO][eft_LNG][eft_LNG] = {
-        eft_LNG, (void*)dpnp_count_nonzero_default_c<int64_t, int64_t>};
+        eft_LNG, (void *)dpnp_count_nonzero_default_c<int64_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_COUNT_NONZERO][eft_FLT][eft_FLT] = {
-        eft_LNG, (void*)dpnp_count_nonzero_default_c<float, int64_t>};
+        eft_LNG, (void *)dpnp_count_nonzero_default_c<float, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_COUNT_NONZERO][eft_DBL][eft_DBL] = {
-        eft_LNG, (void*)dpnp_count_nonzero_default_c<double, int64_t>};
+        eft_LNG, (void *)dpnp_count_nonzero_default_c<double, int64_t>};
 
     fmap[DPNPFuncName::DPNP_FN_COUNT_NONZERO_EXT][eft_BLN][eft_BLN] = {
-        eft_LNG, (void*)dpnp_count_nonzero_ext_c<bool, int64_t>};
+        eft_LNG, (void *)dpnp_count_nonzero_ext_c<bool, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_COUNT_NONZERO_EXT][eft_INT][eft_INT] = {
-        eft_LNG, (void*)dpnp_count_nonzero_ext_c<int32_t, int64_t>};
+        eft_LNG, (void *)dpnp_count_nonzero_ext_c<int32_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_COUNT_NONZERO_EXT][eft_LNG][eft_LNG] = {
-        eft_LNG, (void*)dpnp_count_nonzero_ext_c<int64_t, int64_t>};
+        eft_LNG, (void *)dpnp_count_nonzero_ext_c<int64_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_COUNT_NONZERO_EXT][eft_FLT][eft_FLT] = {
-        eft_LNG, (void*)dpnp_count_nonzero_ext_c<float, int64_t>};
+        eft_LNG, (void *)dpnp_count_nonzero_ext_c<float, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_COUNT_NONZERO_EXT][eft_DBL][eft_DBL] = {
-        eft_LNG, (void*)dpnp_count_nonzero_ext_c<double, int64_t>};
+        eft_LNG, (void *)dpnp_count_nonzero_ext_c<double, int64_t>};
 
-    fmap[DPNPFuncName::DPNP_FN_COV][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_cov_default_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_COV][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_cov_default_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_COV][eft_FLT][eft_FLT] = {eft_DBL, (void*)dpnp_cov_default_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_COV][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_cov_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_COV][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_cov_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_COV][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_cov_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_COV][eft_FLT][eft_FLT] = {
+        eft_DBL, (void *)dpnp_cov_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_COV][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_cov_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_MAX][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_max_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MAX][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_max_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MAX][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_max_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_MAX][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_max_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_MAX][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_max_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_MAX][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_max_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_MAX][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_max_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_MAX][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_max_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_MAX_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_max_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MAX_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_max_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MAX_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_max_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_MAX_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_max_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_MAX_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_max_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_MAX_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_max_ext_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_MAX_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_max_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_MAX_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_max_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_MEAN][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_mean_default_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_MEAN][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_mean_default_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_MEAN][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_mean_default_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_MEAN][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_mean_default_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_MEAN][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_mean_default_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_MEAN][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_mean_default_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_MEAN][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_mean_default_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_MEAN][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_mean_default_c<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_MEDIAN][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_median_default_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_MEDIAN][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_median_default_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_MEDIAN][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_median_default_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_MEDIAN][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_median_default_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_MEDIAN][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_median_default_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_MEDIAN][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_median_default_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_MEDIAN][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_median_default_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_MEDIAN][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_median_default_c<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_MEDIAN_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_median_ext_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_MEDIAN_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_median_ext_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_MEDIAN_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_median_ext_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_MEDIAN_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_median_ext_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_MEDIAN_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_median_ext_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_MEDIAN_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_median_ext_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_MEDIAN_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_median_ext_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_MEDIAN_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_median_ext_c<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_MIN][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_min_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MIN][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_min_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MIN][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_min_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_MIN][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_min_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_MIN][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_min_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_MIN][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_min_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_MIN][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_min_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_MIN][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_min_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_MIN_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_min_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MIN_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_min_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MIN_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_min_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_MIN_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_min_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_MIN_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_min_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_MIN_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_min_ext_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_MIN_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_min_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_MIN_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_min_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_NANVAR][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_nanvar_default_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_NANVAR][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_nanvar_default_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_NANVAR][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_nanvar_default_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_NANVAR][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_nanvar_default_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_NANVAR][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_nanvar_default_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_NANVAR][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_nanvar_default_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_NANVAR][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_nanvar_default_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_NANVAR][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_nanvar_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_NANVAR_EXT][eft_INT][eft_INT] = {eft_INT, (void*)dpnp_nanvar_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_NANVAR_EXT][eft_LNG][eft_LNG] = {eft_LNG, (void*)dpnp_nanvar_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_NANVAR_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_nanvar_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_NANVAR_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_nanvar_ext_c<double>};
+    fmap[DPNPFuncName::DPNP_FN_NANVAR_EXT][eft_INT][eft_INT] = {
+        eft_INT, (void *)dpnp_nanvar_ext_c<int32_t>};
+    fmap[DPNPFuncName::DPNP_FN_NANVAR_EXT][eft_LNG][eft_LNG] = {
+        eft_LNG, (void *)dpnp_nanvar_ext_c<int64_t>};
+    fmap[DPNPFuncName::DPNP_FN_NANVAR_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_nanvar_ext_c<float>};
+    fmap[DPNPFuncName::DPNP_FN_NANVAR_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_nanvar_ext_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_STD][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_std_default_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_STD][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_std_default_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_STD][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_std_default_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_STD][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_std_default_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_STD][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_std_default_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_STD][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_std_default_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_STD][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_std_default_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_STD][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_std_default_c<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_STD_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_std_ext_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_STD_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_std_ext_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_STD_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_std_ext_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_STD_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_std_ext_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_STD_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_std_ext_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_STD_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_std_ext_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_STD_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_std_ext_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_STD_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_std_ext_c<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_VAR][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_var_default_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_VAR][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_var_default_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_VAR][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_var_default_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_VAR][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_var_default_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_VAR][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_var_default_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_VAR][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_var_default_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_VAR][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_var_default_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_VAR][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_var_default_c<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_VAR_EXT][eft_INT][eft_INT] = {eft_DBL, (void*)dpnp_var_ext_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_VAR_EXT][eft_LNG][eft_LNG] = {eft_DBL, (void*)dpnp_var_ext_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_VAR_EXT][eft_FLT][eft_FLT] = {eft_FLT, (void*)dpnp_var_ext_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_VAR_EXT][eft_DBL][eft_DBL] = {eft_DBL, (void*)dpnp_var_ext_c<double, double>};
+    fmap[DPNPFuncName::DPNP_FN_VAR_EXT][eft_INT][eft_INT] = {
+        eft_DBL, (void *)dpnp_var_ext_c<int32_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_VAR_EXT][eft_LNG][eft_LNG] = {
+        eft_DBL, (void *)dpnp_var_ext_c<int64_t, double>};
+    fmap[DPNPFuncName::DPNP_FN_VAR_EXT][eft_FLT][eft_FLT] = {
+        eft_FLT, (void *)dpnp_var_ext_c<float, float>};
+    fmap[DPNPFuncName::DPNP_FN_VAR_EXT][eft_DBL][eft_DBL] = {
+        eft_DBL, (void *)dpnp_var_ext_c<double, double>};
 
     return;
 }

--- a/dpnp/backend/src/constants.cpp
+++ b/dpnp/backend/src/constants.cpp
@@ -27,15 +27,15 @@
 
 #include "constants.hpp"
 
-void* python_constants::py_none = nullptr;
-void* python_constants::py_nan = nullptr;
+void *python_constants::py_none = nullptr;
+void *python_constants::py_nan  = nullptr;
 
-void dpnp_python_constants_initialize_c(void* _py_none, void* _py_nan)
+void dpnp_python_constants_initialize_c(void *_py_none, void *_py_nan)
 {
     python_constants::py_none = _py_none;
-    python_constants::py_nan = _py_nan;
-    //    std::cout << "========dpnp_python_constants_initialize_c=============" << std::endl;
-    //    std::cout << "\t None=" << _py_none
+    python_constants::py_nan  = _py_nan;
+    //    std::cout << "========dpnp_python_constants_initialize_c============="
+    //    << std::endl; std::cout << "\t None=" << _py_none
     //              << "\n\t NaN=" << _py_nan
     //              << "\n\t py_none=" << python_constants::py_none
     //              << "\n\t py_nan=" << python_constants::py_nan

--- a/dpnp/backend/src/constants.cpp
+++ b/dpnp/backend/src/constants.cpp
@@ -28,12 +28,12 @@
 #include "constants.hpp"
 
 void *python_constants::py_none = nullptr;
-void *python_constants::py_nan  = nullptr;
+void *python_constants::py_nan = nullptr;
 
 void dpnp_python_constants_initialize_c(void *_py_none, void *_py_nan)
 {
     python_constants::py_none = _py_none;
-    python_constants::py_nan  = _py_nan;
+    python_constants::py_nan = _py_nan;
     //    std::cout << "========dpnp_python_constants_initialize_c============="
     //    << std::endl; std::cout << "\t None=" << _py_none
     //              << "\n\t NaN=" << _py_nan

--- a/dpnp/backend/src/constants.hpp
+++ b/dpnp/backend/src/constants.hpp
@@ -30,13 +30,13 @@
 #include "dpnp_iface.hpp"
 
 /**
- * This is container for the constants from Python interpreter and other modules. These constants are subject to use
- * in algorithms.
+ * This is container for the constants from Python interpreter and other
+ * modules. These constants are subject to use in algorithms.
  */
 struct python_constants
 {
-    static void* py_none; /**< Python None */
-    static void* py_nan;  /**< Python NAN or NumPy.nan */
+    static void *py_none; /**< Python None */
+    static void *py_nan;  /**< Python NAN or NumPy.nan */
 };
 
 /**
@@ -48,6 +48,7 @@ struct python_constants
  * @param [in]  py_none   Python NONE representation
  * @param [in]  py_nan    Python NAN representation
  */
-INP_DLLEXPORT void dpnp_python_constants_initialize_c(void* py_none, void* py_nan);
+INP_DLLEXPORT void dpnp_python_constants_initialize_c(void *py_none,
+                                                      void *py_nan);
 
 #endif // CONSTANTS_H

--- a/dpnp/backend/src/dpnp_fptr.hpp
+++ b/dpnp/backend/src/dpnp_fptr.hpp
@@ -60,13 +60,13 @@ typedef std::map<DPNPFuncName, map_1p_t> func_map_t;
 /**
  * Internal shortcuts for Data type enum values
  */
-const DPNPFuncType eft_INT  = DPNPFuncType::DPNP_FT_INT;
-const DPNPFuncType eft_LNG  = DPNPFuncType::DPNP_FT_LONG;
-const DPNPFuncType eft_FLT  = DPNPFuncType::DPNP_FT_FLOAT;
-const DPNPFuncType eft_DBL  = DPNPFuncType::DPNP_FT_DOUBLE;
-const DPNPFuncType eft_C64  = DPNPFuncType::DPNP_FT_CMPLX64;
+const DPNPFuncType eft_INT = DPNPFuncType::DPNP_FT_INT;
+const DPNPFuncType eft_LNG = DPNPFuncType::DPNP_FT_LONG;
+const DPNPFuncType eft_FLT = DPNPFuncType::DPNP_FT_FLOAT;
+const DPNPFuncType eft_DBL = DPNPFuncType::DPNP_FT_DOUBLE;
+const DPNPFuncType eft_C64 = DPNPFuncType::DPNP_FT_CMPLX64;
 const DPNPFuncType eft_C128 = DPNPFuncType::DPNP_FT_CMPLX128;
-const DPNPFuncType eft_BLN  = DPNPFuncType::DPNP_FT_BOOL;
+const DPNPFuncType eft_BLN = DPNPFuncType::DPNP_FT_BOOL;
 
 /**
  * An internal structure to build a pair of Data type enum value with C++ type
@@ -235,8 +235,8 @@ public:
                           std::complex<float>, std::complex<double>>)
         {
             bool ret = false;
-            _Xp a    = std::forward<_Xp>(__x);
-            _Yp b    = std::forward<_Yp>(__y);
+            _Xp a = std::forward<_Xp>(__x);
+            _Yp b = std::forward<_Yp>(__y);
 
             if (a.real() < b.real()) {
                 ret = (a.imag() == a.imag() || b.imag() != b.imag());

--- a/dpnp/backend/src/dpnp_fptr.hpp
+++ b/dpnp/backend/src/dpnp_fptr.hpp
@@ -93,8 +93,8 @@ struct func_type_map_factory_t : public Ps...
     using Ps::get_pair...;
 
     template <DPNPFuncType FuncType>
-    using find_type = typename decltype(
-        get_pair(std::integral_constant<DPNPFuncType, FuncType>{}))::type;
+    using find_type = typename decltype(get_pair(
+        std::integral_constant<DPNPFuncType, FuncType>{}))::type;
 };
 
 /**

--- a/dpnp/backend/src/dpnp_fptr.hpp
+++ b/dpnp/backend/src/dpnp_fptr.hpp
@@ -24,16 +24,16 @@
 //*****************************************************************************
 
 /*
- * This header file contains internal function declarations related to FPTR interface.
- * It should not contains public declarations
+ * This header file contains internal function declarations related to FPTR
+ * interface. It should not contains public declarations
  */
 
 #pragma once
 #ifndef BACKEND_FPTR_H // Cython compatibility
 #define BACKEND_FPTR_H
 
-#include <map>
 #include <complex>
+#include <map>
 
 #include <CL/sycl.hpp>
 
@@ -49,7 +49,8 @@
  *
  * contains structure with kernel information
  *
- * if the kernel requires only one input type - use same type for both parameters
+ * if the kernel requires only one input type - use same type for both
+ * parameters
  *
  */
 typedef std::map<DPNPFuncType, DPNPFuncData_t> map_2p_t;
@@ -59,13 +60,13 @@ typedef std::map<DPNPFuncName, map_1p_t> func_map_t;
 /**
  * Internal shortcuts for Data type enum values
  */
-const DPNPFuncType eft_INT = DPNPFuncType::DPNP_FT_INT;
-const DPNPFuncType eft_LNG = DPNPFuncType::DPNP_FT_LONG;
-const DPNPFuncType eft_FLT = DPNPFuncType::DPNP_FT_FLOAT;
-const DPNPFuncType eft_DBL = DPNPFuncType::DPNP_FT_DOUBLE;
-const DPNPFuncType eft_C64 = DPNPFuncType::DPNP_FT_CMPLX64;
+const DPNPFuncType eft_INT  = DPNPFuncType::DPNP_FT_INT;
+const DPNPFuncType eft_LNG  = DPNPFuncType::DPNP_FT_LONG;
+const DPNPFuncType eft_FLT  = DPNPFuncType::DPNP_FT_FLOAT;
+const DPNPFuncType eft_DBL  = DPNPFuncType::DPNP_FT_DOUBLE;
+const DPNPFuncType eft_C64  = DPNPFuncType::DPNP_FT_CMPLX64;
 const DPNPFuncType eft_C128 = DPNPFuncType::DPNP_FT_CMPLX128;
-const DPNPFuncType eft_BLN = DPNPFuncType::DPNP_FT_BOOL;
+const DPNPFuncType eft_BLN  = DPNPFuncType::DPNP_FT_BOOL;
 
 /**
  * An internal structure to build a pair of Data type enum value with C++ type
@@ -73,33 +74,42 @@ const DPNPFuncType eft_BLN = DPNPFuncType::DPNP_FT_BOOL;
 template <DPNPFuncType FuncType, typename T>
 struct func_type_pair_t
 {
-   using type = T;
+    using type = T;
 
-   static func_type_pair_t get_pair(std::integral_constant<DPNPFuncType, FuncType>) { return {}; }
+    static func_type_pair_t
+        get_pair(std::integral_constant<DPNPFuncType, FuncType>)
+    {
+        return {};
+    }
 };
 
 /**
- * An internal structure to create a map of Data type enum value associated with C++ type
+ * An internal structure to create a map of Data type enum value associated with
+ * C++ type
  */
-template <typename ... Ps>
+template <typename... Ps>
 struct func_type_map_factory_t : public Ps...
 {
-   using Ps::get_pair...;
+    using Ps::get_pair...;
 
-   template <DPNPFuncType FuncType>
-   using find_type = typename decltype(get_pair(std::integral_constant<DPNPFuncType, FuncType>{}))::type;
+    template <DPNPFuncType FuncType>
+    using find_type = typename decltype(
+        get_pair(std::integral_constant<DPNPFuncType, FuncType>{}))::type;
 };
 
 /**
- * A map of the FPTR interface to link Data type enum value with accociated C++ type
+ * A map of the FPTR interface to link Data type enum value with accociated C++
+ * type
  */
-typedef func_type_map_factory_t<func_type_pair_t<eft_BLN, bool>,
-                                func_type_pair_t<eft_INT, std::int32_t>,
-                                func_type_pair_t<eft_LNG, std::int64_t>,
-                                func_type_pair_t<eft_FLT, float>,
-                                func_type_pair_t<eft_DBL, double>,
-                                func_type_pair_t<eft_C64, std::complex<float>>,
-                                func_type_pair_t<eft_C128, std::complex<double>>> func_type_map_t;
+typedef func_type_map_factory_t<
+    func_type_pair_t<eft_BLN, bool>,
+    func_type_pair_t<eft_INT, std::int32_t>,
+    func_type_pair_t<eft_LNG, std::int64_t>,
+    func_type_pair_t<eft_FLT, float>,
+    func_type_pair_t<eft_DBL, double>,
+    func_type_pair_t<eft_C64, std::complex<float>>,
+    func_type_pair_t<eft_C128, std::complex<double>>>
+    func_type_map_t;
 
 /**
  * Return an enum value of result type populated from input types.
@@ -107,12 +117,10 @@ typedef func_type_map_factory_t<func_type_pair_t<eft_BLN, bool>,
 template <DPNPFuncType FT1, DPNPFuncType FT2>
 static constexpr DPNPFuncType populate_func_types()
 {
-    if constexpr (FT1 == DPNPFuncType::DPNP_FT_NONE)
-    {
+    if constexpr (FT1 == DPNPFuncType::DPNP_FT_NONE) {
         throw std::runtime_error("Templated enum value of FT1 is None");
     }
-    else if constexpr (FT2 == DPNPFuncType::DPNP_FT_NONE)
-    {
+    else if constexpr (FT2 == DPNPFuncType::DPNP_FT_NONE) {
         throw std::runtime_error("Templated enum value of FT2 is None");
     }
     return (FT1 < FT2) ? FT2 : FT1;
@@ -122,7 +130,7 @@ static constexpr DPNPFuncType populate_func_types()
  * @brief A helper function to cast SYCL vector between types.
  */
 template <typename Op, typename Vec, std::size_t... I>
-static auto dpnp_vec_cast_impl(const Vec& v, std::index_sequence<I...>)
+static auto dpnp_vec_cast_impl(const Vec &v, std::index_sequence<I...>)
 {
     return Op{v[I]...};
 }
@@ -137,10 +145,14 @@ static auto dpnp_vec_cast_impl(const Vec& v, std::index_sequence<I...>)
  * @param s An incoming SYCL vector to cast.
  * @return SYCL vector casted to desctination type.
  */
-template <typename dstT, typename srcT, std::size_t N, typename Indices = std::make_index_sequence<N>>
-static auto dpnp_vec_cast(const sycl::vec<srcT, N>& s)
+template <typename dstT,
+          typename srcT,
+          std::size_t N,
+          typename Indices = std::make_index_sequence<N>>
+static auto dpnp_vec_cast(const sycl::vec<srcT, N> &s)
 {
-    return dpnp_vec_cast_impl<sycl::vec<dstT, N>, sycl::vec<srcT, N>>(s, Indices{});
+    return dpnp_vec_cast_impl<sycl::vec<dstT, N>, sycl::vec<srcT, N>>(
+        s, Indices{});
 }
 
 /**
@@ -154,14 +166,18 @@ static auto dpnp_vec_cast(const sycl::vec<srcT, N>& s)
  * and when type T has to match only one of types Ts.
  */
 template <typename T, typename... Ts>
-struct is_any : std::disjunction<std::is_same<T, Ts>...> {};
+struct is_any : std::disjunction<std::is_same<T, Ts>...>
+{
+};
 
 /**
  * Implements std::is_same<> with variadic number of types to compare with
  * and when type T has to match every type from Ts sequence.
  */
 template <typename T, typename... Ts>
-struct are_same : std::conjunction<std::is_same<T, Ts>...> {};
+struct are_same : std::conjunction<std::is_same<T, Ts>...>
+{
+};
 
 /**
  * A template constant to check if type T matches any type from Ts.
@@ -170,33 +186,38 @@ template <typename T, typename... Ts>
 constexpr auto is_any_v = is_any<T, Ts...>::value;
 
 /**
- * A template constat to check if both types T1 and T2 match every type from Ts sequence.
+ * A template constat to check if both types T1 and T2 match every type from Ts
+ * sequence.
  */
 template <typename T1, typename T2, typename... Ts>
-constexpr auto both_types_are_same = std::conjunction_v<is_any<T1, Ts...>, are_same<T1, T2>>;
+constexpr auto both_types_are_same =
+    std::conjunction_v<is_any<T1, Ts...>, are_same<T1, T2>>;
 
 /**
  * A template constat to check if both types T1 and T2 match any type from Ts.
  */
 template <typename T1, typename T2, typename... Ts>
-constexpr auto both_types_are_any_of = std::conjunction_v<is_any<T1, Ts...>, is_any<T2, Ts...>>;
+constexpr auto both_types_are_any_of =
+    std::conjunction_v<is_any<T1, Ts...>, is_any<T2, Ts...>>;
 
 /**
- * A template constat to check if both types T1 and T2 don't match any type from Ts sequence.
+ * A template constat to check if both types T1 and T2 don't match any type from
+ * Ts sequence.
  */
 template <typename T1, typename T2, typename... Ts>
-constexpr auto none_of_both_types = !std::disjunction_v<is_any<T1, Ts...>, is_any<T2, Ts...>>;
-
+constexpr auto none_of_both_types =
+    !std::disjunction_v<is_any<T1, Ts...>, is_any<T2, Ts...>>;
 
 /**
- * @brief If the type _Tp is a reference type, provides the member typedef type which is the type referred to by _Tp
- * with its topmost cv-qualifiers removed. Otherwise type is _Tp with its topmost cv-qualifiers removed.
+ * @brief If the type _Tp is a reference type, provides the member typedef type
+ * which is the type referred to by _Tp with its topmost cv-qualifiers removed.
+ * Otherwise type is _Tp with its topmost cv-qualifiers removed.
  *
  * @note std::remove_cvref is only available since c++20
  */
-template<typename _Tp>
-using dpnp_remove_cvref_t = typename std::remove_cv_t<typename std::remove_reference_t<_Tp>>;
-
+template <typename _Tp>
+using dpnp_remove_cvref_t =
+    typename std::remove_cv_t<typename std::remove_reference_t<_Tp>>;
 
 /**
  * @brief "<" comparison with complex types support.
@@ -207,34 +228,33 @@ class dpnp_less_comp
 {
 public:
     template <typename _Xp, typename _Yp>
-    bool operator()(_Xp&& __x, _Yp&& __y) const
+    bool operator()(_Xp &&__x, _Yp &&__y) const
     {
-        if constexpr (both_types_are_same<dpnp_remove_cvref_t<_Xp>, dpnp_remove_cvref_t<_Yp>, std::complex<float>, std::complex<double>>)
+        if constexpr (both_types_are_same<
+                          dpnp_remove_cvref_t<_Xp>, dpnp_remove_cvref_t<_Yp>,
+                          std::complex<float>, std::complex<double>>)
         {
             bool ret = false;
-            _Xp a = std::forward<_Xp>(__x);
-            _Yp b = std::forward<_Yp>(__y);
+            _Xp a    = std::forward<_Xp>(__x);
+            _Yp b    = std::forward<_Yp>(__y);
 
-            if (a.real() < b.real())
-            {
+            if (a.real() < b.real()) {
                 ret = (a.imag() == a.imag() || b.imag() != b.imag());
             }
-            else if (a.real() > b.real())
-            {
+            else if (a.real() > b.real()) {
                 ret = (b.imag() != b.imag() && a.imag() == a.imag());
             }
-            else if (a.real() == b.real() || (a.real() != a.real() && b.real() != b.real()))
-            {
-                ret = (a.imag() < b.imag() || (b.imag() != b.imag() && a.imag() == a.imag()));
+            else if (a.real() == b.real() ||
+                     (a.real() != a.real() && b.real() != b.real())) {
+                ret = (a.imag() < b.imag() ||
+                       (b.imag() != b.imag() && a.imag() == a.imag()));
             }
-            else
-            {
+            else {
                 ret = (b.real() != b.real());
             }
             return ret;
         }
-        else
-        {
+        else {
             return std::forward<_Xp>(__x) < std::forward<_Yp>(__y);
         }
     }
@@ -243,20 +263,20 @@ public:
 /**
  * FPTR interface initialization functions
  */
-void func_map_init_arraycreation(func_map_t& fmap);
-void func_map_init_bitwise(func_map_t& fmap);
-void func_map_init_elemwise(func_map_t& fmap);
-void func_map_init_fft_func(func_map_t& fmap);
-void func_map_init_indexing_func(func_map_t& fmap);
-void func_map_init_linalg(func_map_t& fmap);
-void func_map_init_linalg_func(func_map_t& fmap);
-void func_map_init_logic(func_map_t& fmap);
-void func_map_init_manipulation(func_map_t& fmap);
-void func_map_init_mathematical(func_map_t& fmap);
-void func_map_init_random(func_map_t& fmap);
-void func_map_init_reduction(func_map_t& fmap);
-void func_map_init_searching(func_map_t& fmap);
-void func_map_init_sorting(func_map_t& fmap);
-void func_map_init_statistics(func_map_t& fmap);
+void func_map_init_arraycreation(func_map_t &fmap);
+void func_map_init_bitwise(func_map_t &fmap);
+void func_map_init_elemwise(func_map_t &fmap);
+void func_map_init_fft_func(func_map_t &fmap);
+void func_map_init_indexing_func(func_map_t &fmap);
+void func_map_init_linalg(func_map_t &fmap);
+void func_map_init_linalg_func(func_map_t &fmap);
+void func_map_init_logic(func_map_t &fmap);
+void func_map_init_manipulation(func_map_t &fmap);
+void func_map_init_mathematical(func_map_t &fmap);
+void func_map_init_random(func_map_t &fmap);
+void func_map_init_reduction(func_map_t &fmap);
+void func_map_init_searching(func_map_t &fmap);
+void func_map_init_sorting(func_map_t &fmap);
+void func_map_init_statistics(func_map_t &fmap);
 
 #endif // BACKEND_FPTR_H

--- a/dpnp/backend/src/dpnp_iface_fptr.cpp
+++ b/dpnp/backend/src/dpnp_iface_fptr.cpp
@@ -55,7 +55,7 @@ DPNPFuncData_t get_dpnp_function_ptr(DPNPFuncName func_name,
             "DPNP Error: Unsupported function call."); // TODO print Function ID
     }
 
-    const map_1p_t &type1_map             = func_it->second;
+    const map_1p_t &type1_map = func_it->second;
     map_1p_t::const_iterator type1_map_it = type1_map.find(first_type);
     if (type1_map_it == type1_map.cend()) {
         throw std::runtime_error("DPNP Error: Function ID with unsupported "
@@ -63,7 +63,7 @@ DPNPFuncData_t get_dpnp_function_ptr(DPNPFuncName func_name,
                                                            // Function ID
     }
 
-    const map_2p_t &type2_map             = type1_map_it->second;
+    const map_2p_t &type2_map = type1_map_it->second;
     map_2p_t::const_iterator type2_map_it = type2_map.find(local_second_type);
     if (type2_map_it == type2_map.cend()) {
         throw std::runtime_error("DPNP Error: Function ID with unsupported "
@@ -99,7 +99,7 @@ void (*dpnp_dot_default_c)(void *,
 void *get_backend_function_name(const char *func_name, const char *type_name)
 {
     /** Implement it in this way to allow easier play with it */
-    const char *supported_func_name  = "dpnp_dot";
+    const char *supported_func_name = "dpnp_dot";
     const char *supported_type1_name = "double";
     const char *supported_type2_name = "float";
     const char *supported_type3_name = "long";

--- a/dpnp/backend/src/dpnp_iface_fptr.cpp
+++ b/dpnp/backend/src/dpnp_iface_fptr.cpp
@@ -25,8 +25,9 @@
 
 /*
  * This header file is for interface Cython with C++.
- * It should not contains any backend specific headers (like SYCL or math library) because
- * all included headers will be exposed in Cython compilation procedure
+ * It should not contains any backend specific headers (like SYCL or math
+ * library) because all included headers will be exposed in Cython compilation
+ * procedure
  *
  * Also, this file should contains documentation on functions and types
  * which are used in the interface
@@ -41,30 +42,33 @@ static func_map_t func_map_init();
 
 func_map_t func_map = func_map_init();
 
-DPNPFuncData_t get_dpnp_function_ptr(DPNPFuncName func_name, DPNPFuncType first_type, DPNPFuncType second_type)
+DPNPFuncData_t get_dpnp_function_ptr(DPNPFuncName func_name,
+                                     DPNPFuncType first_type,
+                                     DPNPFuncType second_type)
 {
-    DPNPFuncType local_second_type = (second_type == DPNPFuncType::DPNP_FT_NONE) ? first_type : second_type;
+    DPNPFuncType local_second_type =
+        (second_type == DPNPFuncType::DPNP_FT_NONE) ? first_type : second_type;
 
     func_map_t::const_iterator func_it = func_map.find(func_name);
-    if (func_it == func_map.cend())
-    {
-        throw std::runtime_error("DPNP Error: Unsupported function call."); // TODO print Function ID
+    if (func_it == func_map.cend()) {
+        throw std::runtime_error(
+            "DPNP Error: Unsupported function call."); // TODO print Function ID
     }
 
-    const map_1p_t& type1_map = func_it->second;
+    const map_1p_t &type1_map             = func_it->second;
     map_1p_t::const_iterator type1_map_it = type1_map.find(first_type);
-    if (type1_map_it == type1_map.cend())
-    {
-        throw std::runtime_error(
-            "DPNP Error: Function ID with unsupported first parameter type."); // TODO print Function ID
+    if (type1_map_it == type1_map.cend()) {
+        throw std::runtime_error("DPNP Error: Function ID with unsupported "
+                                 "first parameter type."); // TODO print
+                                                           // Function ID
     }
 
-    const map_2p_t& type2_map = type1_map_it->second;
+    const map_2p_t &type2_map             = type1_map_it->second;
     map_2p_t::const_iterator type2_map_it = type2_map.find(local_second_type);
-    if (type2_map_it == type2_map.cend())
-    {
-        throw std::runtime_error(
-            "DPNP Error: Function ID with unsupported second parameter type."); // TODO print Function ID
+    if (type2_map_it == type2_map.cend()) {
+        throw std::runtime_error("DPNP Error: Function ID with unsupported "
+                                 "second parameter type."); // TODO print
+                                                            // Function ID
     }
 
     DPNPFuncData_t func_info = type2_map_it->second;
@@ -72,50 +76,59 @@ DPNPFuncData_t get_dpnp_function_ptr(DPNPFuncName func_name, DPNPFuncType first_
     return func_info;
 }
 
-template <typename _DataType_output, typename _DataType_input1, typename _DataType_input2>
-void (*dpnp_dot_default_c)(void*,
+template <typename _DataType_output,
+          typename _DataType_input1,
+          typename _DataType_input2>
+void (*dpnp_dot_default_c)(void *,
                            const size_t,
                            const size_t,
-                           const shape_elem_type*,
-                           const shape_elem_type*,
-                           const void*,
+                           const shape_elem_type *,
+                           const shape_elem_type *,
+                           const void *,
                            const size_t,
                            const size_t,
-                           const shape_elem_type*,
-                           const shape_elem_type*,
-                           const void*,
+                           const shape_elem_type *,
+                           const shape_elem_type *,
+                           const void *,
                            const size_t,
                            const size_t,
-                           const shape_elem_type*,
-                           const shape_elem_type*) = dpnp_dot_c<_DataType_output, _DataType_input1, _DataType_input2>;
+                           const shape_elem_type *,
+                           const shape_elem_type *) =
+    dpnp_dot_c<_DataType_output, _DataType_input1, _DataType_input2>;
 
-void* get_backend_function_name(const char* func_name, const char* type_name)
+void *get_backend_function_name(const char *func_name, const char *type_name)
 {
     /** Implement it in this way to allow easier play with it */
-    const char* supported_func_name = "dpnp_dot";
-    const char* supported_type1_name = "double";
-    const char* supported_type2_name = "float";
-    const char* supported_type3_name = "long";
-    const char* supported_type4_name = "int";
+    const char *supported_func_name  = "dpnp_dot";
+    const char *supported_type1_name = "double";
+    const char *supported_type2_name = "float";
+    const char *supported_type3_name = "long";
+    const char *supported_type4_name = "int";
 
     /** of coerce it will be converted into std::map later */
-    if (!strncmp(func_name, supported_func_name, strlen(supported_func_name)))
-    {
-        if (!strncmp(type_name, supported_type1_name, strlen(supported_type1_name)))
-        {
-            return reinterpret_cast<void*>(dpnp_dot_default_c<double, double, double>);
+    if (!strncmp(func_name, supported_func_name, strlen(supported_func_name))) {
+        if (!strncmp(type_name, supported_type1_name,
+                     strlen(supported_type1_name))) {
+            return reinterpret_cast<void *>(
+                dpnp_dot_default_c<double, double, double>);
         }
-        else if (!strncmp(type_name, supported_type2_name, strlen(supported_type2_name)))
+        else if (!strncmp(type_name, supported_type2_name,
+                          strlen(supported_type2_name)))
         {
-            return reinterpret_cast<void*>(dpnp_dot_default_c<float, float, float>);
+            return reinterpret_cast<void *>(
+                dpnp_dot_default_c<float, float, float>);
         }
-        else if (!strncmp(type_name, supported_type3_name, strlen(supported_type3_name)))
+        else if (!strncmp(type_name, supported_type3_name,
+                          strlen(supported_type3_name)))
         {
-            return reinterpret_cast<void*>(dpnp_dot_default_c<int64_t, int64_t, int64_t>);
+            return reinterpret_cast<void *>(
+                dpnp_dot_default_c<int64_t, int64_t, int64_t>);
         }
-        else if (!strncmp(type_name, supported_type4_name, strlen(supported_type4_name)))
+        else if (!strncmp(type_name, supported_type4_name,
+                          strlen(supported_type4_name)))
         {
-            return reinterpret_cast<void*>(dpnp_dot_default_c<int32_t, int32_t, int32_t>);
+            return reinterpret_cast<void *>(
+                dpnp_dot_default_c<int32_t, int32_t, int32_t>);
         }
     }
 
@@ -123,7 +136,8 @@ void* get_backend_function_name(const char* func_name, const char* type_name)
 }
 
 /**
- * This operator is needed for compatibility with Cython 0.29 which has a bug in Enum handling
+ * This operator is needed for compatibility with Cython 0.29 which has a bug in
+ * Enum handling
  * TODO needs to be deleted in future
  */
 size_t operator-(DPNPFuncType lhs, DPNPFuncType rhs)
@@ -136,12 +150,13 @@ size_t operator-(DPNPFuncType lhs, DPNPFuncType rhs)
     return result;
 }
 
-void* get_dpnp_function_ptr1(DPNPFuncType& result_type,
+void *get_dpnp_function_ptr1(DPNPFuncType &result_type,
                              DPNPFuncName name,
                              DPNPFuncType first_type,
                              DPNPFuncType second_type)
 {
-    DPNPFuncData_t result = get_dpnp_function_ptr(name, first_type, second_type);
+    DPNPFuncData_t result =
+        get_dpnp_function_ptr(name, first_type, second_type);
 
     result_type = result.return_type;
     return result.ptr;

--- a/dpnp/backend/src/dpnp_iterator.hpp
+++ b/dpnp/backend/src/dpnp_iterator.hpp
@@ -48,18 +48,18 @@ template <typename _Tp>
 class DPNP_USM_iterator final
 {
 public:
-    using value_type        = _Tp;
-    using difference_type   = std::ptrdiff_t;
+    using value_type = _Tp;
+    using difference_type = std::ptrdiff_t;
     using iterator_category = std::random_access_iterator_tag;
-    using pointer           = value_type *;
-    using reference         = value_type &;
-    using size_type         = shape_elem_type;
+    using pointer = value_type *;
+    using reference = value_type &;
+    using size_type = shape_elem_type;
 
     DPNP_USM_iterator(pointer __base_ptr,
                       size_type __id,
                       const size_type *__shape_stride = nullptr,
-                      const size_type *__axes_stride  = nullptr,
-                      size_type __shape_size          = 0)
+                      const size_type *__axes_stride = nullptr,
+                      size_type __shape_size = 0)
         : base(__base_ptr), iter_id(__id), iteration_shape_size(__shape_size),
           iteration_shape_strides(__shape_stride),
           axes_shape_strides(__axes_stride)
@@ -164,7 +164,7 @@ private:
             for (size_t it = 0; it < static_cast<size_t>(iteration_shape_size);
                  ++it) {
                 const size_type axis_val = iteration_shape_strides[it];
-                size_type xyz_id         = reminder / axis_val;
+                size_type xyz_id = reminder / axis_val;
                 offset += (xyz_id * axes_shape_strides[it]);
 
                 reminder = reminder % axis_val;
@@ -184,7 +184,7 @@ private:
         size_type{}; /**< Number of elements in @ref iteration_shape_strides
                         array */
     const size_type *iteration_shape_strides = nullptr;
-    const size_type *axes_shape_strides      = nullptr;
+    const size_type *axes_shape_strides = nullptr;
 };
 
 /**
@@ -200,10 +200,10 @@ class DPNPC_id final
 {
 public:
     using value_type = _Tp;
-    using iterator   = DPNP_USM_iterator<value_type>;
-    using pointer    = value_type *;
-    using reference  = value_type &;
-    using size_type  = shape_elem_type;
+    using iterator = DPNP_USM_iterator<value_type>;
+    using pointer = value_type *;
+    using reference = value_type &;
+    using size_type = shape_elem_type;
 
     DPNPC_id(DPCTLSyclQueueRef q_ref,
              pointer __ptr,
@@ -409,7 +409,7 @@ public:
             free_iteration_memory();
             free_output_memory();
 
-            axes     = get_validated_axes(__axes, input_shape_size);
+            axes = get_validated_axes(__axes, input_shape_size);
             axis_use = true;
 
             output_shape_size = input_shape_size - axes.size();
@@ -501,8 +501,8 @@ private:
         }
 
         if (__ptr != nullptr) {
-            data        = __ptr;
-            input_size  = 1; // means scalar at this stage
+            data = __ptr;
+            input_size = 1;  // means scalar at this stage
             output_size = 1; // if input size is not zero it means we have
                              // scalar as output
             iteration_size = 1;
@@ -542,8 +542,8 @@ private:
         }
 
         if (__ptr != nullptr) {
-            data        = __ptr;
-            input_size  = 1; // means scalar at this stage
+            data = __ptr;
+            input_size = 1;  // means scalar at this stage
             output_size = 1; // if input size is not zero it means we have
                              // scalar as output
             iteration_size = 1;
@@ -637,17 +637,17 @@ private:
 
     void free_input_memory()
     {
-        input_size       = size_type{};
+        input_size = size_type{};
         input_shape_size = size_type{};
         dpnp_memory_free_c(queue_ref, input_shape);
         dpnp_memory_free_c(queue_ref, input_shape_strides);
-        input_shape         = nullptr;
+        input_shape = nullptr;
         input_shape_strides = nullptr;
     }
 
     void free_iteration_memory()
     {
-        iteration_size       = size_type{};
+        iteration_size = size_type{};
         iteration_shape_size = size_type{};
         dpnp_memory_free_c(queue_ref, iteration_shape_strides);
         iteration_shape_strides = nullptr;
@@ -655,11 +655,11 @@ private:
 
     void free_output_memory()
     {
-        output_size       = size_type{};
+        output_size = size_type{};
         output_shape_size = size_type{};
         dpnp_memory_free_c(queue_ref, output_shape);
         dpnp_memory_free_c(queue_ref, output_shape_strides);
-        output_shape         = nullptr;
+        output_shape = nullptr;
         output_shape_strides = nullptr;
     }
 
@@ -674,9 +674,9 @@ private:
 
     DPCTLSyclQueueRef queue_ref = nullptr; /**< reference to SYCL queue */
 
-    pointer data               = nullptr;     /**< input array begin pointer */
-    size_type input_size       = size_type{}; /**< input array size */
-    size_type *input_shape     = nullptr;     /**< input array shape */
+    pointer data = nullptr;                   /**< input array begin pointer */
+    size_type input_size = size_type{};       /**< input array size */
+    size_type *input_shape = nullptr;         /**< input array shape */
     size_type input_shape_size = size_type{}; /**< input array shape size */
     size_type *input_shape_strides =
         nullptr; /**< input array shape strides (same size as input_shape) */
@@ -691,16 +691,16 @@ private:
 
     size_type output_size =
         size_type{}; /**< output array size. Expected is same as GWS */
-    size_type *output_shape     = nullptr;     /**< output array shape */
+    size_type *output_shape = nullptr;         /**< output array shape */
     size_type output_shape_size = size_type{}; /**< output array shape size */
     size_type *output_shape_strides =
         nullptr; /**< output array shape strides (same size as output_shape) */
 
     size_type iteration_size =
         size_type{}; /**< iteration array size in elements */
-    size_type iteration_shape_size     = size_type{};
+    size_type iteration_shape_size = size_type{};
     size_type *iteration_shape_strides = nullptr;
-    size_type *axes_shape_strides      = nullptr;
+    size_type *axes_shape_strides = nullptr;
 };
 
 #endif // DPNP_ITERATOR_H

--- a/dpnp/backend/src/dpnp_iterator.hpp
+++ b/dpnp/backend/src/dpnp_iterator.hpp
@@ -40,31 +40,29 @@
  * @ingroup BACKEND_UTILS
  * @brief Iterator for @ref DPNPC_id type
  *
- * This type should be used to simplify data iteraton over input with parameters "[axis|axes]"
- * It is designed to be used in SYCL environment
+ * This type should be used to simplify data iteraton over input with parameters
+ * "[axis|axes]" It is designed to be used in SYCL environment
  *
  */
 template <typename _Tp>
 class DPNP_USM_iterator final
 {
 public:
-    using value_type = _Tp;
-    using difference_type = std::ptrdiff_t;
+    using value_type        = _Tp;
+    using difference_type   = std::ptrdiff_t;
     using iterator_category = std::random_access_iterator_tag;
-    using pointer = value_type*;
-    using reference = value_type&;
-    using size_type = shape_elem_type;
+    using pointer           = value_type *;
+    using reference         = value_type &;
+    using size_type         = shape_elem_type;
 
     DPNP_USM_iterator(pointer __base_ptr,
                       size_type __id,
-                      const size_type* __shape_stride = nullptr,
-                      const size_type* __axes_stride = nullptr,
-                      size_type __shape_size = 0)
-        : base(__base_ptr)
-        , iter_id(__id)
-        , iteration_shape_size(__shape_size)
-        , iteration_shape_strides(__shape_stride)
-        , axes_shape_strides(__axes_stride)
+                      const size_type *__shape_stride = nullptr,
+                      const size_type *__axes_stride  = nullptr,
+                      size_type __shape_size          = 0)
+        : base(__base_ptr), iter_id(__id), iteration_shape_size(__shape_size),
+          iteration_shape_strides(__shape_stride),
+          axes_shape_strides(__axes_stride)
     {
     }
 
@@ -81,7 +79,7 @@ public:
     }
 
     /// prefix increment
-    inline DPNP_USM_iterator& operator++()
+    inline DPNP_USM_iterator &operator++()
     {
         ++iter_id;
 
@@ -97,18 +95,19 @@ public:
         return tmp;
     }
 
-    inline bool operator==(const DPNP_USM_iterator& __rhs) const
+    inline bool operator==(const DPNP_USM_iterator &__rhs) const
     {
-        assert(base == __rhs.base); // iterators are incomparable if base pointers are different
+        assert(base == __rhs.base); // iterators are incomparable if base
+                                    // pointers are different
         return (iter_id == __rhs.iter_id);
     };
 
-    inline bool operator!=(const DPNP_USM_iterator& __rhs) const
+    inline bool operator!=(const DPNP_USM_iterator &__rhs) const
     {
         return !(*this == __rhs);
     };
 
-    inline bool operator<(const DPNP_USM_iterator& __rhs) const
+    inline bool operator<(const DPNP_USM_iterator &__rhs) const
     {
         return iter_id < __rhs.iter_id;
     };
@@ -121,20 +120,24 @@ public:
         return *ptr(__n);
     }
 
-    inline difference_type operator-(const DPNP_USM_iterator& __rhs) const
+    inline difference_type operator-(const DPNP_USM_iterator &__rhs) const
     {
-        difference_type diff = difference_type(iter_id) - difference_type(__rhs.iter_id);
+        difference_type diff =
+            difference_type(iter_id) - difference_type(__rhs.iter_id);
 
         return diff;
     }
 
     /// Print this container in human readable form in error reporting
-    friend std::ostream& operator<<(std::ostream& __out, const DPNP_USM_iterator& __it)
+    friend std::ostream &operator<<(std::ostream &__out,
+                                    const DPNP_USM_iterator &__it)
     {
         const std::vector<size_type> it_strides(__it.iteration_shape_strides,
-                                                __it.iteration_shape_strides + __it.iteration_shape_size);
-        const std::vector<size_type> it_axes_strides(__it.axes_shape_strides,
-                                                     __it.axes_shape_strides + __it.iteration_shape_size);
+                                                __it.iteration_shape_strides +
+                                                    __it.iteration_shape_size);
+        const std::vector<size_type> it_axes_strides(
+            __it.axes_shape_strides,
+            __it.axes_shape_strides + __it.iteration_shape_size);
 
         __out << "DPNP_USM_iterator(base=" << __it.base;
         __out << ", iter_id=" << __it.iter_id;
@@ -156,20 +159,18 @@ private:
     {
         size_type offset = 0;
 
-        if (iteration_shape_size > 0)
-        {
+        if (iteration_shape_size > 0) {
             long reminder = iteration_id;
-            for (size_t it = 0; it < static_cast<size_t>(iteration_shape_size); ++it)
-            {
+            for (size_t it = 0; it < static_cast<size_t>(iteration_shape_size);
+                 ++it) {
                 const size_type axis_val = iteration_shape_strides[it];
-                size_type xyz_id = reminder / axis_val;
+                size_type xyz_id         = reminder / axis_val;
                 offset += (xyz_id * axes_shape_strides[it]);
 
                 reminder = reminder % axis_val;
             }
         }
-        else
-        {
+        else {
             offset = iteration_id;
         }
 
@@ -177,18 +178,21 @@ private:
     }
 
     const pointer base = nullptr;
-    size_type iter_id = size_type{};                    /**< Iterator logical ID over iteration shape */
-    const size_type iteration_shape_size = size_type{}; /**< Number of elements in @ref iteration_shape_strides array */
-    const size_type* iteration_shape_strides = nullptr;
-    const size_type* axes_shape_strides = nullptr;
+    size_type iter_id =
+        size_type{}; /**< Iterator logical ID over iteration shape */
+    const size_type iteration_shape_size =
+        size_type{}; /**< Number of elements in @ref iteration_shape_strides
+                        array */
+    const size_type *iteration_shape_strides = nullptr;
+    const size_type *axes_shape_strides      = nullptr;
 };
 
 /**
  * @ingroup BACKEND_UTILS
  * @brief Type to keep USM array pointers used in kernels
  *
- * This type should be used in host part of the code to provide pre-calculated data. The @ref DPNP_USM_iterator
- * will be used later in SYCL environment
+ * This type should be used in host part of the code to provide pre-calculated
+ * data. The @ref DPNP_USM_iterator will be used later in SYCL environment
  *
  */
 template <typename _Tp>
@@ -196,12 +200,15 @@ class DPNPC_id final
 {
 public:
     using value_type = _Tp;
-    using iterator = DPNP_USM_iterator<value_type>;
-    using pointer = value_type*;
-    using reference = value_type&;
-    using size_type = shape_elem_type;
+    using iterator   = DPNP_USM_iterator<value_type>;
+    using pointer    = value_type *;
+    using reference  = value_type &;
+    using size_type  = shape_elem_type;
 
-    DPNPC_id(DPCTLSyclQueueRef q_ref, pointer __ptr, const size_type* __shape, const size_type __shape_size)
+    DPNPC_id(DPCTLSyclQueueRef q_ref,
+             pointer __ptr,
+             const size_type *__shape,
+             const size_type __shape_size)
     {
         queue_ref = q_ref;
         std::vector<size_type> shape(__shape, __shape + __shape_size);
@@ -210,8 +217,8 @@ public:
 
     DPNPC_id(DPCTLSyclQueueRef q_ref,
              pointer __ptr,
-             const size_type* __shape,
-             const size_type* __strides,
+             const size_type *__shape,
+             const size_type *__strides,
              const size_type __ndim)
     {
         queue_ref = q_ref;
@@ -232,9 +239,12 @@ public:
      * @param [in]  q_ref    Reference to SYCL queue.
      * @param [in]  __ptr    Pointer to input data. Used to get values only.
      * @param [in]  __shape  Shape of data provided by @ref __ptr.
-     *                       Empty container means scalar value pointed by @ref __ptr.
+     *                       Empty container means scalar value pointed by @ref
+     * __ptr.
      */
-    DPNPC_id(DPCTLSyclQueueRef q_ref, pointer __ptr, const std::vector<size_type>& __shape)
+    DPNPC_id(DPCTLSyclQueueRef q_ref,
+             pointer __ptr,
+             const std::vector<size_type> &__shape)
     {
         queue_ref = q_ref;
         init_container(__ptr, __shape);
@@ -244,16 +254,20 @@ public:
      * @ingroup BACKEND_UTILS
      * @brief Main container for reduction/broadcasting iterator
      *
-     * Construct object to hold @ref __ptr data with shape @ref __shape and strides @ref __strides.
+     * Construct object to hold @ref __ptr data with shape @ref __shape and
+     * strides @ref __strides.
      *
      * @note this function is designed for non-SYCL environment execution
      *
      * @param [in]  __ptr      Pointer to input data. Used to get values only.
      * @param [in]  __shape    Shape of data provided by @ref __ptr.
-     *                         Empty container means scalar value pointed by @ref __ptr.
+     *                         Empty container means scalar value pointed by
+     * @ref __ptr.
      * @param [in]  __strides  Strides of data provided by @ref __ptr.
      */
-    DPNPC_id(pointer __ptr, const std::vector<size_type>& __shape, const std::vector<size_type>& __strides)
+    DPNPC_id(pointer __ptr,
+             const std::vector<size_type> &__shape,
+             const std::vector<size_type> &__strides)
     {
         init_container(__ptr, __shape, __strides);
     }
@@ -271,7 +285,8 @@ public:
         return output_size;
     }
 
-    inline void broadcast_to_shape(const size_type* __shape, const size_type __shape_size)
+    inline void broadcast_to_shape(const size_type *__shape,
+                                   const size_type __shape_size)
     {
         std::vector<size_type> shape(__shape, __shape + __shape_size);
         broadcast_to_shape(shape);
@@ -287,15 +302,13 @@ public:
      *
      * @param [in]  __shape       Output shape.
      */
-    inline void broadcast_to_shape(const std::vector<size_type>& __shape)
+    inline void broadcast_to_shape(const std::vector<size_type> &__shape)
     {
-        if (axis_use)
-        {
+        if (axis_use) {
             return;
         }
 
-        if (broadcastable(input_shape, input_shape_size, __shape))
-        {
+        if (broadcastable(input_shape, input_shape_size, __shape)) {
             free_broadcast_axes_memory();
             free_output_memory();
 
@@ -303,32 +316,38 @@ public:
             broadcast_use = true;
 
             output_shape_size = __shape.size();
-            const size_type output_shape_size_in_bytes = output_shape_size * sizeof(size_type);
-            output_shape = reinterpret_cast<size_type*>(dpnp_memory_alloc_c(queue_ref, output_shape_size_in_bytes));
+            const size_type output_shape_size_in_bytes =
+                output_shape_size * sizeof(size_type);
+            output_shape = reinterpret_cast<size_type *>(
+                dpnp_memory_alloc_c(queue_ref, output_shape_size_in_bytes));
 
-            for (int irit = input_shape_size - 1, orit = output_shape_size - 1; orit >= 0; --irit, --orit)
+            for (int irit = input_shape_size - 1, orit = output_shape_size - 1;
+                 orit >= 0; --irit, --orit)
             {
                 output_shape[orit] = __shape[orit];
 
-                // ex: input_shape = {7, 1, 5}, output_shape = {8, 7, 6, 5} => valid_axes = {0, 2}
-                if (irit < 0 || input_shape[irit] != output_shape[orit])
-                {
+                // ex: input_shape = {7, 1, 5}, output_shape = {8, 7, 6, 5} =>
+                // valid_axes = {0, 2}
+                if (irit < 0 || input_shape[irit] != output_shape[orit]) {
                     valid_axes.insert(valid_axes.begin(), orit);
                 }
             }
 
             broadcast_axes_size = valid_axes.size();
-            const size_type broadcast_axes_size_in_bytes = broadcast_axes_size * sizeof(size_type);
-            broadcast_axes = reinterpret_cast<size_type*>(dpnp_memory_alloc_c(queue_ref,
-                                                                              broadcast_axes_size_in_bytes));
+            const size_type broadcast_axes_size_in_bytes =
+                broadcast_axes_size * sizeof(size_type);
+            broadcast_axes = reinterpret_cast<size_type *>(
+                dpnp_memory_alloc_c(queue_ref, broadcast_axes_size_in_bytes));
             std::copy(valid_axes.begin(), valid_axes.end(), broadcast_axes);
 
-            output_size = std::accumulate(
-                output_shape, output_shape + output_shape_size, size_type(1), std::multiplies<size_type>());
+            output_size =
+                std::accumulate(output_shape, output_shape + output_shape_size,
+                                size_type(1), std::multiplies<size_type>());
 
-            output_shape_strides = reinterpret_cast<size_type*>(dpnp_memory_alloc_c(queue_ref,
-                                                                                    output_shape_size_in_bytes));
-            get_shape_offsets_inkernel<size_type>(output_shape, output_shape_size, output_shape_strides);
+            output_shape_strides = reinterpret_cast<size_type *>(
+                dpnp_memory_alloc_c(queue_ref, output_shape_size_in_bytes));
+            get_shape_offsets_inkernel<size_type>(
+                output_shape, output_shape_size, output_shape_strides);
 
             iteration_size = 1;
         }
@@ -356,7 +375,7 @@ public:
         set_axes({__axis});
     }
 
-    inline void set_axes(const shape_elem_type* __axes, const size_t axes_ndim)
+    inline void set_axes(const shape_elem_type *__axes, const size_t axes_ndim)
     {
         const std::vector<shape_elem_type> axes_vec(__axes, __axes + axes_ndim);
         set_axes(axes_vec);
@@ -379,65 +398,66 @@ public:
      *
      * @param [in]  __axes       Vector of axes of a shape of input array.
      */
-    inline void set_axes(const std::vector<shape_elem_type>& __axes)
+    inline void set_axes(const std::vector<shape_elem_type> &__axes)
     {
-        if (broadcast_use)
-        {
+        if (broadcast_use) {
             return;
         }
 
-        if (!__axes.empty() && input_shape_size)
-        {
+        if (!__axes.empty() && input_shape_size) {
             free_axes_memory();
             free_iteration_memory();
             free_output_memory();
 
-            axes = get_validated_axes(__axes, input_shape_size);
+            axes     = get_validated_axes(__axes, input_shape_size);
             axis_use = true;
 
             output_shape_size = input_shape_size - axes.size();
-            const size_type output_shape_size_in_bytes = output_shape_size * sizeof(size_type);
+            const size_type output_shape_size_in_bytes =
+                output_shape_size * sizeof(size_type);
 
             iteration_shape_size = axes.size();
-            const size_type iteration_shape_size_in_bytes = iteration_shape_size * sizeof(size_type);
+            const size_type iteration_shape_size_in_bytes =
+                iteration_shape_size * sizeof(size_type);
             std::vector<size_type> iteration_shape;
 
-            output_shape = reinterpret_cast<size_type*>(dpnp_memory_alloc_c(queue_ref, output_shape_size_in_bytes));
-            size_type* output_shape_it = output_shape;
-            for (size_type i = 0; i < input_shape_size; ++i)
-            {
-                if (std::find(axes.begin(), axes.end(), i) == axes.end())
-                {
+            output_shape = reinterpret_cast<size_type *>(
+                dpnp_memory_alloc_c(queue_ref, output_shape_size_in_bytes));
+            size_type *output_shape_it = output_shape;
+            for (size_type i = 0; i < input_shape_size; ++i) {
+                if (std::find(axes.begin(), axes.end(), i) == axes.end()) {
                     *output_shape_it = input_shape[i];
                     ++output_shape_it;
                 }
             }
 
-            output_size = std::accumulate(
-                output_shape, output_shape + output_shape_size, size_type(1), std::multiplies<size_type>());
+            output_size =
+                std::accumulate(output_shape, output_shape + output_shape_size,
+                                size_type(1), std::multiplies<size_type>());
 
-            output_shape_strides = reinterpret_cast<size_type*>(dpnp_memory_alloc_c(queue_ref,
-                                                                                    output_shape_size_in_bytes));
-            get_shape_offsets_inkernel<size_type>(output_shape, output_shape_size, output_shape_strides);
+            output_shape_strides = reinterpret_cast<size_type *>(
+                dpnp_memory_alloc_c(queue_ref, output_shape_size_in_bytes));
+            get_shape_offsets_inkernel<size_type>(
+                output_shape, output_shape_size, output_shape_strides);
 
             iteration_size = 1;
             iteration_shape.reserve(iteration_shape_size);
-            for (const auto& axis : axes)
-            {
+            for (const auto &axis : axes) {
                 const size_type axis_dim = input_shape[axis];
                 iteration_shape.push_back(axis_dim);
                 iteration_size *= axis_dim;
             }
 
-            iteration_shape_strides = reinterpret_cast<size_type*>(dpnp_memory_alloc_c(queue_ref,
-                                                                                       iteration_shape_size_in_bytes));
-            get_shape_offsets_inkernel<size_type>(
-                iteration_shape.data(), iteration_shape.size(), iteration_shape_strides);
+            iteration_shape_strides = reinterpret_cast<size_type *>(
+                dpnp_memory_alloc_c(queue_ref, iteration_shape_size_in_bytes));
+            get_shape_offsets_inkernel<size_type>(iteration_shape.data(),
+                                                  iteration_shape.size(),
+                                                  iteration_shape_strides);
 
-            axes_shape_strides = reinterpret_cast<size_type*>(dpnp_memory_alloc_c(queue_ref,
-                                                                                  iteration_shape_size_in_bytes));
-            for (size_t i = 0; i < static_cast<size_t>(iteration_shape_size); ++i)
-            {
+            axes_shape_strides = reinterpret_cast<size_type *>(
+                dpnp_memory_alloc_c(queue_ref, iteration_shape_size_in_bytes));
+            for (size_t i = 0; i < static_cast<size_t>(iteration_shape_size);
+                 ++i) {
                 axes_shape_strides[i] = input_shape_strides[axes[i]];
             }
         }
@@ -446,10 +466,8 @@ public:
     /// this function is designed for SYCL environment execution
     inline iterator begin(size_type output_global_id = 0) const
     {
-        return iterator(data + get_input_begin_offset(output_global_id),
-                        0,
-                        iteration_shape_strides,
-                        axes_shape_strides,
+        return iterator(data + get_input_begin_offset(output_global_id), 0,
+                        iteration_shape_strides, axes_shape_strides,
                         iteration_shape_size);
     }
 
@@ -459,17 +477,14 @@ public:
         // TODO it is better to get begin() iterator as a parameter
 
         return iterator(data + get_input_begin_offset(output_global_id),
-                        get_iteration_size(),
-                        iteration_shape_strides,
-                        axes_shape_strides,
-                        iteration_shape_size);
+                        get_iteration_size(), iteration_shape_strides,
+                        axes_shape_strides, iteration_shape_size);
     }
 
     /// this function is designed for SYCL environment execution
     inline reference operator[](size_type __n) const
     {
-        if (broadcast_use)
-        {
+        if (broadcast_use) {
             return *begin(__n);
         }
 
@@ -478,73 +493,80 @@ public:
     }
 
 private:
-    void init_container(pointer __ptr, const std::vector<size_type>& __shape)
+    void init_container(pointer __ptr, const std::vector<size_type> &__shape)
     {
         // TODO needs to address negative values in __shape with exception
-        if ((__ptr == nullptr) && __shape.empty())
-        {
+        if ((__ptr == nullptr) && __shape.empty()) {
             return;
         }
 
-        if (__ptr != nullptr)
-        {
-            data = __ptr;
-            input_size = 1;  // means scalar at this stage
-            output_size = 1; // if input size is not zero it means we have scalar as output
+        if (__ptr != nullptr) {
+            data        = __ptr;
+            input_size  = 1; // means scalar at this stage
+            output_size = 1; // if input size is not zero it means we have
+                             // scalar as output
             iteration_size = 1;
         }
 
-        if (!__shape.empty())
-        {
-            input_size = std::accumulate(__shape.begin(), __shape.end(), size_type(1), std::multiplies<size_type>());
+        if (!__shape.empty()) {
+            input_size =
+                std::accumulate(__shape.begin(), __shape.end(), size_type(1),
+                                std::multiplies<size_type>());
             if (input_size == 0)
-            {                    // shape might be shape[3, 4, 0, 6]. This means no input memory and no output expected
+            { // shape might be shape[3, 4, 0, 6]. This means no input memory
+              // and no output expected
                 output_size = 0; // depends on axes. zero at this stage only
             }
 
             input_shape_size = __shape.size();
-            input_shape = reinterpret_cast<size_type*>(dpnp_memory_alloc_c(queue_ref,
-                                                                           input_shape_size * sizeof(size_type)));
+            input_shape = reinterpret_cast<size_type *>(dpnp_memory_alloc_c(
+                queue_ref, input_shape_size * sizeof(size_type)));
             std::copy(__shape.begin(), __shape.end(), input_shape);
 
             input_shape_strides =
-                reinterpret_cast<size_type*>(dpnp_memory_alloc_c(queue_ref, input_shape_size * sizeof(size_type)));
-            get_shape_offsets_inkernel<size_type>(input_shape, input_shape_size, input_shape_strides);
+                reinterpret_cast<size_type *>(dpnp_memory_alloc_c(
+                    queue_ref, input_shape_size * sizeof(size_type)));
+            get_shape_offsets_inkernel<size_type>(input_shape, input_shape_size,
+                                                  input_shape_strides);
         }
         iteration_size = input_size;
     }
 
-    void init_container(pointer __ptr, const std::vector<size_type>& __shape, const std::vector<size_type>& __strides)
+    void init_container(pointer __ptr,
+                        const std::vector<size_type> &__shape,
+                        const std::vector<size_type> &__strides)
     {
         // TODO needs to address negative values in __shape with exception
-        if ((__ptr == nullptr) && __shape.empty())
-        {
+        if ((__ptr == nullptr) && __shape.empty()) {
             return;
         }
 
-        if (__ptr != nullptr)
-        {
-            data = __ptr;
-            input_size = 1;  // means scalar at this stage
-            output_size = 1; // if input size is not zero it means we have scalar as output
+        if (__ptr != nullptr) {
+            data        = __ptr;
+            input_size  = 1; // means scalar at this stage
+            output_size = 1; // if input size is not zero it means we have
+                             // scalar as output
             iteration_size = 1;
         }
 
-        if (!__shape.empty())
-        {
-            input_size = std::accumulate(__shape.begin(), __shape.end(), size_type(1), std::multiplies<size_type>());
+        if (!__shape.empty()) {
+            input_size =
+                std::accumulate(__shape.begin(), __shape.end(), size_type(1),
+                                std::multiplies<size_type>());
             if (input_size == 0)
-            {                    // shape might be shape[3, 4, 0, 6]. This means no input memory and no output expected
+            { // shape might be shape[3, 4, 0, 6]. This means no input memory
+              // and no output expected
                 output_size = 0; // depends on axes. zero at this stage only
             }
 
             input_shape_size = __shape.size();
-            input_shape = reinterpret_cast<size_type*>(dpnp_memory_alloc_c(queue_ref,
-                                                                           input_shape_size * sizeof(size_type)));
+            input_shape = reinterpret_cast<size_type *>(dpnp_memory_alloc_c(
+                queue_ref, input_shape_size * sizeof(size_type)));
             std::copy(__shape.begin(), __shape.end(), input_shape);
 
             input_shape_strides =
-                reinterpret_cast<size_type*>(dpnp_memory_alloc_c(queue_ref, input_shape_size * sizeof(size_type)));
+                reinterpret_cast<size_type *>(dpnp_memory_alloc_c(
+                    queue_ref, input_shape_size * sizeof(size_type)));
             std::copy(__strides.begin(), __strides.end(), input_shape_strides);
         }
         iteration_size = input_size;
@@ -554,34 +576,38 @@ private:
     size_type get_input_begin_offset(size_type output_global_id) const
     {
         size_type input_global_id = 0;
-        if (axis_use)
-        {
+        if (axis_use) {
             assert(output_global_id < output_size);
 
-            for (size_t iit = 0, oit = 0; iit < static_cast<size_t>(input_shape_size); ++iit)
+            for (size_t iit = 0, oit = 0;
+                 iit < static_cast<size_t>(input_shape_size); ++iit)
             {
-                if (std::find(axes.begin(), axes.end(), iit) == axes.end())
-                {
-                    const size_type output_xyz_id =
-                        get_xyz_id_by_id_inkernel(output_global_id, output_shape_strides, output_shape_size, oit);
-                    input_global_id += (output_xyz_id * input_shape_strides[iit]);
+                if (std::find(axes.begin(), axes.end(), iit) == axes.end()) {
+                    const size_type output_xyz_id = get_xyz_id_by_id_inkernel(
+                        output_global_id, output_shape_strides,
+                        output_shape_size, oit);
+                    input_global_id +=
+                        (output_xyz_id * input_shape_strides[iit]);
                     ++oit;
                 }
             }
         }
-        else if (broadcast_use)
-        {
+        else if (broadcast_use) {
             assert(output_global_id < output_size);
             assert(input_shape_size <= output_shape_size);
 
-            for (int irit = input_shape_size - 1, orit = output_shape_size - 1; irit >= 0; --irit, --orit)
+            for (int irit = input_shape_size - 1, orit = output_shape_size - 1;
+                 irit >= 0; --irit, --orit)
             {
-                size_type* broadcast_axes_end = broadcast_axes + broadcast_axes_size;
-                if (std::find(broadcast_axes, broadcast_axes_end, orit) == broadcast_axes_end)
-                {
-                    const size_type output_xyz_id =
-                        get_xyz_id_by_id_inkernel(output_global_id, output_shape_strides, output_shape_size, orit);
-                    input_global_id += (output_xyz_id * input_shape_strides[irit]);
+                size_type *broadcast_axes_end =
+                    broadcast_axes + broadcast_axes_size;
+                if (std::find(broadcast_axes, broadcast_axes_end, orit) ==
+                    broadcast_axes_end) {
+                    const size_type output_xyz_id = get_xyz_id_by_id_inkernel(
+                        output_global_id, output_shape_strides,
+                        output_shape_size, orit);
+                    input_global_id +=
+                        (output_xyz_id * input_shape_strides[irit]);
                 }
             }
         }
@@ -611,17 +637,17 @@ private:
 
     void free_input_memory()
     {
-        input_size = size_type{};
+        input_size       = size_type{};
         input_shape_size = size_type{};
         dpnp_memory_free_c(queue_ref, input_shape);
         dpnp_memory_free_c(queue_ref, input_shape_strides);
-        input_shape = nullptr;
+        input_shape         = nullptr;
         input_shape_strides = nullptr;
     }
 
     void free_iteration_memory()
     {
-        iteration_size = size_type{};
+        iteration_size       = size_type{};
         iteration_shape_size = size_type{};
         dpnp_memory_free_c(queue_ref, iteration_shape_strides);
         iteration_shape_strides = nullptr;
@@ -629,11 +655,11 @@ private:
 
     void free_output_memory()
     {
-        output_size = size_type{};
+        output_size       = size_type{};
         output_shape_size = size_type{};
         dpnp_memory_free_c(queue_ref, output_shape);
         dpnp_memory_free_c(queue_ref, output_shape_strides);
-        output_shape = nullptr;
+        output_shape         = nullptr;
         output_shape_strides = nullptr;
     }
 
@@ -646,30 +672,35 @@ private:
         free_output_memory();
     }
 
-    DPCTLSyclQueueRef queue_ref = nullptr;    /**< reference to SYCL queue */
+    DPCTLSyclQueueRef queue_ref = nullptr; /**< reference to SYCL queue */
 
-    pointer data = nullptr;                   /**< input array begin pointer */
-    size_type input_size = size_type{};       /**< input array size */
-    size_type* input_shape = nullptr;         /**< input array shape */
+    pointer data               = nullptr;     /**< input array begin pointer */
+    size_type input_size       = size_type{}; /**< input array size */
+    size_type *input_shape     = nullptr;     /**< input array shape */
     size_type input_shape_size = size_type{}; /**< input array shape size */
-    size_type* input_shape_strides = nullptr; /**< input array shape strides (same size as input_shape) */
+    size_type *input_shape_strides =
+        nullptr; /**< input array shape strides (same size as input_shape) */
 
     std::vector<size_type> axes; /**< input shape reduction axes */
     bool axis_use = false;
 
-    size_type* broadcast_axes = nullptr;         /**< input shape broadcast axes */
-    size_type broadcast_axes_size = size_type{}; /**< input shape broadcast axes size */
+    size_type *broadcast_axes = nullptr; /**< input shape broadcast axes */
+    size_type broadcast_axes_size =
+        size_type{}; /**< input shape broadcast axes size */
     bool broadcast_use = false;
 
-    size_type output_size = size_type{};       /**< output array size. Expected is same as GWS */
-    size_type* output_shape = nullptr;         /**< output array shape */
+    size_type output_size =
+        size_type{}; /**< output array size. Expected is same as GWS */
+    size_type *output_shape     = nullptr;     /**< output array shape */
     size_type output_shape_size = size_type{}; /**< output array shape size */
-    size_type* output_shape_strides = nullptr; /**< output array shape strides (same size as output_shape) */
+    size_type *output_shape_strides =
+        nullptr; /**< output array shape strides (same size as output_shape) */
 
-    size_type iteration_size = size_type{}; /**< iteration array size in elements */
-    size_type iteration_shape_size = size_type{};
-    size_type* iteration_shape_strides = nullptr;
-    size_type* axes_shape_strides = nullptr;
+    size_type iteration_size =
+        size_type{}; /**< iteration array size in elements */
+    size_type iteration_shape_size     = size_type{};
+    size_type *iteration_shape_strides = nullptr;
+    size_type *axes_shape_strides      = nullptr;
 };
 
 #endif // DPNP_ITERATOR_H

--- a/dpnp/backend/src/dpnp_random_state.cpp
+++ b/dpnp/backend/src/dpnp_random_state.cpp
@@ -32,7 +32,7 @@ void MT19937_InitScalarSeed(mt19937_struct *mt19937,
                             DPCTLSyclQueueRef q_ref,
                             uint32_t seed)
 {
-    sycl::queue *q  = reinterpret_cast<sycl::queue *>(q_ref);
+    sycl::queue *q = reinterpret_cast<sycl::queue *>(q_ref);
     mt19937->engine = new mkl_rng::mt19937(*q, seed);
 }
 
@@ -62,7 +62,7 @@ void MT19937_InitVectorSeed(mt19937_struct *mt19937,
 void MT19937_Delete(mt19937_struct *mt19937)
 {
     mkl_rng::mt19937 *engine = static_cast<mkl_rng::mt19937 *>(mt19937->engine);
-    mt19937->engine          = nullptr;
+    mt19937->engine = nullptr;
     delete engine;
 }
 
@@ -71,12 +71,12 @@ void MCG59_InitScalarSeed(mcg59_struct *mcg59,
                           uint64_t seed)
 {
     sycl::queue *q = reinterpret_cast<sycl::queue *>(q_ref);
-    mcg59->engine  = new mkl_rng::mcg59(*q, seed);
+    mcg59->engine = new mkl_rng::mcg59(*q, seed);
 }
 
 void MCG59_Delete(mcg59_struct *mcg59)
 {
     mkl_rng::mcg59 *engine = static_cast<mkl_rng::mcg59 *>(mcg59->engine);
-    mcg59->engine          = nullptr;
+    mcg59->engine = nullptr;
     delete engine;
 }

--- a/dpnp/backend/src/dpnp_random_state.cpp
+++ b/dpnp/backend/src/dpnp_random_state.cpp
@@ -28,40 +28,55 @@
 
 namespace mkl_rng = oneapi::mkl::rng;
 
-void MT19937_InitScalarSeed(mt19937_struct *mt19937, DPCTLSyclQueueRef q_ref, uint32_t seed)
+void MT19937_InitScalarSeed(mt19937_struct *mt19937,
+                            DPCTLSyclQueueRef q_ref,
+                            uint32_t seed)
 {
-    sycl::queue *q = reinterpret_cast<sycl::queue *>(q_ref);
+    sycl::queue *q  = reinterpret_cast<sycl::queue *>(q_ref);
     mt19937->engine = new mkl_rng::mt19937(*q, seed);
 }
 
-void MT19937_InitVectorSeed(mt19937_struct *mt19937, DPCTLSyclQueueRef q_ref, uint32_t *seed, unsigned int n) {
+void MT19937_InitVectorSeed(mt19937_struct *mt19937,
+                            DPCTLSyclQueueRef q_ref,
+                            uint32_t *seed,
+                            unsigned int n)
+{
     sycl::queue *q = reinterpret_cast<sycl::queue *>(q_ref);
 
     switch (n) {
-        case 1: mt19937->engine = new mkl_rng::mt19937(*q, {seed[0]}); break;
-        case 2: mt19937->engine = new mkl_rng::mt19937(*q, {seed[0], seed[1]}); break;
-        case 3: mt19937->engine = new mkl_rng::mt19937(*q, {seed[0], seed[1], seed[2]}); break;
-        default:
+    case 1:
+        mt19937->engine = new mkl_rng::mt19937(*q, {seed[0]});
+        break;
+    case 2:
+        mt19937->engine = new mkl_rng::mt19937(*q, {seed[0], seed[1]});
+        break;
+    case 3:
+        mt19937->engine = new mkl_rng::mt19937(*q, {seed[0], seed[1], seed[2]});
+        break;
+    default:
         // TODO need to get rid of the limitation for seed vector length
         throw std::runtime_error("Too long seed vector");
     }
 }
 
-void MT19937_Delete(mt19937_struct *mt19937) {
+void MT19937_Delete(mt19937_struct *mt19937)
+{
     mkl_rng::mt19937 *engine = static_cast<mkl_rng::mt19937 *>(mt19937->engine);
-    mt19937->engine = nullptr;
+    mt19937->engine          = nullptr;
     delete engine;
 }
 
-void MCG59_InitScalarSeed(mcg59_struct* mcg59, DPCTLSyclQueueRef q_ref, uint64_t seed)
+void MCG59_InitScalarSeed(mcg59_struct *mcg59,
+                          DPCTLSyclQueueRef q_ref,
+                          uint64_t seed)
 {
-    sycl::queue* q = reinterpret_cast<sycl::queue*>(q_ref);
-    mcg59->engine = new mkl_rng::mcg59(*q, seed);
+    sycl::queue *q = reinterpret_cast<sycl::queue *>(q_ref);
+    mcg59->engine  = new mkl_rng::mcg59(*q, seed);
 }
 
-void MCG59_Delete(mcg59_struct* mcg59)
+void MCG59_Delete(mcg59_struct *mcg59)
 {
-    mkl_rng::mcg59* engine = static_cast<mkl_rng::mcg59*>(mcg59->engine);
-    mcg59->engine = nullptr;
+    mkl_rng::mcg59 *engine = static_cast<mkl_rng::mcg59 *>(mcg59->engine);
+    mcg59->engine          = nullptr;
     delete engine;
 }

--- a/dpnp/backend/src/dpnp_random_state.hpp
+++ b/dpnp/backend/src/dpnp_random_state.hpp
@@ -25,11 +25,12 @@
 
 /*
  * This header file is for interface Cython with C++.
- * It should not contains any backend specific headers (like SYCL or math library) because
- * all included headers will be exposed in Cython compilation procedure
+ * It should not contains any backend specific headers (like SYCL or math
+ * library) because all included headers will be exposed in Cython compilation
+ * procedure
  *
- * We would like to avoid backend specific things in higher level Cython modules.
- * Any backend interface functions and types should be defined here.
+ * We would like to avoid backend specific things in higher level Cython
+ * modules. Any backend interface functions and types should be defined here.
  *
  * Also, this file should contains documentation on functions and types
  * which are used in the interface
@@ -50,7 +51,7 @@
 // Structure storing a base MKL engine
 struct engine_struct
 {
-    void* engine;
+    void *engine;
 };
 
 // Structure storing MKL engine for MT199374x32x10 generator
@@ -67,26 +68,38 @@ struct mcg59_struct : engine_struct
  * @ingroup BACKEND_API
  * @brief Create a MKL engine from scalar seed.
  *
- * Invoke a common seed initialization of the engine for MT199374x32x10 algorithm.
+ * Invoke a common seed initialization of the engine for MT199374x32x10
+ * algorithm.
  *
- * @param [in]  mt19937       A structure with MKL engine which will be filled with generated value by MKL.
- * @param [in]  q_ref         A refference on SYCL queue which will be used to obtain random numbers.
+ * @param [in]  mt19937       A structure with MKL engine which will be filled
+ *                            with generated value by MKL.
+ * @param [in]  q_ref         A refference on SYCL queue which will be used to
+ *                            obtain random numbers.
  * @param [in]  seed          An initial condition of the generator state.
  */
-INP_DLLEXPORT void MT19937_InitScalarSeed(mt19937_struct *mt19937, DPCTLSyclQueueRef q_ref, uint32_t seed = 1);
+INP_DLLEXPORT void MT19937_InitScalarSeed(mt19937_struct *mt19937,
+                                          DPCTLSyclQueueRef q_ref,
+                                          uint32_t seed = 1);
 
 /**
  * @ingroup BACKEND_API
  * @brief Create a MKL engine from seed vector.
  *
- * Invoke an extended seed initialization of the engine for MT199374x32x10 algorithm..
+ * Invoke an extended seed initialization of the engine for MT199374x32x10
+ * algorithm..
  *
- * @param [in]  mt19937       A structure with MKL engine which will be filled with generated value by MKL.
- * @param [in]  q_ref         A refference on SYCL queue which will be used to obtain random numbers.
- * @param [in]  seed          A vector with the initial conditions of the generator state.
+ * @param [in]  mt19937       A structure with MKL engine which will be filled
+ *                            with generated value by MKL.
+ * @param [in]  q_ref         A refference on SYCL queue which will be used to
+ *                            obtain random numbers.
+ * @param [in]  seed          A vector with the initial conditions of the
+ *                            generator state.
  * @param [in]  n             Length of the vector.
  */
-INP_DLLEXPORT void MT19937_InitVectorSeed(mt19937_struct *mt19937, DPCTLSyclQueueRef q_ref, uint32_t * seed, unsigned int n);
+INP_DLLEXPORT void MT19937_InitVectorSeed(mt19937_struct *mt19937,
+                                          DPCTLSyclQueueRef q_ref,
+                                          uint32_t *seed,
+                                          unsigned int n);
 
 /**
  * @ingroup BACKEND_API
@@ -104,11 +117,15 @@ INP_DLLEXPORT void MT19937_Delete(mt19937_struct *mt19937);
  *
  * Invoke a common seed initialization of the engine for MCG59 algorithm.
  *
- * @param [in]  mcg59         A structure with MKL engine which will be filled with generated value by MKL.
- * @param [in]  q_ref         A refference on SYCL queue which will be used to obtain random numbers.
+ * @param [in]  mcg59         A structure with MKL engine which will be filled
+ *                            with generated value by MKL.
+ * @param [in]  q_ref         A refference on SYCL queue which will be used to
+ *                            obtain random numbers.
  * @param [in]  seed          An initial condition of the generator state.
  */
-INP_DLLEXPORT void MCG59_InitScalarSeed(mcg59_struct* mcg59, DPCTLSyclQueueRef q_ref, uint64_t seed);
+INP_DLLEXPORT void MCG59_InitScalarSeed(mcg59_struct *mcg59,
+                                        DPCTLSyclQueueRef q_ref,
+                                        uint64_t seed);
 
 /**
  * @ingroup BACKEND_API
@@ -118,6 +135,6 @@ INP_DLLEXPORT void MCG59_InitScalarSeed(mcg59_struct* mcg59, DPCTLSyclQueueRef q
  *
  * @param [in]  mcg59         A structure with the MKL engine.
  */
-INP_DLLEXPORT void MCG59_Delete(mcg59_struct* mcg59);
+INP_DLLEXPORT void MCG59_Delete(mcg59_struct *mcg59);
 
 #endif // BACKEND_RANDOM_STATE_H

--- a/dpnp/backend/src/dpnp_utils.hpp
+++ b/dpnp/backend/src/dpnp_utils.hpp
@@ -95,7 +95,7 @@ void get_shape_offsets_inkernel(const _DataType *shape,
 {
     size_t dim_prod_input = 1;
     for (size_t i = 0; i < shape_size; ++i) {
-        long i_reverse     = shape_size - 1 - i;
+        long i_reverse = shape_size - 1 - i;
         offsets[i_reverse] = dim_prod_input;
         dim_prod_input *= shape[i_reverse];
     }
@@ -127,9 +127,9 @@ void get_xyz_by_id(size_t idx,
     size_t remainder = idx;
 
     for (size_t i = 0; i < ndim; ++i) {
-        quotient  = remainder / offsets[i];
+        quotient = remainder / offsets[i];
         remainder = remainder - quotient * offsets[i];
-        xyz[i]    = quotient;
+        xyz[i] = quotient;
     }
     return;
 }
@@ -162,11 +162,11 @@ _DataType get_xyz_id_by_id_inkernel(size_t global_id,
     assert(axis < offsets_size);
 
     _DataType xyz_id = 0;
-    long reminder    = global_id;
+    long reminder = global_id;
     for (size_t i = 0; i < axis + 1; ++i) {
         const _DataType axis_val = offsets[i];
-        xyz_id                   = reminder / axis_val;
-        reminder                 = reminder % axis_val;
+        xyz_id = reminder / axis_val;
+        reminder = reminder % axis_val;
     }
 
     return xyz_id;

--- a/dpnp/backend/src/dpnp_utils.hpp
+++ b/dpnp/backend/src/dpnp_utils.hpp
@@ -36,13 +36,17 @@
 
 #include <dpnp_iface_fptr.hpp>
 
-#define LIBSYCL_VERSION_GREATER(major, minor, patch)                                                                   \
-    (__LIBSYCL_MAJOR_VERSION > major) || (__LIBSYCL_MAJOR_VERSION == major and __LIBSYCL_MINOR_VERSION > minor) ||     \
-        (__LIBSYCL_MAJOR_VERSION == major and __LIBSYCL_MINOR_VERSION == minor and __LIBSYCL_PATCH_VERSION >= patch)
+#define LIBSYCL_VERSION_GREATER(major, minor, patch)                           \
+    (__LIBSYCL_MAJOR_VERSION > major) ||                                       \
+        (__LIBSYCL_MAJOR_VERSION == major and                                  \
+         __LIBSYCL_MINOR_VERSION > minor) ||                                   \
+        (__LIBSYCL_MAJOR_VERSION == major and                                  \
+         __LIBSYCL_MINOR_VERSION == minor and                                  \
+         __LIBSYCL_PATCH_VERSION >= patch)
 
 /**
- * Version of SYCL DPC++ 2023 compiler where a return type of sycl::abs() is changed
- * from unsinged integer to signed one of input vector.
+ * Version of SYCL DPC++ 2023 compiler where a return type of sycl::abs() is
+ * changed from unsinged integer to signed one of input vector.
  */
 #ifndef __SYCL_COMPILER_VECTOR_ABS_CHANGED
 #define __SYCL_COMPILER_VECTOR_ABS_CHANGED 20230503L
@@ -85,12 +89,13 @@
  * @param [out] offsets     Result array with @ref shape_size size.
  */
 template <typename _DataType>
-void get_shape_offsets_inkernel(const _DataType* shape, size_t shape_size, _DataType* offsets)
+void get_shape_offsets_inkernel(const _DataType *shape,
+                                size_t shape_size,
+                                _DataType *offsets)
 {
     size_t dim_prod_input = 1;
-    for (size_t i = 0; i < shape_size; ++i)
-    {
-        long i_reverse = shape_size - 1 - i;
+    for (size_t i = 0; i < shape_size; ++i) {
+        long i_reverse     = shape_size - 1 - i;
         offsets[i_reverse] = dim_prod_input;
         dim_prod_input *= shape[i_reverse];
     }
@@ -113,16 +118,18 @@ void get_shape_offsets_inkernel(const _DataType* shape, size_t shape_size, _Data
  * @param [out] xyz     indeces.
  */
 template <typename _DataType>
-void get_xyz_by_id(size_t idx, size_t ndim, const _DataType* offsets, _DataType* xyz)
+void get_xyz_by_id(size_t idx,
+                   size_t ndim,
+                   const _DataType *offsets,
+                   _DataType *xyz)
 {
     size_t quotient;
     size_t remainder = idx;
 
-    for (size_t i = 0; i < ndim; ++i)
-    {
-        quotient = remainder / offsets[i];
+    for (size_t i = 0; i < ndim; ++i) {
+        quotient  = remainder / offsets[i];
         remainder = remainder - quotient * offsets[i];
-        xyz[i] = quotient;
+        xyz[i]    = quotient;
     }
     return;
 }
@@ -144,7 +151,10 @@ void get_xyz_by_id(size_t idx, size_t ndim, const _DataType* offsets, _DataType*
  * @param [in]  axis          axis.
  */
 template <typename _DataType>
-_DataType get_xyz_id_by_id_inkernel(size_t global_id, const _DataType* offsets, size_t offsets_size, size_t axis)
+_DataType get_xyz_id_by_id_inkernel(size_t global_id,
+                                    const _DataType *offsets,
+                                    size_t offsets_size,
+                                    size_t axis)
 {
     /* avoid warning unused variable*/
     (void)offsets_size;
@@ -152,12 +162,11 @@ _DataType get_xyz_id_by_id_inkernel(size_t global_id, const _DataType* offsets, 
     assert(axis < offsets_size);
 
     _DataType xyz_id = 0;
-    long reminder = global_id;
-    for (size_t i = 0; i < axis + 1; ++i)
-    {
+    long reminder    = global_id;
+    for (size_t i = 0; i < axis + 1; ++i) {
         const _DataType axis_val = offsets[i];
-        xyz_id = reminder / axis_val;
-        reminder = reminder % axis_val;
+        xyz_id                   = reminder / axis_val;
+        reminder                 = reminder % axis_val;
     }
 
     return xyz_id;
@@ -167,11 +176,9 @@ _DataType get_xyz_id_by_id_inkernel(size_t global_id, const _DataType* offsets, 
  * @ingroup BACKEND_UTILS
  * @brief Calculate linear index from ids array
  *
- * Calculates linear index from ids array by given offsets. This is reverse operation of @ref get_xyz_by_id_inkernel
- * for example:
- *   xyz array ids should be [0, 1, 0]
- *   input_array_shape_offsets[20, 5, 1]
- *   global_id == 5
+ * Calculates linear index from ids array by given offsets. This is reverse
+ * operation of @ref get_xyz_by_id_inkernel for example: xyz array ids should be
+ * [0, 1, 0] input_array_shape_offsets[20, 5, 1] global_id == 5
  *
  * @param [in] xyz       array with array indexes.
  * @param [in] xyz_size  array size for @ref xyz parameter.
@@ -179,13 +186,14 @@ _DataType get_xyz_id_by_id_inkernel(size_t global_id, const _DataType* offsets, 
  * @return               linear index id of the element in multy-D array.
  */
 template <typename _DataType>
-size_t get_id_by_xyz_inkernel(const _DataType* xyz, size_t xyz_size, const _DataType* offsets)
+size_t get_id_by_xyz_inkernel(const _DataType *xyz,
+                              size_t xyz_size,
+                              const _DataType *offsets)
 {
     size_t global_id = 0;
 
     /* calculate linear index based on reconstructed [x][y][z] */
-    for (size_t it = 0; it < xyz_size; ++it)
-    {
+    for (size_t it = 0; it < xyz_size; ++it) {
         global_id += (xyz[it] * offsets[it]);
     }
 
@@ -199,22 +207,23 @@ size_t get_id_by_xyz_inkernel(const _DataType* xyz, size_t xyz_size, const _Data
  * @param [in] input_shape        Input shape.
  * @param [in] output_shape       Output shape.
  *
- * @return                        Input shape is broadcastable to output one or not.
+ * @return                        Input shape is broadcastable to output one or
+ * not.
  */
-static inline bool broadcastable(const std::vector<shape_elem_type>& input_shape,
-                                 const std::vector<shape_elem_type>& output_shape)
+static inline bool
+    broadcastable(const std::vector<shape_elem_type> &input_shape,
+                  const std::vector<shape_elem_type> &output_shape)
 {
-    if (input_shape.size() > output_shape.size())
-    {
+    if (input_shape.size() > output_shape.size()) {
         return false;
     }
 
-    std::vector<shape_elem_type>::const_reverse_iterator irit = input_shape.rbegin();
-    std::vector<shape_elem_type>::const_reverse_iterator orit = output_shape.rbegin();
-    for (; irit != input_shape.rend(); ++irit, ++orit)
-    {
-        if (*irit != 1 && *irit != *orit)
-        {
+    std::vector<shape_elem_type>::const_reverse_iterator irit =
+        input_shape.rbegin();
+    std::vector<shape_elem_type>::const_reverse_iterator orit =
+        output_shape.rbegin();
+    for (; irit != input_shape.rend(); ++irit, ++orit) {
+        if (*irit != 1 && *irit != *orit) {
             return false;
         }
     }
@@ -222,11 +231,13 @@ static inline bool broadcastable(const std::vector<shape_elem_type>& input_shape
     return true;
 }
 
-static inline bool broadcastable(const shape_elem_type* input_shape,
-                                 const size_t input_shape_size,
-                                 const std::vector<shape_elem_type>& output_shape)
+static inline bool
+    broadcastable(const shape_elem_type *input_shape,
+                  const size_t input_shape_size,
+                  const std::vector<shape_elem_type> &output_shape)
 {
-    const std::vector<shape_elem_type> input_shape_vec(input_shape, input_shape + input_shape_size);
+    const std::vector<shape_elem_type> input_shape_vec(
+        input_shape, input_shape + input_shape_size);
     return broadcastable(input_shape_vec, output_shape);
 }
 
@@ -242,8 +253,10 @@ static inline bool broadcastable(const shape_elem_type* input_shape,
  * @return                   Arrays are equal.
  */
 template <typename _DataType>
-static inline bool
-    array_equal(const _DataType* input1, const size_t input1_size, const _DataType* input2, const size_t input2_size)
+static inline bool array_equal(const _DataType *input1,
+                               const size_t input1_size,
+                               const _DataType *input2,
+                               const size_t input2_size)
 {
     if (input1_size != input2_size)
         return false;
@@ -251,7 +264,8 @@ static inline bool
     const std::vector<_DataType> input1_vec(input1, input1 + input1_size);
     const std::vector<_DataType> input2_vec(input2, input2 + input2_size);
 
-    return std::equal(std::begin(input1_vec), std::end(input1_vec), std::begin(input2_vec));
+    return std::equal(std::begin(input1_vec), std::end(input1_vec),
+                      std::begin(input2_vec));
 }
 
 /**
@@ -264,22 +278,21 @@ static inline bool
  */
 namespace
 {
-    [[maybe_unused]]
-    std::vector<sycl::event> cast_event_vector(const DPCTLEventVectorRef event_vec_ref)
-    {
-        const size_t event_vec_size = DPCTLEventVector_Size(event_vec_ref);
+[[maybe_unused]] std::vector<sycl::event>
+    cast_event_vector(const DPCTLEventVectorRef event_vec_ref)
+{
+    const size_t event_vec_size = DPCTLEventVector_Size(event_vec_ref);
 
-        std::vector<sycl::event> event_vec;
-        event_vec.reserve(event_vec_size);
-        for (size_t i = 0; i < event_vec_size; ++i)
-        {
-            DPCTLSyclEventRef event_ref = DPCTLEventVector_GetAt(event_vec_ref, i);
-            sycl::event event = *(reinterpret_cast<sycl::event*>(event_ref));
-            event_vec.push_back(event);
-        }
-        return event_vec;
+    std::vector<sycl::event> event_vec;
+    event_vec.reserve(event_vec_size);
+    for (size_t i = 0; i < event_vec_size; ++i) {
+        DPCTLSyclEventRef event_ref = DPCTLEventVector_GetAt(event_vec_ref, i);
+        sycl::event event = *(reinterpret_cast<sycl::event *>(event_ref));
+        event_vec.push_back(event);
     }
+    return event_vec;
 }
+} // namespace
 
 /**
  * @ingroup BACKEND_UTILS
@@ -299,31 +312,33 @@ namespace
  * @return                         Common shape.
  */
 template <typename _DataType>
-static inline std::vector<_DataType> get_result_shape(const _DataType* input1_shape,
-                                                      const size_t input1_shape_size,
-                                                      const _DataType* input2_shape,
-                                                      const size_t input2_shape_size)
+static inline std::vector<_DataType>
+    get_result_shape(const _DataType *input1_shape,
+                     const size_t input1_shape_size,
+                     const _DataType *input2_shape,
+                     const size_t input2_shape_size)
 {
-    const size_t result_shape_size = (input2_shape_size > input1_shape_size) ? input2_shape_size : input1_shape_size;
+    const size_t result_shape_size = (input2_shape_size > input1_shape_size)
+                                         ? input2_shape_size
+                                         : input1_shape_size;
     std::vector<_DataType> result_shape;
     result_shape.reserve(result_shape_size);
 
-    for (int irit1 = input1_shape_size - 1, irit2 = input2_shape_size - 1; irit1 >= 0 || irit2 >= 0; --irit1, --irit2)
+    for (int irit1 = input1_shape_size - 1, irit2 = input2_shape_size - 1;
+         irit1 >= 0 || irit2 >= 0; --irit1, --irit2)
     {
         _DataType input1_val = (irit1 >= 0) ? input1_shape[irit1] : 1;
         _DataType input2_val = (irit2 >= 0) ? input2_shape[irit2] : 1;
 
-        if (input1_val == input2_val || input1_val == 1)
-        {
+        if (input1_val == input2_val || input1_val == 1) {
             result_shape.insert(result_shape.begin(), input2_val);
         }
-        else if (input2_val == 1)
-        {
+        else if (input2_val == 1) {
             result_shape.insert(result_shape.begin(), input1_val);
         }
-        else
-        {
-            throw std::domain_error("DPNP Error: get_common_shape() failed with input shapes check");
+        else {
+            throw std::domain_error("DPNP Error: get_common_shape() failed "
+                                    "with input shapes check");
         }
     }
 
@@ -339,49 +354,52 @@ static inline std::vector<_DataType> get_result_shape(const _DataType* input1_sh
  * By default, this forbids axes from being specified multiple times.
  *
  * @param [in] __axes             Array with positive or negative indexes.
- * @param [in] __shape_size       The number of dimensions of the array that @ref __axes should be normalized against.
- * @param [in] __allow_duplicate  Disallow an axis from being specified twice. Default: false
+ * @param [in] __shape_size       The number of dimensions of the array that
+ * @ref __axes should be normalized against.
+ * @param [in] __allow_duplicate  Disallow an axis from being specified twice.
+ * Default: false
  *
- * @exception std::range_error    Particular axis is out of range or other error.
- * @return                        The normalized axes indexes, such that `0 <= result < __shape_size`
+ * @exception std::range_error    Particular axis is out of range or other
+ * error.
+ * @return                        The normalized axes indexes, such that `0 <=
+ * result < __shape_size`
  */
-static inline std::vector<shape_elem_type> get_validated_axes(const std::vector<shape_elem_type>& __axes,
-                                                              const size_t __shape_size,
-                                                              const bool __allow_duplicate = false)
+static inline std::vector<shape_elem_type>
+    get_validated_axes(const std::vector<shape_elem_type> &__axes,
+                       const size_t __shape_size,
+                       const bool __allow_duplicate = false)
 {
     std::vector<shape_elem_type> result;
 
-    if (__axes.empty())
-    {
+    if (__axes.empty()) {
         goto out;
     }
 
-    if (__axes.size() > __shape_size)
-    {
+    if (__axes.size() > __shape_size) {
         goto err;
     }
 
     result.reserve(__axes.size());
-    for (std::vector<shape_elem_type>::const_iterator it = __axes.cbegin(); it != __axes.cend(); ++it)
+    for (std::vector<shape_elem_type>::const_iterator it = __axes.cbegin();
+         it != __axes.cend(); ++it)
     {
         const shape_elem_type _axis = *it;
-        const shape_elem_type input_shape_size_signed = static_cast<shape_elem_type>(__shape_size);
-        if (_axis >= input_shape_size_signed)
-        { // positive axis range check
+        const shape_elem_type input_shape_size_signed =
+            static_cast<shape_elem_type>(__shape_size);
+        if (_axis >= input_shape_size_signed) { // positive axis range check
             goto err;
         }
 
-        if (_axis < -input_shape_size_signed)
-        { // negative axis range check
+        if (_axis < -input_shape_size_signed) { // negative axis range check
             goto err;
         }
 
-        const shape_elem_type positive_axis = _axis < 0 ? (_axis + input_shape_size_signed) : _axis;
+        const shape_elem_type positive_axis =
+            _axis < 0 ? (_axis + input_shape_size_signed) : _axis;
 
-        if (!__allow_duplicate)
-        {
-            if (std::find(result.begin(), result.end(), positive_axis) != result.end())
-            { // find axis duplication
+        if (!__allow_duplicate) {
+            if (std::find(result.begin(), result.end(), positive_axis) !=
+                result.end()) { // find axis duplication
                 goto err;
             }
         }
@@ -393,8 +411,10 @@ out:
     return result;
 
 err:
-    // TODO exception if wrong axis? need common function for throwing exceptions
-    throw std::range_error("DPNP Error: validate_axes() failed with axis check");
+    // TODO exception if wrong axis? need common function for throwing
+    // exceptions
+    throw std::range_error(
+        "DPNP Error: validate_axes() failed with axis check");
 }
 
 /**
@@ -419,9 +439,9 @@ static inline void validate_type_for_device(const sycl::device &d)
     }
     else if constexpr (std::is_same_v<T, std::complex<double>>) {
         if (!d.has(sycl::aspect::fp64)) {
-            throw std::runtime_error("Device " +
-                                     d.get_info<sycl::info::device::name>() +
-                                     " does not support type 'complex<double>'");
+            throw std::runtime_error(
+                "Device " + d.get_info<sycl::info::device::name>() +
+                " does not support type 'complex<double>'");
         }
     }
     else if constexpr (std::is_same_v<T, sycl::half>) {
@@ -458,17 +478,16 @@ static inline void validate_type_for_device(const sycl::queue &q)
  * @param [in]  vec  std::vector with types with ability to be printed.
  */
 template <typename T>
-std::ostream& operator<<(std::ostream& out, const std::vector<T>& vec)
+std::ostream &operator<<(std::ostream &out, const std::vector<T> &vec)
 {
     std::string delimeter;
     out << "{";
     // std::copy(vec.begin(), vec.end(), std::ostream_iterator<T>(out, ", "));
-    // out << "\b\b}"; // last two 'backspaces' needs to eliminate last delimiter. ex: {2, 3, 4, }
-    for (auto& elem : vec)
-    {
+    // out << "\b\b}"; // last two 'backspaces' needs to eliminate last
+    // delimiter. ex: {2, 3, 4, }
+    for (auto &elem : vec) {
         out << delimeter << elem;
-        if (delimeter.empty())
-        {
+        if (delimeter.empty()) {
             delimeter.assign(", ");
         }
     }
@@ -487,7 +506,7 @@ std::ostream& operator<<(std::ostream& out, const std::vector<T>& vec)
  * @param [in]  elem  DPNPFuncType value to be printed.
  */
 template <typename T>
-std::ostream& operator<<(std::ostream& out, DPNPFuncType elem)
+std::ostream &operator<<(std::ostream &out, DPNPFuncType elem)
 {
     out << static_cast<size_t>(elem);
 

--- a/dpnp/backend/src/dpnpc_memory_adapter.hpp
+++ b/dpnp/backend/src/dpnpc_memory_adapter.hpp
@@ -65,16 +65,16 @@ public:
     DPNPC_ptr_adapter(DPCTLSyclQueueRef q_ref,
                       const void *src_ptr,
                       const size_t size,
-                      bool target_no_sycl    = false,
+                      bool target_no_sycl = false,
                       bool copy_back_request = false)
     {
-        queue_ref       = q_ref;
-        queue           = *(reinterpret_cast<sycl::queue *>(queue_ref));
+        queue_ref = q_ref;
+        queue = *(reinterpret_cast<sycl::queue *>(queue_ref));
         target_no_queue = target_no_sycl;
-        copy_back       = copy_back_request;
-        orig_ptr        = const_cast<void *>(src_ptr);
-        size_in_bytes   = size * sizeof(_DataType);
-        deps            = std::vector<sycl::event>{};
+        copy_back = copy_back_request;
+        orig_ptr = const_cast<void *>(src_ptr);
+        size_in_bytes = size * sizeof(_DataType);
+        deps = std::vector<sycl::event>{};
 
         // enum class alloc { host = 0, device = 1, shared = 2, unknown = 3 };
         sycl::usm::alloc src_ptr_type = sycl::usm::alloc::unknown;

--- a/dpnp/backend/src/queue_sycl.cpp
+++ b/dpnp/backend/src/queue_sycl.cpp
@@ -34,7 +34,7 @@
 #if defined(DPNP_LOCAL_QUEUE)
 sycl::queue *backend_sycl::queue = nullptr;
 #endif
-mkl_rng::mt19937 *backend_sycl::rng_engine     = nullptr;
+mkl_rng::mt19937 *backend_sycl::rng_engine = nullptr;
 mkl_rng::mcg59 *backend_sycl::rng_mcg59_engine = nullptr;
 
 static void dpnpc_show_mathlib_version()
@@ -90,7 +90,7 @@ static void show_available_sycl_devices()
 static sycl::device get_default_sycl_device()
 {
     int dpnpc_queue_gpu = 0;
-    sycl::device dev    = sycl::device(sycl::cpu_selector());
+    sycl::device dev = sycl::device(sycl::cpu_selector());
 
     const char *dpnpc_queue_gpu_var = getenv("DPNPC_QUEUE_GPU");
     if (dpnpc_queue_gpu_var != NULL) {
@@ -236,7 +236,7 @@ void backend_sycl::backend_sycl_rng_engine_init(size_t seed)
     if (rng_engine) {
         backend_sycl::destroy_rng_engine();
     }
-    rng_engine       = new mkl_rng::mt19937(DPNP_QUEUE, seed);
+    rng_engine = new mkl_rng::mt19937(DPNP_QUEUE, seed);
     rng_mcg59_engine = new mkl_rng::mcg59(DPNP_QUEUE, seed);
 }
 

--- a/dpnp/backend/src/queue_sycl.cpp
+++ b/dpnp/backend/src/queue_sycl.cpp
@@ -27,15 +27,15 @@
 #include <exception>
 #include <iostream>
 
-#include <dpnp_iface.hpp>
-#include "queue_sycl.hpp"
+#include "dpnp_iface.hpp"
 #include "dpnp_utils.hpp"
+#include "queue_sycl.hpp"
 
 #if defined(DPNP_LOCAL_QUEUE)
-sycl::queue* backend_sycl::queue = nullptr;
+sycl::queue *backend_sycl::queue = nullptr;
 #endif
-mkl_rng::mt19937* backend_sycl::rng_engine = nullptr;
-mkl_rng::mcg59* backend_sycl::rng_mcg59_engine = nullptr;
+mkl_rng::mt19937 *backend_sycl::rng_engine     = nullptr;
+mkl_rng::mcg59 *backend_sycl::rng_mcg59_engine = nullptr;
 
 static void dpnpc_show_mathlib_version()
 {
@@ -43,7 +43,8 @@ static void dpnpc_show_mathlib_version()
     const int len = 256;
     std::string mathlib_version_str(len, 0x0);
 
-    char* buf = const_cast<char*>(mathlib_version_str.c_str()); // TODO avoid write into the container
+    char *buf = const_cast<char *>(
+        mathlib_version_str.c_str()); // TODO avoid write into the container
 
     mkl_get_version_string(buf, len);
 
@@ -54,8 +55,9 @@ static void dpnpc_show_mathlib_version()
 
     mkl_get_version(&version);
 
-    std::cout << "Math backend version: " << version.MajorVersion << "." << version.UpdateVersion << "."
-              << version.MinorVersion << std::endl;
+    std::cout << "Math backend version: " << version.MajorVersion << "."
+              << version.UpdateVersion << "." << version.MinorVersion
+              << std::endl;
 #endif
 }
 
@@ -65,15 +67,21 @@ static void show_available_sycl_devices()
     const std::vector<sycl::device> devices = sycl::device::get_devices();
 
     std::cout << "Available SYCL devices:" << std::endl;
-    for (std::vector<sycl::device>::const_iterator it = devices.cbegin(); it != devices.cend(); ++it)
+    for (std::vector<sycl::device>::const_iterator it = devices.cbegin();
+         it != devices.cend(); ++it)
     {
         std::cout
-            // not yet implemented error << " " << it->has(sycl::aspect::usm_shared_allocations)  << " "
+            // not yet implemented error << " " <<
+            // it->has(sycl::aspect::usm_shared_allocations)  << " "
             << " - id=" << it->get_info<sycl::info::device::vendor_id>()
-            << ", type=" << static_cast<pi_uint64>(it->get_info<sycl::info::device::device_type>())
-            << ", gws=" << it->get_info<sycl::info::device::max_work_group_size>()
+            << ", type="
+            << static_cast<pi_uint64>(
+                   it->get_info<sycl::info::device::device_type>())
+            << ", gws="
+            << it->get_info<sycl::info::device::max_work_group_size>()
             << ", cu=" << it->get_info<sycl::info::device::max_compute_units>()
-            << ", name=" << it->get_info<sycl::info::device::name>() << std::endl;
+            << ", name=" << it->get_info<sycl::info::device::name>()
+            << std::endl;
     }
 }
 #endif
@@ -82,16 +90,14 @@ static void show_available_sycl_devices()
 static sycl::device get_default_sycl_device()
 {
     int dpnpc_queue_gpu = 0;
-    sycl::device dev = sycl::device(sycl::cpu_selector());
+    sycl::device dev    = sycl::device(sycl::cpu_selector());
 
-    const char* dpnpc_queue_gpu_var = getenv("DPNPC_QUEUE_GPU");
-    if (dpnpc_queue_gpu_var != NULL)
-    {
+    const char *dpnpc_queue_gpu_var = getenv("DPNPC_QUEUE_GPU");
+    if (dpnpc_queue_gpu_var != NULL) {
         dpnpc_queue_gpu = atoi(dpnpc_queue_gpu_var);
     }
 
-    if (dpnpc_queue_gpu)
-    {
+    if (dpnpc_queue_gpu) {
         dev = sycl::device(sycl::gpu_selector());
     }
 
@@ -101,15 +107,19 @@ static sycl::device get_default_sycl_device()
 
 #if defined(DPNPC_TOUCH_KERNEL_TO_LINK)
 /**
- * Function push the SYCL kernels to be linked (final stage of the compilation) for the current queue
+ * Function push the SYCL kernels to be linked (final stage of the compilation)
+ * for the current queue
  *
- * TODO it is not the best idea to just a call some kernel. Needs better solution.
+ * TODO it is not the best idea to just a call some kernel. Needs better
+ * solution.
  */
 static long dpnp_kernels_link()
 {
     /* must use memory pre-allocated at the current queue */
-    long* value_ptr = reinterpret_cast<long*>(dpnp_memory_alloc_c(1 * sizeof(long)));
-    long* result_ptr = reinterpret_cast<long*>(dpnp_memory_alloc_c(1 * sizeof(long)));
+    long *value_ptr =
+        reinterpret_cast<long *>(dpnp_memory_alloc_c(1 * sizeof(long)));
+    long *result_ptr =
+        reinterpret_cast<long *>(dpnp_memory_alloc_c(1 * sizeof(long)));
     long result = 1;
 
     *value_ptr = 2;
@@ -129,15 +139,12 @@ static long dpnp_kernels_link()
 // Catch asynchronous exceptions
 static void exception_handler(sycl::exception_list exceptions)
 {
-    for (std::exception_ptr const& e : exceptions)
-    {
-        try
-        {
+    for (std::exception_ptr const &e : exceptions) {
+        try {
             std::rethrow_exception(e);
-        }
-        catch (sycl::exception const& e)
-        {
-            std::cout << "DPNP. Caught asynchronous SYCL exception:\n" << e.what() << std::endl;
+        } catch (sycl::exception const &e) {
+            std::cout << "DPNP. Caught asynchronous SYCL exception:\n"
+                      << e.what() << std::endl;
         }
     }
 };
@@ -146,10 +153,10 @@ static void exception_handler(sycl::exception_list exceptions)
 void backend_sycl::backend_sycl_queue_init(QueueOptions selector)
 {
 #if defined(DPNP_LOCAL_QUEUE)
-    std::chrono::high_resolution_clock::time_point t1 = std::chrono::high_resolution_clock::now();
+    std::chrono::high_resolution_clock::time_point t1 =
+        std::chrono::high_resolution_clock::now();
 
-    if (queue)
-    {
+    if (queue) {
         backend_sycl::destroy();
     }
 
@@ -159,51 +166,55 @@ void backend_sycl::backend_sycl_queue_init(QueueOptions selector)
     show_available_sycl_devices();
 #endif
 
-    if (QueueOptions::CPU_SELECTOR == selector)
-    {
+    if (QueueOptions::CPU_SELECTOR == selector) {
         dev = sycl::device(sycl::cpu_selector());
     }
-    else if (QueueOptions::GPU_SELECTOR == selector)
-    {
+    else if (QueueOptions::GPU_SELECTOR == selector) {
         dev = sycl::device(sycl::gpu_selector());
     }
-    else
-    {
+    else {
         dev = get_default_sycl_device();
     }
 
-    if (is_verbose_mode())
-    {
-        sycl::property_list properties{sycl::property::queue::enable_profiling()};
+    if (is_verbose_mode()) {
+        sycl::property_list properties{
+            sycl::property::queue::enable_profiling()};
         queue = new sycl::queue(dev, exception_handler, properties);
     }
-    else
-    {
+    else {
         queue = new sycl::queue(dev, exception_handler);
     }
 
-    std::chrono::high_resolution_clock::time_point t2 = std::chrono::high_resolution_clock::now();
-    std::chrono::duration<double> time_queue_init = std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1);
+    std::chrono::high_resolution_clock::time_point t2 =
+        std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> time_queue_init =
+        std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1);
 #else
     (void)selector;
 #endif
 
-    std::chrono::high_resolution_clock::time_point t3 = std::chrono::high_resolution_clock::now();
+    std::chrono::high_resolution_clock::time_point t3 =
+        std::chrono::high_resolution_clock::now();
 #if defined(DPNPC_TOUCH_KERNEL_TO_LINK)
     // Remove pre-link kernel library at startup time
     dpnp_kernels_link();
 #endif
-    std::chrono::high_resolution_clock::time_point t4 = std::chrono::high_resolution_clock::now();
+    std::chrono::high_resolution_clock::time_point t4 =
+        std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> time_kernels_link =
         std::chrono::duration_cast<std::chrono::duration<double>>(t4 - t3);
 
-    std::cout << "Running on: " << DPNP_QUEUE.get_device().get_info<sycl::info::device::name>() << "\n";
+    std::cout << "Running on: "
+              << DPNP_QUEUE.get_device().get_info<sycl::info::device::name>()
+              << "\n";
 #if defined(DPNP_LOCAL_QUEUE)
-    std::cout << "queue initialization time: " << time_queue_init.count() << " (sec.)\n";
+    std::cout << "queue initialization time: " << time_queue_init.count()
+              << " (sec.)\n";
 #else
     std::cout << "DPCtrl SYCL queue used\n";
 #endif
-    std::cout << "SYCL kernels link time: " << time_kernels_link.count() << " (sec.)\n";
+    std::cout << "SYCL kernels link time: " << time_kernels_link.count()
+              << " (sec.)\n";
     dpnpc_show_mathlib_version();
 
     std::cout << std::endl;
@@ -211,7 +222,7 @@ void backend_sycl::backend_sycl_queue_init(QueueOptions selector)
 
 bool backend_sycl::backend_sycl_is_cpu()
 {
-    sycl::queue& qptr = get_queue();
+    sycl::queue &qptr = get_queue();
 
     if (qptr.get_device().is_cpu()) {
         return true;
@@ -222,11 +233,10 @@ bool backend_sycl::backend_sycl_is_cpu()
 
 void backend_sycl::backend_sycl_rng_engine_init(size_t seed)
 {
-    if (rng_engine)
-    {
+    if (rng_engine) {
         backend_sycl::destroy_rng_engine();
     }
-    rng_engine = new mkl_rng::mt19937(DPNP_QUEUE, seed);
+    rng_engine       = new mkl_rng::mt19937(DPNP_QUEUE, seed);
     rng_mcg59_engine = new mkl_rng::mcg59(DPNP_QUEUE, seed);
 }
 

--- a/dpnp/backend/src/queue_sycl.hpp
+++ b/dpnp/backend/src/queue_sycl.hpp
@@ -61,20 +61,24 @@ namespace mkl_rng = oneapi::mkl::rng;
 #define DPNP_RNG_MCG59_ENGINE backend_sycl::get_rng_mcg59_engine()
 
 /**
- * This is container for the SYCL queue, random number generation engine and related functions like queue and engine
- * initialization and maintenance.
- * The queue could not be initialized as a global object. Global object initialization order is undefined.
- * This class postpone initialization of the SYCL queue and mt19937 random number generation engine.
+ * This is container for the SYCL queue, random number generation engine and
+ * related functions like queue and engine initialization and maintenance. The
+ * queue could not be initialized as a global object. Global object
+ * initialization order is undefined. This class postpone initialization of the
+ * SYCL queue and mt19937 random number generation engine.
  */
 class backend_sycl
 {
 #if defined(DPNP_LOCAL_QUEUE)
-    static sycl::queue* queue; /**< contains SYCL queue pointer initialized in @ref backend_sycl_queue_init */
+    static sycl::queue *queue; /**< contains SYCL queue pointer initialized in
+                                  @ref backend_sycl_queue_init */
 #endif
-    static mkl_rng::mt19937*
-        rng_engine;       /**< RNG MT19937 engine ptr. initialized in @ref backend_sycl_rng_engine_init */
-    static mkl_rng::mcg59*
-        rng_mcg59_engine; /**< RNG MCG59 engine ptr. initialized in @ref backend_sycl_rng_engine_init */
+    static mkl_rng::mt19937
+        *rng_engine; /**< RNG MT19937 engine ptr. initialized in @ref
+                        backend_sycl_rng_engine_init */
+    static mkl_rng::mcg59
+        *rng_mcg59_engine; /**< RNG MCG59 engine ptr. initialized in @ref
+                              backend_sycl_rng_engine_init */
 
     static void destroy()
     {
@@ -90,7 +94,7 @@ class backend_sycl
         delete rng_engine;
         delete rng_mcg59_engine;
 
-        rng_engine = nullptr;
+        rng_engine       = nullptr;
         rng_mcg59_engine = nullptr;
     }
 
@@ -98,7 +102,7 @@ public:
     backend_sycl()
     {
 #if defined(DPNP_LOCAL_QUEUE)
-        queue = nullptr;
+        queue      = nullptr;
         rng_engine = nullptr;
 #endif
     }
@@ -111,13 +115,14 @@ public:
     /**
      * Explicitly disallow copying
      */
-    backend_sycl(const backend_sycl&) = delete;
-    backend_sycl& operator=(const backend_sycl&) = delete;
+    backend_sycl(const backend_sycl &) = delete;
+    backend_sycl &operator=(const backend_sycl &) = delete;
 
     /**
      * Initialize @ref queue
      */
-    static void backend_sycl_queue_init(QueueOptions selector = QueueOptions::CPU_SELECTOR);
+    static void backend_sycl_queue_init(
+        QueueOptions selector = QueueOptions::CPU_SELECTOR);
 
     /**
      * Return True if current @ref queue is related to cpu device
@@ -132,11 +137,10 @@ public:
     /**
      * Return the @ref queue to the user
      */
-    static sycl::queue& get_queue()
+    static sycl::queue &get_queue()
     {
 #if defined(DPNP_LOCAL_QUEUE)
-        if (!queue)
-        {
+        if (!queue) {
             backend_sycl_queue_init();
         }
 
@@ -144,24 +148,26 @@ public:
 #else
         // temporal solution. Started from Sept-2020
         DPCTLSyclQueueRef DPCtrl_queue = DPCTLQueueMgr_GetCurrentQueue();
-        if (DPCtrl_queue == nullptr)
-        {
-            std::string reason = (DPCTLQueueMgr_GetQueueStackSize() == static_cast<size_t>(-1))
-                                     ? ": the queue stack is empty, probably no device is available."
-                                     : ".";
-            throw std::runtime_error("Failed to create a copy of SYCL queue with default device" + reason);
+        if (DPCtrl_queue == nullptr) {
+            std::string reason =
+                (DPCTLQueueMgr_GetQueueStackSize() == static_cast<size_t>(-1))
+                    ? ": the queue stack is empty, probably no device is "
+                      "available."
+                    : ".";
+            throw std::runtime_error(
+                "Failed to create a copy of SYCL queue with default device" +
+                reason);
         }
-        return *(reinterpret_cast<sycl::queue*>(DPCtrl_queue));
+        return *(reinterpret_cast<sycl::queue *>(DPCtrl_queue));
 #endif
     }
 
     /**
      * Return the @ref rng_engine to the user
      */
-    static mkl_rng::mt19937& get_rng_engine()
+    static mkl_rng::mt19937 &get_rng_engine()
     {
-        if (!rng_engine)
-        {
+        if (!rng_engine) {
             backend_sycl_rng_engine_init();
         }
         return *rng_engine;
@@ -170,10 +176,9 @@ public:
     /**
      * Return the @ref rng_mcg59_engine to the user
      */
-    static mkl_rng::mcg59& get_rng_mcg59_engine()
+    static mkl_rng::mcg59 &get_rng_mcg59_engine()
     {
-        if (!rng_engine)
-        {
+        if (!rng_engine) {
             backend_sycl_rng_engine_init();
         }
         return *rng_mcg59_engine;

--- a/dpnp/backend/src/queue_sycl.hpp
+++ b/dpnp/backend/src/queue_sycl.hpp
@@ -94,7 +94,7 @@ class backend_sycl
         delete rng_engine;
         delete rng_mcg59_engine;
 
-        rng_engine       = nullptr;
+        rng_engine = nullptr;
         rng_mcg59_engine = nullptr;
     }
 
@@ -102,7 +102,7 @@ public:
     backend_sycl()
     {
 #if defined(DPNP_LOCAL_QUEUE)
-        queue      = nullptr;
+        queue = nullptr;
         rng_engine = nullptr;
 #endif
     }

--- a/dpnp/backend/src/verbose.cpp
+++ b/dpnp/backend/src/verbose.cpp
@@ -26,17 +26,15 @@
 #include "verbose.hpp"
 #include <iostream>
 
-bool _is_verbose_mode = false;
+bool _is_verbose_mode      = false;
 bool _is_verbose_mode_init = false;
 
 bool is_verbose_mode()
 {
-    if (!_is_verbose_mode_init)
-    {
-        _is_verbose_mode = false;
-        const char* env_var = std::getenv("DPNP_VERBOSE");
-        if (env_var and env_var == std::string("1"))
-        {
+    if (!_is_verbose_mode_init) {
+        _is_verbose_mode    = false;
+        const char *env_var = std::getenv("DPNP_VERBOSE");
+        if (env_var and env_var == std::string("1")) {
             _is_verbose_mode = true;
         }
         _is_verbose_mode_init = true;
@@ -46,23 +44,29 @@ bool is_verbose_mode()
 
 class barrierKernelClass;
 
-void set_barrier_event(sycl::queue queue, std::vector<sycl::event>& depends)
+void set_barrier_event(sycl::queue queue, std::vector<sycl::event> &depends)
 {
-    if (is_verbose_mode())
-    {
-        sycl::event barrier_event = queue.single_task<barrierKernelClass>(depends, [=] {});
+    if (is_verbose_mode()) {
+        sycl::event barrier_event =
+            queue.single_task<barrierKernelClass>(depends, [=] {});
         depends.clear();
         depends.push_back(barrier_event);
     }
 }
 
-void verbose_print(std::string header, sycl::event first_event, sycl::event last_event)
+void verbose_print(std::string header,
+                   sycl::event first_event,
+                   sycl::event last_event)
 {
-    if (is_verbose_mode())
-    {
-        auto first_event_end = first_event.get_profiling_info<sycl::info::event_profiling::command_end>();
-        auto last_event_end = last_event.get_profiling_info<sycl::info::event_profiling::command_end>();
-        std::cout << "DPNP_VERBOSE " << header << " Time: " << (last_event_end - first_event_end) / 1.0e9 << " s"
-                  << std::endl;
+    if (is_verbose_mode()) {
+        auto first_event_end =
+            first_event
+                .get_profiling_info<sycl::info::event_profiling::command_end>();
+        auto last_event_end =
+            last_event
+                .get_profiling_info<sycl::info::event_profiling::command_end>();
+        std::cout << "DPNP_VERBOSE " << header
+                  << " Time: " << (last_event_end - first_event_end) / 1.0e9
+                  << " s" << std::endl;
     }
 }

--- a/dpnp/backend/src/verbose.cpp
+++ b/dpnp/backend/src/verbose.cpp
@@ -26,13 +26,13 @@
 #include "verbose.hpp"
 #include <iostream>
 
-bool _is_verbose_mode      = false;
+bool _is_verbose_mode = false;
 bool _is_verbose_mode_init = false;
 
 bool is_verbose_mode()
 {
     if (!_is_verbose_mode_init) {
-        _is_verbose_mode    = false;
+        _is_verbose_mode = false;
         const char *env_var = std::getenv("DPNP_VERBOSE");
         if (env_var and env_var == std::string("1")) {
             _is_verbose_mode = true;

--- a/dpnp/backend/src/verbose.hpp
+++ b/dpnp/backend/src/verbose.hpp
@@ -30,7 +30,9 @@
 #include <CL/sycl.hpp>
 
 bool is_verbose_mode();
-void set_barrier_event(sycl::queue queue, std::vector<sycl::event>& depends);
-void verbose_print(std::string header, sycl::event first_event, sycl::event last_event);
+void set_barrier_event(sycl::queue queue, std::vector<sycl::event> &depends);
+void verbose_print(std::string header,
+                   sycl::event first_event,
+                   sycl::event last_event);
 
 #endif // VERBOSE_H

--- a/dpnp/backend/tests/dpnp_test_utils.hpp
+++ b/dpnp/backend/tests/dpnp_test_utils.hpp
@@ -4,7 +4,7 @@
 #include "dpnp_iterator.hpp"
 
 using namespace std;
-using dpnpc_it_t    = DPNPC_id<size_t>::iterator;
+using dpnpc_it_t = DPNPC_id<size_t>::iterator;
 using dpnpc_value_t = dpnpc_it_t::value_type;
 using dpnpc_index_t = dpnpc_it_t::size_type;
 

--- a/dpnp/backend/tests/dpnp_test_utils.hpp
+++ b/dpnp/backend/tests/dpnp_test_utils.hpp
@@ -4,26 +4,30 @@
 #include "dpnp_iterator.hpp"
 
 using namespace std;
-using dpnpc_it_t = DPNPC_id<size_t>::iterator;
+using dpnpc_it_t    = DPNPC_id<size_t>::iterator;
 using dpnpc_value_t = dpnpc_it_t::value_type;
 using dpnpc_index_t = dpnpc_it_t::size_type;
 
 template <typename _DataType>
-vector<_DataType> get_input_data(const vector<dpnpc_index_t>& shape)
+vector<_DataType> get_input_data(const vector<dpnpc_index_t> &shape)
 {
-    const dpnpc_index_t size = accumulate(shape.begin(), shape.end(), dpnpc_index_t(1), multiplies<dpnpc_index_t>());
+    const dpnpc_index_t size =
+        accumulate(shape.begin(), shape.end(), dpnpc_index_t(1),
+                   multiplies<dpnpc_index_t>());
 
     vector<_DataType> input_data(size);
-    iota(input_data.begin(), input_data.end(), 1); // let's start from 1 to avoid cleaned memory comparison
+    iota(input_data.begin(), input_data.end(),
+         1); // let's start from 1 to avoid cleaned memory comparison
 
     return input_data;
 }
 
 template <typename _DataType>
-_DataType* get_shared_data(const vector<_DataType>& input_data)
+_DataType *get_shared_data(const vector<_DataType> &input_data)
 {
     const size_t data_size_in_bytes = input_data.size() * sizeof(_DataType);
-    _DataType* shared_data = reinterpret_cast<_DataType*>(dpnp_memory_alloc_c(data_size_in_bytes));
+    _DataType *shared_data =
+        reinterpret_cast<_DataType *>(dpnp_memory_alloc_c(data_size_in_bytes));
     copy(input_data.begin(), input_data.end(), shared_data);
 
     return shared_data;

--- a/dpnp/backend/tests/test_broadcast_iterator.cpp
+++ b/dpnp/backend/tests/test_broadcast_iterator.cpp
@@ -30,7 +30,8 @@
 #include "dpnp_iterator.hpp"
 #include "dpnp_test_utils.hpp"
 
-#define DPNP_LOCAL_QUEUE 1 // TODO need to fix build procedure and remove this workaround. Issue #551
+// TODO need to fix build procedure and remove this workaround. Issue #551
+#define DPNP_LOCAL_QUEUE 1
 #include "queue_sycl.hpp"
 
 struct IteratorParameters
@@ -39,10 +40,13 @@ struct IteratorParameters
     vector<dpnpc_it_t::size_type> output_shape;
     vector<dpnpc_value_t> result;
 
-    /// Operator needs to print this container in human readable form in error reporting
-    friend std::ostream& operator<<(std::ostream& out, const IteratorParameters& data)
+    /// Operator needs to print this container in human readable form in error
+    /// reporting
+    friend std::ostream &operator<<(std::ostream &out,
+                                    const IteratorParameters &data)
     {
-        out << "IteratorParameters(input_shape=" << data.input_shape << ", output_shape=" << data.output_shape
+        out << "IteratorParameters(input_shape=" << data.input_shape
+            << ", output_shape=" << data.output_shape
             << ", result=" << data.result << ")";
 
         return out;
@@ -57,8 +61,9 @@ TEST_P(IteratorBroadcasting, loop_broadcast)
 {
     using data_type = double;
 
-    const IteratorParameters& param = GetParam();
-    std::vector<data_type> input_data = get_input_data<data_type>(param.input_shape);
+    const IteratorParameters &param = GetParam();
+    std::vector<data_type> input_data =
+        get_input_data<data_type>(param.input_shape);
 
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
 
@@ -67,7 +72,8 @@ TEST_P(IteratorBroadcasting, loop_broadcast)
 
     ASSERT_EQ(input.get_output_size(), param.result.size());
 
-    for (dpnpc_index_t output_id = 0; output_id < input.get_output_size(); ++output_id)
+    for (dpnpc_index_t output_id = 0; output_id < input.get_output_size();
+         ++output_id)
     {
         EXPECT_EQ(input[output_id], param.result.at(output_id));
     }
@@ -77,17 +83,20 @@ TEST_P(IteratorBroadcasting, sycl_broadcast)
 {
     using data_type = double;
 
-    const IteratorParameters& param = GetParam();
+    const IteratorParameters &param = GetParam();
     const dpnpc_index_t result_size = param.result.size();
-    data_type* result = reinterpret_cast<data_type*>(dpnp_memory_alloc_c(result_size * sizeof(data_type)));
+    data_type *result               = reinterpret_cast<data_type *>(
+        dpnp_memory_alloc_c(result_size * sizeof(data_type)));
 
-    std::vector<data_type> input_data = get_input_data<data_type>(param.input_shape);
-    data_type* shared_data = get_shared_data<data_type>(input_data);
+    std::vector<data_type> input_data =
+        get_input_data<data_type>(param.input_shape);
+    data_type *shared_data = get_shared_data<data_type>(input_data);
 
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
 
-    DPNPC_id<data_type>* input_it;
-    input_it = reinterpret_cast<DPNPC_id<data_type>*>(dpnp_memory_alloc_c(q_ref, sizeof(DPNPC_id<data_type>)));
+    DPNPC_id<data_type> *input_it;
+    input_it = reinterpret_cast<DPNPC_id<data_type> *>(
+        dpnp_memory_alloc_c(q_ref, sizeof(DPNPC_id<data_type>)));
     new (input_it) DPNPC_id<data_type>(q_ref, shared_data, param.input_shape);
 
     input_it->broadcast_to_shape(param.output_shape);
@@ -97,18 +106,18 @@ TEST_P(IteratorBroadcasting, sycl_broadcast)
     sycl::range<1> gws(result_size);
     auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
         const size_t idx = global_id[0];
-        result[idx] = (*input_it)[idx];
+        result[idx]      = (*input_it)[idx];
     };
 
-    auto kernel_func = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class test_sycl_reduce_axis_kernel>(gws, kernel_parallel_for_func);
+    auto kernel_func = [&](sycl::handler &cgh) {
+        cgh.parallel_for<class test_sycl_reduce_axis_kernel>(
+            gws, kernel_parallel_for_func);
     };
 
     sycl::event event = DPNP_QUEUE.submit(kernel_func);
     event.wait();
 
-    for (dpnpc_index_t i = 0; i < result_size; ++i)
-    {
+    for (dpnpc_index_t i = 0; i < result_size; ++i) {
         EXPECT_EQ(result[i], param.result.at(i));
     }
 
@@ -133,7 +142,8 @@ TEST_P(IteratorBroadcasting, sycl_broadcast)
  * print(f"output shape={output.shape}")
  *
  * result = input * output
- * print(f"result={np.array2string(result.reshape(result.size), separator=', ')}\n", sep=", ")
+ * print(f"result={np.array2string(result.reshape(result.size), separator=',
+ * ')}\n", sep=", ")
  */
 INSTANTIATE_TEST_SUITE_P(
     TestBroadcastIterator,
@@ -142,16 +152,27 @@ INSTANTIATE_TEST_SUITE_P(
         IteratorParameters{{1}, {1}, {1}},
         IteratorParameters{{1}, {4}, {1, 1, 1, 1}},
         IteratorParameters{{1}, {3, 4}, {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}},
-        IteratorParameters{{1}, {2, 3, 4}, {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}},
+        IteratorParameters{{1}, {2, 3, 4}, {1, 1, 1, 1, 1, 1, 1, 1,
+                                            1, 1, 1, 1, 1, 1, 1, 1,
+                                            1, 1, 1, 1, 1, 1, 1, 1}},
         IteratorParameters{{4}, {4}, {1, 2, 3, 4}},
         IteratorParameters{{4}, {3, 4}, {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}},
-        IteratorParameters{{4}, {2, 3, 4}, {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}},
-        IteratorParameters{{3, 4}, {3, 4}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}},
-        IteratorParameters{
-            {3, 4}, {2, 3, 4}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}},
-        IteratorParameters{{2, 3, 4}, {2, 3, 4}, {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
-                                                  13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}},
-        IteratorParameters{
-            {2, 3, 1}, {2, 3, 4}, {1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6}},
-        IteratorParameters{
-            {2, 1, 4}, {2, 3, 4}, {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 5, 6, 7, 8, 5, 6, 7, 8, 5, 6, 7, 8}}));
+        IteratorParameters{{4}, {2, 3, 4}, {1, 2, 3, 4, 1, 2, 3, 4,
+                                            1, 2, 3, 4, 1, 2, 3, 4,
+                                            1, 2, 3, 4, 1, 2, 3, 4}},
+        IteratorParameters{{3, 4},
+                           {3, 4},
+                           {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}},
+        IteratorParameters{{3, 4}, {2, 3, 4}, {1, 2,  3,  4,  5, 6,  7,  8,
+                                               9, 10, 11, 12, 1, 2,  3,  4,
+                                               5, 6,  7,  8,  9, 10, 11, 12}},
+        IteratorParameters{{2, 3, 4},
+                           {2, 3, 4},
+                           {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
+                            13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}},
+        IteratorParameters{{2, 3, 1}, {2, 3, 4}, {1, 1, 1, 1, 2, 2, 2, 2,
+                                                  3, 3, 3, 3, 4, 4, 4, 4,
+                                                  5, 5, 5, 5, 6, 6, 6, 6}},
+        IteratorParameters{{2, 1, 4}, {2, 3, 4}, {1, 2, 3, 4, 1, 2, 3, 4,
+                                                  1, 2, 3, 4, 5, 6, 7, 8,
+                                                  5, 6, 7, 8, 5, 6, 7, 8}}));

--- a/dpnp/backend/tests/test_broadcast_iterator.cpp
+++ b/dpnp/backend/tests/test_broadcast_iterator.cpp
@@ -85,7 +85,7 @@ TEST_P(IteratorBroadcasting, sycl_broadcast)
 
     const IteratorParameters &param = GetParam();
     const dpnpc_index_t result_size = param.result.size();
-    data_type *result               = reinterpret_cast<data_type *>(
+    data_type *result = reinterpret_cast<data_type *>(
         dpnp_memory_alloc_c(result_size * sizeof(data_type)));
 
     std::vector<data_type> input_data =
@@ -106,7 +106,7 @@ TEST_P(IteratorBroadcasting, sycl_broadcast)
     sycl::range<1> gws(result_size);
     auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
         const size_t idx = global_id[0];
-        result[idx]      = (*input_it)[idx];
+        result[idx] = (*input_it)[idx];
     };
 
     auto kernel_func = [&](sycl::handler &cgh) {

--- a/dpnp/backend/tests/test_main.cpp
+++ b/dpnp/backend/tests/test_main.cpp
@@ -37,12 +37,10 @@ public:
         // TODO update print
         std::cout << "starting new env" << std::endl << std::endl;
     }
-    void TearDown() override
-    {
-    }
+    void TearDown() override {}
 };
 
-int RunAllTests(DPNPCTestEnvironment* env)
+int RunAllTests(DPNPCTestEnvironment *env)
 {
     // testing::internal::GetUnitTestImpl()->ClearAdHocTestResult();
     (void)env;
@@ -51,7 +49,7 @@ int RunAllTests(DPNPCTestEnvironment* env)
     return RUN_ALL_TESTS();
 }
 
-int main(int argc, char** argv)
+int main(int argc, char **argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
 

--- a/dpnp/backend/tests/test_random.cpp
+++ b/dpnp/backend/tests/test_random.cpp
@@ -76,7 +76,7 @@ protected:
 
 double *RandomTestCase::result1 = nullptr;
 double *RandomTestCase::result2 = nullptr;
-size_t RandomTestCase::size     = 10;
+size_t RandomTestCase::size = 10;
 
 template <typename _DataType>
 bool check_statistics(_DataType *r,
@@ -92,7 +92,7 @@ bool check_statistics(_DataType *r,
     double DeltaM, DeltaD;
 
     /***** Sample moments *****/
-    sum  = 0.0;
+    sum = 0.0;
     sum2 = 0.0;
     for (size_t i = 0; i < size; i++) {
         sum += (double)r[i];
@@ -102,9 +102,9 @@ bool check_statistics(_DataType *r,
     sD = sum2 / (double)size - (sM * sM);
 
     /***** Comparison of theoretical and sample moments *****/
-    n   = (double)size;
+    n = (double)size;
     tD2 = tD * tD;
-    s   = ((tQ - tD2) / n) - (2 * (tQ - 2 * tD2) / (n * n)) +
+    s = ((tQ - tD2) / n) - (2 * (tQ - 2 * tD2) / (n * n)) +
         ((tQ - 3 * tD2) / (n * n * n));
 
     DeltaM = (tM - sM) / sqrt(tD / n);
@@ -118,8 +118,8 @@ bool check_statistics(_DataType *r,
 TEST_F(RandomTestCase, rng_beta_test_seed)
 {
     const size_t seed = 10;
-    const double a    = 0.4;
-    const double b    = 0.5;
+    const double a = 0.4;
+    const double b = 0.5;
 
     dpnp_rng_srand_c(seed);
     dpnp_rng_beta_c<double>(result1, a, b, size);
@@ -134,7 +134,7 @@ TEST_F(RandomTestCase, rng_beta_test_seed)
 
 TEST_F(RandomTestCase, rng_f_test_seed)
 {
-    const size_t seed  = 10;
+    const size_t seed = 10;
     const double dfnum = 10.4;
     const double dfden = 12.5;
 
@@ -151,8 +151,8 @@ TEST_F(RandomTestCase, rng_f_test_seed)
 
 TEST_F(RandomTestCase, rng_normal_test_seed)
 {
-    const size_t seed  = 10;
-    const double loc   = 2.56;
+    const size_t seed = 10;
+    const double loc = 2.56;
     const double scale = 0.8;
 
     dpnp_rng_srand_c(seed);
@@ -169,8 +169,8 @@ TEST_F(RandomTestCase, rng_normal_test_seed)
 TEST_F(RandomTestCase, rng_uniform_test_seed)
 {
     const size_t seed = 10;
-    const long low    = 1;
-    const long high   = 120;
+    const long low = 1;
+    const long high = 120;
 
     dpnp_rng_srand_c(seed);
     dpnp_rng_uniform_c<double>(result1, low, high, size);
@@ -185,10 +185,10 @@ TEST_F(RandomTestCase, rng_uniform_test_seed)
 
 TEST(TestBackendRandomUniform, test_statistics)
 {
-    const size_t size         = 256;
-    size_t seed               = 10;
-    long a                    = 1;
-    long b                    = 120;
+    const size_t size = 256;
+    size_t seed = 10;
+    long a = 1;
+    long b = 120;
     bool check_statistics_res = false;
 
     /***** Theoretical moments *****/
@@ -208,7 +208,7 @@ TEST(TestBackendRandomUniform, test_statistics)
 // Generalization for all DPNPFuncName
 TEST(TestBackendRandomSrand, test_func_ptr)
 {
-    void *fptr               = nullptr;
+    void *fptr = nullptr;
     DPNPFuncData kernel_data = get_dpnp_function_ptr(
         DPNPFuncName::DPNP_FN_RNG_SRAND, DPNPFuncType::DPNP_FT_DOUBLE,
         DPNPFuncType::DPNP_FT_DOUBLE);

--- a/dpnp/backend/tests/test_random.cpp
+++ b/dpnp/backend/tests/test_random.cpp
@@ -34,7 +34,8 @@
 #include "gtest/gtest.h"
 
 // TODO
-// * data management will be redesigned: allocation as chars (and casting on teste suits)
+// * data management will be redesigned: allocation as chars (and casting on
+// teste suits)
 // * this class will be generlized
 class RandomTestCase : public ::testing::Test
 {
@@ -52,36 +53,37 @@ public:
 
     void SetUp() override
     {
-        for (size_t i = 0; i < size; ++i)
-        {
+        for (size_t i = 0; i < size; ++i) {
             result1[i] = 1;
             result2[i] = 0;
         }
     }
 
-    void TearDown() override
-    {
-    }
+    void TearDown() override {}
 
 private:
     static void _get_device_mem()
     {
-        result1 = (double*)dpnp_memory_alloc_c(size * 2 * sizeof(double));
+        result1 = (double *)dpnp_memory_alloc_c(size * 2 * sizeof(double));
         result2 = result1 + size;
     }
 
 protected:
     static size_t size;
-    static double* result1;
-    static double* result2;
+    static double *result1;
+    static double *result2;
 };
 
-double* RandomTestCase::result1 = nullptr;
-double* RandomTestCase::result2 = nullptr;
-size_t RandomTestCase::size = 10;
+double *RandomTestCase::result1 = nullptr;
+double *RandomTestCase::result2 = nullptr;
+size_t RandomTestCase::size     = 10;
 
 template <typename _DataType>
-bool check_statistics(_DataType* r, double tM, double tD, double tQ, size_t size)
+bool check_statistics(_DataType *r,
+                      double tM,
+                      double tD,
+                      double tQ,
+                      size_t size)
 {
     double tD2;
     double sM, sD;
@@ -90,10 +92,9 @@ bool check_statistics(_DataType* r, double tM, double tD, double tQ, size_t size
     double DeltaM, DeltaD;
 
     /***** Sample moments *****/
-    sum = 0.0;
+    sum  = 0.0;
     sum2 = 0.0;
-    for (size_t i = 0; i < size; i++)
-    {
+    for (size_t i = 0; i < size; i++) {
         sum += (double)r[i];
         sum2 += (double)r[i] * (double)r[i];
     }
@@ -101,9 +102,10 @@ bool check_statistics(_DataType* r, double tM, double tD, double tQ, size_t size
     sD = sum2 / (double)size - (sM * sM);
 
     /***** Comparison of theoretical and sample moments *****/
-    n = (double)size;
+    n   = (double)size;
     tD2 = tD * tD;
-    s = ((tQ - tD2) / n) - (2 * (tQ - 2 * tD2) / (n * n)) + ((tQ - 3 * tD2) / (n * n * n));
+    s   = ((tQ - tD2) / n) - (2 * (tQ - 2 * tD2) / (n * n)) +
+        ((tQ - 3 * tD2) / (n * n * n));
 
     DeltaM = (tM - sM) / sqrt(tD / n);
     DeltaD = (tD - sD) / sqrt(s);
@@ -116,8 +118,8 @@ bool check_statistics(_DataType* r, double tM, double tD, double tQ, size_t size
 TEST_F(RandomTestCase, rng_beta_test_seed)
 {
     const size_t seed = 10;
-    const double a = 0.4;
-    const double b = 0.5;
+    const double a    = 0.4;
+    const double b    = 0.5;
 
     dpnp_rng_srand_c(seed);
     dpnp_rng_beta_c<double>(result1, a, b, size);
@@ -125,15 +127,14 @@ TEST_F(RandomTestCase, rng_beta_test_seed)
     dpnp_rng_srand_c(seed);
     dpnp_rng_beta_c<double>(result2, a, b, size);
 
-    for (size_t i = 0; i < size; ++i)
-    {
+    for (size_t i = 0; i < size; ++i) {
         EXPECT_NEAR(result1[i], result2[i], 0.004);
     }
 }
 
 TEST_F(RandomTestCase, rng_f_test_seed)
 {
-    const size_t seed = 10;
+    const size_t seed  = 10;
     const double dfnum = 10.4;
     const double dfden = 12.5;
 
@@ -143,16 +144,15 @@ TEST_F(RandomTestCase, rng_f_test_seed)
     dpnp_rng_srand_c(seed);
     dpnp_rng_f_c<double>(result2, dfnum, dfden, size);
 
-    for (size_t i = 0; i < size; ++i)
-    {
+    for (size_t i = 0; i < size; ++i) {
         EXPECT_NEAR(result1[i], result2[i], 0.004);
     }
 }
 
 TEST_F(RandomTestCase, rng_normal_test_seed)
 {
-    const size_t seed = 10;
-    const double loc = 2.56;
+    const size_t seed  = 10;
+    const double loc   = 2.56;
     const double scale = 0.8;
 
     dpnp_rng_srand_c(seed);
@@ -161,8 +161,7 @@ TEST_F(RandomTestCase, rng_normal_test_seed)
     dpnp_rng_srand_c(seed);
     dpnp_rng_normal_c<double>(result2, loc, scale, size);
 
-    for (size_t i = 0; i < size; ++i)
-    {
+    for (size_t i = 0; i < size; ++i) {
         EXPECT_NEAR(result1[i], result2[i], 0.004);
     }
 }
@@ -170,8 +169,8 @@ TEST_F(RandomTestCase, rng_normal_test_seed)
 TEST_F(RandomTestCase, rng_uniform_test_seed)
 {
     const size_t seed = 10;
-    const long low = 1;
-    const long high = 120;
+    const long low    = 1;
+    const long high   = 120;
 
     dpnp_rng_srand_c(seed);
     dpnp_rng_uniform_c<double>(result1, low, high, size);
@@ -179,18 +178,17 @@ TEST_F(RandomTestCase, rng_uniform_test_seed)
     dpnp_rng_srand_c(seed);
     dpnp_rng_uniform_c<double>(result2, low, high, size);
 
-    for (size_t i = 0; i < size; ++i)
-    {
+    for (size_t i = 0; i < size; ++i) {
         EXPECT_NEAR(result1[i], result2[i], 0.004);
     }
 }
 
 TEST(TestBackendRandomUniform, test_statistics)
 {
-    const size_t size = 256;
-    size_t seed = 10;
-    long a = 1;
-    long b = 120;
+    const size_t size         = 256;
+    size_t seed               = 10;
+    long a                    = 1;
+    long b                    = 120;
     bool check_statistics_res = false;
 
     /***** Theoretical moments *****/
@@ -198,7 +196,7 @@ TEST(TestBackendRandomUniform, test_statistics)
     double tD = ((b - a) * (b - a)) / 12.0;
     double tQ = ((b - a) * (b - a) * (b - a) * (b - a)) / 80.0;
 
-    double* result = (double*)dpnp_memory_alloc_c(size * sizeof(double));
+    double *result = (double *)dpnp_memory_alloc_c(size * sizeof(double));
     dpnp_rng_srand_c(seed);
     dpnp_rng_uniform_c<double>(result, a, b, size);
     check_statistics_res = check_statistics<double>(result, tM, tD, tQ, size);
@@ -210,14 +208,14 @@ TEST(TestBackendRandomUniform, test_statistics)
 // Generalization for all DPNPFuncName
 TEST(TestBackendRandomSrand, test_func_ptr)
 {
-    void* fptr = nullptr;
+    void *fptr               = nullptr;
     DPNPFuncData kernel_data = get_dpnp_function_ptr(
-        DPNPFuncName::DPNP_FN_RNG_SRAND, DPNPFuncType::DPNP_FT_DOUBLE, DPNPFuncType::DPNP_FT_DOUBLE);
+        DPNPFuncName::DPNP_FN_RNG_SRAND, DPNPFuncType::DPNP_FT_DOUBLE,
+        DPNPFuncType::DPNP_FT_DOUBLE);
 
-    fptr = get_dpnp_function_ptr1(kernel_data.return_type,
-                                  DPNPFuncName::DPNP_FN_RNG_SRAND,
-                                  DPNPFuncType::DPNP_FT_DOUBLE,
-                                  DPNPFuncType::DPNP_FT_DOUBLE);
+    fptr = get_dpnp_function_ptr1(
+        kernel_data.return_type, DPNPFuncName::DPNP_FN_RNG_SRAND,
+        DPNPFuncType::DPNP_FT_DOUBLE, DPNPFuncType::DPNP_FT_DOUBLE);
 
     EXPECT_TRUE(fptr != nullptr);
 }

--- a/dpnp/backend/tests/test_utils.cpp
+++ b/dpnp/backend/tests/test_utils.cpp
@@ -37,11 +37,15 @@ struct AxesParameters
     bool duplications = bool{};
     vector<size_t> result;
 
-    /// Operator needs to print this container in human readable form in error reporting
-    friend std::ostream& operator<<(std::ostream& out, const AxesParameters& data)
+    /// Operator needs to print this container in human readable form in error
+    /// reporting
+    friend std::ostream &operator<<(std::ostream &out,
+                                    const AxesParameters &data)
     {
-        out << "AxesParameters(axes=" << data.axes << ", shape_size=" << data.shape_size
-            << ", duplications=" << data.duplications << ", result=" << data.result << ")";
+        out << "AxesParameters(axes=" << data.axes
+            << ", shape_size=" << data.shape_size
+            << ", duplications=" << data.duplications
+            << ", result=" << data.result << ")";
 
         return out;
     }
@@ -53,12 +57,14 @@ struct AxesNormalization : public ::testing::TestWithParam<AxesParameters>
     struct PrintToStringParamName
     {
         template <class ParamType>
-        string operator()(const testing::TestParamInfo<ParamType>& info) const
+        string operator()(const testing::TestParamInfo<ParamType> &info) const
         {
-            const AxesParameters& param = static_cast<AxesParameters>(info.param);
+            const AxesParameters &param =
+                static_cast<AxesParameters>(info.param);
             stringstream ss;
             ss << "axes=" << param.axes << ", shape_size=" << param.shape_size
-               << ", duplications=" << param.duplications << ", result=" << param.result;
+               << ", duplications=" << param.duplications
+               << ", result=" << param.result;
             return ss.str();
         }
     };
@@ -66,24 +72,26 @@ struct AxesNormalization : public ::testing::TestWithParam<AxesParameters>
 
 TEST_P(AxesNormalization, get_validated_axes)
 {
-    const AxesParameters& param = GetParam();
-    vector<size_t> result = get_validated_axes(param.axes, param.shape_size, param.duplications);
+    const AxesParameters &param = GetParam();
+    vector<size_t> result =
+        get_validated_axes(param.axes, param.shape_size, param.duplications);
     EXPECT_EQ(result, param.result);
 }
 
-INSTANTIATE_TEST_SUITE_P(TestUtilsAxesNormalization,
-                         AxesNormalization,
-                         testing::Values(AxesParameters{{0}, 1, true, {0}},
-                                         AxesParameters{{1}, 4, false, {1}},
-                                         AxesParameters{{-1}, 4, false, {3}},
-                                         AxesParameters{{0, 1, 2, 3}, 4, false, {0, 1, 2, 3}},
-                                         /* AxesParameters{{0, 1, 1, 3}, 4, false, {0, 1, 3}}, */
-                                         AxesParameters{{0, 1, 1, 3}, 4, true, {0, 1, 1, 3}},
-                                         AxesParameters{{-2, 1, -4, 3}, 4, false, {2, 1, 0, 3}},
-                                         AxesParameters{{-4, -3, -2, -1}, 4, false, {0, 1, 2, 3}},
-                                         AxesParameters{{-1, -2, -3, -4}, 4, false, {3, 2, 1, 0}},
-                                         AxesParameters{{}, 0, true, {}},
-                                         AxesParameters{{}, 0, false, {}},
-                                         AxesParameters{{}, 2, true, {}})
-                         /*, AxesNormalization::PrintToStringParamName()*/
+INSTANTIATE_TEST_SUITE_P(
+    TestUtilsAxesNormalization,
+    AxesNormalization,
+    testing::Values(AxesParameters{{0}, 1, true, {0}},
+                    AxesParameters{{1}, 4, false, {1}},
+                    AxesParameters{{-1}, 4, false, {3}},
+                    AxesParameters{{0, 1, 2, 3}, 4, false, {0, 1, 2, 3}},
+                    /* AxesParameters{{0, 1, 1, 3}, 4, false, {0, 1, 3}}, */
+                    AxesParameters{{0, 1, 1, 3}, 4, true, {0, 1, 1, 3}},
+                    AxesParameters{{-2, 1, -4, 3}, 4, false, {2, 1, 0, 3}},
+                    AxesParameters{{-4, -3, -2, -1}, 4, false, {0, 1, 2, 3}},
+                    AxesParameters{{-1, -2, -3, -4}, 4, false, {3, 2, 1, 0}},
+                    AxesParameters{{}, 0, true, {}},
+                    AxesParameters{{}, 0, false, {}},
+                    AxesParameters{{}, 2, true, {}})
+    /*, AxesNormalization::PrintToStringParamName()*/
 );

--- a/dpnp/backend/tests/test_utils_iterator.cpp
+++ b/dpnp/backend/tests/test_utils_iterator.cpp
@@ -30,7 +30,8 @@
 #include "dpnp_iterator.hpp"
 #include "dpnp_test_utils.hpp"
 
-#define DPNP_LOCAL_QUEUE 1 // TODO need to fix build procedure and remove this workaround. Issue #551
+// TODO need to fix build procedure and remove this workaround. Issue #551
+#define DPNP_LOCAL_QUEUE 1
 #include "queue_sycl.hpp"
 
 using namespace std;
@@ -45,7 +46,7 @@ TEST(TestUtilsIterator, begin_prefix_postfix)
     DPNPC_id<dpnpc_value_t> result_obj(q_ref, input_data.data(), {2});
 
     test_it begin = result_obj.begin();
-    test_it end = result_obj.end();
+    test_it end   = result_obj.end();
 
     EXPECT_NE(begin, end);
 
@@ -92,8 +93,7 @@ TEST(TestUtilsIterator, take_value_loop)
     DPNPC_id<dpnpc_value_t> result_obj(q_ref, input_data.data(), {4});
 
     dpnpc_it_t begin = result_obj.begin();
-    for (size_t i = 0; i < input_data.size(); ++i, ++begin)
-    {
+    for (size_t i = 0; i < input_data.size(); ++i, ++begin) {
         EXPECT_EQ(result_obj[i], i + 1);
     }
 }
@@ -107,8 +107,7 @@ TEST(TestUtilsIterator, take_value_loop_3D)
     DPNPC_id<dpnpc_value_t> result_obj(q_ref, input_data.data(), {2, 3, 4});
 
     dpnpc_it_t begin = result_obj.begin();
-    for (size_t i = 0; i < input_data.size(); ++i, ++begin)
-    {
+    for (size_t i = 0; i < input_data.size(); ++i, ++begin) {
         EXPECT_EQ(result_obj[i], i + 1);
     }
 }
@@ -124,8 +123,9 @@ TEST(TestUtilsIterator, take_value_axes_loop_3D)
     result_obj.set_axes({0, 2});
 
     vector<dpnpc_value_t>::iterator expected_it = expected_data.begin();
-    DPNPC_id<dpnpc_value_t>::iterator end = result_obj.end();
-    for (DPNPC_id<dpnpc_value_t>::iterator it = result_obj.begin(); it != end; ++it, ++expected_it)
+    DPNPC_id<dpnpc_value_t>::iterator end       = result_obj.end();
+    for (DPNPC_id<dpnpc_value_t>::iterator it = result_obj.begin(); it != end;
+         ++it, ++expected_it)
     {
         EXPECT_EQ(*it, *expected_it);
     }
@@ -140,7 +140,7 @@ TEST(TestUtilsIterator, take_value_axis_0_0)
     result_obj.set_axis(0); // expected data {{1, 3}, {2 ,4}} with shape {2, 2}
 
     dpnpc_it_t begin = result_obj.begin();
-    dpnpc_it_t end = result_obj.end();
+    dpnpc_it_t end   = result_obj.end();
     EXPECT_NE(begin, end);
     EXPECT_EQ(*begin, 1);
 
@@ -157,7 +157,7 @@ TEST(TestUtilsIterator, take_value_axis_0_1)
     result_obj.set_axis(0); // expected data {{1, 3}, {2 ,4}} with shape {2, 2}
 
     dpnpc_it_t begin = result_obj.begin(1);
-    dpnpc_it_t end = result_obj.end(1);
+    dpnpc_it_t end   = result_obj.end(1);
     EXPECT_NE(begin, end);
     EXPECT_EQ(*begin, 2);
 
@@ -174,7 +174,7 @@ TEST(TestUtilsIterator, take_value_axis_1)
     result_obj.set_axis(1); // expected data {{1, 2}, {3 ,4}}
 
     dpnpc_it_t begin = result_obj.begin();
-    dpnpc_it_t end = result_obj.end();
+    dpnpc_it_t end   = result_obj.end();
     EXPECT_NE(begin, end);
     EXPECT_EQ(*begin, 1);
     EXPECT_EQ(*end, 3); // linear data space
@@ -191,7 +191,8 @@ TEST(TestUtilsIterator, full_reduction_with_input_shape)
     DPNPC_id<dpnpc_value_t> result_obj(q_ref, input_data.data(), {2, 3});
 
     dpnpc_value_t result = 0;
-    for (dpnpc_it_t data_it = result_obj.begin(0); data_it != result_obj.end(0); ++data_it)
+    for (dpnpc_it_t data_it = result_obj.begin(0); data_it != result_obj.end(0);
+         ++data_it)
     {
         result += *data_it;
     }
@@ -282,10 +283,9 @@ TEST(TestUtilsIterator, iterator_loop)
     iota(result.begin(), result.end(), 1);
 
     vector<dpnpc_value_t>::iterator it_expected = expected.begin();
-    dpnpc_it_t it_result = result.begin();
+    dpnpc_it_t it_result                        = result.begin();
 
-    for (; it_expected != expected.end(); ++it_expected, ++it_result)
-    {
+    for (; it_expected != expected.end(); ++it_expected, ++it_result) {
         EXPECT_EQ(*it_expected, *it_result);
     }
 }
@@ -322,21 +322,26 @@ TEST(TestUtilsIterator, iterator_distance)
     vector<dpnpc_value_t> input_data = get_input_data<dpnpc_value_t>({3, 4});
     DPNPC_id<dpnpc_value_t> obj(q_ref, input_data.data(), {3, 4});
 
-    dpnpc_it_t::difference_type default_diff_distance = std::distance(obj.begin(), obj.end());
+    dpnpc_it_t::difference_type default_diff_distance =
+        std::distance(obj.begin(), obj.end());
     EXPECT_EQ(default_diff_distance, 12);
 
     obj.set_axis(0);
-    dpnpc_it_t::difference_type axis_0_diff_distance = std::distance(obj.begin(), obj.end());
+    dpnpc_it_t::difference_type axis_0_diff_distance =
+        std::distance(obj.begin(), obj.end());
     EXPECT_EQ(axis_0_diff_distance, 3);
 
-    dpnpc_it_t::difference_type axis_0_1_diff_distance = std::distance(obj.begin(1), obj.end(1));
+    dpnpc_it_t::difference_type axis_0_1_diff_distance =
+        std::distance(obj.begin(1), obj.end(1));
     EXPECT_EQ(axis_0_1_diff_distance, 3);
 
     obj.set_axis(1);
-    dpnpc_it_t::difference_type axis_1_diff_distance = std::distance(obj.begin(), obj.end());
+    dpnpc_it_t::difference_type axis_1_diff_distance =
+        std::distance(obj.begin(), obj.end());
     EXPECT_EQ(axis_1_diff_distance, 4);
 
-    dpnpc_it_t::difference_type axis_1_1_diff_distance = std::distance(obj.begin(1), obj.end(1));
+    dpnpc_it_t::difference_type axis_1_1_diff_distance =
+        std::distance(obj.begin(1), obj.end(1));
     EXPECT_EQ(axis_1_1_diff_distance, 4);
 }
 
@@ -346,11 +351,13 @@ struct IteratorParameters
     vector<long> axes;
     vector<dpnpc_value_t> result;
 
-    /// Operator needs to print this container in human readable form in error reporting
-    friend std::ostream& operator<<(std::ostream& out, const IteratorParameters& data)
+    /// Operator needs to print this container in human readable form in error
+    /// reporting
+    friend std::ostream &operator<<(std::ostream &out,
+                                    const IteratorParameters &data)
     {
-        out << "IteratorParameters(input_shape=" << data.input_shape << ", axis=" << data.axes
-            << ", result=" << data.result << ")";
+        out << "IteratorParameters(input_shape=" << data.input_shape
+            << ", axis=" << data.axes << ", result=" << data.result << ")";
 
         return out;
     }
@@ -362,22 +369,23 @@ class IteratorReduction : public ::testing::TestWithParam<IteratorParameters>
 
 TEST_P(IteratorReduction, loop_reduce_axis)
 {
-    const IteratorParameters& param = GetParam();
+    const IteratorParameters &param = GetParam();
     const dpnpc_index_t result_size = param.result.size();
 
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
 
-    vector<dpnpc_value_t> input_data = get_input_data<dpnpc_value_t>(param.input_shape);
+    vector<dpnpc_value_t> input_data =
+        get_input_data<dpnpc_value_t>(param.input_shape);
     DPNPC_id<dpnpc_value_t> input(q_ref, input_data.data(), param.input_shape);
     input.set_axes(param.axes);
 
     ASSERT_EQ(input.get_output_size(), result_size);
 
     vector<dpnpc_value_t> test_result(result_size, 42);
-    for (dpnpc_index_t output_id = 0; output_id < result_size; ++output_id)
-    {
+    for (dpnpc_index_t output_id = 0; output_id < result_size; ++output_id) {
         test_result[output_id] = 0;
-        for (dpnpc_it_t data_it = input.begin(output_id); data_it != input.end(output_id); ++data_it)
+        for (dpnpc_it_t data_it = input.begin(output_id);
+             data_it != input.end(output_id); ++data_it)
         {
             test_result[output_id] += *data_it;
         }
@@ -390,7 +398,7 @@ TEST_P(IteratorReduction, pstl_reduce_axis)
 {
     using data_type = double;
 
-    const IteratorParameters& param = GetParam();
+    const IteratorParameters &param = GetParam();
     const dpnpc_index_t result_size = param.result.size();
 
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
@@ -402,11 +410,12 @@ TEST_P(IteratorReduction, pstl_reduce_axis)
     ASSERT_EQ(input.get_output_size(), result_size);
 
     vector<data_type> result(result_size, 42);
-    for (dpnpc_index_t output_id = 0; output_id < result_size; ++output_id)
-    {
-        auto policy = oneapi::dpl::execution::make_device_policy<class test_pstl_reduce_axis_kernel>(DPNP_QUEUE);
+    for (dpnpc_index_t output_id = 0; output_id < result_size; ++output_id) {
+        auto policy = oneapi::dpl::execution::make_device_policy<
+            class test_pstl_reduce_axis_kernel>(DPNP_QUEUE);
         result[output_id] =
-            std::reduce(policy, input.begin(output_id), input.end(output_id), data_type(0), std::plus<data_type>());
+            std::reduce(policy, input.begin(output_id), input.end(output_id),
+                        data_type(0), std::plus<data_type>());
         policy.queue().wait();
 
         EXPECT_EQ(result[output_id], param.result.at(output_id));
@@ -417,10 +426,10 @@ TEST_P(IteratorReduction, sycl_reduce_axis)
 {
     using data_type = double;
 
-    const IteratorParameters& param = GetParam();
+    const IteratorParameters &param = GetParam();
     const dpnpc_index_t result_size = param.result.size();
     vector<data_type> result(result_size, 42);
-    data_type* result_ptr = result.data();
+    data_type *result_ptr = result.data();
 
     DPCTLSyclQueueRef q_ref = reinterpret_cast<DPCTLSyclQueueRef>(&DPNP_QUEUE);
 
@@ -431,27 +440,28 @@ TEST_P(IteratorReduction, sycl_reduce_axis)
     ASSERT_EQ(input.get_output_size(), result_size);
 
     sycl::range<1> gws(result_size);
-    const DPNPC_id<data_type>* input_it = &input;
-    auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
+    const DPNPC_id<data_type> *input_it = &input;
+    auto kernel_parallel_for_func       = [=](sycl::id<1> global_id) {
         const size_t idx = global_id[0];
 
         data_type accumulator = 0;
-        for (DPNPC_id<data_type>::iterator data_it = input_it->begin(idx); data_it != input_it->end(idx); ++data_it)
+        for (DPNPC_id<data_type>::iterator data_it = input_it->begin(idx);
+             data_it != input_it->end(idx); ++data_it)
         {
             accumulator += *data_it;
         }
         result_ptr[idx] = accumulator;
     };
 
-    auto kernel_func = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class test_sycl_reduce_axis_kernel>(gws, kernel_parallel_for_func);
+    auto kernel_func = [&](sycl::handler &cgh) {
+        cgh.parallel_for<class test_sycl_reduce_axis_kernel>(
+            gws, kernel_parallel_for_func);
     };
 
     sycl::event event = DPNP_QUEUE.submit(kernel_func);
     event.wait();
 
-    for (dpnpc_index_t i = 0; i < result_size; ++i)
-    {
+    for (dpnpc_index_t i = 0; i < result_size; ++i) {
         EXPECT_EQ(result.at(i), param.result.at(i));
     }
 }
@@ -474,42 +484,66 @@ TEST_P(IteratorReduction, sycl_reduce_axis)
  * print(f"result.dtype={result.dtype}")
  * print(f"result shape={result.shape}")
  *
- * print(f"result={np.array2string(result.reshape(result.size), separator=',')}\n", sep=",")
+ * print(f"result={np.array2string(result.reshape(result.size),
+ * separator=',')}\n", sep=",")
  */
 INSTANTIATE_TEST_SUITE_P(
     TestUtilsIterator,
     IteratorReduction,
     testing::Values(
-        IteratorParameters{{2, 3, 4}, {0}, {14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36}},
+        IteratorParameters{{2, 3, 4},
+                           {0},
+                           {14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36}},
         IteratorParameters{{2, 3, 4}, {1}, {15, 18, 21, 24, 51, 54, 57, 60}},
         IteratorParameters{{2, 3, 4}, {2}, {10, 26, 42, 58, 74, 90}},
         IteratorParameters{{1, 1, 1}, {0}, {1}},
         IteratorParameters{{1, 1, 1}, {1}, {1}},
         IteratorParameters{{1, 1, 1}, {2}, {1}},
-        IteratorParameters{{2, 3, 4, 2}, {0}, {26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48,
-                                               50, 52, 54, 56, 58, 60, 62, 64, 66, 68, 70, 72}},
-        IteratorParameters{{2, 3, 4, 2}, {1}, {27, 30, 33, 36, 39, 42, 45, 48, 99, 102, 105, 108, 111, 114, 117, 120}},
-        IteratorParameters{{2, 3, 4, 2}, {2}, {16, 20, 48, 52, 80, 84, 112, 116, 144, 148, 176, 180}},
-        IteratorParameters{{2, 3, 4, 2}, {3}, {3,  7,  11, 15, 19, 23, 27, 31, 35, 39, 43, 47,
-                                               51, 55, 59, 63, 67, 71, 75, 79, 83, 87, 91, 95}},
-        IteratorParameters{{2, 3, 4, 2}, {0, 1}, {126, 132, 138, 144, 150, 156, 162, 168}},
+        IteratorParameters{{2, 3, 4, 2}, {0}, {26, 28, 30, 32, 34, 36, 38, 40,
+                                               42, 44, 46, 48, 50, 52, 54, 56,
+                                               58, 60, 62, 64, 66, 68, 70, 72}},
+        IteratorParameters{{2, 3, 4, 2},
+                           {1},
+                           {27, 30, 33, 36, 39, 42, 45, 48, 99, 102, 105, 108,
+                            111, 114, 117, 120}},
+        IteratorParameters{
+            {2, 3, 4, 2},
+            {2},
+            {16, 20, 48, 52, 80, 84, 112, 116, 144, 148, 176, 180}},
+        IteratorParameters{{2, 3, 4, 2}, {3}, {3,  7,  11, 15, 19, 23, 27, 31,
+                                               35, 39, 43, 47, 51, 55, 59, 63,
+                                               67, 71, 75, 79, 83, 87, 91, 95}},
+        IteratorParameters{{2, 3, 4, 2},
+                           {0, 1},
+                           {126, 132, 138, 144, 150, 156, 162, 168}},
         IteratorParameters{{2, 3, 4, 2}, {2, 3}, {36, 100, 164, 228, 292, 356}},
-        IteratorParameters{{2, 3, 4, 2}, {0, 3}, {54, 62, 70, 78, 86, 94, 102, 110, 118, 126, 134, 142}},
+        IteratorParameters{
+            {2, 3, 4, 2},
+            {0, 3},
+            {54, 62, 70, 78, 86, 94, 102, 110, 118, 126, 134, 142}},
         IteratorParameters{{2, 3, 4, 2}, {0, 1, 2}, {576, 600}},
         IteratorParameters{{2, 3, 4, 2}, {0, 2, 3}, {264, 392, 520}},
         IteratorParameters{{2, 3, 4, 2}, {0, -2, -1}, {264, 392, 520}},
         IteratorParameters{{3, 4}, {0}, {15, 18, 21, 24}},
         IteratorParameters{{3, 4}, {1}, {10, 26, 42}},
         IteratorParameters{{2, 3, 4, 5, 6}, {0, 1, 2, 3, 4}, {259560}},
-        IteratorParameters{{2, 3, 4, 5, 6}, {0, 1, 3, 4}, {56790, 62190, 67590, 72990}},
+        IteratorParameters{{2, 3, 4, 5, 6},
+                           {0, 1, 3, 4},
+                           {56790, 62190, 67590, 72990}},
         IteratorParameters{{2, 3, 4, 5, 6},
                            {1, 2, 3},
-                           {10680, 10740, 10800, 10860, 10920, 10980, 32280, 32340, 32400, 32460, 32520, 32580}},
+                           {10680, 10740, 10800, 10860, 10920, 10980, 32280,
+                            32340, 32400, 32460, 32520, 32580}},
         IteratorParameters{{2, 3, 4, 5, 6},
                            {3, 1, 2},
-                           {10680, 10740, 10800, 10860, 10920, 10980, 32280, 32340, 32400, 32460, 32520, 32580}},
-        IteratorParameters{{2, 3, 4, 5, 6}, {0, 3, 1, 2}, {42960, 43080, 43200, 43320, 43440, 43560}},
-        IteratorParameters{{2, 3, 4, 5}, {1, 3}, {345, 420, 495, 570, 1245, 1320, 1395, 1470}},
+                           {10680, 10740, 10800, 10860, 10920, 10980, 32280,
+                            32340, 32400, 32460, 32520, 32580}},
+        IteratorParameters{{2, 3, 4, 5, 6},
+                           {0, 3, 1, 2},
+                           {42960, 43080, 43200, 43320, 43440, 43560}},
+        IteratorParameters{{2, 3, 4, 5},
+                           {1, 3},
+                           {345, 420, 495, 570, 1245, 1320, 1395, 1470}},
         IteratorParameters{{2, 3, 0, 5}, {1, 3}, {}},
         IteratorParameters{{2, 0, 4, 5}, {1, 3}, {0, 0, 0, 0, 0, 0, 0, 0}},
         // IteratorParameters{{2, 3, -4, 5}, {1, 3}, {}},
@@ -518,4 +552,7 @@ INSTANTIATE_TEST_SUITE_P(
         IteratorParameters{{0}, {}, {}},
         IteratorParameters{{}, {0}, {1}},
         IteratorParameters{{0}, {0}, {0}},
-        IteratorParameters{{1}, {0}, {1}}) /*TODO ,  testing::PrintToStringParamName() */);
+        IteratorParameters{
+            {1},
+            {0},
+            {1}}) /*TODO ,  testing::PrintToStringParamName() */);

--- a/dpnp/backend/tests/test_utils_iterator.cpp
+++ b/dpnp/backend/tests/test_utils_iterator.cpp
@@ -46,7 +46,7 @@ TEST(TestUtilsIterator, begin_prefix_postfix)
     DPNPC_id<dpnpc_value_t> result_obj(q_ref, input_data.data(), {2});
 
     test_it begin = result_obj.begin();
-    test_it end   = result_obj.end();
+    test_it end = result_obj.end();
 
     EXPECT_NE(begin, end);
 
@@ -123,7 +123,7 @@ TEST(TestUtilsIterator, take_value_axes_loop_3D)
     result_obj.set_axes({0, 2});
 
     vector<dpnpc_value_t>::iterator expected_it = expected_data.begin();
-    DPNPC_id<dpnpc_value_t>::iterator end       = result_obj.end();
+    DPNPC_id<dpnpc_value_t>::iterator end = result_obj.end();
     for (DPNPC_id<dpnpc_value_t>::iterator it = result_obj.begin(); it != end;
          ++it, ++expected_it)
     {
@@ -140,7 +140,7 @@ TEST(TestUtilsIterator, take_value_axis_0_0)
     result_obj.set_axis(0); // expected data {{1, 3}, {2 ,4}} with shape {2, 2}
 
     dpnpc_it_t begin = result_obj.begin();
-    dpnpc_it_t end   = result_obj.end();
+    dpnpc_it_t end = result_obj.end();
     EXPECT_NE(begin, end);
     EXPECT_EQ(*begin, 1);
 
@@ -157,7 +157,7 @@ TEST(TestUtilsIterator, take_value_axis_0_1)
     result_obj.set_axis(0); // expected data {{1, 3}, {2 ,4}} with shape {2, 2}
 
     dpnpc_it_t begin = result_obj.begin(1);
-    dpnpc_it_t end   = result_obj.end(1);
+    dpnpc_it_t end = result_obj.end(1);
     EXPECT_NE(begin, end);
     EXPECT_EQ(*begin, 2);
 
@@ -174,7 +174,7 @@ TEST(TestUtilsIterator, take_value_axis_1)
     result_obj.set_axis(1); // expected data {{1, 2}, {3 ,4}}
 
     dpnpc_it_t begin = result_obj.begin();
-    dpnpc_it_t end   = result_obj.end();
+    dpnpc_it_t end = result_obj.end();
     EXPECT_NE(begin, end);
     EXPECT_EQ(*begin, 1);
     EXPECT_EQ(*end, 3); // linear data space
@@ -283,7 +283,7 @@ TEST(TestUtilsIterator, iterator_loop)
     iota(result.begin(), result.end(), 1);
 
     vector<dpnpc_value_t>::iterator it_expected = expected.begin();
-    dpnpc_it_t it_result                        = result.begin();
+    dpnpc_it_t it_result = result.begin();
 
     for (; it_expected != expected.end(); ++it_expected, ++it_result) {
         EXPECT_EQ(*it_expected, *it_result);
@@ -441,7 +441,7 @@ TEST_P(IteratorReduction, sycl_reduce_axis)
 
     sycl::range<1> gws(result_size);
     const DPNPC_id<data_type> *input_it = &input;
-    auto kernel_parallel_for_func       = [=](sycl::id<1> global_id) {
+    auto kernel_parallel_for_func = [=](sycl::id<1> global_id) {
         const size_t idx = global_id[0];
 
         data_type accumulator = 0;


### PR DESCRIPTION
The PR proposes to extend pre-commit configuration with `clang` tool.

There is a hard dependency to run the check with `clang-format-12`, since it is the latest version available for Ubuntu 20.04.
Need to note that different versions of `clang-format` might be incompatible with each other and so format C++ code differently.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
