### PR TITLE
Continue parallel uploading in case of error

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -350,7 +350,7 @@ jobs:
       run:
         shell: ${{ matrix.os == 'windows-latest' && 'cmd /C CALL {0}' || 'bash -l {0}' }}
 
-    continue-on-error: false
+    continue-on-error: true
 
     if: |
       (github.repository == 'IntelPython/dpnp') &&


### PR DESCRIPTION
The PR proposes to permit parallel uploading to conda even if any single upload job fails.

It might be a case when uploading of any built conda package is failed due to some connectivity issue and it would be enough to rerun it. But with option `continue-on-error: false` all other running upload jobs will be cancelled due to that.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
