### PR TITLE
Update test_statistic.py to run on Iris Xe

### DIFF
--- a/dpnp/backend/kernels/dpnp_krnl_common.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_common.cpp
@@ -1167,17 +1167,17 @@ void func_map_init_linalg(func_map_t &fmap)
         eft_DBL, (void *)dpnp_eig_default_c<double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_EIG_EXT][eft_INT][eft_INT] = {
-        get_default_floating_type<>(),
+        get_default_floating_type(),
         (void *)dpnp_eig_ext_c<
-            int32_t, func_type_map_t::find_type<get_default_floating_type<>()>>,
+            int32_t, func_type_map_t::find_type<get_default_floating_type()>>,
         get_default_floating_type<std::false_type>(),
         (void *)dpnp_eig_ext_c<
             int32_t, func_type_map_t::find_type<
                          get_default_floating_type<std::false_type>()>>};
     fmap[DPNPFuncName::DPNP_FN_EIG_EXT][eft_LNG][eft_LNG] = {
-        get_default_floating_type<>(),
+        get_default_floating_type(),
         (void *)dpnp_eig_ext_c<
-            int64_t, func_type_map_t::find_type<get_default_floating_type<>()>>,
+            int64_t, func_type_map_t::find_type<get_default_floating_type()>>,
         get_default_floating_type<std::false_type>(),
         (void *)dpnp_eig_ext_c<
             int64_t, func_type_map_t::find_type<
@@ -1197,17 +1197,17 @@ void func_map_init_linalg(func_map_t &fmap)
         eft_DBL, (void *)dpnp_eigvals_default_c<double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_EIGVALS_EXT][eft_INT][eft_INT] = {
-        get_default_floating_type<>(),
+        get_default_floating_type(),
         (void *)dpnp_eigvals_ext_c<
-            int32_t, func_type_map_t::find_type<get_default_floating_type<>()>>,
+            int32_t, func_type_map_t::find_type<get_default_floating_type()>>,
         get_default_floating_type<std::false_type>(),
         (void *)dpnp_eigvals_ext_c<
             int32_t, func_type_map_t::find_type<
                          get_default_floating_type<std::false_type>()>>};
     fmap[DPNPFuncName::DPNP_FN_EIGVALS_EXT][eft_LNG][eft_LNG] = {
-        get_default_floating_type<>(),
+        get_default_floating_type(),
         (void *)dpnp_eigvals_ext_c<
-            int64_t, func_type_map_t::find_type<get_default_floating_type<>()>>,
+            int64_t, func_type_map_t::find_type<get_default_floating_type()>>,
         get_default_floating_type<std::false_type>(),
         (void *)dpnp_eigvals_ext_c<
             int64_t, func_type_map_t::find_type<

--- a/dpnp/backend/kernels/dpnp_krnl_linalg.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_linalg.cpp
@@ -879,17 +879,17 @@ void func_map_init_linalg_func(func_map_t &fmap)
         eft_DBL, (void *)dpnp_inv_default_c<double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_INV_EXT][eft_INT][eft_INT] = {
-        get_default_floating_type<>(),
+        get_default_floating_type(),
         (void *)dpnp_inv_ext_c<
-            int32_t, func_type_map_t::find_type<get_default_floating_type<>()>>,
+            int32_t, func_type_map_t::find_type<get_default_floating_type()>>,
         get_default_floating_type<std::false_type>(),
         (void *)dpnp_inv_ext_c<
             int32_t, func_type_map_t::find_type<
                          get_default_floating_type<std::false_type>()>>};
     fmap[DPNPFuncName::DPNP_FN_INV_EXT][eft_LNG][eft_LNG] = {
-        get_default_floating_type<>(),
+        get_default_floating_type(),
         (void *)dpnp_inv_ext_c<
-            int64_t, func_type_map_t::find_type<get_default_floating_type<>()>>,
+            int64_t, func_type_map_t::find_type<get_default_floating_type()>>,
         get_default_floating_type<std::false_type>(),
         (void *)dpnp_inv_ext_c<
             int64_t, func_type_map_t::find_type<
@@ -1051,17 +1051,17 @@ void func_map_init_linalg_func(func_map_t &fmap)
     // eft_C128, (void*)dpnp_qr_c<std::complex<double>, std::complex<double>>};
 
     fmap[DPNPFuncName::DPNP_FN_QR_EXT][eft_INT][eft_INT] = {
-        get_default_floating_type<>(),
+        get_default_floating_type(),
         (void *)dpnp_qr_ext_c<
-            int32_t, func_type_map_t::find_type<get_default_floating_type<>()>>,
+            int32_t, func_type_map_t::find_type<get_default_floating_type()>>,
         get_default_floating_type<std::false_type>(),
         (void *)dpnp_qr_ext_c<
             int32_t, func_type_map_t::find_type<
                          get_default_floating_type<std::false_type>()>>};
     fmap[DPNPFuncName::DPNP_FN_QR_EXT][eft_LNG][eft_LNG] = {
-        get_default_floating_type<>(),
+        get_default_floating_type(),
         (void *)dpnp_qr_ext_c<
-            int64_t, func_type_map_t::find_type<get_default_floating_type<>()>>,
+            int64_t, func_type_map_t::find_type<get_default_floating_type()>>,
         get_default_floating_type<std::false_type>(),
         (void *)dpnp_qr_ext_c<
             int64_t, func_type_map_t::find_type<
@@ -1086,10 +1086,10 @@ void func_map_init_linalg_func(func_map_t &fmap)
                                              std::complex<double>, double>};
 
     fmap[DPNPFuncName::DPNP_FN_SVD_EXT][eft_INT][eft_INT] = {
-        get_default_floating_type<>(),
+        get_default_floating_type(),
         (void *)dpnp_svd_ext_c<
-            int32_t, func_type_map_t::find_type<get_default_floating_type<>()>,
-            func_type_map_t::find_type<get_default_floating_type<>()>>,
+            int32_t, func_type_map_t::find_type<get_default_floating_type()>,
+            func_type_map_t::find_type<get_default_floating_type()>>,
         get_default_floating_type<std::false_type>(),
         (void *)
             dpnp_svd_ext_c<int32_t,
@@ -1098,10 +1098,10 @@ void func_map_init_linalg_func(func_map_t &fmap)
                            func_type_map_t::find_type<
                                get_default_floating_type<std::false_type>()>>};
     fmap[DPNPFuncName::DPNP_FN_SVD_EXT][eft_LNG][eft_LNG] = {
-        get_default_floating_type<>(),
+        get_default_floating_type(),
         (void *)dpnp_svd_ext_c<
-            int64_t, func_type_map_t::find_type<get_default_floating_type<>()>,
-            func_type_map_t::find_type<get_default_floating_type<>()>>,
+            int64_t, func_type_map_t::find_type<get_default_floating_type()>,
+            func_type_map_t::find_type<get_default_floating_type()>>,
         get_default_floating_type<std::false_type>(),
         (void *)
             dpnp_svd_ext_c<int64_t,

--- a/dpnp/backend/kernels/dpnp_krnl_statistics.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_statistics.cpp
@@ -1330,9 +1330,21 @@ void func_map_init_statistics(func_map_t &fmap)
         eft_DBL, (void *)dpnp_median_default_c<double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_MEDIAN_EXT][eft_INT][eft_INT] = {
-        eft_DBL, (void *)dpnp_median_ext_c<int32_t, double>};
+        get_default_floating_type<>(),
+        (void *)dpnp_median_ext_c<
+            int32_t, func_type_map_t::find_type<get_default_floating_type<>()>>,
+        get_default_floating_type<std::false_type>(),
+        (void *)dpnp_median_ext_c<
+            int32_t, func_type_map_t::find_type<
+                         get_default_floating_type<std::false_type>()>>};
     fmap[DPNPFuncName::DPNP_FN_MEDIAN_EXT][eft_LNG][eft_LNG] = {
-        eft_DBL, (void *)dpnp_median_ext_c<int64_t, double>};
+        get_default_floating_type<>(),
+        (void *)dpnp_median_ext_c<
+            int64_t, func_type_map_t::find_type<get_default_floating_type<>()>>,
+        get_default_floating_type<std::false_type>(),
+        (void *)dpnp_median_ext_c<
+            int64_t, func_type_map_t::find_type<
+                         get_default_floating_type<std::false_type>()>>};
     fmap[DPNPFuncName::DPNP_FN_MEDIAN_EXT][eft_FLT][eft_FLT] = {
         eft_FLT, (void *)dpnp_median_ext_c<float, float>};
     fmap[DPNPFuncName::DPNP_FN_MEDIAN_EXT][eft_DBL][eft_DBL] = {

--- a/dpnp/backend/kernels/dpnp_krnl_statistics.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_statistics.cpp
@@ -1330,17 +1330,17 @@ void func_map_init_statistics(func_map_t &fmap)
         eft_DBL, (void *)dpnp_median_default_c<double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_MEDIAN_EXT][eft_INT][eft_INT] = {
-        get_default_floating_type<>(),
+        get_default_floating_type(),
         (void *)dpnp_median_ext_c<
-            int32_t, func_type_map_t::find_type<get_default_floating_type<>()>>,
+            int32_t, func_type_map_t::find_type<get_default_floating_type()>>,
         get_default_floating_type<std::false_type>(),
         (void *)dpnp_median_ext_c<
             int32_t, func_type_map_t::find_type<
                          get_default_floating_type<std::false_type>()>>};
     fmap[DPNPFuncName::DPNP_FN_MEDIAN_EXT][eft_LNG][eft_LNG] = {
-        get_default_floating_type<>(),
+        get_default_floating_type(),
         (void *)dpnp_median_ext_c<
-            int64_t, func_type_map_t::find_type<get_default_floating_type<>()>>,
+            int64_t, func_type_map_t::find_type<get_default_floating_type()>>,
         get_default_floating_type<std::false_type>(),
         (void *)dpnp_median_ext_c<
             int64_t, func_type_map_t::find_type<

--- a/dpnp/dpnp_algo/dpnp_algo_statistics.pxi
+++ b/dpnp/dpnp_algo/dpnp_algo_statistics.pxi
@@ -75,16 +75,6 @@ ctypedef c_dpctl.DPCTLSyclEventRef(*custom_statistic_1in_1out_func_ptr_t_max)(c_
                                                                               const c_dpctl.DPCTLEventVectorRef)
 
 
-cdef (DPNPFuncType, void *) get_ret_type_and_func(x1_obj, DPNPFuncData kernel_data):
-    if dpnp.issubdtype(x1_obj.dtype, dpnp.integer) and not x1_obj.sycl_device.has_aspect_fp64:
-        return_type = kernel_data.return_type_no_fp64
-        func = kernel_data.ptr_no_fp64
-    else:
-        return_type = kernel_data.return_type
-        func = kernel_data.ptr
-    return return_type, func
-
-
 cdef utils.dpnp_descriptor call_fptr_custom_std_var_1in_1out(DPNPFuncName fptr_name, utils.dpnp_descriptor x1, ddof):
     cdef shape_type_c x1_shape = x1.shape
 
@@ -275,7 +265,7 @@ cpdef utils.dpnp_descriptor dpnp_median(utils.dpnp_descriptor array1):
 
     array1_obj = array1.get_array()
 
-    cdef (DPNPFuncType, void *) ret_type_and_func = get_ret_type_and_func(array1_obj, kernel_data)
+    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(array1_obj, kernel_data)
     cdef DPNPFuncType return_type = ret_type_and_func[0]
     cdef custom_statistic_1in_1out_func_ptr_t func = < custom_statistic_1in_1out_func_ptr_t > ret_type_and_func[1]
 

--- a/dpnp/dpnp_utils/dpnp_algo_utils.pxd
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pxd
@@ -28,7 +28,7 @@
 from libcpp cimport bool as cpp_bool
 
 from dpnp.dpnp_algo cimport shape_type_c
-from dpnp.dpnp_algo.dpnp_algo cimport DPNPFuncName, DPNPFuncType
+from dpnp.dpnp_algo.dpnp_algo cimport DPNPFuncData, DPNPFuncName, DPNPFuncType
 
 
 cpdef checker_throw_runtime_error(function_name, message)
@@ -161,4 +161,10 @@ Get or calculate srtides based on shape.
 cdef tuple get_common_usm_allocation(dpnp_descriptor x1, dpnp_descriptor x2)
 """
 Get common USM allocation in the form of (sycl_device, usm_type, sycl_queue)
+"""
+
+cdef (DPNPFuncType, void *) get_ret_type_and_func(x1_obj, DPNPFuncData kernel_data)
+"""
+Get the corresponding return type and function pointer based on the
+capability of the allocated input array device for the integer types.
 """

--- a/dpnp/dpnp_utils/dpnp_algo_utils.pyx
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pyx
@@ -663,6 +663,16 @@ cdef tuple get_common_usm_allocation(dpnp_descriptor x1, dpnp_descriptor x2):
     return (common_sycl_queue.sycl_device, common_usm_type, common_sycl_queue)
 
 
+cdef (DPNPFuncType, void *) get_ret_type_and_func(x1_obj, DPNPFuncData kernel_data):
+    if dpnp.issubdtype(x1_obj.dtype, dpnp.integer) and not x1_obj.sycl_device.has_aspect_fp64:
+        return_type = kernel_data.return_type_no_fp64
+        func = kernel_data.ptr_no_fp64
+    else:
+        return_type = kernel_data.return_type
+        func = kernel_data.ptr
+    return return_type, func
+
+
 cdef class dpnp_descriptor:
     def __init__(self, obj, dpnp_descriptor orig_desc=None):
         """ Initialze variables """

--- a/dpnp/dpnp_utils/dpnp_utils_statistics.py
+++ b/dpnp/dpnp_utils/dpnp_utils_statistics.py
@@ -59,6 +59,11 @@ def dpnp_cov(m, y=None, rowvar=True, dtype=None):
         It casts to another dtype, if the input array differs from requested one.
 
         """
+        # dtype map for devices without double precision type support
+        dtype_map = {
+            dpnp.float64: dpnp.float32,
+            dpnp.complex128: dpnp.complex64,
+        }
 
         if x.ndim == 0:
             x = x.reshape((1, 1))
@@ -69,6 +74,10 @@ def dpnp_cov(m, y=None, rowvar=True, dtype=None):
             x = x.T
 
         if x.dtype != dtype:
+            fp64 = x.sycl_device.has_aspect_fp64
+            # TODO: remove when dpctl.result_type() is fixed
+            if not fp64:
+                dtype = dtype_map[dtype.type]
             x = dpnp.astype(x, dtype)
         return x
 

--- a/dpnp/linalg/dpnp_algo_linalg.pyx
+++ b/dpnp/linalg/dpnp_algo_linalg.pyx
@@ -79,16 +79,6 @@ ctypedef c_dpctl.DPCTLSyclEventRef(*custom_linalg_2in_1out_func_ptr_t)(c_dpctl.D
                                                                        const c_dpctl.DPCTLEventVectorRef)
 
 
-cdef (DPNPFuncType, void *) get_ret_type_and_func(x1_obj, DPNPFuncData kernel_data):
-    if dpnp.issubdtype(x1_obj.dtype, dpnp.integer) and not x1_obj.sycl_device.has_aspect_fp64:
-        return_type = kernel_data.return_type_no_fp64
-        func = kernel_data.ptr_no_fp64
-    else:
-        return_type = kernel_data.return_type
-        func = kernel_data.ptr
-    return return_type, func
-
-
 cpdef utils.dpnp_descriptor dpnp_cholesky(utils.dpnp_descriptor input_):
     size_ = input_.shape[-1]
 
@@ -206,7 +196,7 @@ cpdef tuple dpnp_eig(utils.dpnp_descriptor x1):
 
     x1_obj = x1.get_array()
 
-    cdef (DPNPFuncType, void *) ret_type_and_func = get_ret_type_and_func(x1_obj, kernel_data)
+    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(x1_obj, kernel_data)
     cdef DPNPFuncType return_type = ret_type_and_func[0]
     cdef custom_linalg_2in_1out_func_ptr_t func = < custom_linalg_2in_1out_func_ptr_t > ret_type_and_func[1]
 
@@ -252,7 +242,7 @@ cpdef utils.dpnp_descriptor dpnp_eigvals(utils.dpnp_descriptor input):
 
     input_obj = input.get_array()
 
-    cdef (DPNPFuncType, void *) ret_type_and_func = get_ret_type_and_func(input_obj, kernel_data)
+    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(input_obj, kernel_data)
     cdef DPNPFuncType return_type = ret_type_and_func[0]
     cdef custom_linalg_1in_1out_with_size_func_ptr_t_ func = < custom_linalg_1in_1out_with_size_func_ptr_t_ > ret_type_and_func[1]
 
@@ -291,7 +281,7 @@ cpdef utils.dpnp_descriptor dpnp_inv(utils.dpnp_descriptor input):
 
     input_obj = input.get_array()
 
-    cdef (DPNPFuncType, void *) ret_type_and_func = get_ret_type_and_func(input_obj, kernel_data)
+    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(input_obj, kernel_data)
     cdef DPNPFuncType return_type = ret_type_and_func[0]
     cdef custom_linalg_1in_1out_func_ptr_t func = < custom_linalg_1in_1out_func_ptr_t > ret_type_and_func[1]
 
@@ -472,7 +462,7 @@ cpdef tuple dpnp_qr(utils.dpnp_descriptor x1, str mode):
 
     x1_obj = x1.get_array()
 
-    cdef (DPNPFuncType, void *) ret_type_and_func = get_ret_type_and_func(x1_obj, kernel_data)
+    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(x1_obj, kernel_data)
     cdef DPNPFuncType return_type = ret_type_and_func[0]
     cdef custom_linalg_1in_3out_shape_t func = < custom_linalg_1in_3out_shape_t > ret_type_and_func[1]
 
@@ -525,7 +515,7 @@ cpdef tuple dpnp_svd(utils.dpnp_descriptor x1, cpp_bool full_matrices, cpp_bool 
 
     x1_obj = x1.get_array()
 
-    cdef (DPNPFuncType, void *) ret_type_and_func = get_ret_type_and_func(x1_obj, kernel_data)
+    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(x1_obj, kernel_data)
     cdef DPNPFuncType return_type = ret_type_and_func[0]
     cdef custom_linalg_1in_3out_shape_t func = < custom_linalg_1in_3out_shape_t > ret_type_and_func[1]
 

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -1,5 +1,6 @@
 import numpy
 import pytest
+from numpy.testing import assert_allclose
 
 import dpnp
 
@@ -7,31 +8,30 @@ from .helper import get_all_dtypes
 
 
 @pytest.mark.parametrize(
-    "type",
-    [numpy.float64, numpy.float32, numpy.int64, numpy.int32],
-    ids=["float64", "float32", "int64", "int32"],
+    "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
 )
 @pytest.mark.parametrize("size", [2, 4, 8, 16, 3, 9, 27, 81])
-def test_median(type, size):
-    a = numpy.arange(size, dtype=type)
+def test_median(dtype, size):
+    a = numpy.arange(size, dtype=dtype)
     ia = dpnp.array(a)
 
     np_res = numpy.median(a)
     dpnp_res = dpnp.median(ia)
 
-    numpy.testing.assert_allclose(dpnp_res, np_res)
+    assert_allclose(dpnp_res, np_res)
 
 
 @pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("axis", [0, 1, -1, 2, -2, (1, 2), (0, -2)])
 def test_max(axis):
-    a = numpy.arange(768, dtype=numpy.float64).reshape((4, 4, 6, 8))
+    dtype = dpnp.default_float_type()
+    a = numpy.arange(768, dtype=dtype).reshape((4, 4, 6, 8))
     ia = dpnp.array(a)
 
     np_res = numpy.max(a, axis=axis)
     dpnp_res = dpnp.max(ia, axis=axis)
 
-    numpy.testing.assert_allclose(dpnp_res, np_res)
+    assert_allclose(dpnp_res, np_res)
 
 
 @pytest.mark.usefixtures("allow_fall_back_on_numpy")
@@ -71,16 +71,17 @@ def test_max(axis):
     ],
 )
 def test_nanvar(array):
-    a = numpy.array(array)
+    dtype = dpnp.default_float_type()
+    a = numpy.array(array, dtype=dtype)
     ia = dpnp.array(a)
     for ddof in range(a.ndim):
         expected = numpy.nanvar(a, ddof=ddof)
         result = dpnp.nanvar(ia, ddof=ddof)
-        numpy.testing.assert_array_equal(expected, result)
+        assert_allclose(expected, result, rtol=1e-06)
 
     expected = numpy.nanvar(a, axis=None, ddof=0)
     result = dpnp.nanvar(ia, axis=None, ddof=0)
-    numpy.testing.assert_array_equal(expected, result)
+    assert_allclose(expected, result, rtol=1e-06)
 
 
 @pytest.mark.usefixtures("allow_fall_back_on_numpy")
@@ -99,7 +100,7 @@ class TestBincount:
 
         expected = numpy.bincount(np_a, minlength=minlength)
         result = dpnp.bincount(dpnp_a, minlength=minlength)
-        numpy.testing.assert_array_equal(expected, result)
+        assert_allclose(expected, result)
 
     @pytest.mark.parametrize(
         "array", [[1, 2, 2, 1, 2, 4]], ids=["[1, 2, 2, 1, 2, 4]"]
@@ -115,7 +116,7 @@ class TestBincount:
 
         expected = numpy.bincount(np_a, weights=weights)
         result = dpnp.bincount(dpnp_a, weights=weights)
-        numpy.testing.assert_array_equal(expected, result)
+        assert_allclose(expected, result)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -23,8 +23,10 @@ def test_median(dtype, size):
 
 @pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("axis", [0, 1, -1, 2, -2, (1, 2), (0, -2)])
-def test_max(axis):
-    dtype = dpnp.default_float_type()
+@pytest.mark.parametrize(
+    "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
+)
+def test_max(axis, dtype):
     a = numpy.arange(768, dtype=dtype).reshape((4, 4, 6, 8))
     ia = dpnp.array(a)
 
@@ -70,7 +72,10 @@ def test_max(axis):
         "[[np.nan, np.nan], [np.inf, np.nan]]",
     ],
 )
-def test_nanvar(array):
+@pytest.mark.parametrize(
+    "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
+)
+def test_nanvar(array, dtype):
     dtype = dpnp.default_float_type()
     a = numpy.array(array, dtype=dtype)
     ia = dpnp.array(a)
@@ -125,10 +130,8 @@ class TestBincount:
 def test_cov_rowvar(dtype):
     a = dpnp.array([[0, 2], [1, 1], [2, 0]], dtype=dtype)
     b = numpy.array([[0, 2], [1, 1], [2, 0]], dtype=dtype)
-    numpy.testing.assert_array_equal(dpnp.cov(a.T), dpnp.cov(a, rowvar=False))
-    numpy.testing.assert_array_equal(
-        numpy.cov(b, rowvar=False), dpnp.cov(a, rowvar=False)
-    )
+    assert_allclose(dpnp.cov(a.T), dpnp.cov(a, rowvar=False))
+    assert_allclose(numpy.cov(b, rowvar=False), dpnp.cov(a, rowvar=False))
 
 
 @pytest.mark.parametrize(
@@ -137,6 +140,4 @@ def test_cov_rowvar(dtype):
 def test_cov_1D_rowvar(dtype):
     a = dpnp.array([[0, 1, 2]], dtype=dtype)
     b = numpy.array([[0, 1, 2]], dtype=dtype)
-    numpy.testing.assert_array_equal(
-        numpy.cov(b, rowvar=False), dpnp.cov(a, rowvar=False)
-    )
+    assert_allclose(numpy.cov(b, rowvar=False), dpnp.cov(a, rowvar=False))


### PR DESCRIPTION
This PR solves updates tests and backend of some `statistic functions` to run on Iris Xe which does not support double precision floating point type.
It solves part of #1293

Also it moves `get_ret_type_and_func` function to `dpnp_algo_utils` file for common use in cython files 

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
