### PR TITLE
Use get_ret_type_and_func in call_fptr functions 

### DIFF
--- a/dpnp/dpnp_algo/dpnp_algo.pyx
+++ b/dpnp/dpnp_algo/dpnp_algo.pyx
@@ -350,6 +350,7 @@ cdef utils.dpnp_descriptor call_fptr_1in_1out_strides(DPNPFuncName fptr_name,
 
     x1_obj = x1.get_array()
 
+    # get FPTR function and return type
     cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(x1_obj.sycl_device, kernel_data)
     cdef DPNPFuncType return_type = ret_type_and_func[0]
     cdef fptr_1in_1out_strides_t func = < fptr_1in_1out_strides_t > ret_type_and_func[1]
@@ -425,6 +426,7 @@ cdef utils.dpnp_descriptor call_fptr_2in_1out(DPNPFuncName fptr_name,
 
     result_sycl_device, result_usm_type, result_sycl_queue = utils.get_common_usm_allocation(x1_obj, x2_obj)
 
+    # get FPTR function and return type
     cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(result_sycl_device, kernel_data)
     cdef DPNPFuncType return_type = ret_type_and_func[0]
     cdef fptr_2in_1out_t func = < fptr_2in_1out_t > ret_type_and_func[1]
@@ -492,6 +494,13 @@ cdef utils.dpnp_descriptor call_fptr_2in_1out_strides(DPNPFuncName fptr_name,
     # get the FPTR data structure
     cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(fptr_name, x1_c_type, x2_c_type)
 
+    result_sycl_device, result_usm_type, result_sycl_queue = utils.get_common_usm_allocation(x1_obj, x2_obj)
+
+    # get FPTR function and return type
+    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(result_sycl_device, kernel_data)
+    cdef DPNPFuncType return_type = ret_type_and_func[0]
+    cdef fptr_2in_1out_strides_t func = < fptr_2in_1out_strides_t > ret_type_and_func[1]
+
     # Create result array
     cdef shape_type_c x1_shape = x1_obj.shape
 
@@ -501,12 +510,6 @@ cdef utils.dpnp_descriptor call_fptr_2in_1out_strides(DPNPFuncName fptr_name,
 
     cdef shape_type_c result_shape = utils.get_common_shape(x1_shape, x2_shape)
     cdef utils.dpnp_descriptor result
-
-    result_sycl_device, result_usm_type, result_sycl_queue = utils.get_common_usm_allocation(x1_obj, x2_obj)
-
-    # get FPTR function and return type
-    cdef fptr_2in_1out_strides_t func = < fptr_2in_1out_strides_t > kernel_data.ptr
-    cdef DPNPFuncType return_type = kernel_data.return_type
 
     # check 'out' parameter data
     if out is not None:

--- a/dpnp/dpnp_algo/dpnp_algo.pyx
+++ b/dpnp/dpnp_algo/dpnp_algo.pyx
@@ -351,7 +351,8 @@ cdef utils.dpnp_descriptor call_fptr_1in_1out_strides(DPNPFuncName fptr_name,
     x1_obj = x1.get_array()
 
     # get FPTR function and return type
-    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(x1_obj.sycl_device, kernel_data)
+    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(kernel_data,
+                                                                                x1_obj.sycl_device.has_aspect_fp64)
     cdef DPNPFuncType return_type = ret_type_and_func[0]
     cdef fptr_1in_1out_strides_t func = < fptr_1in_1out_strides_t > ret_type_and_func[1]
 
@@ -427,7 +428,8 @@ cdef utils.dpnp_descriptor call_fptr_2in_1out(DPNPFuncName fptr_name,
     result_sycl_device, result_usm_type, result_sycl_queue = utils.get_common_usm_allocation(x1_obj, x2_obj)
 
     # get FPTR function and return type
-    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(result_sycl_device, kernel_data)
+    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(kernel_data,
+                                                                                result_sycl_device.has_aspect_fp64)
     cdef DPNPFuncType return_type = ret_type_and_func[0]
     cdef fptr_2in_1out_t func = < fptr_2in_1out_t > ret_type_and_func[1]
 
@@ -497,7 +499,8 @@ cdef utils.dpnp_descriptor call_fptr_2in_1out_strides(DPNPFuncName fptr_name,
     result_sycl_device, result_usm_type, result_sycl_queue = utils.get_common_usm_allocation(x1_obj, x2_obj)
 
     # get FPTR function and return type
-    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(result_sycl_device, kernel_data)
+    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(kernel_data,
+                                                                                result_sycl_device.has_aspect_fp64)
     cdef DPNPFuncType return_type = ret_type_and_func[0]
     cdef fptr_2in_1out_strides_t func = < fptr_2in_1out_strides_t > ret_type_and_func[1]
 

--- a/dpnp/dpnp_algo/dpnp_algo_statistics.pxi
+++ b/dpnp/dpnp_algo/dpnp_algo_statistics.pxi
@@ -265,7 +265,7 @@ cpdef utils.dpnp_descriptor dpnp_median(utils.dpnp_descriptor array1):
 
     array1_obj = array1.get_array()
 
-    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(array1_obj, kernel_data)
+    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(array1_obj.sycl_device, kernel_data)
     cdef DPNPFuncType return_type = ret_type_and_func[0]
     cdef custom_statistic_1in_1out_func_ptr_t func = < custom_statistic_1in_1out_func_ptr_t > ret_type_and_func[1]
 

--- a/dpnp/dpnp_algo/dpnp_algo_statistics.pxi
+++ b/dpnp/dpnp_algo/dpnp_algo_statistics.pxi
@@ -265,7 +265,8 @@ cpdef utils.dpnp_descriptor dpnp_median(utils.dpnp_descriptor array1):
 
     array1_obj = array1.get_array()
 
-    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(array1_obj.sycl_device, kernel_data)
+    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(kernel_data,
+                                                                                array1_obj.sycl_device.has_aspect_fp64)
     cdef DPNPFuncType return_type = ret_type_and_func[0]
     cdef custom_statistic_1in_1out_func_ptr_t func = < custom_statistic_1in_1out_func_ptr_t > ret_type_and_func[1]
 

--- a/dpnp/dpnp_utils/dpnp_algo_utils.pxd
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pxd
@@ -163,8 +163,9 @@ cdef tuple get_common_usm_allocation(dpnp_descriptor x1, dpnp_descriptor x2)
 Get common USM allocation in the form of (sycl_device, usm_type, sycl_queue)
 """
 
-cdef (DPNPFuncType, void *) get_ret_type_and_func(device, DPNPFuncData kernel_data)
+cdef (DPNPFuncType, void *) get_ret_type_and_func(DPNPFuncData kernel_data,
+                                                  cpp_bool has_aspect_fp64)
 """
 Get the corresponding return type and function pointer based on the
-capability of the allocated input array device.
+capability of the allocated result array device.
 """

--- a/dpnp/dpnp_utils/dpnp_algo_utils.pxd
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pxd
@@ -163,8 +163,8 @@ cdef tuple get_common_usm_allocation(dpnp_descriptor x1, dpnp_descriptor x2)
 Get common USM allocation in the form of (sycl_device, usm_type, sycl_queue)
 """
 
-cdef (DPNPFuncType, void *) get_ret_type_and_func(x1_obj, DPNPFuncData kernel_data)
+cdef (DPNPFuncType, void *) get_ret_type_and_func(device, DPNPFuncData kernel_data)
 """
 Get the corresponding return type and function pointer based on the
-capability of the allocated input array device for the integer types.
+capability of the allocated input array device.
 """

--- a/dpnp/dpnp_utils/dpnp_algo_utils.pyx
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pyx
@@ -663,15 +663,16 @@ cdef tuple get_common_usm_allocation(dpnp_descriptor x1, dpnp_descriptor x2):
     return (common_sycl_queue.sycl_device, common_usm_type, common_sycl_queue)
 
 
-cdef (DPNPFuncType, void *) get_ret_type_and_func(device, DPNPFuncData kernel_data):
+cdef (DPNPFuncType, void *) get_ret_type_and_func(DPNPFuncData kernel_data,
+                                                  cpp_bool has_aspect_fp64):
     """
     This function is responsible for determining the appropriate return type
-    and function pointer based on the capability of the allocated input array device.
+    and function pointer based on the capability of the allocated result array device.
     """
     return_type = kernel_data.return_type
     func = kernel_data.ptr
 
-    if kernel_data.ptr_no_fp64 != NULL and not device.has_aspect_fp64:
+    if kernel_data.ptr_no_fp64 != NULL and not has_aspect_fp64:
 
         return_type = kernel_data.return_type_no_fp64
         func = kernel_data.ptr_no_fp64

--- a/dpnp/dpnp_utils/dpnp_algo_utils.pyx
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pyx
@@ -663,13 +663,20 @@ cdef tuple get_common_usm_allocation(dpnp_descriptor x1, dpnp_descriptor x2):
     return (common_sycl_queue.sycl_device, common_usm_type, common_sycl_queue)
 
 
-cdef (DPNPFuncType, void *) get_ret_type_and_func(x1_obj, DPNPFuncData kernel_data):
-    if dpnp.issubdtype(x1_obj.dtype, dpnp.integer) and not x1_obj.sycl_device.has_aspect_fp64:
+cdef (DPNPFuncType, void *) get_ret_type_and_func(device, DPNPFuncData kernel_data):
+    """
+    This function is responsible for determining the appropriate return type
+    and function pointer based on the capability of the allocated input array device
+    for integer types and its definition.
+    """
+    return_type = kernel_data.return_type
+    func = kernel_data.ptr
+
+    if kernel_data.ptr_no_fp64 != NULL and not device.has_aspect_fp64:
+
         return_type = kernel_data.return_type_no_fp64
         func = kernel_data.ptr_no_fp64
-    else:
-        return_type = kernel_data.return_type
-        func = kernel_data.ptr
+
     return return_type, func
 
 

--- a/dpnp/dpnp_utils/dpnp_algo_utils.pyx
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pyx
@@ -666,8 +666,7 @@ cdef tuple get_common_usm_allocation(dpnp_descriptor x1, dpnp_descriptor x2):
 cdef (DPNPFuncType, void *) get_ret_type_and_func(device, DPNPFuncData kernel_data):
     """
     This function is responsible for determining the appropriate return type
-    and function pointer based on the capability of the allocated input array device
-    for integer types and its definition.
+    and function pointer based on the capability of the allocated input array device.
     """
     return_type = kernel_data.return_type
     func = kernel_data.ptr

--- a/dpnp/dpnp_utils/dpnp_utils_statistics.py
+++ b/dpnp/dpnp_utils/dpnp_utils_statistics.py
@@ -79,8 +79,8 @@ def dpnp_cov(m, y=None, rowvar=True, dtype=None):
         dtypes = [m.dtype, dpnp.default_float_type(sycl_queue=queue)]
         if y is not None:
             dtypes.append(y.dtype)
-        dtype = dpt.result_type(*dtypes)
-        # TODO: remove when dpctl.result_type() is fixed
+        dtype = dpnp.result_type(*dtypes)
+        # TODO: remove when dpctl.result_type() is returned dtype based on fp64
         fp64 = queue.sycl_device.has_aspect_fp64
         if not fp64:
             if dtype == dpnp.float64:

--- a/dpnp/linalg/dpnp_algo_linalg.pyx
+++ b/dpnp/linalg/dpnp_algo_linalg.pyx
@@ -196,7 +196,7 @@ cpdef tuple dpnp_eig(utils.dpnp_descriptor x1):
 
     x1_obj = x1.get_array()
 
-    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(x1_obj, kernel_data)
+    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(x1_obj.sycl_device, kernel_data)
     cdef DPNPFuncType return_type = ret_type_and_func[0]
     cdef custom_linalg_2in_1out_func_ptr_t func = < custom_linalg_2in_1out_func_ptr_t > ret_type_and_func[1]
 
@@ -242,7 +242,7 @@ cpdef utils.dpnp_descriptor dpnp_eigvals(utils.dpnp_descriptor input):
 
     input_obj = input.get_array()
 
-    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(input_obj, kernel_data)
+    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(input_obj.sycl_device, kernel_data)
     cdef DPNPFuncType return_type = ret_type_and_func[0]
     cdef custom_linalg_1in_1out_with_size_func_ptr_t_ func = < custom_linalg_1in_1out_with_size_func_ptr_t_ > ret_type_and_func[1]
 
@@ -281,7 +281,7 @@ cpdef utils.dpnp_descriptor dpnp_inv(utils.dpnp_descriptor input):
 
     input_obj = input.get_array()
 
-    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(input_obj, kernel_data)
+    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(input_obj.sycl_device, kernel_data)
     cdef DPNPFuncType return_type = ret_type_and_func[0]
     cdef custom_linalg_1in_1out_func_ptr_t func = < custom_linalg_1in_1out_func_ptr_t > ret_type_and_func[1]
 
@@ -462,7 +462,7 @@ cpdef tuple dpnp_qr(utils.dpnp_descriptor x1, str mode):
 
     x1_obj = x1.get_array()
 
-    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(x1_obj, kernel_data)
+    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(x1_obj.sycl_device, kernel_data)
     cdef DPNPFuncType return_type = ret_type_and_func[0]
     cdef custom_linalg_1in_3out_shape_t func = < custom_linalg_1in_3out_shape_t > ret_type_and_func[1]
 
@@ -515,7 +515,7 @@ cpdef tuple dpnp_svd(utils.dpnp_descriptor x1, cpp_bool full_matrices, cpp_bool 
 
     x1_obj = x1.get_array()
 
-    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(x1_obj, kernel_data)
+    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(x1_obj.sycl_device, kernel_data)
     cdef DPNPFuncType return_type = ret_type_and_func[0]
     cdef custom_linalg_1in_3out_shape_t func = < custom_linalg_1in_3out_shape_t > ret_type_and_func[1]
 

--- a/dpnp/linalg/dpnp_algo_linalg.pyx
+++ b/dpnp/linalg/dpnp_algo_linalg.pyx
@@ -196,7 +196,8 @@ cpdef tuple dpnp_eig(utils.dpnp_descriptor x1):
 
     x1_obj = x1.get_array()
 
-    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(x1_obj.sycl_device, kernel_data)
+    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(kernel_data,
+                                                                                x1_obj.sycl_device.has_aspect_fp64)
     cdef DPNPFuncType return_type = ret_type_and_func[0]
     cdef custom_linalg_2in_1out_func_ptr_t func = < custom_linalg_2in_1out_func_ptr_t > ret_type_and_func[1]
 
@@ -242,7 +243,8 @@ cpdef utils.dpnp_descriptor dpnp_eigvals(utils.dpnp_descriptor input):
 
     input_obj = input.get_array()
 
-    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(input_obj.sycl_device, kernel_data)
+    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(kernel_data,
+                                                                                input_obj.sycl_device.has_aspect_fp64)
     cdef DPNPFuncType return_type = ret_type_and_func[0]
     cdef custom_linalg_1in_1out_with_size_func_ptr_t_ func = < custom_linalg_1in_1out_with_size_func_ptr_t_ > ret_type_and_func[1]
 
@@ -281,7 +283,8 @@ cpdef utils.dpnp_descriptor dpnp_inv(utils.dpnp_descriptor input):
 
     input_obj = input.get_array()
 
-    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(input_obj.sycl_device, kernel_data)
+    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(kernel_data,
+                                                                                input_obj.sycl_device.has_aspect_fp64)
     cdef DPNPFuncType return_type = ret_type_and_func[0]
     cdef custom_linalg_1in_1out_func_ptr_t func = < custom_linalg_1in_1out_func_ptr_t > ret_type_and_func[1]
 
@@ -462,7 +465,8 @@ cpdef tuple dpnp_qr(utils.dpnp_descriptor x1, str mode):
 
     x1_obj = x1.get_array()
 
-    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(x1_obj.sycl_device, kernel_data)
+    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(kernel_data,
+                                                                                x1_obj.sycl_device.has_aspect_fp64)
     cdef DPNPFuncType return_type = ret_type_and_func[0]
     cdef custom_linalg_1in_3out_shape_t func = < custom_linalg_1in_3out_shape_t > ret_type_and_func[1]
 
@@ -515,7 +519,8 @@ cpdef tuple dpnp_svd(utils.dpnp_descriptor x1, cpp_bool full_matrices, cpp_bool 
 
     x1_obj = x1.get_array()
 
-    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(x1_obj.sycl_device, kernel_data)
+    cdef (DPNPFuncType, void *) ret_type_and_func = utils.get_ret_type_and_func(kernel_data,
+                                                                                x1_obj.sycl_device.has_aspect_fp64)
     cdef DPNPFuncType return_type = ret_type_and_func[0]
     cdef custom_linalg_1in_3out_shape_t func = < custom_linalg_1in_3out_shape_t > ret_type_and_func[1]
 


### PR DESCRIPTION
This PR changes signature of `get_ret_type_and_func` function. The updated function takes `sycl_device` argument instead of `x1_obj` and checks null pointer to kernel with no `fp64` support. 

Also the PR suggests using updated `get_ret_type_and_func` function in `call_fptr_1in_1out_strides`, `call_fptr_2in_1out` and `call_fptr_2in_1out_strides` functions for further test updates to run on Iris Xe. 

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
