### PR TITLE
Upgrade flake8 and black to newer version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
     -   id: rst-inline-touching-normal
     -   id: text-unicode-replacement-char
 -   repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
     -   id: black
         args: ["--check", "--diff", "--color"]
@@ -59,7 +59,7 @@ repos:
         name: isort (pyi)
         types: [pyi]
 -   repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
     -   id: flake8
         args: ["--config=.flake8"]

--- a/dpnp/dpnp_iface_indexing.py
+++ b/dpnp/dpnp_iface_indexing.py
@@ -435,7 +435,7 @@ def put(x1, ind, v, mode="raise"):
     if x1_desc:
         if mode != "raise":
             pass
-        elif type(ind) != type(v):
+        elif type(ind) is not type(v):
             pass
         elif (
             numpy.max(ind) >= x1_desc.size or numpy.min(ind) + x1_desc.size < 0


### PR DESCRIPTION
The PR is aimed to upgrade pre-commit hooks with `flake8` and `black` tools to the latest available version.
The PR also suppresses one new warning E721 reporting by flake8.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
