### PR TITLE
Pin to dpctl 0.14.5

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -13,7 +13,7 @@ requirements:
       - cmake >=3.21
       - ninja
       - git
-      - dpctl >=0.14.3
+      - dpctl >=0.14.5
       - mkl-devel-dpcpp {{ environ.get('MKL_VER', '>=2023.1.0') }}
       - onedpl-devel
       - tbb-devel
@@ -25,7 +25,7 @@ requirements:
       - sysroot_linux-64 >=2.28 # [linux]
     run:
       - python
-      - dpctl >=0.14.3
+      - dpctl >=0.14.5
       - {{ pin_compatible('dpcpp-cpp-rt', min_pin='x.x', max_pin='x') }}
       - {{ pin_compatible('mkl-dpcpp', min_pin='x.x', max_pin='x') }}
       - {{ pin_compatible('numpy', min_pin='x.x', max_pin='x') }}


### PR DESCRIPTION
The PR pins host & run dependencies on dpctl with version `0.14.5` in scope of OOC dpnp release.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
