### PR TITLE
Corrected name of OneAPI compiler package

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           sudo apt-get install intel-oneapi-mkl                \
                                intel-oneapi-mkl-devel          \
-                               intel-oneapi-dpcpp-cpp-compiler
+                               intel-oneapi-compiler-dpcpp-cpp
 
       # https://github.com/marketplace/actions/checkout
       - name: Install nvidia-cuda support drivers


### PR DESCRIPTION
The PR resolves failure in `build-sphinx` action where incorrect name was used to install OneAPI package of DPC++ compiler.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
