### PR TITLE
Use specilized kernel for f-arrays and sum by axis=1. Add keepdims support

### DIFF
--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -1828,12 +1828,18 @@ def sum(
     elif where is not True:
         pass
     else:
-        if axis == (0,) and len(x.shape) == 2 and not keepdims:
+        if len(x.shape) == 2 and (
+            (axis == (0,) and x.flags.c_contiguous)
+            or (axis == (1,) and x.flags.f_contiguous)
+        ):
             from dpctl.tensor._reduction import _default_reduction_dtype
 
             from dpnp.backend.extensions.sycl_ext import _sycl_ext_impl
 
-            input = dpnp.get_usm_ndarray(x)
+            input = x
+            if axis == (1,):
+                input = input.T
+            input = dpnp.get_usm_ndarray(input)
 
             queue = input.sycl_queue
             out_dtype = (
@@ -1850,7 +1856,14 @@ def sum(
 
             if sum:
                 sum(input, output, []).wait()
-                return dpnp_array._create_from_usm_ndarray(output)
+                result = dpnp_array._create_from_usm_ndarray(output)
+
+                if keepdims:
+                    result = result.reshape((1,) + output.shape)
+                    if axis == (1,):
+                        result = result.T
+
+                return result
 
         y = dpt.sum(
             dpnp.get_usm_ndarray(x), axis=axis, dtype=dtype, keepdims=keepdims

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -1859,9 +1859,11 @@ def sum(
                 result = dpnp_array._create_from_usm_ndarray(output)
 
                 if keepdims:
-                    result = result.reshape((1,) + output.shape)
-                    if axis == (1,):
-                        result = result.T
+                    if axis == (0,):
+                        res_sh = (1,) + output.shape
+                    else:
+                        res_sh = output.shape + (1,)
+                    result = result.reshape(res_sh)
 
                 return result
 


### PR DESCRIPTION
- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [x] If this PR is a work in progress, are you filing the PR as a draft?

Tests in https://github.com/IntelPython/dpnp/pull/1488 covers this functionality. Except `keepdims` due to https://github.com/IntelPython/dpnp/issues/1487

Speeds up `cov` with `rowvar=False` parameter.  As it is used in `pca` workload.

```python
import dpnp
import numpy
import time

a = dpnp.ones((1048576, 128))

dpnp.cov(a, rowvar=False, dtype=a.dtype)
start = time.time()
dpnp.cov(a, rowvar=False, dtype=a.dtype)
print(time.time() - start)
```

Before:
```
0.6248629093170166
```

After:
```
0.229935884475708
```
