### PR TITLE
Pin to numpy<1.24 in build_sphinx

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Install dpnp dependencies
         run: |
-          conda install dpctl mkl-devel-dpcpp onedpl-devel tbb-devel dpcpp_linux-64 \
+          conda install numpy"<1.24" dpctl mkl-devel-dpcpp onedpl-devel tbb-devel dpcpp_linux-64 \
               cmake cython"<3" pytest ninja scikit-build sysroot_linux-64">=2.28" ${{ env.CHANNELS }}
 
       - name: Install cuPy dependencies


### PR DESCRIPTION
This PR pines `numpy<1.24` to build sphinx documentation. The change is necessary cause `cupy` uses `numpy.bool` which expired in version `numpy>1.24` [NumPy 1.24 Release Notes](https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations) 
```
 File "/usr/share/miniconda3/envs/docs/lib/python3.9/site-packages/cupyx/scipy/sparse/_index.py", line 22, in <module>
    _bool_scalar_types = (bool, numpy.bool, numpy.bool_)
  File "/usr/share/miniconda3/envs/docs/lib/python3.9/site-packages/numpy/__init__.py", line 305, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'bool'.
```

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
