### PR TITLE
Resolve `Arguments in wrong order` issue reported by Coverity tool

### DIFF
--- a/dpnp/backend/kernels/dpnp_krnl_common.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_common.cpp
@@ -852,15 +852,15 @@ DPCTLSyclEventRef dpnp_matmul_c(DPCTLSyclQueueRef q_ref,
     {
         // using std::max for these ldx variables is required by math library
         const std::int64_t lda =
-            std::max<size_t>(1UL, size_k); // First dimensions of array_1
+            std::max<size_t>(1UL, size_n); // First dimensions of array_1
         const std::int64_t ldb =
-            std::max<size_t>(1UL, size_n); // First dimensions of array_2
+            std::max<size_t>(1UL, size_k); // First dimensions of array_2
         const std::int64_t ldc =
             std::max<size_t>(1UL, size_n); // Fast dimensions of result
 
         event = mkl_blas::gemm(q, oneapi::mkl::transpose::nontrans,
                                oneapi::mkl::transpose::nontrans, size_n, size_m,
-                               size_k, _DataType(1), array_2, ldb, array_1, lda,
+                               size_k, _DataType(1), array_2, lda, array_1, ldb,
                                _DataType(0), result, ldc, dep_events);
     }
     else {

--- a/dpnp/backend/kernels/dpnp_krnl_common.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_common.cpp
@@ -851,17 +851,18 @@ DPCTLSyclEventRef dpnp_matmul_c(DPCTLSyclQueueRef q_ref,
                   std::is_same<_DataType, float>::value)
     {
         // using std::max for these ldx variables is required by math library
-        const std::int64_t lda =
-            std::max<size_t>(1UL, size_n); // First dimensions of array_1
-        const std::int64_t ldb =
-            std::max<size_t>(1UL, size_k); // First dimensions of array_2
-        const std::int64_t ldc =
+        const std::int64_t ld_array_2 =
+            std::max<size_t>(1UL, size_n); // First dimensions of array_2
+        const std::int64_t ld_array_1 =
+            std::max<size_t>(1UL, size_k); // First dimensions of array_1
+        const std::int64_t ld_result =
             std::max<size_t>(1UL, size_n); // Fast dimensions of result
 
         event = mkl_blas::gemm(q, oneapi::mkl::transpose::nontrans,
                                oneapi::mkl::transpose::nontrans, size_n, size_m,
-                               size_k, _DataType(1), array_2, lda, array_1, ldb,
-                               _DataType(0), result, ldc, dep_events);
+                               size_k, _DataType(1), array_2, ld_array_2,
+                               array_1, ld_array_1, _DataType(0), result,
+                               ld_result, dep_events);
     }
     else {
         // input1: M x K


### PR DESCRIPTION
The TR is intended to resolve an issue from Coverity report with "high" severity.

The tool claims that the positions of arguments in the call to `mkl_blas::gemm` do not match the ordering of the parameters: `ldb` is passed to `lda`, `lda` is passed to `ldb`.
Actually, the issue is false positive, since local variables `lda` and `ldb` are assigning to correct values. But the PR proposes to resolve the reported problem to avoid future misleading.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
