### PR TITLE
Pin miniconda version

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -9,6 +9,7 @@ on:
 env:
   PACKAGE_NAME: dpnp
   MODULE_NAME: dpnp
+  MINICONDA_VER: py310_23.3.1-0
   CHANNELS: '-c dppy/label/dev -c intel -c conda-forge --override-channels'
   TEST_SCOPE: >-
       test_arraycreation.py
@@ -63,7 +64,7 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python }}
-          miniconda-version: 'latest'
+          miniconda-version: ${{ env.MINICONDA_VER }}
           activate-environment: 'build'
 
       - if: matrix.os == 'ubuntu-20.04'
@@ -145,7 +146,7 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python }}
-          miniconda-version: 'latest'
+          miniconda-version: ${{ env.MINICONDA_VER }}
           activate-environment: 'test'
 
       # Needed to be able to run conda index
@@ -254,7 +255,7 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python }}
-          miniconda-version: 'latest'
+          miniconda-version: ${{ env.MINICONDA_VER }}
           activate-environment: ${{ env.active-env-name }}
 
       - name: Store conda paths as envs
@@ -371,7 +372,7 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python }}
-          miniconda-version: 'latest'
+          miniconda-version: ${{ env.MINICONDA_VER }}
           activate-environment: 'upload'
 
       - name: Install anaconda-client

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -60,7 +60,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup miniconda
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v2.1.1
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python }}
@@ -142,7 +142,7 @@ jobs:
           tar -xvf ${{ env.pkg-path-in-channel }}/${{ env.PACKAGE_NAME }}-*.tar.bz2 -C ${{ env.extracted-pkg-path }}
 
       - name: Setup miniconda
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v2.1.1
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python }}
@@ -251,7 +251,7 @@ jobs:
           dir ${{ env.extracted-pkg-path }}
 
       - name: Setup miniconda
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v2.1.1
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python }}
@@ -368,7 +368,7 @@ jobs:
           name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python }}
 
       - name: Setup miniconda
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v2.1.1
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python }}


### PR DESCRIPTION
The PR implements workaround solution with temporary pining of conda to `23.3.1` version, since the last released one `23.5.0` brings a `conda.bat init --all` failure on Windows (which is observing in  "Conda package" action running on Windows).

The PR is going to be reverted ones conda issue [#12873](https://github.com/conda/conda/issues/12873) is resolved and new conda release is available.

Note, `conda-incubator/setup-miniconda` is downgraded from `v2.2.0` to `v2.1.1` due to unresolved issue [#261](https://github.com/conda-incubator/setup-miniconda/issues/261), which breaks pinning to specific versions of miniconda.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
