### PR TITLE
dpnp.power doesn`t work properly on Iris Xe

### DIFF
--- a/dpnp/backend/include/dpnp_gen_2arg_3type_tbl.hpp
+++ b/dpnp/backend/include/dpnp_gen_2arg_3type_tbl.hpp
@@ -180,16 +180,16 @@ MACRO_2ARG_3TYPES_OP(dpnp_multiply_c,
                                         std::complex<float>,
                                         std::complex<double>))
 
-MACRO_2ARG_3TYPES_OP(dpnp_power_c,
-                     static_cast<_DataType_output>(std::pow(input1_elem,
-                                                            input2_elem)),
-                     sycl::pow(x1, x2),
-                     MACRO_UNPACK_TYPES(float, double),
-                     oneapi::mkl::vm::pow,
-                     MACRO_UNPACK_TYPES(float,
-                                        double,
-                                        std::complex<float>,
-                                        std::complex<double>))
+MACRO_2ARG_3TYPES_OP(
+    dpnp_power_c,
+    static_cast<_DataType_output>(dispatch_pow_op(input1_elem, input2_elem)),
+    sycl::pow(x1, x2),
+    MACRO_UNPACK_TYPES(float, double),
+    oneapi::mkl::vm::pow,
+    MACRO_UNPACK_TYPES(float,
+                       double,
+                       std::complex<float>,
+                       std::complex<double>))
 
 MACRO_2ARG_3TYPES_OP(dpnp_subtract_c,
                      input1_elem - input2_elem,

--- a/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
@@ -1198,6 +1198,49 @@ static void func_map_init_elemwise_1arg_1type(func_map_t &fmap)
     return;
 }
 
+/**
+ * A template function that calculates exponentiation for integer and boolean
+ * types using different implementations based on the type T.
+ */
+template <typename T>
+constexpr T powi(T base, T exp)
+{
+    if (exp < 0) {
+        base = 1 / base;
+        exp = -exp;
+    }
+
+    T result = 1;
+    for (;;) {
+        if constexpr (std::is_same_v<T, bool>) {
+            if (exp)
+                result = result && base;
+            break;
+        }
+        else {
+            if (exp & 1)
+                result *= base;
+            exp >>= 1;
+            if (!exp)
+                break;
+            base *= base;
+        }
+    }
+
+    return result;
+}
+
+template <typename T>
+constexpr T dispatch_pow_op(T elem1, T elem2)
+{
+    if constexpr (is_any_v<T, std::int32_t, std::int64_t, bool>) {
+        return powi(elem1, elem2);
+    }
+    else {
+        return std::pow(elem1, elem2);
+    }
+}
+
 #define MACRO_2ARG_3TYPES_OP(__name__, __operation__, __vec_operation__,       \
                              __vec_types__, __mkl_operation__, __mkl_types__)  \
     template <typename _KernelNameSpecialization1,                             \

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -990,13 +990,10 @@ class TestPower:
 
     @pytest.mark.parametrize("dtype", [dpnp.int32, dpnp.int64])
     def test_integer_to_negative_power(self, dtype):
-        ones = dpnp.ones(10, dtype=dtype)
         a = dpnp.arange(2, 10, dtype=dtype)
-        b = dpnp.full(10, -2, dtype=dtype)
+        zeros = dpnp.zeros(8, dtype=dtype)
 
-        assert_array_equal(ones ** (-2), ones)
-        assert_equal(a ** (-3), 0)  # positive integer to negative integer power
-        assert_equal(b ** (-4), 0)  # negative integer to negative integer power
+        assert_equal(a ** (-3), zeros)
 
     def test_float_to_inf(self):
         a = numpy.array(

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -894,7 +894,7 @@ class TestPower:
         np_array2 = numpy.array(array2_data, dtype=dtype)
         expected = numpy.power(np_array1, np_array2, out=out)
 
-        assert_allclose(expected, result)
+        assert_allclose(expected, result, rtol=1e-06)
 
     @pytest.mark.parametrize(
         "dtype", get_all_dtypes(no_complex=True, no_none=True)
@@ -912,7 +912,7 @@ class TestPower:
         dp_out = dpnp.empty(size, dtype=dpnp.complex64)
         result = dpnp.power(dp_array1, dp_array2, out=dp_out)
 
-        assert_array_equal(expected, result)
+        assert_allclose(expected, result, rtol=1e-06)
 
     @pytest.mark.parametrize(
         "dtype", get_all_dtypes(no_bool=True, no_complex=True, no_none=True)
@@ -947,9 +947,9 @@ class TestPower:
         "shape", [(0,), (15,), (2, 2)], ids=["(0,)", "(15, )", "(2,2)"]
     )
     def test_invalid_shape(self, shape):
-        dp_array1 = dpnp.arange(10, dtype=dpnp.float64)
-        dp_array2 = dpnp.arange(5, 15, dtype=dpnp.float64)
-        dp_out = dpnp.empty(shape, dtype=dpnp.float64)
+        dp_array1 = dpnp.arange(10, dtype=dpnp.float32)
+        dp_array2 = dpnp.arange(5, 15, dtype=dpnp.float32)
+        dp_out = dpnp.empty(shape, dtype=dpnp.float32)
 
         with pytest.raises(ValueError):
             dpnp.power(dp_array1, dp_array2, out=dp_out)


### PR DESCRIPTION
When `dpnp.power` is called with integer and boolean types it uses the `std::pow` function which casts the passed arguments to double so `RuntimeError` error is raised 
```
import dpnp

dpnp.array([4]) ** 2
RuntimeError: Required aspect fp64 is not supported on the device
```

This PR adds a new implementation of template function `ipow` which is used for integer and boolean types of input arguments.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
