### PR TITLE
Update dpnp.sqrt using dpctl and OneMKL implementations 

### DIFF
--- a/dpnp/backend/extensions/vm/CMakeLists.txt
+++ b/dpnp/backend/extensions/vm/CMakeLists.txt
@@ -28,6 +28,7 @@ set(python_module_name _vm_impl)
 pybind11_add_module(${python_module_name} MODULE
     vm_py.cpp
     div.cpp
+    sqrt.cpp
 )
 
 if (WIN32)

--- a/dpnp/backend/extensions/vm/sqrt.cpp
+++ b/dpnp/backend/extensions/vm/sqrt.cpp
@@ -1,0 +1,295 @@
+//*****************************************************************************
+// Copyright (c) 2023, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//*****************************************************************************
+
+#include <pybind11/pybind11.h>
+
+// dpctl tensor headers
+#include "utils/memory_overlap.hpp"
+#include "utils/type_utils.hpp"
+
+#include "sqrt.hpp"
+#include "types_matrix.hpp"
+
+#include "dpnp_utils.hpp"
+
+namespace dpnp
+{
+namespace backend
+{
+namespace ext
+{
+namespace vm
+{
+
+namespace mkl_vm = oneapi::mkl::vm;
+namespace py = pybind11;
+namespace type_utils = dpctl::tensor::type_utils;
+
+typedef sycl::event (*sqrt_impl_fn_ptr_t)(sycl::queue,
+                                          const std::int64_t,
+                                          const char *,
+                                          char *,
+                                          const std::vector<sycl::event> &);
+
+static sqrt_impl_fn_ptr_t sqrt_dispatch_vector[dpctl_td_ns::num_types];
+
+template <typename T>
+static sycl::event sqrt_impl(sycl::queue exec_q,
+                             const std::int64_t n,
+                             const char *in_a,
+                             char *out_y,
+                             const std::vector<sycl::event> &depends)
+{
+    type_utils::validate_type_for_device<T>(exec_q);
+
+    const T *a = reinterpret_cast<const T *>(in_a);
+    T *y = reinterpret_cast<T *>(out_y);
+
+    return mkl_vm::sqrt(exec_q,
+                        n, // number of elements to be calculated
+                        a, // pointer `a` containing input vector of size n
+                        y, // pointer `y` to the output vector of size n
+                        depends);
+}
+
+std::pair<sycl::event, sycl::event>
+    sqrt(sycl::queue exec_q,
+         dpctl::tensor::usm_ndarray src,
+         dpctl::tensor::usm_ndarray dst, // dst = op(src), elementwise
+         const std::vector<sycl::event> &depends)
+{
+    // check type_nums
+    int src_typenum = src.get_typenum();
+    int dst_typenum = dst.get_typenum();
+
+    auto array_types = dpctl_td_ns::usm_ndarray_types();
+    int src_typeid = array_types.typenum_to_lookup_id(src_typenum);
+    int dst_typeid = array_types.typenum_to_lookup_id(dst_typenum);
+
+    if (src_typeid != dst_typeid) {
+        throw py::value_error(
+            "Input array and output array have different types");
+    }
+
+    // check that queues are compatible
+    if (!dpctl::utils::queues_are_compatible(exec_q, {src, dst})) {
+        throw py::value_error(
+            "Execution queue is not compatible with allocation queues");
+    }
+
+    // check shapes, broadcasting is assumed done by caller
+    // check that dimensions are the same
+    int dst_nd = dst.get_ndim();
+    if (dst_nd != src.get_ndim()) {
+        throw py::value_error("Array dimensions are not the same.");
+    }
+
+    // check that shapes are the same
+    const py::ssize_t *src_shape = src.get_shape_raw();
+    const py::ssize_t *dst_shape = dst.get_shape_raw();
+    bool shapes_equal(true);
+    size_t src_nelems(1);
+
+    for (int i = 0; i < dst_nd; ++i) {
+        src_nelems *= static_cast<size_t>(src_shape[i]);
+        shapes_equal = shapes_equal && (src_shape[i] == dst_shape[i]);
+    }
+    if (!shapes_equal) {
+        throw py::value_error("Array shapes are not the same.");
+    }
+
+    // if nelems is zero, return
+    if (src_nelems == 0) {
+        return std::make_pair(sycl::event(), sycl::event());
+    }
+
+    // ensure that output is ample enough to accomodate all elements
+    auto dst_offsets = dst.get_minmax_offsets();
+    // destination must be ample enough to accomodate all elements
+    {
+        size_t range =
+            static_cast<size_t>(dst_offsets.second - dst_offsets.first);
+        if (range + 1 < src_nelems) {
+            throw py::value_error(
+                "Destination array can not accomodate all the "
+                "elements of source array.");
+        }
+    }
+
+    // check memory overlap
+    auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
+    if (overlap(src, dst)) {
+        throw py::value_error("Array index overlapping segments of memory");
+    }
+
+    const char *src_data = src.get_data();
+    char *dst_data = dst.get_data();
+
+    // handle contiguous inputs
+    bool is_src_c_contig = src.is_c_contiguous();
+    bool is_dst_c_contig = dst.is_c_contiguous();
+
+    bool all_c_contig = (is_src_c_contig && is_dst_c_contig);
+    if (!all_c_contig) {
+        throw py::value_error("Input and outpur arrays must be C-contiguous");
+    }
+
+    auto sqrt_fn = sqrt_dispatch_vector[dst_typeid];
+    if (sqrt_fn == nullptr) {
+        throw py::value_error("No sqrt implementation defined");
+    }
+    sycl::event sum_ev =
+        sqrt_fn(exec_q, src_nelems, src_data, dst_data, depends);
+
+    sycl::event ht_ev =
+        dpctl::utils::keep_args_alive(exec_q, {src, dst}, {sum_ev});
+    return std::make_pair(ht_ev, sum_ev);
+    return std::make_pair(sycl::event(), sycl::event());
+}
+
+bool can_call_sqrt(sycl::queue exec_q,
+                   dpctl::tensor::usm_ndarray src,
+                   dpctl::tensor::usm_ndarray dst)
+{
+#if INTEL_MKL_VERSION >= 20230002
+    // check type_nums
+    int src_typenum = src.get_typenum();
+    int dst_typenum = dst.get_typenum();
+
+    auto array_types = dpctl_td_ns::usm_ndarray_types();
+    int src_typeid = array_types.typenum_to_lookup_id(src_typenum);
+    int dst_typeid = array_types.typenum_to_lookup_id(dst_typenum);
+
+    // types must be the same
+    if (src_typeid != dst_typeid) {
+        return false;
+    }
+
+    // OneMKL VM functions perform a copy on host if no double type support
+    if (!exec_q.get_device().has(sycl::aspect::fp64)) {
+        return false;
+    }
+
+    // check that queues are compatible
+    if (!dpctl::utils::queues_are_compatible(exec_q, {src, dst})) {
+        return false;
+    }
+
+    // dimensions must be the same
+    int dst_nd = dst.get_ndim();
+    if (dst_nd != src.get_ndim()) {
+        return false;
+    }
+    else if (dst_nd == 0) {
+        // don't call OneMKL for 0d arrays
+        return false;
+    }
+
+    // shapes must be the same
+    const py::ssize_t *src_shape = src.get_shape_raw();
+    const py::ssize_t *dst_shape = dst.get_shape_raw();
+    bool shapes_equal(true);
+    size_t src_nelems(1);
+
+    for (int i = 0; i < dst_nd; ++i) {
+        src_nelems *= static_cast<size_t>(src_shape[i]);
+        shapes_equal = shapes_equal && (src_shape[i] == dst_shape[i]);
+    }
+    if (!shapes_equal) {
+        return false;
+    }
+
+    // if nelems is zero, return false
+    if (src_nelems == 0) {
+        return false;
+    }
+
+    // ensure that output is ample enough to accomodate all elements
+    auto dst_offsets = dst.get_minmax_offsets();
+    // destination must be ample enough to accomodate all elements
+    {
+        size_t range =
+            static_cast<size_t>(dst_offsets.second - dst_offsets.first);
+        if (range + 1 < src_nelems) {
+            return false;
+        }
+    }
+
+    // check memory overlap
+    auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
+    if (overlap(src, dst)) {
+        return false;
+    }
+
+    // suppport only contiguous inputs
+    bool is_src_c_contig = src.is_c_contiguous();
+    bool is_dst_c_contig = dst.is_c_contiguous();
+
+    bool all_c_contig = (is_src_c_contig && is_dst_c_contig);
+    if (!all_c_contig) {
+        return false;
+    }
+
+    // MKL function is not defined for the type
+    if (sqrt_dispatch_vector[src_typeid] == nullptr) {
+        return false;
+    }
+    return true;
+#else
+    // In OneMKL 2023.1.0 the call of oneapi::mkl::vm::sqrt() is going to dead
+    // lock inside ~usm_wrapper_to_host()->{...; q_->wait_and_throw(); ...}
+
+    (void)exec_q;
+    (void)src;
+    (void)dst;
+    return false;
+#endif // INTEL_MKL_VERSION >= 20230002
+}
+
+template <typename fnT, typename T>
+struct SqrtContigFactory
+{
+    fnT get()
+    {
+        if constexpr (types::SqrtTypeSupportFactory<T>::is_defined) {
+            return sqrt_impl<T>;
+        }
+        else {
+            return nullptr;
+        }
+    }
+};
+
+void init_sqrt_dispatch_vector(void)
+{
+    dpctl_td_ns::DispatchVectorBuilder<sqrt_impl_fn_ptr_t, SqrtContigFactory,
+                                       dpctl_td_ns::num_types>
+        contig;
+    contig.populate_dispatch_vector(sqrt_dispatch_vector);
+}
+} // namespace vm
+} // namespace ext
+} // namespace backend
+} // namespace dpnp

--- a/dpnp/backend/extensions/vm/sqrt.hpp
+++ b/dpnp/backend/extensions/vm/sqrt.hpp
@@ -1,0 +1,56 @@
+//*****************************************************************************
+// Copyright (c) 2023, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//*****************************************************************************
+
+#pragma once
+
+#include <CL/sycl.hpp>
+#include <oneapi/mkl.hpp>
+
+#include <dpctl4pybind11.hpp>
+#include <pybind11/numpy.h>
+
+namespace dpnp
+{
+namespace backend
+{
+namespace ext
+{
+namespace vm
+{
+extern std::pair<sycl::event, sycl::event>
+    sqrt(sycl::queue exec_q,
+         dpctl::tensor::usm_ndarray src,
+         dpctl::tensor::usm_ndarray dst,
+         const std::vector<sycl::event> &depends);
+
+extern bool can_call_sqrt(sycl::queue exec_q,
+                          dpctl::tensor::usm_ndarray src,
+                          dpctl::tensor::usm_ndarray dst);
+
+extern void init_sqrt_dispatch_vector(void);
+} // namespace vm
+} // namespace ext
+} // namespace backend
+} // namespace dpnp

--- a/dpnp/backend/extensions/vm/types_matrix.hpp
+++ b/dpnp/backend/extensions/vm/types_matrix.hpp
@@ -66,6 +66,22 @@ struct DivTypePairSupportFactory
         // fall-through
         dpctl_td_ns::NotDefinedEntry>::is_defined;
 };
+
+/**
+ * @brief A factory to define supported types for which
+ * MKL VM library provides support in oneapi::mkl::vm::sqrt<T> function.
+ *
+ * @tparam T Type of input vector `a` and of result vector `y`.
+ */
+template <typename T>
+struct SqrtTypeSupportFactory
+{
+    static constexpr bool is_defined =
+        std::disjunction<std::bool_constant<std::is_same_v<T, float>>,
+                         std::bool_constant<std::is_same_v<T, double>>,
+                         // fall-through
+                         std::false_type>::value;
+};
 } // namespace types
 } // namespace vm
 } // namespace ext

--- a/dpnp/backend/extensions/vm/types_matrix.hpp
+++ b/dpnp/backend/extensions/vm/types_matrix.hpp
@@ -76,11 +76,13 @@ struct DivTypePairSupportFactory
 template <typename T>
 struct SqrtTypeSupportFactory
 {
-    static constexpr bool is_defined =
-        std::disjunction<std::bool_constant<std::is_same_v<T, float>>,
-                         std::bool_constant<std::is_same_v<T, double>>,
-                         // fall-through
-                         std::false_type>::value;
+    static constexpr bool is_defined = std::disjunction<
+        std::bool_constant<std::is_same_v<T, float>>,
+        std::bool_constant<std::is_same_v<T, double>>,
+        std::bool_constant<std::is_same_v<T, std::complex<float>>>,
+        std::bool_constant<std::is_same_v<T, std::complex<double>>>,
+        // fall-through
+        std::false_type>::value;
 };
 } // namespace types
 } // namespace vm

--- a/dpnp/backend/extensions/vm/vm_py.cpp
+++ b/dpnp/backend/extensions/vm/vm_py.cpp
@@ -31,6 +31,7 @@
 #include <pybind11/stl.h>
 
 #include "div.hpp"
+#include "sqrt.hpp"
 
 namespace vm_ext = dpnp::backend::ext::vm;
 namespace py = pybind11;
@@ -39,6 +40,7 @@ namespace py = pybind11;
 void init_dispatch_vectors(void)
 {
     vm_ext::init_div_dispatch_vector();
+    vm_ext::init_sqrt_dispatch_vector();
 }
 
 // populate dispatch tables
@@ -61,4 +63,16 @@ PYBIND11_MODULE(_vm_impl, m)
           "library can be used",
           py::arg("sycl_queue"), py::arg("src1"), py::arg("src2"),
           py::arg("dst"));
+
+    m.def("_sqrt", &vm_ext::sqrt,
+          "Call `sqrt` from OneMKL VM library to performs element by element "
+          "operation of extracting the square root "
+          "of vector `src` to resulting vector `dst`",
+          py::arg("sycl_queue"), py::arg("src"), py::arg("dst"),
+          py::arg("depends") = py::list());
+
+    m.def("_can_call_sqrt", &vm_ext::can_call_sqrt,
+          "Check input arrays to answer if `sqrt` function from OneMKL VM "
+          "library can be used",
+          py::arg("sycl_queue"), py::arg("src"), py::arg("dst"));
 }

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -297,8 +297,6 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_SINH_EXT
         DPNP_FN_SORT
         DPNP_FN_SORT_EXT
-        DPNP_FN_SQRT
-        DPNP_FN_SQRT_EXT
         DPNP_FN_SQUARE
         DPNP_FN_SQUARE_EXT
         DPNP_FN_STD
@@ -554,7 +552,6 @@ cpdef dpnp_descriptor dpnp_radians(dpnp_descriptor array1)
 cpdef dpnp_descriptor dpnp_recip(dpnp_descriptor array1)
 cpdef dpnp_descriptor dpnp_sin(dpnp_descriptor array1, dpnp_descriptor out)
 cpdef dpnp_descriptor dpnp_sinh(dpnp_descriptor array1)
-cpdef dpnp_descriptor dpnp_sqrt(dpnp_descriptor array1, dpnp_descriptor out)
 cpdef dpnp_descriptor dpnp_square(dpnp_descriptor array1)
 cpdef dpnp_descriptor dpnp_tan(dpnp_descriptor array1, dpnp_descriptor out)
 cpdef dpnp_descriptor dpnp_tanh(dpnp_descriptor array1)

--- a/dpnp/dpnp_algo/dpnp_algo_trigonometric.pxi
+++ b/dpnp/dpnp_algo/dpnp_algo_trigonometric.pxi
@@ -57,7 +57,6 @@ __all__ += [
     'dpnp_recip',
     'dpnp_sin',
     'dpnp_sinh',
-    'dpnp_sqrt',
     'dpnp_square',
     'dpnp_tan',
     'dpnp_tanh',
@@ -147,10 +146,6 @@ cpdef utils.dpnp_descriptor dpnp_sin(utils.dpnp_descriptor x1, utils.dpnp_descri
 
 cpdef utils.dpnp_descriptor dpnp_sinh(utils.dpnp_descriptor x1):
     return call_fptr_1in_1out_strides(DPNP_FN_SINH_EXT, x1)
-
-
-cpdef utils.dpnp_descriptor dpnp_sqrt(utils.dpnp_descriptor x1, utils.dpnp_descriptor out):
-    return call_fptr_1in_1out_strides(DPNP_FN_SQRT_EXT, x1, dtype=None, out=out, where=True, func_name='sqrt')
 
 
 cpdef utils.dpnp_descriptor dpnp_square(utils.dpnp_descriptor x1):

--- a/dpnp/dpnp_algo/dpnp_elementwise_common.py
+++ b/dpnp/dpnp_algo/dpnp_elementwise_common.py
@@ -55,8 +55,8 @@ __all__ = [
     "dpnp_logical_xor",
     "dpnp_multiply",
     "dpnp_not_equal",
-    "dpnp_subtract",
     "dpnp_sqrt",
+    "dpnp_subtract",
 ]
 
 
@@ -700,6 +700,52 @@ def dpnp_not_equal(x1, x2, out=None, order="K"):
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
+_sqrt_docstring_ = """
+sqrt(x, out=None, order='K')
+Computes the non-negative square-root for each element `x_i` for input array `x`.
+Args:
+    x (dpnp.ndarray):
+        Input array.
+    out ({None, dpnp.ndarray}, optional):
+        Output array to populate. Array must have the correct
+        shape and the expected data type.
+    order ("C","F","A","K", optional): memory layout of the new
+        output array, if parameter `out` is `None`.
+        Default: "K".
+Return:
+    usm_ndarray:
+        An array containing the element-wise square-root results.
+"""
+
+
+def dpnp_sqrt(x, out=None, order="K"):
+    """Invokes sqrt() from dpctl.tensor implementation for sqrt() function."""
+
+    def _call_sqrt(src, dst, sycl_queue, depends=None):
+        """A callback to register in UnaryElementwiseFunc class of dpctl.tensor"""
+
+        if depends is None:
+            depends = []
+
+        if vmi._can_call_sqrt(sycl_queue, src, dst):
+            # call pybind11 extension for sqrt() function from OneMKL VM
+            return vmi._sqrt(sycl_queue, src, dst, depends)
+        return ti._sqrt(src, dst, sycl_queue, depends)
+
+    # dpctl.tensor only works with usm_ndarray or scalar
+    x_usm = dpnp.get_usm_ndarray(x)
+    out_usm = None if out is None else dpnp.get_usm_ndarray(out)
+
+    func = UnaryElementwiseFunc(
+        "sqrt",
+        ti._sqrt_result_type,
+        _call_sqrt,
+        _sqrt_docstring_,
+    )
+    res_usm = func(x_usm, out=out_usm, order=order)
+    return dpnp_array._create_from_usm_ndarray(res_usm)
+
+
 _subtract_docstring_ = """
 subtract(x1, x2, out=None, order="K")
 
@@ -757,50 +803,4 @@ def dpnp_subtract(x1, x2, out=None, order="K"):
         ti._subtract_inplace,
     )
     res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
-
-
-_sqrt_docstring_ = """
-sqrt(x, out=None, order='K')
-Computes the non-negative square-root for each element `x_i` for input array `x`.
-Args:
-    x (dpnp.ndarray):
-        Input array.
-    out ({None, dpnp.ndarray}, optional):
-        Output array to populate. Array must have the correct
-        shape and the expected data type.
-    order ("C","F","A","K", optional): memory layout of the new
-        output array, if parameter `out` is `None`.
-        Default: "K".
-Return:
-    usm_ndarray:
-        An array containing the element-wise square-root results.
-"""
-
-
-def dpnp_sqrt(x, out=None, order="K"):
-    """Invokes sqrt() from dpctl.tensor implementation for sqrt() function."""
-
-    def _call_sqrt(src, dst, sycl_queue, depends=None):
-        """A callback to register in UnaryElementwiseFunc class of dpctl.tensor"""
-
-        if depends is None:
-            depends = []
-
-        if vmi._can_call_sqrt(sycl_queue, src, dst):
-            # call pybind11 extension for sqrt() function from OneMKL VM
-            return vmi._sqrt(sycl_queue, src, dst, depends)
-        return ti._sqrt(src, dst, sycl_queue, depends)
-
-    # dpctl.tensor only works with usm_ndarray or scalar
-    x_usm = dpnp.get_usm_ndarray(x)
-    out_usm = None if out is None else dpnp.get_usm_ndarray(out)
-
-    func = UnaryElementwiseFunc(
-        "sqrt",
-        ti._sqrt_result_type,
-        _call_sqrt,
-        _sqrt_docstring_,
-    )
-    res_usm = func(x_usm, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)

--- a/dpnp/dpnp_algo/dpnp_elementwise_common.py
+++ b/dpnp/dpnp_algo/dpnp_elementwise_common.py
@@ -56,6 +56,7 @@ __all__ = [
     "dpnp_multiply",
     "dpnp_not_equal",
     "dpnp_subtract",
+    "dpnp_sqrt",
 ]
 
 
@@ -756,4 +757,39 @@ def dpnp_subtract(x1, x2, out=None, order="K"):
         ti._subtract_inplace,
     )
     res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
+    return dpnp_array._create_from_usm_ndarray(res_usm)
+
+
+_sqrt_docstring_ = """
+sqrt(x, out=None, order='K')
+Computes the non-negative square-root for each element `x_i` for input array `x`.
+Args:
+    x (dpnp.ndarray):
+        Input array.
+    out ({None, dpnp.ndarray}, optional):
+        Output array to populate. Array must have the correct
+        shape and the expected data type.
+    order ("C","F","A","K", optional): memory layout of the new
+        output array, if parameter `out` is `None`.
+        Default: "K".
+Return:
+    usm_ndarray:
+        An array containing the element-wise square-root results.
+"""
+
+
+def dpnp_sqrt(x, out=None, order="K"):
+    """Invokes sqrt() from dpctl.tensor implementation for sqrt() function."""
+
+    # dpctl.tensor only works with usm_ndarray or scalar
+    x_usm = dpnp.get_usm_ndarray(x)
+    out_usm = None if out is None else dpnp.get_usm_ndarray(out)
+
+    func = UnaryElementwiseFunc(
+        "sqrt",
+        ti._sqrt_result_type,
+        ti._sqrt,
+        _sqrt_docstring_,
+    )
+    res_usm = func(x_usm, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)

--- a/dpnp/dpnp_iface_bitwise.py
+++ b/dpnp/dpnp_iface_bitwise.py
@@ -133,7 +133,7 @@ def bitwise_and(x1, x2, dtype=None, out=None, where=True, **kwargs):
     Returns
     -------
     y : dpnp.ndarray
-        An array containing the element-wise results.
+        An array containing the element-wise results of positive square root.
 
     Limitations
     -----------

--- a/dpnp/dpnp_iface_trigonometric.py
+++ b/dpnp/dpnp_iface_trigonometric.py
@@ -40,12 +40,16 @@ it contains:
 """
 
 
-import dpctl.tensor as dpt
 import numpy
 
 import dpnp
 from dpnp.dpnp_algo import *
 from dpnp.dpnp_utils import *
+
+from .dpnp_algo.dpnp_elementwise_common import (
+    check_nd_call_func,
+    dpnp_sqrt,
+)
 
 __all__ = [
     "arccos",
@@ -996,7 +1000,17 @@ def sinh(x1):
     return call_origin(numpy.sinh, x1, **kwargs)
 
 
-def sqrt(x1, /, out=None, **kwargs):
+def sqrt(
+    x,
+    /,
+    out=None,
+    *,
+    order="K",
+    where=True,
+    dtype=None,
+    subok=True,
+    **kwargs,
+):
     """
     Return the positive square-root of an array, element-wise.
 
@@ -1007,8 +1021,8 @@ def sqrt(x1, /, out=None, **kwargs):
     Input array is supported as either :class:`dpnp.ndarray` or :class:`dpctl.tensor.usm_ndarray`.
     Parameter `out` is supported as class:`dpnp.ndarray`, class:`dpctl.tensor.usm_ndarray` or
     with default value ``None``.
+    Parameters `where`, `dtype` and `subok` are supported with their default values.
     Otherwise the function will be executed sequentially on CPU.
-    Keyword arguments ``kwargs`` are currently unsupported.
     Input array data types are limited by supported DPNP :ref:`Data types`.
 
     Examples
@@ -1021,26 +1035,17 @@ def sqrt(x1, /, out=None, **kwargs):
 
     """
 
-    x1_desc = (
-        dpnp.get_dpnp_descriptor(
-            x1, copy_when_strides=False, copy_when_nondefault_queue=False
-        )
-        if not kwargs
-        else None
+    return check_nd_call_func(
+        numpy.sqrt,
+        dpnp_sqrt,
+        x,
+        out=out,
+        where=where,
+        order=order,
+        dtype=dtype,
+        subok=subok,
+        **kwargs,
     )
-    if x1_desc:
-        if out is not None:
-            if not isinstance(out, (dpnp.ndarray, dpt.usm_ndarray)):
-                raise TypeError("return array must be of supported array type")
-            out_desc = (
-                dpnp.get_dpnp_descriptor(out, copy_when_nondefault_queue=False)
-                or None
-            )
-        else:
-            out_desc = None
-        return dpnp_sqrt(x1_desc, out=out_desc).get_pyobj()
-
-    return call_origin(numpy.sqrt, x1, out=out, **kwargs)
 
 
 def square(x1):

--- a/dpnp/dpnp_iface_trigonometric.py
+++ b/dpnp/dpnp_iface_trigonometric.py
@@ -1016,6 +1016,11 @@ def sqrt(
 
     For full documentation refer to :obj:`numpy.sqrt`.
 
+    Returns
+    -------
+    y : dpnp.ndarray
+        An array containing the element-wise results of positive square root.
+
     Limitations
     -----------
     Input array is supported as either :class:`dpnp.ndarray` or :class:`dpctl.tensor.usm_ndarray`.
@@ -1029,9 +1034,12 @@ def sqrt(
     --------
     >>> import dpnp as np
     >>> x = np.array([1, 4, 9])
-    >>> out = np.sqrt(x)
-    >>> [i for i in out]
-    [1.0, 2.0, 3.0]
+    >>> np.sqrt(x)
+    array([1., 2., 3.])
+
+    >>> x2 = np.array([4, -1, np.inf])
+    >>> np.sqrt(x2)
+    array([ 2., nan, inf])
 
     """
 

--- a/tests/test_umath.py
+++ b/tests/test_umath.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_allclose, assert_array_equal
 
 import dpnp
 
-from .helper import get_all_dtypes, get_float_dtypes
+from .helper import get_all_dtypes, get_float_complex_dtypes
 
 # full list of umaths
 umaths = [i for i in dir(numpy) if isinstance(getattr(numpy, i), numpy.ufunc)]
@@ -408,8 +408,22 @@ class TestArctan2:
 
 
 class TestSqrt:
-    @pytest.mark.parametrize("dtype", get_float_dtypes())
+    @pytest.mark.parametrize("dtype", get_all_dtypes())
     def test_sqrt_ordinary(self, dtype):
+        array_data = numpy.arange(10)
+
+        # DPNP
+        dp_array = dpnp.array(array_data, dtype=dtype)
+        result = dpnp.sqrt(dp_array)
+
+        # original
+        np_array = numpy.array(array_data, dtype=dtype)
+        expected = numpy.sqrt(np_array)
+
+        numpy.testing.assert_allclose(expected, result)
+
+    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
+    def test_sqrt_out(self, dtype):
         array_data = numpy.arange(10)
         out = numpy.empty(10, dtype=dtype)
 

--- a/tests/test_umath.py
+++ b/tests/test_umath.py
@@ -432,7 +432,7 @@ class TestSqrt:
         dp_array = dpnp.arange(10, dtype=dpnp.float32)
         dp_out = dpnp.empty(10, dtype=dtype)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             dpnp.sqrt(dp_array, out=dp_out)
 
     @pytest.mark.parametrize(
@@ -442,7 +442,7 @@ class TestSqrt:
         dp_array = dpnp.arange(10, dtype=dpnp.float32)
         dp_out = dpnp.empty(shape, dtype=dpnp.float32)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             dpnp.sqrt(dp_array, out=dp_out)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds the ability to rely on `dpctl.tensor.sqrt()` implementation for `dpnp.sqrt` function and call `sqrt` from pybind11 extension of OneMKL if possible

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
