### PR TITLE
Require DPC++ and OneMKL pacakges from 2023.2

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -14,14 +14,14 @@ requirements:
       - ninja
       - git
       - dpctl >=0.14.5
-      - mkl-devel-dpcpp {{ environ.get('MKL_VER', '>=2023.1.0') }}
+      - mkl-devel-dpcpp {{ environ.get('MKL_VER', '>=2023.2.0') }}
       - onedpl-devel
       - tbb-devel
       - wheel
       - scikit-build
     build:
       - {{ compiler('cxx') }}
-      - {{ compiler('dpcpp') }}  >=2023.1.0  # [not osx]
+      - {{ compiler('dpcpp') }}  >=2023.2.0  # [not osx]
       - sysroot_linux-64 >=2.28 # [linux]
     run:
       - python

--- a/dpnp/backend/extensions/vm/common.hpp
+++ b/dpnp/backend/extensions/vm/common.hpp
@@ -37,6 +37,11 @@
 #include "utils/type_dispatch.hpp"
 #include "utils/type_utils.hpp"
 
+#include "dpnp_utils.hpp"
+
+static_assert(INTEL_MKL_VERSION >= __INTEL_MKL_2023_2_0_VERSION_REQUIRED,
+              "OneMKL does not meet minimum version requirement");
+
 // OneMKL namespace with VM functions
 namespace mkl_vm = oneapi::mkl::vm;
 
@@ -272,7 +277,6 @@ bool need_to_call_unary_ufunc(sycl::queue exec_q,
                               dpctl::tensor::usm_ndarray dst,
                               const dispatchT &dispatch_vector)
 {
-#if INTEL_MKL_VERSION >= 20230002
     // check type_nums
     int src_typenum = src.get_typenum();
     int dst_typenum = dst.get_typenum();
@@ -356,16 +360,6 @@ bool need_to_call_unary_ufunc(sycl::queue exec_q,
         return false;
     }
     return true;
-#else
-    // In OneMKL 2023.1.0 the call of oneapi::mkl::vm::div() is going to dead
-    // lock inside ~usm_wrapper_to_host()->{...; q_->wait_and_throw(); ...}
-
-    (void)exec_q;
-    (void)src;
-    (void)dst;
-    (void)dispatch_vector;
-    return false;
-#endif // INTEL_MKL_VERSION >= 20230002
 }
 
 template <typename dispatchT>
@@ -375,7 +369,6 @@ bool need_to_call_binary_ufunc(sycl::queue exec_q,
                                dpctl::tensor::usm_ndarray dst,
                                const dispatchT &dispatch_vector)
 {
-#if INTEL_MKL_VERSION >= 20230002
     // check type_nums
     int src1_typenum = src1.get_typenum();
     int src2_typenum = src2.get_typenum();
@@ -465,17 +458,6 @@ bool need_to_call_binary_ufunc(sycl::queue exec_q,
         return false;
     }
     return true;
-#else
-    // In OneMKL 2023.1.0 the call of oneapi::mkl::vm::div() is going to dead
-    // lock inside ~usm_wrapper_to_host()->{...; q_->wait_and_throw(); ...}
-
-    (void)exec_q;
-    (void)src1;
-    (void)src2;
-    (void)dst;
-    (void)dispatch_vector;
-    return false;
-#endif // INTEL_MKL_VERSION >= 20230002
 }
 
 template <typename dispatchT,

--- a/dpnp/backend/kernels/dpnp_krnl_mathematical.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_mathematical.cpp
@@ -35,6 +35,9 @@
 #include "dpnpc_memory_adapter.hpp"
 #include "queue_sycl.hpp"
 
+static_assert(__SYCL_COMPILER_VERSION >= __SYCL_COMPILER_VECTOR_ABS_CHANGED,
+              "SYCL DPC++ compiler does not meet minimum version requirement");
+
 template <typename _KernelNameSpecialization>
 class dpnp_around_c_kernel;
 
@@ -180,18 +183,8 @@ DPCTLSyclEventRef
                 sycl::vec<_DataType_input, vec_sz> data_vec =
                     sg.load<vec_sz>(input_ptrT(&array1[start]));
 
-#if (__SYCL_COMPILER_VERSION < __SYCL_COMPILER_VECTOR_ABS_CHANGED)
-                // sycl::abs() returns unsigned integers only, so explicit
-                // casting to signed ones is required
-                using result_absT = typename cl::sycl::detail::make_unsigned<
-                    _DataType_output>::type;
-                sycl::vec<_DataType_output, vec_sz> res_vec =
-                    dpnp_vec_cast<_DataType_output, result_absT, vec_sz>(
-                        sycl::abs(data_vec));
-#else
                 sycl::vec<_DataType_output, vec_sz> res_vec =
                     sycl::abs(data_vec);
-#endif
 
                 sg.store<vec_sz>(result_ptrT(&result[start]), res_vec);
             }

--- a/dpnp/backend/kernels/dpnp_krnl_random.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_random.cpp
@@ -37,8 +37,8 @@
 #include "dpnpc_memory_adapter.hpp"
 #include "queue_sycl.hpp"
 
-static_assert(INTEL_MKL_VERSION >= __INTEL_MKL_2023_VERSION_REQUIRED,
-              "MKL does not meet minimum version requirement");
+static_assert(INTEL_MKL_VERSION >= __INTEL_MKL_2023_0_0_VERSION_REQUIRED,
+              "OneMKL does not meet minimum version requirement");
 
 namespace mkl_blas = oneapi::mkl::blas;
 namespace mkl_rng = oneapi::mkl::rng;

--- a/dpnp/backend/src/dpnp_utils.hpp
+++ b/dpnp/backend/src/dpnp_utils.hpp
@@ -64,8 +64,18 @@
 /**
  * Version of Intel MKL at which transition to OneMKL release 2023.0.0 occurs.
  */
-#ifndef __INTEL_MKL_2023_VERSION_REQUIRED
-#define __INTEL_MKL_2023_VERSION_REQUIRED 20230000
+#ifndef __INTEL_MKL_2023_0_0_VERSION_REQUIRED
+#define __INTEL_MKL_2023_0_0_VERSION_REQUIRED 20230000
+#endif
+
+/**
+ * Version of Intel MKL at which transition to OneMKL release 2023.2.0 occurs.
+ *
+ * @note with OneMKL=2023.1.0 the call of oneapi::mkl::vm::div() was dead
+ * locked inside ~usm_wrapper_to_host()->{...; q_->wait_and_throw(); ...}
+ */
+#ifndef __INTEL_MKL_2023_2_0_VERSION_REQUIRED
+#define __INTEL_MKL_2023_2_0_VERSION_REQUIRED 20230002L
 #endif
 
 /**


### PR DESCRIPTION
The PR proposes to update run and build dependencies on DPC++ and OneMKL packages from `2023.2` release.

Temporary workarounds to work with DPC++ and OneMKL packages from `2023.1` are removed from the code and secured with static asserts.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
