### PR TITLE
Exclude docker image removal

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
+        with:
+          docker-images: false
 
       - name: Install Intel repository
         run: |


### PR DESCRIPTION
The github action with a pre-step to free additional space during building the docs was updated with a new version and so it enabled docker image removal by default.
The PR proposal to explicitly disable removal of docker images, since the image is required.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
