### PR TITLE
Fixed assigning a value to potentially none-valued dictionary

### DIFF
--- a/scripts/gen_coverage.py
+++ b/scripts/gen_coverage.py
@@ -41,13 +41,15 @@ def run(
         "-DDPNP_GENERATE_COVERAGE=ON",
     ]
 
-    env = None
+    env = {}
     if bin_llvm:
         env = {
             "PATH": ":".join((os.environ.get("PATH", ""), bin_llvm)),
             "LLVM_TOOLS_HOME": bin_llvm,
         }
-        env.update({k: v for k, v in os.environ.items() if k != "PATH"})
+
+    # extend with global enviroment variables
+    env.update({k: v for k, v in os.environ.items() if k != "PATH"})
 
     subprocess.check_call(cmake_args, shell=False, cwd=setup_dir, env=env)
 


### PR DESCRIPTION
The PR proposes to resolve an exception which might be potentially raised during run of coverage generation script.
The issue will come visible if to run the script with `bin_llvm=None`.

Note, the issue was identified by Coverity tool and classified as `Very high` severity.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
