### PR TITLE
Use _depenv_s in dpnp/backend on Windows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,4 +32,4 @@ repos:
     rev: v1.3.5
     hooks:
     -   id: clang-format
-        args: ["-i", "--version=12"]
+        args: ["-i"]

--- a/dpnp/backend/src/memory_sycl.cpp
+++ b/dpnp/backend/src/memory_sycl.cpp
@@ -33,9 +33,21 @@
 static bool use_sycl_device_memory()
 {
     // TODO need to move all getenv() into common dpnpc place
-    const char *dpnpc_memtype_device =
-        getenv("DPNPC_OUTPUT_DPARRAY_USE_MEMORY_DEVICE");
+    char *dpnpc_memtype_device = nullptr;
+
+#ifdef _WIN32
+    size_t dpnpc_memtype_device_size = 0;
+    _dupenv_s(&dpnpc_memtype_device, &dpnpc_memtype_device_size,
+              "DPNPC_OUTPUT_DPARRAY_USE_MEMORY_DEVICE");
+#else
+    dpnpc_memtype_device =
+        std::getenv("DPNPC_OUTPUT_DPARRAY_USE_MEMORY_DEVICE");
+#endif
+
     if (dpnpc_memtype_device != nullptr) {
+#ifdef _WIN32
+        free(dpnpc_memtype_device);
+#endif
         return true;
     }
 

--- a/dpnp/backend/src/verbose.cpp
+++ b/dpnp/backend/src/verbose.cpp
@@ -33,11 +33,25 @@ bool is_verbose_mode()
 {
     if (!_is_verbose_mode_init) {
         _is_verbose_mode = false;
-        const char *env_var = std::getenv("DPNP_VERBOSE");
-        if (env_var and env_var == std::string("1")) {
+        char *env_var = nullptr;
+
+#ifdef _WIN32
+        size_t env_var_size = 0;
+        _dupenv_s(&env_var, &env_var_size, "DPNP_VERBOSE");
+#else
+        env_var = std::getenv("DPNP_VERBOSE");
+#endif
+
+        if (env_var && std::string(env_var) == "1") {
             _is_verbose_mode = true;
         }
         _is_verbose_mode_init = true;
+
+#ifdef _WIN32
+        if (env_var != nullptr)
+            free(env_var);
+#endif
+
     }
     return _is_verbose_mode;
 }

--- a/dpnp/backend/src/verbose.cpp
+++ b/dpnp/backend/src/verbose.cpp
@@ -51,7 +51,6 @@ bool is_verbose_mode()
         if (env_var != nullptr)
             free(env_var);
 #endif
-
     }
     return _is_verbose_mode;
 }


### PR DESCRIPTION
This RP refactors `use_sycl_device_memory` and `is_verbose_mode` functions to solve [SAT-5868](https://jira.devtools.intel.com/browse/SAT-5868) and suggest the usage of `_dupenv_s` for Windows by conditional compilation.

Also this PR removes `--version` argument for clang-format hook due to [pre-commit-hooks/issues/44 ](https://github.com/pocc/pre-commit-hooks/issues/44)

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
