### PR TITLE
Add metadata to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,13 +12,41 @@ version_mod = imm.SourceFileLoader(
 ).load_module()
 __version__ = version_mod.__version__
 
+"""
+Set project auxilary data like readme and licence files
+"""
+with open('README.md') as f:
+    __readme_file__ = f.read()
+
+CLASSIFIERS = """\
+Development Status :: 3 - Alpha
+Intended Audience :: Science/Research
+Intended Audience :: Developers
+License :: OSI Approved :: Apache Software License
+Programming Language :: C
+Programming Language :: Python
+Programming Language :: Python :: 3
+Programming Language :: Python :: 3.8
+Programming Language :: Python :: 3.9
+Programming Language :: Python :: 3.10
+Programming Language :: Python :: Implementation :: CPython
+Topic :: Software Development
+Topic :: Scientific/Engineering
+Operating System :: Microsoft :: Windows
+Operating System :: POSIX
+Operating System :: Unix
+"""
+
 setup(
     name="dpnp",
     version=__version__,
-    description="",
-    long_description="",
+    description="NumPy-like API accelerated with SYCL",
+    long_description=__readme_file__,
     long_description_content_type="text/markdown",
     license="Apache 2.0",
+    classifiers=[_f for _f in CLASSIFIERS.split('\n') if _f],
+    keywords="sycl numpy python3 intel mkl oneapi gpu dpcpp",
+    platforms=["Linux", "Windows"],
     author="Intel Corporation",
     url="https://github.com/IntelPython/dpnp",
     packages=[


### PR DESCRIPTION
Previously gold/2021 had a good metadata defined in setup.py, but it was lost after merges from master.
This PR brings it back.

- [X ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
