### PR TITLE
Leveraged dpctl.tensor.stack() implementation

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -12,6 +12,7 @@ env:
   CHANNELS: '-c dppy/label/dev -c intel -c conda-forge --override-channels'
   TEST_SCOPE: >-
       test_arraycreation.py
+      test_arraymanipulation.py
       test_dot.py
       test_dparray.py
       test_fft.py
@@ -23,6 +24,7 @@ env:
       test_umath.py
       test_usm_type.py
       third_party/cupy/linalg_tests/test_product.py
+      third_party/cupy/manipulation_tests/test_join.py
       third_party/cupy/math_tests/test_explog.py
       third_party/cupy/math_tests/test_misc.py
       third_party/cupy/math_tests/test_trigonometric.py

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -237,7 +237,7 @@ def broadcast_to(x, /, shape, subok=False):
     return call_origin(numpy.broadcast_to, x, shape=shape, subok=subok)
 
 
-def concatenate(arrays, *, axis=0, out=None, dtype=None, **kwargs):
+def concatenate(arrays, /, *, axis=0, out=None, dtype=None, **kwargs):
     """
     Join a sequence of arrays along an existing axis.
 
@@ -253,8 +253,7 @@ def concatenate(arrays, *, axis=0, out=None, dtype=None, **kwargs):
     Each array in `arrays` is supported as either :class:`dpnp.ndarray`
     or :class:`dpctl.tensor.usm_ndarray`. Otherwise ``TypeError`` exeption
     will be raised.
-    Parameter `out` is supported with default value.
-    Parameter `dtype` is supported with default value.
+    Parameters `out` and `dtype are supported with default value.
     Keyword argument ``kwargs`` is currently unsupported.
     Otherwise the function will be executed sequentially on CPU.
 
@@ -834,15 +833,77 @@ def squeeze(x, /, axis=None):
     return call_origin(numpy.squeeze, x, axis)
 
 
-def stack(arrays, axis=0, out=None):
+def stack(arrays, /, *, axis=0, out=None, dtype=None, **kwargs):
     """
     Join a sequence of arrays along a new axis.
 
     For full documentation refer to :obj:`numpy.stack`.
 
+    Returns
+    -------
+    out : dpnp.ndarray
+        The stacked array which has one more dimension than the input arrays.
+
+    Limitations
+    -----------
+    Each array in `arrays` is supported as either :class:`dpnp.ndarray`
+    or :class:`dpctl.tensor.usm_ndarray`. Otherwise ``TypeError`` exeption
+    will be raised.
+    Parameters `out` and `dtype are supported with default value.
+    Keyword argument ``kwargs`` is currently unsupported.
+    Otherwise the function will be executed sequentially on CPU.
+
+    See Also
+    --------
+    :obj:`dpnp.concatenate` : Join a sequence of arrays along an existing axis.
+    :obj:`dpnp.block` : Assemble an nd-array from nested lists of blocks.
+    :obj:`dpnp.split` : Split array into a list of multiple sub-arrays of equal size.
+
+    Examples
+    --------
+    >>> import dpnp as np
+    >>> arrays = [np.random.randn(3, 4) for _ in range(10)]
+    >>> np.stack(arrays, axis=0).shape
+    (10, 3, 4)
+
+    >>> np.stack(arrays, axis=1).shape
+    (3, 10, 4)
+
+    >>> np.stack(arrays, axis=2).shape
+    (3, 4, 10)
+
+    >>> a = np.array([1, 2, 3])
+    >>> b = np.array([4, 5, 6])
+    >>> np.stack((a, b))
+    array([[1, 2, 3],
+           [4, 5, 6]])
+
+    >>> np.stack((a, b), axis=-1)
+    array([[1, 4],
+           [2, 5],
+           [3, 6]])
+
     """
 
-    return call_origin(numpy.stack, arrays, axis, out)
+    if kwargs:
+        pass
+    elif out is not None:
+        pass
+    elif dtype is not None:
+        pass
+    else:
+        usm_arrays = [dpnp.get_usm_ndarray(x) for x in arrays]
+        usm_res = dpt.stack(usm_arrays, axis=axis)
+        return dpnp_array._create_from_usm_ndarray(usm_res)
+
+    return call_origin(
+        numpy.stack,
+        arrays,
+        axis=axis,
+        out=out,
+        dtype=dtype,
+        **kwargs,
+    )
 
 
 def swapaxes(x1, axis1, axis2):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,14 @@ def allow_fall_back_on_numpy(monkeypatch):
 
 
 @pytest.fixture
+def suppress_complex_warning():
+    sup = numpy.testing.suppress_warnings("always")
+    sup.filter(numpy.ComplexWarning)
+    with sup:
+        yield
+
+
+@pytest.fixture
 def suppress_divide_numpy_warnings():
     # divide: treatment for division by zero (infinite result obtained from finite numbers)
     old_settings = numpy.seterr(divide="ignore")

--- a/tests/third_party/cupy/manipulation_tests/test_join.py
+++ b/tests/third_party/cupy/manipulation_tests/test_join.py
@@ -375,7 +375,6 @@ class TestJoin(unittest.TestCase):
         # may raise TypeError or ComplexWarning
         return xp.vstack((a, b), dtype=dtype2, casting=casting)
 
-    @pytest.mark.skip("dpnp.stack() is not implemented yet")
     @testing.numpy_cupy_array_equal()
     def test_stack(self, xp):
         a = testing.shaped_arange((2, 3), xp)
@@ -383,61 +382,53 @@ class TestJoin(unittest.TestCase):
         c = testing.shaped_arange((2, 3), xp)
         return xp.stack((a, b, c))
 
-    @pytest.mark.skip("dpnp.stack() is not implemented yet")
     def test_stack_value(self):
         a = testing.shaped_arange((2, 3), cupy)
         b = testing.shaped_arange((2, 3), cupy)
         c = testing.shaped_arange((2, 3), cupy)
         s = cupy.stack((a, b, c))
         assert s.shape == (3, 2, 3)
-        cupy.testing.assert_array_equal(s[0], a)
-        cupy.testing.assert_array_equal(s[1], b)
-        cupy.testing.assert_array_equal(s[2], c)
+        testing.assert_array_equal(s[0], a)
+        testing.assert_array_equal(s[1], b)
+        testing.assert_array_equal(s[2], c)
 
-    @pytest.mark.skip("dpnp.stack() is not implemented yet")
     @testing.numpy_cupy_array_equal()
     def test_stack_with_axis1(self, xp):
         a = testing.shaped_arange((2, 3), xp)
         return xp.stack((a, a), axis=1)
 
-    @pytest.mark.skip("dpnp.stack() is not implemented yet")
     @testing.numpy_cupy_array_equal()
     def test_stack_with_axis2(self, xp):
         a = testing.shaped_arange((2, 3), xp)
         return xp.stack((a, a), axis=2)
 
-    @pytest.mark.skip("dpnp.stack() is not implemented yet")
     def test_stack_with_axis_over(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3), xp)
             with pytest.raises(ValueError):
                 xp.stack((a, a), axis=3)
 
-    @pytest.mark.skip("dpnp.stack() is not implemented yet")
     def test_stack_with_axis_value(self):
         a = testing.shaped_arange((2, 3), cupy)
         s = cupy.stack((a, a), axis=1)
 
         assert s.shape == (2, 2, 3)
-        cupy.testing.assert_array_equal(s[:, 0, :], a)
-        cupy.testing.assert_array_equal(s[:, 1, :], a)
+        testing.assert_array_equal(s[:, 0, :], a)
+        testing.assert_array_equal(s[:, 1, :], a)
 
-    @pytest.mark.skip("dpnp.stack() is not implemented yet")
     @testing.numpy_cupy_array_equal()
     def test_stack_with_negative_axis(self, xp):
         a = testing.shaped_arange((2, 3), xp)
         return xp.stack((a, a), axis=-1)
 
-    @pytest.mark.skip("dpnp.stack() is not implemented yet")
     def test_stack_with_negative_axis_value(self):
         a = testing.shaped_arange((2, 3), cupy)
         s = cupy.stack((a, a), axis=-1)
 
         assert s.shape == (2, 3, 2)
-        cupy.testing.assert_array_equal(s[:, :, 0], a)
-        cupy.testing.assert_array_equal(s[:, :, 1], a)
+        testing.assert_array_equal(s[:, :, 0], a)
+        testing.assert_array_equal(s[:, :, 1], a)
 
-    @pytest.mark.skip("dpnp.stack() is not implemented yet")
     def test_stack_different_shape(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3), xp)
@@ -445,20 +436,18 @@ class TestJoin(unittest.TestCase):
             with pytest.raises(ValueError):
                 xp.stack([a, b])
 
-    @pytest.mark.skip("dpnp.stack() is not implemented yet")
     def test_stack_out_of_bounds1(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3), xp)
             with pytest.raises(ValueError):
                 xp.stack([a, a], axis=3)
 
-    @pytest.mark.skip("dpnp.stack() is not implemented yet")
     def test_stack_out_of_bounds2(self):
         a = testing.shaped_arange((2, 3), cupy)
         with pytest.raises(numpy.AxisError):
             return cupy.stack([a, a], axis=3)
 
-    @pytest.mark.skip("dpnp.stack() is not implemented yet")
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes(name="dtype")
     @testing.numpy_cupy_array_equal()
     def test_stack_out(self, xp, dtype):
@@ -469,47 +458,47 @@ class TestJoin(unittest.TestCase):
         xp.stack((a, b, c), axis=1, out=out)
         return out
 
-    @pytest.mark.skip("dpnp.stack() is not implemented yet")
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_stack_out_same_kind(self, xp):
-        a = testing.shaped_arange((3, 4), xp, xp.float64)
-        b = testing.shaped_reverse_arange((3, 4), xp, xp.float64)
-        c = testing.shaped_arange((3, 4), xp, xp.float64)
+        a = testing.shaped_arange((3, 4), xp, xp.float32)
+        b = testing.shaped_reverse_arange((3, 4), xp, xp.float32)
+        c = testing.shaped_arange((3, 4), xp, xp.float32)
         out = xp.zeros((3, 3, 4), dtype=xp.float32)
         xp.stack((a, b, c), axis=1, out=out)
         return out
 
-    @pytest.mark.skip("dpnp.stack() is not implemented yet")
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_stack_out_invalid_shape(self):
         for xp in (numpy, cupy):
-            a = testing.shaped_arange((3, 4), xp, xp.float64)
-            b = testing.shaped_reverse_arange((3, 4), xp, xp.float64)
-            c = testing.shaped_arange((3, 4), xp, xp.float64)
-            out = xp.zeros((3, 3, 10), dtype=xp.float64)
+            a = testing.shaped_arange((3, 4), xp, xp.float32)
+            b = testing.shaped_reverse_arange((3, 4), xp, xp.float32)
+            c = testing.shaped_arange((3, 4), xp, xp.float32)
+            out = xp.zeros((3, 3, 10), dtype=xp.float32)
             with pytest.raises(ValueError):
                 xp.stack((a, b, c), axis=1, out=out)
 
-    @pytest.mark.skip("dpnp.stack() is not implemented yet")
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_stack_out_invalid_shape_2(self):
         for xp in (numpy, cupy):
-            a = testing.shaped_arange((3, 4), xp, xp.float64)
-            b = testing.shaped_reverse_arange((3, 4), xp, xp.float64)
-            c = testing.shaped_arange((3, 4), xp, xp.float64)
-            out = xp.zeros((3, 3, 3, 10), dtype=xp.float64)
+            a = testing.shaped_arange((3, 4), xp, xp.float32)
+            b = testing.shaped_reverse_arange((3, 4), xp, xp.float32)
+            c = testing.shaped_arange((3, 4), xp, xp.float32)
+            out = xp.zeros((3, 3, 3, 10), dtype=xp.float32)
             with pytest.raises(ValueError):
                 xp.stack((a, b, c), axis=1, out=out)
 
-    @pytest.mark.skip("dpnp.stack() is not implemented yet")
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_stack_out_invalid_dtype(self):
         for xp in (numpy, cupy):
-            a = testing.shaped_arange((3, 4), xp, xp.float64)
-            b = testing.shaped_reverse_arange((3, 4), xp, xp.float64)
-            c = testing.shaped_arange((3, 4), xp, xp.float64)
+            a = testing.shaped_arange((3, 4), xp, xp.float32)
+            b = testing.shaped_reverse_arange((3, 4), xp, xp.float32)
+            c = testing.shaped_arange((3, 4), xp, xp.float32)
             out = xp.zeros((3, 3, 4), dtype=xp.int64)
             with pytest.raises(TypeError):
                 xp.stack((a, b, c), axis=1, out=out)
 
-    @pytest.mark.skip("dpnp.stack() is not implemented yet")
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.with_requires("numpy>=1.24.0")
     @testing.for_all_dtypes_combination(names=["dtype1", "dtype2"])
     @testing.numpy_cupy_array_equal(accept_error=TypeError)
@@ -518,18 +507,9 @@ class TestJoin(unittest.TestCase):
         b = testing.shaped_arange((3, 4), xp, dtype1)
         return xp.stack((a, b), dtype=dtype2)
 
-    @pytest.mark.skip("dpnp.stack() is not implemented yet")
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.with_requires("numpy>=1.24.0")
-    @pytest.mark.parametrize(
-        "casting",
-        [
-            "no",
-            "equiv",
-            "safe",
-            "same_kind",
-            "unsafe",
-        ],
-    )
+    @testing.for_castings()
     @testing.for_all_dtypes_combination(names=["dtype1", "dtype2"])
     @testing.numpy_cupy_array_equal(
         accept_error=(TypeError, numpy.ComplexWarning)
@@ -537,7 +517,6 @@ class TestJoin(unittest.TestCase):
     def test_stack_casting(self, xp, dtype1, dtype2, casting):
         a = testing.shaped_arange((3, 4), xp, dtype1)
         b = testing.shaped_arange((3, 4), xp, dtype1)
-        # may raise TypeError or ComplexWarning
         return xp.stack((a, b), dtype=dtype2, casting=casting)
 
     @pytest.mark.skip("dpnp.row_stack() is not implemented yet")


### PR DESCRIPTION
The PR propose to rework implementation of `dpnp.stack()` to fully rely on `dpctl.tensor.stack`.

Additionally, a scope of public CI verification is extended with array manipulation tests.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
