### PR TITLE
Improve dpnp.square() implementation

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -23,6 +23,7 @@ env:
       test_umath.py
       test_usm_type.py
       third_party/cupy/math_tests/test_explog.py
+      third_party/cupy/math_tests/test_misc.py
       third_party/cupy/math_tests/test_trigonometric.py
       third_party/cupy/sorting_tests/test_sort.py
   VER_JSON_NAME: 'version.json'

--- a/dpnp/backend/extensions/vm/sqr.hpp
+++ b/dpnp/backend/extensions/vm/sqr.hpp
@@ -1,0 +1,78 @@
+//*****************************************************************************
+// Copyright (c) 2023, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//*****************************************************************************
+
+#pragma once
+
+#include <CL/sycl.hpp>
+
+#include "common.hpp"
+#include "types_matrix.hpp"
+
+namespace dpnp
+{
+namespace backend
+{
+namespace ext
+{
+namespace vm
+{
+template <typename T>
+sycl::event sqr_contig_impl(sycl::queue exec_q,
+                            const std::int64_t n,
+                            const char *in_a,
+                            char *out_y,
+                            const std::vector<sycl::event> &depends)
+{
+    type_utils::validate_type_for_device<T>(exec_q);
+
+    const T *a = reinterpret_cast<const T *>(in_a);
+    T *y = reinterpret_cast<T *>(out_y);
+
+    return mkl_vm::sqr(exec_q,
+                       n, // number of elements to be calculated
+                       a, // pointer `a` containing input vector of size n
+                       y, // pointer `y` to the output vector of size n
+                       depends);
+}
+
+template <typename fnT, typename T>
+struct SqrContigFactory
+{
+    fnT get()
+    {
+        if constexpr (std::is_same_v<
+                          typename types::SqrOutputType<T>::value_type, void>)
+        {
+            return nullptr;
+        }
+        else {
+            return sqr_contig_impl<T>;
+        }
+    }
+};
+} // namespace vm
+} // namespace ext
+} // namespace backend
+} // namespace dpnp

--- a/dpnp/backend/extensions/vm/types_matrix.hpp
+++ b/dpnp/backend/extensions/vm/types_matrix.hpp
@@ -127,6 +127,21 @@ struct SinOutputType
 
 /**
  * @brief A factory to define pairs of supported types for which
+ * MKL VM library provides support in oneapi::mkl::vm::sqr<T> function.
+ *
+ * @tparam T Type of input vector `a` and of result vector `y`.
+ */
+template <typename T>
+struct SqrOutputType
+{
+    using value_type = typename std::disjunction<
+        dpctl_td_ns::TypeMapResultEntry<T, double, double>,
+        dpctl_td_ns::TypeMapResultEntry<T, float, float>,
+        dpctl_td_ns::DefaultResultEntry<void>>::result_type;
+};
+
+/**
+ * @brief A factory to define pairs of supported types for which
  * MKL VM library provides support in oneapi::mkl::vm::sqrt<T> function.
  *
  * @tparam T Type of input vector `a` and of result vector `y`.

--- a/dpnp/backend/include/dpnp_iface_fptr.hpp
+++ b/dpnp/backend/include/dpnp_iface_fptr.hpp
@@ -476,9 +476,7 @@ enum class DPNPFuncName : size_t
     DPNP_FN_SQRT_EXT, /**< Used in numpy.sqrt() impl, requires extra parameters
                        */
     DPNP_FN_SQUARE,   /**< Used in numpy.square() impl  */
-    DPNP_FN_SQUARE_EXT, /**< Used in numpy.square() impl, requires extra
-                           parameters */
-    DPNP_FN_STD,        /**< Used in numpy.std() impl  */
+    DPNP_FN_STD,      /**< Used in numpy.std() impl  */
     DPNP_FN_STD_EXT, /**< Used in numpy.std() impl, requires extra parameters */
     DPNP_FN_SUBTRACT,     /**< Used in numpy.subtract() impl  */
     DPNP_FN_SUBTRACT_EXT, /**< Used in numpy.subtract() impl, requires extra

--- a/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
@@ -1156,15 +1156,6 @@ static void func_map_init_elemwise_1arg_1type(func_map_t &fmap)
     fmap[DPNPFuncName::DPNP_FN_SQUARE][eft_DBL][eft_DBL] = {
         eft_DBL, (void *)dpnp_square_c_default<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_SQUARE_EXT][eft_INT][eft_INT] = {
-        eft_INT, (void *)dpnp_square_c_ext<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_SQUARE_EXT][eft_LNG][eft_LNG] = {
-        eft_LNG, (void *)dpnp_square_c_ext<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_SQUARE_EXT][eft_FLT][eft_FLT] = {
-        eft_FLT, (void *)dpnp_square_c_ext<float>};
-    fmap[DPNPFuncName::DPNP_FN_SQUARE_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void *)dpnp_square_c_ext<double>};
-
     return;
 }
 

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -291,8 +291,6 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_SINH_EXT
         DPNP_FN_SORT
         DPNP_FN_SORT_EXT
-        DPNP_FN_SQUARE
-        DPNP_FN_SQUARE_EXT
         DPNP_FN_STD
         DPNP_FN_STD_EXT
         DPNP_FN_SUM
@@ -543,6 +541,5 @@ cpdef dpnp_descriptor dpnp_log2(dpnp_descriptor array1)
 cpdef dpnp_descriptor dpnp_radians(dpnp_descriptor array1)
 cpdef dpnp_descriptor dpnp_recip(dpnp_descriptor array1)
 cpdef dpnp_descriptor dpnp_sinh(dpnp_descriptor array1)
-cpdef dpnp_descriptor dpnp_square(dpnp_descriptor array1)
 cpdef dpnp_descriptor dpnp_tan(dpnp_descriptor array1, dpnp_descriptor out)
 cpdef dpnp_descriptor dpnp_tanh(dpnp_descriptor array1)

--- a/dpnp/dpnp_algo/dpnp_algo_trigonometric.pxi
+++ b/dpnp/dpnp_algo/dpnp_algo_trigonometric.pxi
@@ -54,7 +54,6 @@ __all__ += [
     'dpnp_radians',
     'dpnp_recip',
     'dpnp_sinh',
-    'dpnp_square',
     'dpnp_tan',
     'dpnp_tanh',
     'dpnp_unwrap'
@@ -131,10 +130,6 @@ cpdef utils.dpnp_descriptor dpnp_radians(utils.dpnp_descriptor x1):
 
 cpdef utils.dpnp_descriptor dpnp_sinh(utils.dpnp_descriptor x1):
     return call_fptr_1in_1out_strides(DPNP_FN_SINH_EXT, x1)
-
-
-cpdef utils.dpnp_descriptor dpnp_square(utils.dpnp_descriptor x1):
-    return call_fptr_1in_1out_strides(DPNP_FN_SQUARE_EXT, x1)
 
 
 cpdef utils.dpnp_descriptor dpnp_tan(utils.dpnp_descriptor x1, utils.dpnp_descriptor out):

--- a/dpnp/dpnp_iface_trigonometric.py
+++ b/dpnp/dpnp_iface_trigonometric.py
@@ -52,6 +52,7 @@ from .dpnp_algo.dpnp_elementwise_common import (
     dpnp_log,
     dpnp_sin,
     dpnp_sqrt,
+    dpnp_square,
 )
 
 __all__ = [
@@ -1108,19 +1109,40 @@ def sqrt(
     )
 
 
-def square(x1):
+def square(
+    x,
+    /,
+    out=None,
+    *,
+    order="K",
+    where=True,
+    dtype=None,
+    subok=True,
+    **kwargs,
+):
     """
     Return the element-wise square of the input.
 
     For full documentation refer to :obj:`numpy.square`.
 
+    Returns
+    -------
+    y : dpnp.ndarray
+        Element-wise `x * x`, of the same shape and dtype as `x`.
+
     Limitations
     -----------
-    Input array is supported as :obj:`dpnp.ndarray`.
+    Input array is supported as either :class:`dpnp.ndarray` or :class:`dpctl.tensor.usm_ndarray`.
+    Parameter `out` is supported as class:`dpnp.ndarray`, class:`dpctl.tensor.usm_ndarray` or
+    with default value ``None``.
+    Parameters `where`, `dtype` and `subok` are supported with their default values.
+    Otherwise the function will be executed sequentially on CPU.
     Input array data types are limited by supported DPNP :ref:`Data types`.
 
     See Also
     --------
+    :obj:`dpnp..linalg.matrix_power` : Raise a square matrix
+                                       to the (integer) power `n`.
     :obj:`dpnp.sqrt` : Return the positive square-root of an array,
                        element-wise.
     :obj:`dpnp.power` : First array elements raised to powers
@@ -1129,20 +1151,23 @@ def square(x1):
     Examples
     --------
     >>> import dpnp as np
-    >>> x = np.array([1, 2, 3])
-    >>> out = np.square(x)
-    >>> [i for i in out]
-    [1, 4, 9]
+    >>> x = np.array([-1j, 1])
+    >>> np.square(x)
+    array([-1.+0.j,  1.+0.j])
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(
-        x1, copy_when_strides=False, copy_when_nondefault_queue=False
+    return check_nd_call_func(
+        numpy.square,
+        dpnp_square,
+        x,
+        out=out,
+        where=where,
+        order=order,
+        dtype=dtype,
+        subok=subok,
+        **kwargs,
     )
-    if x1_desc:
-        return dpnp_square(x1_desc).get_pyobj()
-
-    return call_origin(numpy.square, x1, **kwargs)
 
 
 def tan(x1, out=None, **kwargs):

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -725,25 +725,154 @@ tests/third_party/cupy/math_tests/test_floating.py::TestFloating::test_ldexp
 tests/third_party/cupy/math_tests/test_floating.py::TestFloating::test_nextafter_combination
 tests/third_party/cupy/math_tests/test_floating.py::TestFloating::test_nextafter_float
 tests/third_party/cupy/math_tests/test_floating.py::TestFloating::test_signbit
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_absolute_negative
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_clip1
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_clip2
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_clip3
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_clip_max_none
+
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_clip_min_max_none
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_clip_min_none
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_external_clip1
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_external_clip2
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_external_clip4
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_absolute_negative
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_sign_negative
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_maximum_nan
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_minimum_nan
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_fmax_nan
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_fmin_nan
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_for_old_numpy
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_inf
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_inf_nan
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_nan
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_negative
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_for_old_numpy
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_negative_for_old_numpy
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_sign_negative
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_inf
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_nan
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_inf_nan
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_nan_arg
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_inf_arg
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_broadcast[nan]
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_broadcast[posinf]
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_broadcast[neginf]
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveInvalid_param_0_{mode='valid'}::test_convolve_empty
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveInvalid_param_0_{mode='valid'}::test_convolve_ndim
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveInvalid_param_1_{mode='same'}::test_convolve_empty
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveInvalid_param_1_{mode='same'}::test_convolve_ndim
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveInvalid_param_2_{mode='full'}::test_convolve_empty
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveInvalid_param_2_{mode='full'}::test_convolve_ndim
+
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_clip1
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_clip3
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_clip_min_none
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_clip_max_none
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_external_clip1
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_external_clip2
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_external_clip3
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_clip2
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_cbrt
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_fabs
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_fabs_negative
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_scalar_nan
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_copy
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_inplace
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_real_if_close_real_dtypes
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_real_if_close_with_tol_real_dtypes
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_real_if_close_true
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_real_if_close_false
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_real_if_close_with_integer_tol_true
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_real_if_close_with_integer_tol_false
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_real_if_close_with_float_tol_true
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_real_if_close_with_float_tol_false
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_interp
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_interp_period
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_interp_left_right
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_interp_nan_fy
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_interp_nan_fx
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_interp_nan_x
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_interp_inf_fy
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_interp_inf_fx
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_interp_inf_x
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_interp_size1
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_interp_inf_to_nan
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_heaviside
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_heaviside_nan_inf
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_0_{mode='valid', shape1=(), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_1_{mode='valid', shape1=(), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_2_{mode='valid', shape1=(), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_3_{mode='valid', shape1=(), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_4_{mode='valid', shape1=(), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_5_{mode='valid', shape1=(5,), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_6_{mode='valid', shape1=(5,), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_7_{mode='valid', shape1=(5,), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_8_{mode='valid', shape1=(5,), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_9_{mode='valid', shape1=(5,), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_10_{mode='valid', shape1=(6,), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_11_{mode='valid', shape1=(6,), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_12_{mode='valid', shape1=(6,), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_13_{mode='valid', shape1=(6,), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_14_{mode='valid', shape1=(6,), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_15_{mode='valid', shape1=(20,), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_16_{mode='valid', shape1=(20,), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_17_{mode='valid', shape1=(20,), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_18_{mode='valid', shape1=(20,), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_19_{mode='valid', shape1=(20,), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_20_{mode='valid', shape1=(21,), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_21_{mode='valid', shape1=(21,), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_22_{mode='valid', shape1=(21,), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_23_{mode='valid', shape1=(21,), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_24_{mode='valid', shape1=(21,), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_25_{mode='same', shape1=(), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_26_{mode='same', shape1=(), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_27_{mode='same', shape1=(), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_28_{mode='same', shape1=(), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_29_{mode='same', shape1=(), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_30_{mode='same', shape1=(5,), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_31_{mode='same', shape1=(5,), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_32_{mode='same', shape1=(5,), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_33_{mode='same', shape1=(5,), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_34_{mode='same', shape1=(5,), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_35_{mode='same', shape1=(6,), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_36_{mode='same', shape1=(6,), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_37_{mode='same', shape1=(6,), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_38_{mode='same', shape1=(6,), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_39_{mode='same', shape1=(6,), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_40_{mode='same', shape1=(20,), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_41_{mode='same', shape1=(20,), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_42_{mode='same', shape1=(20,), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_43_{mode='same', shape1=(20,), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_44_{mode='same', shape1=(20,), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_45_{mode='same', shape1=(21,), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_46_{mode='same', shape1=(21,), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_47_{mode='same', shape1=(21,), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_48_{mode='same', shape1=(21,), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_49_{mode='same', shape1=(21,), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_50_{mode='full', shape1=(), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_51_{mode='full', shape1=(), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_52_{mode='full', shape1=(), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_53_{mode='full', shape1=(), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_54_{mode='full', shape1=(), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_55_{mode='full', shape1=(5,), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_56_{mode='full', shape1=(5,), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_57_{mode='full', shape1=(5,), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_58_{mode='full', shape1=(5,), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_59_{mode='full', shape1=(5,), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_60_{mode='full', shape1=(6,), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_61_{mode='full', shape1=(6,), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_62_{mode='full', shape1=(6,), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_63_{mode='full', shape1=(6,), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_64_{mode='full', shape1=(6,), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_65_{mode='full', shape1=(20,), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_66_{mode='full', shape1=(20,), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_67_{mode='full', shape1=(20,), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_68_{mode='full', shape1=(20,), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_69_{mode='full', shape1=(20,), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_70_{mode='full', shape1=(21,), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_71_{mode='full', shape1=(21,), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_72_{mode='full', shape1=(21,), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_73_{mode='full', shape1=(21,), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_74_{mode='full', shape1=(21,), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolve::test_convolve_non_contiguous[valid]
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolve::test_convolve_non_contiguous[same]
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolve::test_convolve_non_contiguous[full]
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolve::test_convolve_large_non_contiguous[valid]
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolve::test_convolve_large_non_contiguous[same]
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolve::test_convolve_large_non_contiguous[full]
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolve::test_convolve_diff_types[valid]
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolve::test_convolve_diff_types[same]
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolve::test_convolve_diff_types[full]
+
 tests/third_party/cupy/math_tests/test_rounding.py::TestRoundBorder_param_0_{value=(14, -1)}::test_around_negative2
 tests/third_party/cupy/math_tests/test_rounding.py::TestRoundBorder_param_0_{value=(14, -1)}::test_around_positive2
 tests/third_party/cupy/math_tests/test_rounding.py::TestRoundBorder_param_1_{value=(15, -1)}::test_around_negative2

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -856,25 +856,154 @@ tests/third_party/cupy/math_tests/test_floating.py::TestFloating::test_ldexp
 tests/third_party/cupy/math_tests/test_floating.py::TestFloating::test_nextafter_combination
 tests/third_party/cupy/math_tests/test_floating.py::TestFloating::test_nextafter_float
 tests/third_party/cupy/math_tests/test_floating.py::TestFloating::test_signbit
+
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_clip_min_max_none
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_external_clip4
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_absolute_negative
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_sign_negative
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_clip1
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_clip2
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_clip3
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_clip_max_none
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_clip_min_max_none
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_clip_min_none
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_external_clip1
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_external_clip2
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_maximum_nan
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_minimum_nan
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_fmax_nan
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_fmin_nan
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_for_old_numpy
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_inf
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_inf_nan
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_nan
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_negative
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_for_old_numpy
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_negative_for_old_numpy
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_inf
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_nan
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_inf_nan
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_nan_arg
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_inf_arg
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_broadcast[nan]
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_broadcast[posinf]
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_broadcast[neginf]
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveInvalid_param_0_{mode='valid'}::test_convolve_empty
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveInvalid_param_0_{mode='valid'}::test_convolve_ndim
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveInvalid_param_1_{mode='same'}::test_convolve_empty
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveInvalid_param_1_{mode='same'}::test_convolve_ndim
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveInvalid_param_2_{mode='full'}::test_convolve_empty
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveInvalid_param_2_{mode='full'}::test_convolve_ndim
+
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_clip1
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_clip3
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_clip_min_none
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_clip_max_none
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_external_clip1
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_external_clip2
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_external_clip3
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_clip2
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_cbrt
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_fabs
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_fabs_negative
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_scalar_nan
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_copy
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_inplace
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_real_if_close_real_dtypes
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_real_if_close_with_tol_real_dtypes
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_real_if_close_true
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_real_if_close_false
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_real_if_close_with_integer_tol_true
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_real_if_close_with_integer_tol_false
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_real_if_close_with_float_tol_true
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_real_if_close_with_float_tol_false
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_interp
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_interp_period
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_interp_left_right
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_interp_nan_fy
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_interp_nan_fx
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_interp_nan_x
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_interp_inf_fy
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_interp_inf_fx
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_interp_inf_x
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_interp_size1
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_interp_inf_to_nan
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_heaviside
+tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_heaviside_nan_inf
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_0_{mode='valid', shape1=(), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_1_{mode='valid', shape1=(), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_2_{mode='valid', shape1=(), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_3_{mode='valid', shape1=(), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_4_{mode='valid', shape1=(), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_5_{mode='valid', shape1=(5,), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_6_{mode='valid', shape1=(5,), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_7_{mode='valid', shape1=(5,), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_8_{mode='valid', shape1=(5,), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_9_{mode='valid', shape1=(5,), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_10_{mode='valid', shape1=(6,), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_11_{mode='valid', shape1=(6,), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_12_{mode='valid', shape1=(6,), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_13_{mode='valid', shape1=(6,), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_14_{mode='valid', shape1=(6,), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_15_{mode='valid', shape1=(20,), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_16_{mode='valid', shape1=(20,), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_17_{mode='valid', shape1=(20,), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_18_{mode='valid', shape1=(20,), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_19_{mode='valid', shape1=(20,), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_20_{mode='valid', shape1=(21,), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_21_{mode='valid', shape1=(21,), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_22_{mode='valid', shape1=(21,), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_23_{mode='valid', shape1=(21,), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_24_{mode='valid', shape1=(21,), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_25_{mode='same', shape1=(), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_26_{mode='same', shape1=(), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_27_{mode='same', shape1=(), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_28_{mode='same', shape1=(), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_29_{mode='same', shape1=(), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_30_{mode='same', shape1=(5,), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_31_{mode='same', shape1=(5,), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_32_{mode='same', shape1=(5,), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_33_{mode='same', shape1=(5,), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_34_{mode='same', shape1=(5,), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_35_{mode='same', shape1=(6,), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_36_{mode='same', shape1=(6,), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_37_{mode='same', shape1=(6,), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_38_{mode='same', shape1=(6,), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_39_{mode='same', shape1=(6,), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_40_{mode='same', shape1=(20,), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_41_{mode='same', shape1=(20,), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_42_{mode='same', shape1=(20,), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_43_{mode='same', shape1=(20,), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_44_{mode='same', shape1=(20,), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_45_{mode='same', shape1=(21,), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_46_{mode='same', shape1=(21,), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_47_{mode='same', shape1=(21,), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_48_{mode='same', shape1=(21,), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_49_{mode='same', shape1=(21,), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_50_{mode='full', shape1=(), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_51_{mode='full', shape1=(), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_52_{mode='full', shape1=(), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_53_{mode='full', shape1=(), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_54_{mode='full', shape1=(), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_55_{mode='full', shape1=(5,), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_56_{mode='full', shape1=(5,), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_57_{mode='full', shape1=(5,), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_58_{mode='full', shape1=(5,), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_59_{mode='full', shape1=(5,), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_60_{mode='full', shape1=(6,), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_61_{mode='full', shape1=(6,), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_62_{mode='full', shape1=(6,), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_63_{mode='full', shape1=(6,), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_64_{mode='full', shape1=(6,), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_65_{mode='full', shape1=(20,), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_66_{mode='full', shape1=(20,), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_67_{mode='full', shape1=(20,), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_68_{mode='full', shape1=(20,), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_69_{mode='full', shape1=(20,), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_70_{mode='full', shape1=(21,), shape2=()}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_71_{mode='full', shape1=(21,), shape2=(5,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_72_{mode='full', shape1=(21,), shape2=(6,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_73_{mode='full', shape1=(21,), shape2=(20,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolveShapeCombination_param_74_{mode='full', shape1=(21,), shape2=(21,)}::test_convolve
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolve::test_convolve_non_contiguous[valid]
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolve::test_convolve_non_contiguous[same]
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolve::test_convolve_non_contiguous[full]
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolve::test_convolve_large_non_contiguous[valid]
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolve::test_convolve_large_non_contiguous[same]
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolve::test_convolve_large_non_contiguous[full]
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolve::test_convolve_diff_types[valid]
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolve::test_convolve_diff_types[same]
+tests/third_party/cupy/math_tests/test_misc.py::TestConvolve::test_convolve_diff_types[full]
+
 tests/third_party/cupy/math_tests/test_rounding.py::TestRoundBorder_param_0_{value=(14, -1)}::test_around_negative2
 tests/third_party/cupy/math_tests/test_rounding.py::TestRoundBorder_param_0_{value=(14, -1)}::test_around_positive2
 tests/third_party/cupy/math_tests/test_rounding.py::TestRoundBorder_param_1_{value=(15, -1)}::test_around_negative2

--- a/tests/test_umath.py
+++ b/tests/test_umath.py
@@ -634,3 +634,65 @@ class TestSqrt:
 
         numpy.testing.assert_raises(TypeError, dpnp.sqrt, a, out)
         numpy.testing.assert_raises(TypeError, numpy.sqrt, a.asnumpy(), out)
+
+
+class TestSquare:
+    @pytest.mark.parametrize(
+        "dtype", get_all_dtypes(no_bool=True, no_none=True)
+    )
+    def test_square(self, dtype):
+        np_array = numpy.arange(10, dtype=dtype)
+        np_out = numpy.empty(10, dtype=dtype)
+
+        # DPNP
+        dp_out = dpnp.array(np_out, dtype=dtype)
+        dp_array = dpnp.array(np_array, dtype=dtype)
+        result = dpnp.square(dp_array, out=dp_out)
+
+        # original
+        expected = numpy.square(np_array, out=np_out)
+        assert_allclose(expected, result)
+
+    def test_square_bool(self):
+        np_array = numpy.arange(2, dtype=numpy.bool_)
+        np_out = numpy.empty(2, dtype=numpy.int8)
+
+        # DPNP
+        dp_array = dpnp.array(np_array, dtype=np_array.dtype)
+        dp_out = dpnp.array(np_out, dtype=np_out.dtype)
+        result = dpnp.square(dp_array, out=dp_out)
+
+        # original
+        expected = numpy.square(np_array, out=np_out)
+        assert_allclose(expected, result)
+
+    @pytest.mark.parametrize(
+        "dtype", get_all_dtypes(no_bool=True, no_none=True)
+    )
+    def test_invalid_dtype(self, dtype):
+        dp_array = dpnp.ones(10, dtype=dpnp.bool)
+        dp_out = dpnp.empty(10, dtype=dtype)
+
+        with pytest.raises(TypeError):
+            dpnp.square(dp_array, out=dp_out)
+
+    @pytest.mark.parametrize(
+        "shape", [(0,), (15,), (2, 2)], ids=["(0,)", "(15, )", "(2,2)"]
+    )
+    def test_invalid_shape(self, shape):
+        dp_array = dpnp.arange(10, dtype=dpnp.float32)
+        dp_out = dpnp.empty(shape, dtype=dpnp.float32)
+
+        with pytest.raises(TypeError):
+            dpnp.square(dp_array, out=dp_out)
+
+    @pytest.mark.parametrize(
+        "out",
+        [4, (), [], (3, 7), [2, 4]],
+        ids=["4", "()", "[]", "(3, 7)", "[2, 4]"],
+    )
+    def test_invalid_out(self, out):
+        a = dpnp.arange(10)
+
+        numpy.testing.assert_raises(TypeError, dpnp.square, a, out)
+        numpy.testing.assert_raises(TypeError, numpy.square, a.asnumpy(), out)

--- a/tests/third_party/cupy/math_tests/test_misc.py
+++ b/tests/third_party/cupy/math_tests/test_misc.py
@@ -1,6 +1,3 @@
-import sys
-import unittest
-
 import numpy
 import pytest
 
@@ -8,10 +5,9 @@ import dpnp as cupy
 from tests.third_party.cupy import testing
 
 
-@testing.gpu
-class TestMisc(unittest.TestCase):
+class TestMisc:
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(atol=1e-5)
+    @testing.numpy_cupy_allclose(atol=1e-5, type_check=False)
     def check_unary(self, name, xp, dtype, no_bool=False):
         if no_bool and numpy.dtype(dtype).char == "?":
             return numpy.int_(0)
@@ -27,7 +23,7 @@ class TestMisc(unittest.TestCase):
         b = testing.shaped_reverse_arange((2, 3), xp, dtype)
         return getattr(xp, name)(a, b)
 
-    @testing.for_dtypes(["i", "q", "f", "d"])
+    @testing.for_dtypes(["?", "b", "h", "i", "q", "e", "f", "d", "F", "D"])
     @testing.numpy_cupy_allclose(atol=1e-5)
     def check_unary_negative(self, name, xp, dtype, no_bool=False):
         if no_bool and numpy.dtype(dtype).char == "?":
@@ -37,9 +33,9 @@ class TestMisc(unittest.TestCase):
             a += (a * 1j).astype(dtype)
         return getattr(xp, name)(a)
 
-    @testing.for_dtypes(["f", "d"])
+    @testing.for_dtypes(["e", "f", "d", "F", "D"])
     @testing.numpy_cupy_allclose(atol=1e-5)
-    def check_unary_inf(self, name, xp, dtype):
+    def check_unary_inf(self, name, xp, dtype, **kwargs):
         inf = numpy.inf
         if numpy.dtype(dtype).kind != "c":
             a = xp.array([0, -1, 1, -inf, inf], dtype=dtype)
@@ -52,11 +48,11 @@ class TestMisc(unittest.TestCase):
                 ],
                 dtype=dtype,
             )
-        return getattr(xp, name)(a)
+        return getattr(xp, name)(a, **kwargs)
 
-    @testing.for_dtypes(["f", "d"])
+    @testing.for_dtypes(["e", "f", "d", "F", "D"])
     @testing.numpy_cupy_allclose(atol=1e-5)
-    def check_unary_nan(self, name, xp, dtype):
+    def check_unary_nan(self, name, xp, dtype, **kwargs):
         nan = numpy.nan
         if numpy.dtype(dtype).kind != "c":
             a = xp.array([0, -1, 1, -nan, nan], dtype=dtype)
@@ -69,9 +65,9 @@ class TestMisc(unittest.TestCase):
                 ],
                 dtype=dtype,
             )
-        return getattr(xp, name)(a)
+        return getattr(xp, name)(a, **kwargs)
 
-    @testing.for_dtypes(["f", "d"])
+    @testing.for_dtypes(["e", "f", "d", "F", "D"])
     @testing.numpy_cupy_allclose(atol=1e-5)
     def check_unary_inf_nan(self, name, xp, dtype):
         inf = numpy.inf
@@ -89,7 +85,7 @@ class TestMisc(unittest.TestCase):
             )
         return getattr(xp, name)(a)
 
-    @testing.for_dtypes(["f", "d"])
+    @testing.for_dtypes(["e", "f", "d", "F", "D"])
     @testing.numpy_cupy_array_equal()
     def check_binary_nan(self, name, xp, dtype):
         a = xp.array(
@@ -100,7 +96,6 @@ class TestMisc(unittest.TestCase):
         )
         return getattr(xp, name)(a, b)
 
-    @unittest.skipIf(sys.platform == "win32", "dtype problem on Windows")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_array_equal()
     def test_clip1(self, xp, dtype):
@@ -132,7 +127,6 @@ class TestMisc(unittest.TestCase):
             with pytest.raises(ValueError):
                 a.clip(None, None)
 
-    @unittest.skipIf(sys.platform == "win32", "dtype problem on Windows")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_array_equal()
     def test_external_clip1(self, xp, dtype):
@@ -144,6 +138,19 @@ class TestMisc(unittest.TestCase):
     def test_external_clip2(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return xp.clip(a, 3, 13)
+
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_external_clip3(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return xp.clip(a, 8, 4)
+
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    def test_external_clip4(self, dtype):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp, dtype)
+            with pytest.raises(TypeError):
+                xp.clip(a, 3)
 
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_array_equal()
@@ -171,8 +178,17 @@ class TestMisc(unittest.TestCase):
     def test_absolute_negative(self):
         self.check_unary_negative("absolute")
 
-    def test_fabs(self):
-        self.check_unary("fabs")
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def test_fabs(self, xp, dtype):
+        a = xp.array([2, 3, 4], dtype=dtype)
+        return xp.fabs(a)
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def test_fabs_negative(self, xp, dtype):
+        a = xp.array([-2.0, -4.0, 0.0, 4.0], dtype=dtype)
+        return xp.fabs(a)
 
     def test_sign(self):
         self.check_unary("sign", no_bool=True)
@@ -222,5 +238,312 @@ class TestMisc(unittest.TestCase):
     def test_nan_to_num_nan(self):
         self.check_unary_nan("nan_to_num")
 
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def test_nan_to_num_scalar_nan(self, xp):
+        return xp.nan_to_num(xp.nan)
+
     def test_nan_to_num_inf_nan(self):
         self.check_unary_inf_nan("nan_to_num")
+
+    def test_nan_to_num_nan_arg(self):
+        self.check_unary_nan("nan_to_num", nan=1.0)
+
+    def test_nan_to_num_inf_arg(self):
+        self.check_unary_inf("nan_to_num", posinf=1.0, neginf=-1.0)
+
+    @testing.numpy_cupy_array_equal()
+    def test_nan_to_num_copy(self, xp):
+        x = xp.asarray([0, 1, xp.nan, 4], dtype=xp.float64)
+        y = xp.nan_to_num(x, copy=True)
+        assert x is not y
+        return y
+
+    @testing.numpy_cupy_array_equal()
+    def test_nan_to_num_inplace(self, xp):
+        x = xp.asarray([0, 1, xp.nan, 4], dtype=xp.float64)
+        y = xp.nan_to_num(x, copy=False)
+        assert x is y
+        return y
+
+    @pytest.mark.parametrize("kwarg", ["nan", "posinf", "neginf"])
+    def test_nan_to_num_broadcast(self, kwarg):
+        for xp in (numpy, cupy):
+            x = xp.asarray([0, 1, xp.nan, 4], dtype=xp.float64)
+            y = xp.zeros((2, 4), dtype=xp.float64)
+            with pytest.raises(ValueError):
+                xp.nan_to_num(x, **{kwarg: y})
+            with pytest.raises(ValueError):
+                xp.nan_to_num(0.0, **{kwarg: y})
+
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_real_if_close_real_dtypes(self, xp, dtype):
+        x = testing.shaped_random((10,), xp, dtype)
+        return xp.real_if_close(x)
+
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_real_if_close_with_tol_real_dtypes(self, xp, dtype):
+        x = testing.shaped_random((10,), xp, dtype)
+        return xp.real_if_close(x, tol=1e-6)
+
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_real_if_close_true(self, xp, dtype):
+        dtype = numpy.dtype(dtype).char.lower()
+        tol = numpy.finfo(dtype).eps * 90
+        x = testing.shaped_random((10,), xp, dtype) + tol * 1j
+        out = xp.real_if_close(x)
+        assert x.dtype != out.dtype
+        return out
+
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_real_if_close_false(self, xp, dtype):
+        dtype = numpy.dtype(dtype).char.lower()
+        tol = numpy.finfo(dtype).eps * 110
+        x = testing.shaped_random((10,), xp, dtype) + tol * 1j
+        out = xp.real_if_close(x)
+        assert x.dtype == out.dtype
+        return out
+
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_real_if_close_with_integer_tol_true(self, xp, dtype):
+        dtype = numpy.dtype(dtype).char.lower()
+        tol = numpy.finfo(dtype).eps * 140
+        x = testing.shaped_random((10,), xp, dtype) + tol * 1j
+        out = xp.real_if_close(x, tol=150)
+        assert x.dtype != out.dtype
+        return out
+
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_real_if_close_with_integer_tol_false(self, xp, dtype):
+        dtype = numpy.dtype(dtype).char.lower()
+        tol = numpy.finfo(dtype).eps * 50
+        x = testing.shaped_random((10,), xp, dtype) + tol * 1j
+        out = xp.real_if_close(x, tol=30)
+        assert x.dtype == out.dtype
+        return out
+
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_real_if_close_with_float_tol_true(self, xp, dtype):
+        dtype = numpy.dtype(dtype).char.lower()
+        x = testing.shaped_random((10,), xp, dtype) + 3e-4j
+        out = xp.real_if_close(x, tol=1e-3)
+        assert x.dtype != out.dtype
+        return out
+
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_real_if_close_with_float_tol_false(self, xp, dtype):
+        dtype = numpy.dtype(dtype).char.lower()
+        x = testing.shaped_random((10,), xp, dtype) + 3e-3j
+        out = xp.real_if_close(x, tol=1e-3)
+        assert x.dtype == out.dtype
+        return out
+
+    @testing.for_all_dtypes(name="dtype_x", no_bool=True, no_complex=True)
+    @testing.for_all_dtypes(name="dtype_y", no_bool=True)
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def test_interp(self, xp, dtype_y, dtype_x):
+        # interpolate at points on and outside the boundaries
+        x = xp.asarray([0, 1, 2, 4, 6, 8, 9, 10], dtype=dtype_x)
+        fx = xp.asarray([1, 3, 5, 7, 9], dtype=dtype_x)
+        fy = xp.sin(fx).astype(dtype_y)
+        return xp.interp(x, fx, fy)
+
+    @testing.for_all_dtypes(name="dtype_x", no_bool=True, no_complex=True)
+    @testing.for_all_dtypes(name="dtype_y", no_bool=True)
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def test_interp_period(self, xp, dtype_y, dtype_x):
+        # interpolate at points on and outside the boundaries
+        x = xp.asarray([0, 1, 2, 4, 6, 8, 9, 10], dtype=dtype_x)
+        fx = xp.asarray([1, 3, 5, 7, 9], dtype=dtype_x)
+        fy = xp.sin(fx).astype(dtype_y)
+        return xp.interp(x, fx, fy, period=5)
+
+    @testing.for_all_dtypes(name="dtype_x", no_bool=True, no_complex=True)
+    @testing.for_all_dtypes(name="dtype_y", no_bool=True)
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def test_interp_left_right(self, xp, dtype_y, dtype_x):
+        # interpolate at points on and outside the boundaries
+        x = xp.asarray([0, 1, 2, 4, 6, 8, 9, 10], dtype=dtype_x)
+        fx = xp.asarray([1, 3, 5, 7, 9], dtype=dtype_x)
+        fy = xp.sin(fx).astype(dtype_y)
+        left = 10
+        right = 20
+        return xp.interp(x, fx, fy, left, right)
+
+    @testing.with_requires("numpy>=1.17.0")
+    @testing.for_all_dtypes(name="dtype_x", no_bool=True, no_complex=True)
+    @testing.for_dtypes("efdFD", name="dtype_y")
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def test_interp_nan_fy(self, xp, dtype_y, dtype_x):
+        # interpolate at points on and outside the boundaries
+        x = xp.asarray([0, 1, 2, 4, 6, 8, 9, 10], dtype=dtype_x)
+        fx = xp.asarray([1, 3, 5, 7, 9], dtype=dtype_x)
+        fy = xp.sin(fx).astype(dtype_y)
+        fy[0] = fy[2] = fy[-1] = numpy.nan
+        return xp.interp(x, fx, fy)
+
+    @testing.with_requires("numpy>=1.17.0")
+    @testing.for_float_dtypes(name="dtype_x")
+    @testing.for_dtypes("efdFD", name="dtype_y")
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def test_interp_nan_fx(self, xp, dtype_y, dtype_x):
+        # interpolate at points on and outside the boundaries
+        x = xp.asarray([0, 1, 2, 4, 6, 8, 9, 10], dtype=dtype_x)
+        fx = xp.asarray([1, 3, 5, 7, 9], dtype=dtype_x)
+        fy = xp.sin(fx).astype(dtype_y)
+        fx[-1] = numpy.nan  # x and fx must remain sorted (NaNs are the last)
+        return xp.interp(x, fx, fy)
+
+    @testing.with_requires("numpy>=1.17.0")
+    @testing.for_float_dtypes(name="dtype_x")
+    @testing.for_dtypes("efdFD", name="dtype_y")
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def test_interp_nan_x(self, xp, dtype_y, dtype_x):
+        # interpolate at points on and outside the boundaries
+        x = xp.asarray([0, 1, 2, 4, 6, 8, 9, 10], dtype=dtype_x)
+        fx = xp.asarray([1, 3, 5, 7, 9], dtype=dtype_x)
+        fy = xp.sin(fx).astype(dtype_y)
+        x[-1] = numpy.nan  # x and fx must remain sorted (NaNs are the last)
+        return xp.interp(x, fx, fy)
+
+    @testing.with_requires("numpy>=1.17.0")
+    @testing.for_all_dtypes(name="dtype_x", no_bool=True, no_complex=True)
+    @testing.for_dtypes("efdFD", name="dtype_y")
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def test_interp_inf_fy(self, xp, dtype_y, dtype_x):
+        # interpolate at points on and outside the boundaries
+        x = xp.asarray([0, 1, 2, 4, 6, 8, 9, 10], dtype=dtype_x)
+        fx = xp.asarray([1, 3, 5, 7, 9], dtype=dtype_x)
+        fy = xp.sin(fx).astype(dtype_y)
+        fy[0] = fy[2] = fy[-1] = numpy.inf
+        return xp.interp(x, fx, fy)
+
+    @testing.with_requires("numpy>=1.17.0")
+    @testing.for_float_dtypes(name="dtype_x")
+    @testing.for_dtypes("efdFD", name="dtype_y")
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def test_interp_inf_fx(self, xp, dtype_y, dtype_x):
+        # interpolate at points on and outside the boundaries
+        x = xp.asarray([0, 1, 2, 4, 6, 8, 9, 10], dtype=dtype_x)
+        fx = xp.asarray([1, 3, 5, 7, 9], dtype=dtype_x)
+        fy = xp.sin(fx).astype(dtype_y)
+        fx[-1] = numpy.inf  # x and fx must remain sorted
+        return xp.interp(x, fx, fy)
+
+    @testing.with_requires("numpy>=1.17.0")
+    @testing.for_float_dtypes(name="dtype_x")
+    @testing.for_dtypes("efdFD", name="dtype_y")
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def test_interp_inf_x(self, xp, dtype_y, dtype_x):
+        # interpolate at points on and outside the boundaries
+        x = xp.asarray([0, 1, 2, 4, 6, 8, 9, 10], dtype=dtype_x)
+        fx = xp.asarray([1, 3, 5, 7, 9], dtype=dtype_x)
+        fy = xp.sin(fx).astype(dtype_y)
+        x[-1] = numpy.inf  # x and fx must remain sorted
+        return xp.interp(x, fx, fy)
+
+    @testing.for_all_dtypes(name="dtype_x", no_bool=True, no_complex=True)
+    @testing.for_all_dtypes(name="dtype_y", no_bool=True)
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def test_interp_size1(self, xp, dtype_y, dtype_x):
+        # interpolate at points on and outside the boundaries
+        x = xp.asarray([0, 1, 2, 4, 6, 8, 9, 10], dtype=dtype_x)
+        fx = xp.asarray([5], dtype=dtype_x)
+        fy = xp.sin(fx).astype(dtype_y)
+        left = 10
+        right = 20
+        return xp.interp(x, fx, fy, left, right)
+
+    @testing.with_requires("numpy>=1.17.0")
+    @testing.for_float_dtypes(name="dtype_x")
+    @testing.for_dtypes("efdFD", name="dtype_y")
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def test_interp_inf_to_nan(self, xp, dtype_y, dtype_x):
+        # from NumPy's test_non_finite_inf
+        x = xp.asarray([0.5], dtype=dtype_x)
+        fx = xp.asarray([-numpy.inf, numpy.inf], dtype=dtype_x)
+        fy = xp.asarray([0, 10], dtype=dtype_y)
+        return xp.interp(x, fx, fy)
+
+    @testing.for_all_dtypes(name="dtype_2", no_bool=True, no_complex=True)
+    @testing.for_all_dtypes(name="dtype_1", no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_heaviside(self, xp, dtype_1, dtype_2):
+        x = testing.shaped_random((10,), xp, dtype_1)
+        h = xp.asarray([10], dtype=dtype_2)
+        return xp.heaviside(x, h)
+
+    @testing.for_all_dtypes(name="dtype_2", no_bool=True, no_complex=True)
+    @testing.for_float_dtypes(name="dtype_1")
+    @testing.numpy_cupy_array_equal()
+    def test_heaviside_nan_inf(self, xp, dtype_1, dtype_2):
+        x = xp.asarray([-2.0, 0.0, 3.0, xp.nan, xp.inf, -xp.inf], dtype=dtype_1)
+        h = xp.asarray([10], dtype=dtype_2)
+        return xp.heaviside(x, h)
+
+
+@testing.parameterize(
+    *testing.product(
+        {
+            "mode": ["valid", "same", "full"],
+            "shape1": [(), (5,), (6,), (20,), (21,)],
+            "shape2": [(), (5,), (6,), (20,), (21,)],
+        }
+    )
+)
+class TestConvolveShapeCombination:
+    @testing.for_all_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose(rtol=1e-3)
+    def test_convolve(self, xp, dtype):
+        a = testing.shaped_arange(self.shape1, xp, dtype)
+        b = testing.shaped_arange(self.shape2, xp, dtype)
+        return xp.convolve(a, b, mode=self.mode)
+
+
+@pytest.mark.parametrize("mode", ["valid", "same", "full"])
+class TestConvolve:
+    @testing.for_all_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose(rtol=1e-6)
+    def test_convolve_non_contiguous(self, xp, dtype, mode):
+        a = testing.shaped_arange((300,), xp, dtype)
+        b = testing.shaped_arange((100,), xp, dtype)
+        return xp.convolve(a[::200], b[10::70], mode=mode)
+
+    @testing.for_all_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose(rtol=1e-4)
+    def test_convolve_large_non_contiguous(self, xp, dtype, mode):
+        a = testing.shaped_arange((10000,), xp, dtype)
+        b = testing.shaped_arange((100,), xp, dtype)
+        return xp.convolve(a[200::], b[10::70], mode=mode)
+
+    @testing.for_all_dtypes_combination(names=["dtype1", "dtype2"])
+    @testing.numpy_cupy_allclose(rtol=1e-2)
+    def test_convolve_diff_types(self, xp, dtype1, dtype2, mode):
+        a = testing.shaped_random((200,), xp, dtype1)
+        b = testing.shaped_random((100,), xp, dtype2)
+        return xp.convolve(a, b, mode=mode)
+
+
+@testing.parameterize(*testing.product({"mode": ["valid", "same", "full"]}))
+class TestConvolveInvalid:
+    @testing.for_all_dtypes()
+    def test_convolve_empty(self, dtype):
+        for xp in (numpy, cupy):
+            a = xp.zeros((0,), dtype)
+            with pytest.raises(ValueError):
+                xp.convolve(a, a, mode=self.mode)
+
+    @testing.for_all_dtypes()
+    def test_convolve_ndim(self, dtype):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp, dtype)
+            b = testing.shaped_arange((10, 5), xp, dtype)
+            with pytest.raises(ValueError):
+                xp.convolve(a, b, mode=self.mode)


### PR DESCRIPTION
The new logic assumes to call `square` and `sin` from pybind11 extension of OneMKL VM if possible or fully rely on dpctl.tensor implementation otherwise.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
