### PR TITLE
Reuse dpctl.tensort.take for dpnp.take

### DIFF
--- a/dpnp/backend/include/dpnp_iface_fptr.hpp
+++ b/dpnp/backend/include/dpnp_iface_fptr.hpp
@@ -487,9 +487,7 @@ enum class DPNPFuncName : size_t
     DPNP_FN_SVD_EXT, /**< Used in numpy.linalg.svd() impl, requires extra
                         parameters */
     DPNP_FN_TAKE,    /**< Used in numpy.take() impl  */
-    DPNP_FN_TAKE_EXT, /**< Used in numpy.take() impl, requires extra parameters
-                       */
-    DPNP_FN_TAN,      /**< Used in numpy.tan() impl  */
+    DPNP_FN_TAN,     /**< Used in numpy.tan() impl  */
     DPNP_FN_TAN_EXT, /**< Used in numpy.tan() impl, requires extra parameters */
     DPNP_FN_TANH,    /**< Used in numpy.tanh() impl  */
     DPNP_FN_TANH_EXT,  /**< Used in numpy.tanh() impl, requires extra parameters

--- a/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
@@ -1059,32 +1059,5 @@ void func_map_init_indexing_func(func_map_t &fmap)
     fmap[DPNPFuncName::DPNP_FN_TAKE][eft_C128][eft_LNG] = {
         eft_C128, (void *)dpnp_take_default_c<std::complex<double>, int64_t>};
 
-    // TODO: add a handling of other indexes types once DPCtl implementation of
-    // data copy is ready
-    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_BLN][eft_INT] = {
-        eft_BLN, (void *)dpnp_take_ext_c<bool, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_INT][eft_INT] = {
-        eft_INT, (void *)dpnp_take_ext_c<int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_LNG][eft_INT] = {
-        eft_LNG, (void *)dpnp_take_ext_c<int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_FLT][eft_INT] = {
-        eft_FLT, (void *)dpnp_take_ext_c<float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_DBL][eft_INT] = {
-        eft_DBL, (void *)dpnp_take_ext_c<double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_C128][eft_INT] = {
-        eft_C128, (void *)dpnp_take_ext_c<std::complex<double>, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_BLN][eft_LNG] = {
-        eft_BLN, (void *)dpnp_take_ext_c<bool, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_INT][eft_LNG] = {
-        eft_INT, (void *)dpnp_take_ext_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_LNG][eft_LNG] = {
-        eft_LNG, (void *)dpnp_take_ext_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_FLT][eft_LNG] = {
-        eft_FLT, (void *)dpnp_take_ext_c<float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_DBL][eft_LNG] = {
-        eft_DBL, (void *)dpnp_take_ext_c<double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TAKE_EXT][eft_C128][eft_LNG] = {
-        eft_C128, (void *)dpnp_take_ext_c<std::complex<double>, int64_t>};
-
     return;
 }

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -295,8 +295,6 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_SUM_EXT
         DPNP_FN_SVD
         DPNP_FN_SVD_EXT
-        DPNP_FN_TAKE
-        DPNP_FN_TAKE_EXT
         DPNP_FN_TAN
         DPNP_FN_TAN_EXT
         DPNP_FN_TANH

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -1033,15 +1033,15 @@ class dpnp_array:
 
     # 'swapaxes',
 
-    def take(self, indices, axis=None, out=None, mode="raise"):
+    def take(self, indices, /, *, axis=None, out=None, mode="wrap"):
         """
-        Take elements from an array.
+        Take elements from an array along an axis.
 
         For full documentation refer to :obj:`numpy.take`.
 
         """
 
-        return dpnp.take(self, indices, axis, out, mode)
+        return dpnp.take(self, indices, axis=axis, out=out, mode=mode)
 
     # 'tobytes',
     # 'tofile',

--- a/dpnp/dpnp_iface_indexing.py
+++ b/dpnp/dpnp_iface_indexing.py
@@ -580,6 +580,8 @@ def take(x, indices, /, *, axis=None, out=None, mode="wrap"):
     >>> np.take(x, indices)
     array([4, 3, 6])
 
+    In this example "fancy" indexing can be used.
+
     >>> x[indices]
     array([4, 3, 6])
 
@@ -589,6 +591,7 @@ def take(x, indices, /, *, axis=None, out=None, mode="wrap"):
 
     >>> np.take(x, indices, mode="clip")
     array([4, 4, 4, 8, 8])
+
     """
 
     if dpnp.is_supported_array_type(x) and dpnp.is_supported_array_type(
@@ -605,12 +608,8 @@ def take(x, indices, /, *, axis=None, out=None, mode="wrap"):
         elif mode not in ("clip", "wrap"):
             pass
         else:
-            dpt_array = x.get_array() if isinstance(x, dpnp_array) else x
-            dpt_indices = (
-                indices.get_array()
-                if isinstance(indices, dpnp_array)
-                else indices
-            )
+            dpt_array = dpnp.get_usm_ndarray(x)
+            dpt_indices = dpnp.get_usm_ndarray(indices)
             return dpnp_array._create_from_usm_ndarray(
                 dpt.take(dpt_array, dpt_indices, axis=axis, mode=mode)
             )

--- a/dpnp/dpnp_iface_indexing.py
+++ b/dpnp/dpnp_iface_indexing.py
@@ -70,13 +70,6 @@ __all__ = [
 ]
 
 
-def _is_supported_class(x):
-    # Check if the given object `x` is an instance of either as :class:`dpnp.ndarray`
-    # or :class:`dpctl.tensor.usm_ndarray`.
-
-    return isinstance(x, (dpnp_array, dpt.usm_ndarray))
-
-
 def choose(x1, choices, out=None, mode="raise"):
     """
     Construct an array from an index array and a set of arrays to choose from.
@@ -556,7 +549,7 @@ def take(x, indices, /, *, axis=None, out=None, mode="wrap"):
     -------
     dpnp.ndarray
         An array with shape x.shape[:axis] + indices.shape + x.shape[axis + 1:]
-        filled with elements.
+        filled with elements from `x`.
 
     Limitations
     -----------
@@ -578,9 +571,29 @@ def take(x, indices, /, *, axis=None, out=None, mode="wrap"):
     How out-of-bounds indices will be handled.
     "wrap" - clamps indices to (-n <= i < n), then wraps negative indices.
     "clip" - clips indices to (0 <= i < n)
+
+    Examples
+    --------
+    >>> import dpnp as np
+    >>> x = np.array([4, 3, 5, 7, 6, 8])
+    >>> indices = np.array([0, 1, 4])
+    >>> np.take(x, indices)
+    array([4, 3, 6])
+
+    >>> x[indices]
+    array([4, 3, 6])
+
+    >>> indices = dpnp.array([-1, -6, -7, 5, 6])
+    >>> np.take(x, indices)
+    array([8, 4, 4, 8, 8])
+
+    >>> np.take(x, indices, mode="clip")
+    array([4, 4, 4, 8, 8])
     """
 
-    if _is_supported_class(x) and _is_supported_class(indices):
+    if dpnp.is_supported_array_type(x) and dpnp.is_supported_array_type(
+        indices
+    ):
         if indices.ndim != 1 or not dpnp.issubdtype(
             indices.dtype, dpnp.integer
         ):

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -401,7 +401,6 @@ tests/third_party/cupy/indexing_tests/test_indexing.py::TestIndexing::test_compr
 tests/third_party/cupy/indexing_tests/test_indexing.py::TestIndexing::test_compress_empty_1dim_no_axis
 tests/third_party/cupy/indexing_tests/test_indexing.py::TestIndexing::test_compress_no_axis
 tests/third_party/cupy/indexing_tests/test_indexing.py::TestIndexing::test_compress_no_bool
-tests/third_party/cupy/indexing_tests/test_indexing.py::TestIndexing::test_take_index_range_overflow
 tests/third_party/cupy/indexing_tests/test_indexing.py::TestSelect::test_select
 tests/third_party/cupy/indexing_tests/test_indexing.py::TestSelect::test_select_1D_choicelist
 tests/third_party/cupy/indexing_tests/test_indexing.py::TestSelect::test_select_choicelist_condlist_broadcast

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -49,7 +49,6 @@ tests/test_sycl_queue.py::test_modf[level_zero:gpu:0]
 tests/test_sycl_queue.py::test_1in_1out[opencl:gpu:0-trapz-data19]
 tests/test_sycl_queue.py::test_1in_1out[opencl:cpu:0-trapz-data19]
 
-tests/third_party/cupy/indexing_tests/test_indexing.py::TestIndexing::test_take_no_axis
 tests/third_party/cupy/indexing_tests/test_insert.py::TestDiagIndices_param_0_{n=2, ndim=2}::test_diag_indices
 tests/third_party/cupy/indexing_tests/test_insert.py::TestDiagIndices_param_1_{n=2, ndim=3}::test_diag_indices
 tests/third_party/cupy/indexing_tests/test_insert.py::TestDiagIndices_param_2_{n=2, ndim=1}::test_diag_indices
@@ -597,7 +596,6 @@ tests/third_party/cupy/indexing_tests/test_indexing.py::TestIndexing::test_compr
 tests/third_party/cupy/indexing_tests/test_indexing.py::TestIndexing::test_compress_empty_1dim_no_axis
 tests/third_party/cupy/indexing_tests/test_indexing.py::TestIndexing::test_compress_no_axis
 tests/third_party/cupy/indexing_tests/test_indexing.py::TestIndexing::test_compress_no_bool
-tests/third_party/cupy/indexing_tests/test_indexing.py::TestIndexing::test_take_index_range_overflow
 tests/third_party/cupy/indexing_tests/test_indexing.py::TestSelect::test_select
 tests/third_party/cupy/indexing_tests/test_indexing.py::TestSelect::test_select_1D_choicelist
 tests/third_party/cupy/indexing_tests/test_indexing.py::TestSelect::test_select_choicelist_condlist_broadcast

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -592,61 +592,51 @@ def test_select():
     assert_array_equal(expected, result)
 
 
-@pytest.mark.parametrize(
-    "array_type",
-    [
-        numpy.bool8,
-        numpy.int32,
-        numpy.int64,
-        numpy.float32,
-        numpy.float64,
-        numpy.complex128,
-    ],
-    ids=["bool8", "int32", "int64", "float32", "float64", "complex128"],
-)
+@pytest.mark.parametrize("array_type", get_all_dtypes())
 @pytest.mark.parametrize(
     "indices_type", [numpy.int32, numpy.int64], ids=["int32", "int64"]
 )
 @pytest.mark.parametrize(
-    "indices",
-    [[[0, 0], [0, 0]], [[1, 2], [1, 2]], [[1, 2], [3, 4]]],
-    ids=["[[0, 0], [0, 0]]", "[[1, 2], [1, 2]]", "[[1, 2], [3, 4]]"],
+    "indices", [[-2, 2], [-5, 4]], ids=["[-2, 2]", "[-5, 4]"]
 )
-@pytest.mark.parametrize(
-    "array",
-    [
-        [[0, 1, 2], [3, 4, 5], [6, 7, 8]],
-        [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]],
-        [[[1, 2], [3, 4]], [[1, 2], [2, 1]], [[1, 3], [3, 1]]],
-        [
-            [[[1, 2], [3, 4]], [[1, 2], [2, 1]]],
-            [[[1, 3], [3, 1]], [[0, 1], [1, 3]]],
-        ],
-        [
-            [[[1, 2, 3], [3, 4, 5]], [[1, 2, 3], [2, 1, 0]]],
-            [[[1, 3, 5], [3, 1, 0]], [[0, 1, 2], [1, 3, 4]]],
-        ],
-        [
-            [[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]],
-            [[[13, 14, 15], [16, 17, 18]], [[19, 20, 21], [22, 23, 24]]],
-        ],
-    ],
-    ids=[
-        "[[0, 1, 2], [3, 4, 5], [6, 7, 8]]",
-        "[[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]",
-        "[[[1, 2], [3, 4]], [[1, 2], [2, 1]], [[1, 3], [3, 1]]]",
-        "[[[[1, 2], [3, 4]], [[1, 2], [2, 1]]], [[[1, 3], [3, 1]], [[0, 1], [1, 3]]]]",
-        "[[[[1, 2, 3], [3, 4, 5]], [[1, 2, 3], [2, 1, 0]]], [[[1, 3, 5], [3, 1, 0]], [[0, 1, 2], [1, 3, 4]]]]",
-        "[[[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]], [[[13, 14, 15], [16, 17, 18]], [[19, 20, 21], [22, 23, 24]]]]",
-    ],
-)
-def test_take(array, indices, array_type, indices_type):
-    a = numpy.array(array, dtype=array_type)
+@pytest.mark.parametrize("mode", ["clip", "wrap"], ids=["clip", "wrap"])
+def test_take_1d(indices, array_type, indices_type, mode):
+    a = numpy.array([-2, -1, 0, 1, 2], dtype=array_type)
     ind = numpy.array(indices, dtype=indices_type)
     ia = dpnp.array(a)
     iind = dpnp.array(ind)
-    expected = numpy.take(a, ind)
-    result = dpnp.take(ia, iind)
+    expected = numpy.take(a, ind, mode=mode)
+    result = dpnp.take(ia, iind, mode=mode)
+    assert_array_equal(expected, result)
+
+
+@pytest.mark.parametrize("array_type", get_all_dtypes())
+@pytest.mark.parametrize(
+    "indices_type", [numpy.int32, numpy.int64], ids=["int32", "int64"]
+)
+@pytest.mark.parametrize(
+    "indices", [[-1, 0], [-3, 2]], ids=["[-1, 0]", "[-3, 2]"]
+)
+@pytest.mark.parametrize("mode", ["clip", "wrap"], ids=["clip", "wrap"])
+@pytest.mark.parametrize("axis", [0, 1], ids=["0", "1"])
+def test_take_2d(indices, array_type, indices_type, axis, mode):
+    a = numpy.array([[-1, 0, 1], [-2, -3, -4], [2, 3, 4]], dtype=array_type)
+    ind = numpy.array(indices, dtype=indices_type)
+    ia = dpnp.array(a)
+    iind = dpnp.array(ind)
+    expected = numpy.take(a, ind, axis=axis, mode=mode)
+    result = dpnp.take(ia, iind, axis=axis, mode=mode)
+    assert_array_equal(expected, result)
+
+
+@pytest.mark.parametrize("array_type", get_all_dtypes())
+@pytest.mark.parametrize("indices", [[-5, 5]], ids=["[-5, 5]"])
+@pytest.mark.parametrize("mode", ["clip", "wrap"], ids=["clip", "wrap"])
+def test_take_over_index(indices, array_type, mode):
+    a = dpnp.array([-2, -1, 0, 1, 2], dtype=array_type)
+    ind = dpnp.array(indices, dtype=dpnp.int64)
+    expected = dpnp.array([-2, 2], dtype=a.dtype)
+    result = dpnp.take(a, ind, mode=mode)
     assert_array_equal(expected, result)
 
 

--- a/tests/third_party/cupy/indexing_tests/test_indexing.py
+++ b/tests/third_party/cupy/indexing_tests/test_indexing.py
@@ -28,6 +28,7 @@ class TestIndexing(unittest.TestCase):
         b = xp.array([[1, 3], [2, 0]])
         return a.take(b, axis=1)
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_take_no_axis(self, xp):
         a = testing.shaped_arange((2, 3, 4), xp)
@@ -46,7 +47,7 @@ class TestIndexing(unittest.TestCase):
         if dtype in (numpy.int32, numpy.uint32):
             pytest.skip()
         iinfo = numpy.iinfo(dtype)
-        a = xp.broadcast_to(xp.ones(1), (iinfo.max + 1,))
+        a = xp.broadcast_to(xp.ones(1, dtype=dtype), (iinfo.max + 1,))
         b = xp.array([0], dtype=dtype)
         return a.take(b)
 


### PR DESCRIPTION
This PR modifies `dpnp.take()` implementation to use `dpctl.tensor.take()` instead of dpnp implementation.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
