### PR TITLE
Resolve warning and error with cython 3.0.0

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Install dpnp dependencies
         run: |
           conda install dpctl mkl-devel-dpcpp onedpl-devel tbb-devel dpcpp_linux-64 \
-              cmake cython"<3" pytest ninja scikit-build sysroot_linux-64">=2.28" ${{ env.CHANNELS }}
+              cmake cython pytest ninja scikit-build sysroot_linux-64">=2.28" ${{ env.CHANNELS }}
 
       - name: Install cuPy dependencies
         run: conda install cupy cudatoolkit=10.0

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -41,7 +41,7 @@ jobs:
           sudo apt-get install lcov
       - name: Install dpnp dependencies
         run: |
-          conda install cython"<3" llvm cmake">=3.21" scikit-build ninja pytest pytest-cov coverage[toml] \
+          conda install cython llvm cmake">=3.21" scikit-build ninja pytest pytest-cov coverage[toml] \
               dpctl dpcpp_linux-64 sysroot_linux-64">=2.28" mkl-devel-dpcpp tbb-devel onedpl-devel ${{ env.CHANNELS }}
       - name: Conda info
         run: |

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -9,7 +9,7 @@ requirements:
       - python
       - setuptools
       - numpy >=1.19,<1.25a0
-      - cython <3
+      - cython
       - cmake >=3.21
       - ninja
       - git

--- a/dpnp/CMakeLists.txt
+++ b/dpnp/CMakeLists.txt
@@ -9,6 +9,7 @@ function(build_dpnp_cython_ext _trgt _src _dest)
   if (DPNP_GENERATE_COVERAGE)
     target_compile_definitions(${_trgt} PRIVATE CYTHON_TRACE=1 CYTHON_TRACE_NOGIL=1)
   endif()
+  target_compile_definitions(${_trgt} PRIVATE NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION)
   # NumPy
   target_include_directories(${_trgt} PRIVATE ${NumPy_INCLUDE_DIR})
   # Dpctl

--- a/dpnp/dparray.pyx
+++ b/dpnp/dparray.pyx
@@ -40,7 +40,13 @@ from libcpp cimport bool as cpp_bool
 
 import numpy
 
+from dpnp.dpnp_algo import (
+    dpnp_astype,
+    dpnp_flatten,
+)
+
 # to avoid interference with Python internal functions
+from dpnp.dpnp_iface import asnumpy
 from dpnp.dpnp_iface import get_dpnp_descriptor as iface_get_dpnp_descriptor
 from dpnp.dpnp_iface import prod as iface_prod
 from dpnp.dpnp_iface import sum as iface_sum
@@ -86,29 +92,63 @@ from dpnp.dpnp_iface_arraycreation import (
     zeros,
     zeros_like,
 )
-from dpnp.dpnp_iface_bitwise import *
-from dpnp.dpnp_iface_counting import *
-from dpnp.dpnp_iface_indexing import *
-from dpnp.dpnp_iface_libmath import *
-from dpnp.dpnp_iface_linearalgebra import *
-from dpnp.dpnp_iface_logic import *
-from dpnp.dpnp_iface_logic import all, any  # TODO do the same as for iface_sum
-from dpnp.dpnp_iface_manipulation import *
-from dpnp.dpnp_iface_mathematical import *
-from dpnp.dpnp_iface_searching import *
-from dpnp.dpnp_iface_sorting import *
-from dpnp.dpnp_iface_statistics import *
+from dpnp.dpnp_iface_indexing import (
+    choose,
+    diagonal,
+    take,
+)
+from dpnp.dpnp_iface_linearalgebra import matmul
+from dpnp.dpnp_iface_logic import (  # TODO do the same as for iface_sum
+    all,
+    any,
+    equal,
+    greater,
+    greater_equal,
+    less,
+    less_equal,
+    not_equal,
+)
+from dpnp.dpnp_iface_manipulation import (
+    copyto,
+    repeat,
+    squeeze,
+    transpose,
+)
+from dpnp.dpnp_iface_mathematical import (
+    add,
+    around,
+    conjugate,
+    cumprod,
+    cumsum,
+    divide,
+    multiply,
+    negative,
+    power,
+    remainder,
+    subtract,
+)
+from dpnp.dpnp_iface_searching import argmax, argmin
+from dpnp.dpnp_iface_sorting import (
+    argsort,
+    partition,
+    sort,
+)
 from dpnp.dpnp_iface_statistics import (  # TODO do the same as for iface_sum
     max,
+    mean,
     min,
+    std,
+    var,
 )
-from dpnp.dpnp_iface_trigonometric import *
-from dpnp.dpnp_iface_types import *
+from dpnp.dpnp_iface_types import float64
 
 cimport numpy
 
 cimport dpnp.dpnp_utils as utils
-from dpnp.dpnp_algo cimport *
+from dpnp.dpnp_algo cimport (
+    dpnp_memory_alloc_c,
+    dpnp_memory_free_c,
+)
 
 
 # initially copied from original


### PR DESCRIPTION
The PR resolves compilation error which mainly looks relating to incorrect code generation by cython 3.0.0 in case of any import with asterisk. By the way, all asterisk imports were removed from `dparray.pyx`, since it makes the code more clear.

Also the PR suppresses a compilation warning caused by the deprecated pre-NumPy-1.7 C-API. The suppression is implemented by defining `-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION` through cmake following the cython recommendation.

Remaining warnings are caused by either dpctl or cython issues.

The PR removes temporary pining to cython "<3" in the receipt and from actions, since all issues are resolved.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
