### PR TITLE
Check dtype support of each array in resulting tuple in call_origin

### DIFF
--- a/dpnp/dpnp_utils/dpnp_algo_utils.pyx
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pyx
@@ -201,7 +201,11 @@ def call_origin(function, *args, **kwargs):
         for res_origin in result:
             res = res_origin
             if isinstance(res_origin, numpy.ndarray):
-                res = dpnp_container.empty(res_origin.shape, dtype=res_origin.dtype, sycl_queue=exec_q)
+                if exec_q is not None:
+                    result_dtype = map_dtype_to_device(res_origin.dtype, exec_q.sycl_device)
+                else:
+                    result_dtype = res_origin.d_type
+                res = dpnp_container.empty(res_origin.shape, dtype=result_dtype, sycl_queue=exec_q)
                 copy_from_origin(res, res_origin)
             result_list.append(res)
 

--- a/tests/test_histograms.py
+++ b/tests/test_histograms.py
@@ -3,8 +3,6 @@ import pytest
 
 import dpnp
 
-from .helper import has_support_aspect64
-
 
 class TestHistogram:
     def setup(self):
@@ -17,19 +15,12 @@ class TestHistogram:
     def test_simple(self):
         n = 100
         v = dpnp.random.rand(n)
-        (a, b) = dpnp.histogram(v)
+        a, _ = dpnp.histogram(v)
         # check if the sum of the bins equals the number of samples
         numpy.testing.assert_equal(dpnp.sum(a, axis=0), n)
         # check that the bin counts are evenly spaced when the data is from
         # a linear function
-        (a, b) = dpnp.histogram(
-            numpy.linspace(
-                0,
-                10,
-                100,
-                dtype="float64" if has_support_aspect64() else "float32",
-            )
-        )
+        a, _ = dpnp.histogram(dpnp.linspace(0, 10, 100))
         numpy.testing.assert_array_equal(a, 10)
 
     @pytest.mark.usefixtures("allow_fall_back_on_numpy")
@@ -76,7 +67,7 @@ class TestHistogram:
 
         # Taken from a bug report from N. Becker on the numpy-discussion
         # mailing list Aug. 6, 2010.
-        counts, dmy = dpnp.histogram(
+        counts, _ = dpnp.histogram(
             [1, 2, 3, 4], [0.5, 1.5, numpy.inf], density=True
         )
         numpy.testing.assert_equal(counts, [0.25, 0])

--- a/tests/test_histograms.py
+++ b/tests/test_histograms.py
@@ -3,6 +3,8 @@ import pytest
 
 import dpnp
 
+from .helper import has_support_aspect64
+
 
 class TestHistogram:
     def setup(self):
@@ -20,7 +22,14 @@ class TestHistogram:
         numpy.testing.assert_equal(dpnp.sum(a, axis=0), n)
         # check that the bin counts are evenly spaced when the data is from
         # a linear function
-        (a, b) = dpnp.histogram(numpy.linspace(0, 10, 100))
+        (a, b) = dpnp.histogram(
+            numpy.linspace(
+                0,
+                10,
+                100,
+                dtype="float64" if has_support_aspect64() else "float32",
+            )
+        )
         numpy.testing.assert_array_equal(a, 10)
 
     @pytest.mark.usefixtures("allow_fall_back_on_numpy")


### PR DESCRIPTION
The `call_origin` function does not check the resulting array `dtype` and its support by device after `numpy function` is called when the result is tuple of arrays so `ValueError` error was raised when running on Iris Xe.

```
import dpnp
h, e = dpnp.histogram([1, 2], bins=1)
ValueError: Device Intel(R) Graphics does not provide native support for double-precision floating point type.
``` 

This PR adds the use of  `map_dtype_to_device` function for each `dtype`  of array from the resulting tuple. 


- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
