### PR TITLE
create_Unary_BinaryElementwisefunc_during_module_import

### DIFF
--- a/dpnp/backend/extensions/vm/add.hpp
+++ b/dpnp/backend/extensions/vm/add.hpp
@@ -1,0 +1,81 @@
+//*****************************************************************************
+// Copyright (c) 2023, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//*****************************************************************************
+
+#pragma once
+
+#include <CL/sycl.hpp>
+
+#include "common.hpp"
+#include "types_matrix.hpp"
+
+namespace dpnp
+{
+namespace backend
+{
+namespace ext
+{
+namespace vm
+{
+template <typename T>
+sycl::event add_contig_impl(sycl::queue exec_q,
+                            const std::int64_t n,
+                            const char *in_a,
+                            const char *in_b,
+                            char *out_y,
+                            const std::vector<sycl::event> &depends)
+{
+    type_utils::validate_type_for_device<T>(exec_q);
+
+    const T *a = reinterpret_cast<const T *>(in_a);
+    const T *b = reinterpret_cast<const T *>(in_b);
+    T *y = reinterpret_cast<T *>(out_y);
+
+    return mkl_vm::add(exec_q,
+                       n, // number of elements to be calculated
+                       a, // pointer `a` containing 1st input vector of size n
+                       b, // pointer `b` containing 2nd input vector of size n
+                       y, // pointer `y` to the output vector of size n
+                       depends);
+}
+
+template <typename fnT, typename T>
+struct AddContigFactory
+{
+    fnT get()
+    {
+        if constexpr (std::is_same_v<
+                          typename types::AddOutputType<T>::value_type, void>)
+        {
+            return nullptr;
+        }
+        else {
+            return add_contig_impl<T>;
+        }
+    }
+};
+} // namespace vm
+} // namespace ext
+} // namespace backend
+} // namespace dpnp

--- a/dpnp/backend/extensions/vm/mul.hpp
+++ b/dpnp/backend/extensions/vm/mul.hpp
@@ -1,0 +1,81 @@
+//*****************************************************************************
+// Copyright (c) 2023, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//*****************************************************************************
+
+#pragma once
+
+#include <CL/sycl.hpp>
+
+#include "common.hpp"
+#include "types_matrix.hpp"
+
+namespace dpnp
+{
+namespace backend
+{
+namespace ext
+{
+namespace vm
+{
+template <typename T>
+sycl::event mul_contig_impl(sycl::queue exec_q,
+                            const std::int64_t n,
+                            const char *in_a,
+                            const char *in_b,
+                            char *out_y,
+                            const std::vector<sycl::event> &depends)
+{
+    type_utils::validate_type_for_device<T>(exec_q);
+
+    const T *a = reinterpret_cast<const T *>(in_a);
+    const T *b = reinterpret_cast<const T *>(in_b);
+    T *y = reinterpret_cast<T *>(out_y);
+
+    return mkl_vm::mul(exec_q,
+                       n, // number of elements to be calculated
+                       a, // pointer `a` containing 1st input vector of size n
+                       b, // pointer `b` containing 2nd input vector of size n
+                       y, // pointer `y` to the output vector of size n
+                       depends);
+}
+
+template <typename fnT, typename T>
+struct MulContigFactory
+{
+    fnT get()
+    {
+        if constexpr (std::is_same_v<
+                          typename types::MulOutputType<T>::value_type, void>)
+        {
+            return nullptr;
+        }
+        else {
+            return mul_contig_impl<T>;
+        }
+    }
+};
+} // namespace vm
+} // namespace ext
+} // namespace backend
+} // namespace dpnp

--- a/dpnp/backend/extensions/vm/sub.hpp
+++ b/dpnp/backend/extensions/vm/sub.hpp
@@ -1,0 +1,81 @@
+//*****************************************************************************
+// Copyright (c) 2023, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//*****************************************************************************
+
+#pragma once
+
+#include <CL/sycl.hpp>
+
+#include "common.hpp"
+#include "types_matrix.hpp"
+
+namespace dpnp
+{
+namespace backend
+{
+namespace ext
+{
+namespace vm
+{
+template <typename T>
+sycl::event sub_contig_impl(sycl::queue exec_q,
+                            const std::int64_t n,
+                            const char *in_a,
+                            const char *in_b,
+                            char *out_y,
+                            const std::vector<sycl::event> &depends)
+{
+    type_utils::validate_type_for_device<T>(exec_q);
+
+    const T *a = reinterpret_cast<const T *>(in_a);
+    const T *b = reinterpret_cast<const T *>(in_b);
+    T *y = reinterpret_cast<T *>(out_y);
+
+    return mkl_vm::sub(exec_q,
+                       n, // number of elements to be calculated
+                       a, // pointer `a` containing 1st input vector of size n
+                       b, // pointer `b` containing 2nd input vector of size n
+                       y, // pointer `y` to the output vector of size n
+                       depends);
+}
+
+template <typename fnT, typename T>
+struct SubContigFactory
+{
+    fnT get()
+    {
+        if constexpr (std::is_same_v<
+                          typename types::SubOutputType<T>::value_type, void>)
+        {
+            return nullptr;
+        }
+        else {
+            return sub_contig_impl<T>;
+        }
+    }
+};
+} // namespace vm
+} // namespace ext
+} // namespace backend
+} // namespace dpnp

--- a/dpnp/backend/extensions/vm/types_matrix.hpp
+++ b/dpnp/backend/extensions/vm/types_matrix.hpp
@@ -45,6 +45,31 @@ namespace types
 {
 /**
  * @brief A factory to define pairs of supported types for which
+ * MKL VM library provides support in oneapi::mkl::vm::add<T> function.
+ *
+ * @tparam T Type of input vectors `a` and `b` and of result vector `y`.
+ */
+template <typename T>
+struct AddOutputType
+{
+    using value_type = typename std::disjunction<
+        dpctl_td_ns::BinaryTypeMapResultEntry<T,
+                                              std::complex<double>,
+                                              T,
+                                              std::complex<double>,
+                                              std::complex<double>>,
+        dpctl_td_ns::BinaryTypeMapResultEntry<T,
+                                              std::complex<float>,
+                                              T,
+                                              std::complex<float>,
+                                              std::complex<float>>,
+        dpctl_td_ns::BinaryTypeMapResultEntry<T, double, T, double, double>,
+        dpctl_td_ns::BinaryTypeMapResultEntry<T, float, T, float, float>,
+        dpctl_td_ns::DefaultResultEntry<void>>::result_type;
+};
+
+/**
+ * @brief A factory to define pairs of supported types for which
  * MKL VM library provides support in oneapi::mkl::vm::div<T> function.
  *
  * @tparam T Type of input vectors `a` and `b` and of result vector `y`.
@@ -80,6 +105,56 @@ struct CeilOutputType
     using value_type = typename std::disjunction<
         dpctl_td_ns::TypeMapResultEntry<T, double, double>,
         dpctl_td_ns::TypeMapResultEntry<T, float, float>,
+        dpctl_td_ns::DefaultResultEntry<void>>::result_type;
+};
+
+/**
+ * @brief A factory to define pairs of supported types for which     
+ * MKL VM library provides support in oneapi::mkl::vm::mul<T> function.
+ *
+ * @tparam T Type of input vectors `a` and `b` and of result vector `y`.
+ */
+template <typename T>
+struct MulOutputType
+{
+    using value_type = typename std::disjunction<
+        dpctl_td_ns::BinaryTypeMapResultEntry<T,
+                                              std::complex<double>,
+                                              T,
+                                              std::complex<double>,
+                                              std::complex<double>>,
+        dpctl_td_ns::BinaryTypeMapResultEntry<T,
+                                              std::complex<float>,
+                                              T,
+                                              std::complex<float>,
+                                              std::complex<float>>,
+        dpctl_td_ns::BinaryTypeMapResultEntry<T, double, T, double, double>,
+        dpctl_td_ns::BinaryTypeMapResultEntry<T, float, T, float, float>,
+        dpctl_td_ns::DefaultResultEntry<void>>::result_type;
+};
+
+/**
+ * @brief A factory to define pairs of supported types for which
+ * MKL VM library provides support in oneapi::mkl::vm::sub<T> function.
+ *
+ * @tparam T Type of input vectors `a` and `b` and of result vector `y`.
+ */
+template <typename T>
+struct SubOutputType
+{
+    using value_type = typename std::disjunction<
+        dpctl_td_ns::BinaryTypeMapResultEntry<T,
+                                              std::complex<double>,
+                                              T,
+                                              std::complex<double>,
+                                              std::complex<double>>,
+        dpctl_td_ns::BinaryTypeMapResultEntry<T,
+                                              std::complex<float>,
+                                              T,
+                                              std::complex<float>,
+                                              std::complex<float>>,
+        dpctl_td_ns::BinaryTypeMapResultEntry<T, double, T, double, double>,
+        dpctl_td_ns::BinaryTypeMapResultEntry<T, float, T, float, float>,
         dpctl_td_ns::DefaultResultEntry<void>>::result_type;
 };
 

--- a/dpnp/backend/extensions/vm/types_matrix.hpp
+++ b/dpnp/backend/extensions/vm/types_matrix.hpp
@@ -70,6 +70,40 @@ struct AddOutputType
 
 /**
  * @brief A factory to define pairs of supported types for which
+ * MKL VM library provides support in oneapi::mkl::vm::ceil<T> function.
+ *
+ * @tparam T Type of input vector `a` and of result vector `y`.
+ */
+template <typename T>
+struct CeilOutputType
+{
+    using value_type = typename std::disjunction<
+        dpctl_td_ns::TypeMapResultEntry<T, double, double>,
+        dpctl_td_ns::TypeMapResultEntry<T, float, float>,
+        dpctl_td_ns::DefaultResultEntry<void>>::result_type;
+};
+
+/**
+ * @brief A factory to define pairs of supported types for which
+ * MKL VM library provides support in oneapi::mkl::vm::cos<T> function.
+ *
+ * @tparam T Type of input vector `a` and of result vector `y`.
+ */
+template <typename T>
+struct CosOutputType
+{
+    using value_type = typename std::disjunction<
+        dpctl_td_ns::
+            TypeMapResultEntry<T, std::complex<double>, std::complex<double>>,
+        dpctl_td_ns::
+            TypeMapResultEntry<T, std::complex<float>, std::complex<float>>,
+        dpctl_td_ns::TypeMapResultEntry<T, double, double>,
+        dpctl_td_ns::TypeMapResultEntry<T, float, float>,
+        dpctl_td_ns::DefaultResultEntry<void>>::result_type;
+};
+
+/**
+ * @brief A factory to define pairs of supported types for which
  * MKL VM library provides support in oneapi::mkl::vm::div<T> function.
  *
  * @tparam T Type of input vectors `a` and `b` and of result vector `y`.
@@ -90,90 +124,6 @@ struct DivOutputType
                                               std::complex<float>>,
         dpctl_td_ns::BinaryTypeMapResultEntry<T, double, T, double, double>,
         dpctl_td_ns::BinaryTypeMapResultEntry<T, float, T, float, float>,
-        dpctl_td_ns::DefaultResultEntry<void>>::result_type;
-};
-
-/**
- * @brief A factory to define pairs of supported types for which
- * MKL VM library provides support in oneapi::mkl::vm::ceil<T> function.
- *
- * @tparam T Type of input vector `a` and of result vector `y`.
- */
-template <typename T>
-struct CeilOutputType
-{
-    using value_type = typename std::disjunction<
-        dpctl_td_ns::TypeMapResultEntry<T, double, double>,
-        dpctl_td_ns::TypeMapResultEntry<T, float, float>,
-        dpctl_td_ns::DefaultResultEntry<void>>::result_type;
-};
-
-/**
- * @brief A factory to define pairs of supported types for which     
- * MKL VM library provides support in oneapi::mkl::vm::mul<T> function.
- *
- * @tparam T Type of input vectors `a` and `b` and of result vector `y`.
- */
-template <typename T>
-struct MulOutputType
-{
-    using value_type = typename std::disjunction<
-        dpctl_td_ns::BinaryTypeMapResultEntry<T,
-                                              std::complex<double>,
-                                              T,
-                                              std::complex<double>,
-                                              std::complex<double>>,
-        dpctl_td_ns::BinaryTypeMapResultEntry<T,
-                                              std::complex<float>,
-                                              T,
-                                              std::complex<float>,
-                                              std::complex<float>>,
-        dpctl_td_ns::BinaryTypeMapResultEntry<T, double, T, double, double>,
-        dpctl_td_ns::BinaryTypeMapResultEntry<T, float, T, float, float>,
-        dpctl_td_ns::DefaultResultEntry<void>>::result_type;
-};
-
-/**
- * @brief A factory to define pairs of supported types for which
- * MKL VM library provides support in oneapi::mkl::vm::sub<T> function.
- *
- * @tparam T Type of input vectors `a` and `b` and of result vector `y`.
- */
-template <typename T>
-struct SubOutputType
-{
-    using value_type = typename std::disjunction<
-        dpctl_td_ns::BinaryTypeMapResultEntry<T,
-                                              std::complex<double>,
-                                              T,
-                                              std::complex<double>,
-                                              std::complex<double>>,
-        dpctl_td_ns::BinaryTypeMapResultEntry<T,
-                                              std::complex<float>,
-                                              T,
-                                              std::complex<float>,
-                                              std::complex<float>>,
-        dpctl_td_ns::BinaryTypeMapResultEntry<T, double, T, double, double>,
-        dpctl_td_ns::BinaryTypeMapResultEntry<T, float, T, float, float>,
-        dpctl_td_ns::DefaultResultEntry<void>>::result_type;
-};
-
-/**
- * @brief A factory to define pairs of supported types for which
- * MKL VM library provides support in oneapi::mkl::vm::cos<T> function.
- *
- * @tparam T Type of input vector `a` and of result vector `y`.
- */
-template <typename T>
-struct CosOutputType
-{
-    using value_type = typename std::disjunction<
-        dpctl_td_ns::
-            TypeMapResultEntry<T, std::complex<double>, std::complex<double>>,
-        dpctl_td_ns::
-            TypeMapResultEntry<T, std::complex<float>, std::complex<float>>,
-        dpctl_td_ns::TypeMapResultEntry<T, double, double>,
-        dpctl_td_ns::TypeMapResultEntry<T, float, float>,
         dpctl_td_ns::DefaultResultEntry<void>>::result_type;
 };
 
@@ -208,6 +158,31 @@ struct LnOutputType
             TypeMapResultEntry<T, std::complex<float>, std::complex<float>>,
         dpctl_td_ns::TypeMapResultEntry<T, double, double>,
         dpctl_td_ns::TypeMapResultEntry<T, float, float>,
+        dpctl_td_ns::DefaultResultEntry<void>>::result_type;
+};
+
+/**
+ * @brief A factory to define pairs of supported types for which
+ * MKL VM library provides support in oneapi::mkl::vm::mul<T> function.
+ *
+ * @tparam T Type of input vectors `a` and `b` and of result vector `y`.
+ */
+template <typename T>
+struct MulOutputType
+{
+    using value_type = typename std::disjunction<
+        dpctl_td_ns::BinaryTypeMapResultEntry<T,
+                                              std::complex<double>,
+                                              T,
+                                              std::complex<double>,
+                                              std::complex<double>>,
+        dpctl_td_ns::BinaryTypeMapResultEntry<T,
+                                              std::complex<float>,
+                                              T,
+                                              std::complex<float>,
+                                              std::complex<float>>,
+        dpctl_td_ns::BinaryTypeMapResultEntry<T, double, T, double, double>,
+        dpctl_td_ns::BinaryTypeMapResultEntry<T, float, T, float, float>,
         dpctl_td_ns::DefaultResultEntry<void>>::result_type;
 };
 
@@ -261,6 +236,31 @@ struct SqrtOutputType
             TypeMapResultEntry<T, std::complex<float>, std::complex<float>>,
         dpctl_td_ns::TypeMapResultEntry<T, double, double>,
         dpctl_td_ns::TypeMapResultEntry<T, float, float>,
+        dpctl_td_ns::DefaultResultEntry<void>>::result_type;
+};
+
+/**
+ * @brief A factory to define pairs of supported types for which
+ * MKL VM library provides support in oneapi::mkl::vm::sub<T> function.
+ *
+ * @tparam T Type of input vectors `a` and `b` and of result vector `y`.
+ */
+template <typename T>
+struct SubOutputType
+{
+    using value_type = typename std::disjunction<
+        dpctl_td_ns::BinaryTypeMapResultEntry<T,
+                                              std::complex<double>,
+                                              T,
+                                              std::complex<double>,
+                                              std::complex<double>>,
+        dpctl_td_ns::BinaryTypeMapResultEntry<T,
+                                              std::complex<float>,
+                                              T,
+                                              std::complex<float>,
+                                              std::complex<float>>,
+        dpctl_td_ns::BinaryTypeMapResultEntry<T, double, T, double, double>,
+        dpctl_td_ns::BinaryTypeMapResultEntry<T, float, T, float, float>,
         dpctl_td_ns::DefaultResultEntry<void>>::result_type;
 };
 

--- a/dpnp/backend/extensions/vm/vm_py.cpp
+++ b/dpnp/backend/extensions/vm/vm_py.cpp
@@ -30,15 +30,18 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#include "ceil.hpp"
 #include "common.hpp"
+#include "add.hpp"
+#include "ceil.hpp"
 #include "cos.hpp"
 #include "div.hpp"
 #include "floor.hpp"
 #include "ln.hpp"
+#include "mul.hpp"
 #include "sin.hpp"
 #include "sqr.hpp"
 #include "sqrt.hpp"
+#include "sub.hpp"
 #include "trunc.hpp"
 #include "types_matrix.hpp"
 
@@ -48,7 +51,10 @@ namespace vm_ext = dpnp::backend::ext::vm;
 using vm_ext::binary_impl_fn_ptr_t;
 using vm_ext::unary_impl_fn_ptr_t;
 
+static binary_impl_fn_ptr_t add_dispatch_vector[dpctl_td_ns::num_types];
 static binary_impl_fn_ptr_t div_dispatch_vector[dpctl_td_ns::num_types];
+static binary_impl_fn_ptr_t mul_dispatch_vector[dpctl_td_ns::num_types];
+static binary_impl_fn_ptr_t sub_dispatch_vector[dpctl_td_ns::num_types];
 
 static unary_impl_fn_ptr_t ceil_dispatch_vector[dpctl_td_ns::num_types];
 static unary_impl_fn_ptr_t cos_dispatch_vector[dpctl_td_ns::num_types];
@@ -61,6 +67,39 @@ static unary_impl_fn_ptr_t trunc_dispatch_vector[dpctl_td_ns::num_types];
 
 PYBIND11_MODULE(_vm_impl, m)
 {
+    using arrayT = dpctl::tensor::usm_ndarray;
+    using event_vecT = std::vector<sycl::event>;
+
+    // BinaryUfunc: ==== Add(x1, x2) ====
+    {
+        vm_ext::init_ufunc_dispatch_vector<binary_impl_fn_ptr_t,
+                                           vm_ext::AddContigFactory>(
+            add_dispatch_vector);
+
+        auto add_pyapi = [&](sycl::queue exec_q, arrayT src1, arrayT src2,
+                             arrayT dst, const event_vecT &depends = {}) {
+            return vm_ext::binary_ufunc(exec_q, src1, src2, dst, depends,
+                                        add_dispatch_vector);
+        };
+        m.def("_add", add_pyapi,
+              "Call `add` function from OneMKL VM library to performs element "
+              "by element addition of vector `src1` by vector `src2` "
+              "to resulting vector `dst`",
+              py::arg("sycl_queue"), py::arg("src1"), py::arg("src2"),
+              py::arg("dst"), py::arg("depends") = py::list());
+
+        auto add_need_to_call_pyapi = [&](sycl::queue exec_q, arrayT src1,
+                                          arrayT src2, arrayT dst) {
+            return vm_ext::need_to_call_binary_ufunc(exec_q, src1, src2, dst,
+                                                     add_dispatch_vector);
+        };
+        m.def("_mkl_add_to_call", add_need_to_call_pyapi,
+              "Check input arguments to answer if `add` function from "
+              "OneMKL VM library can be used",
+              py::arg("sycl_queue"), py::arg("src1"), py::arg("src2"),
+              py::arg("dst"));
+    }
+
     using arrayT = dpctl::tensor::usm_ndarray;
     using event_vecT = std::vector<sycl::event>;
 
@@ -120,6 +159,70 @@ PYBIND11_MODULE(_vm_impl, m)
               "Check input arguments to answer if `ceil` function from "
               "OneMKL VM library can be used",
               py::arg("sycl_queue"), py::arg("src"), py::arg("dst"));
+    using arrayT = dpctl::tensor::usm_ndarray;
+    using event_vecT = std::vector<sycl::event>;
+
+    // BinaryUfunc: ==== Mul(x1, x2) ====
+    {
+        vm_ext::init_ufunc_dispatch_vector<binary_impl_fn_ptr_t,
+                                           vm_ext::MulContigFactory>(
+            mul_dispatch_vector);
+
+        auto mul_pyapi = [&](sycl::queue exec_q, arrayT src1, arrayT src2,
+                             arrayT dst, const event_vecT &depends = {}) {
+            return vm_ext::binary_ufunc(exec_q, src1, src2, dst, depends,
+                                        mul_dispatch_vector);
+        };
+        m.def("_mul", mul_pyapi,
+              "Call `mul` function from OneMKL VM library to performs element "
+              "by element multiplication of vector `src1` by vector `src2` "
+              "to resulting vector `dst`",
+              py::arg("sycl_queue"), py::arg("src1"), py::arg("src2"),
+              py::arg("dst"), py::arg("depends") = py::list());
+
+        auto mul_need_to_call_pyapi = [&](sycl::queue exec_q, arrayT src1,
+                                          arrayT src2, arrayT dst) {
+            return vm_ext::need_to_call_binary_ufunc(exec_q, src1, src2, dst,
+                                                     mul_dispatch_vector);
+        };
+        m.def("_mkl_mul_to_call", mul_need_to_call_pyapi,
+              "Check input arguments to answer if `mul` function from "
+              "OneMKL VM library can be used",
+              py::arg("sycl_queue"), py::arg("src1"), py::arg("src2"),
+              py::arg("dst"));
+    }
+
+    using arrayT = dpctl::tensor::usm_ndarray;
+    using event_vecT = std::vector<sycl::event>;
+
+    // BinaryUfunc: ==== Sub(x1, x2) ====
+    {
+        vm_ext::init_ufunc_dispatch_vector<binary_impl_fn_ptr_t,
+                                           vm_ext::SubContigFactory>(
+            sub_dispatch_vector);
+
+        auto sub_pyapi = [&](sycl::queue exec_q, arrayT src1, arrayT src2,
+                             arrayT dst, const event_vecT &depends = {}) {
+            return vm_ext::binary_ufunc(exec_q, src1, src2, dst, depends,
+                                        sub_dispatch_vector);
+        };
+        m.def("_sub", sub_pyapi,
+              "Call `sub` function from OneMKL VM library to performs element "
+              "by element subtraction of vector `src1` by vector `src2` "
+              "to resulting vector `dst`",
+              py::arg("sycl_queue"), py::arg("src1"), py::arg("src2"),
+              py::arg("dst"), py::arg("depends") = py::list());
+
+        auto sub_need_to_call_pyapi = [&](sycl::queue exec_q, arrayT src1,
+                                          arrayT src2, arrayT dst) {
+            return vm_ext::need_to_call_binary_ufunc(exec_q, src1, src2, dst,
+                                                     sub_dispatch_vector);
+        };
+        m.def("_mkl_sub_to_call", sub_need_to_call_pyapi,
+              "Check input arguments to answer if `sub` function from "
+              "OneMKL VM library can be used",
+              py::arg("sycl_queue"), py::arg("src1"), py::arg("src2"),
+              py::arg("dst"));
     }
 
     // UnaryUfunc: ==== Cos(x) ====

--- a/dpnp/dpnp_algo/dpnp_elementwise_common.py
+++ b/dpnp/dpnp_algo/dpnp_elementwise_common.py
@@ -215,6 +215,14 @@ Returns:
 """
 
 
+bitwise_and_func = BinaryElementwiseFunc(
+    "bitwise_and",
+    ti._bitwise_and_result_type,
+    ti._bitwise_and,
+    _bitwise_and_docstring_,
+)
+
+
 def dpnp_bitwise_and(x1, x2, out=None, order="K"):
     """Invokes bitwise_and() from dpctl.tensor implementation for bitwise_and() function."""
 
@@ -223,13 +231,9 @@ def dpnp_bitwise_and(x1, x2, out=None, order="K"):
     x2_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x2)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = BinaryElementwiseFunc(
-        "bitwise_and",
-        ti._bitwise_and_result_type,
-        ti._bitwise_and,
-        _bitwise_and_docstring_,
+    res_usm = bitwise_and_func(
+        x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
@@ -259,6 +263,14 @@ Returns:
 """
 
 
+bitwise_or_func = BinaryElementwiseFunc(
+    "bitwise_or",
+    ti._bitwise_or_result_type,
+    ti._bitwise_or,
+    _bitwise_or_docstring_,
+)
+
+
 def dpnp_bitwise_or(x1, x2, out=None, order="K"):
     """Invokes bitwise_or() from dpctl.tensor implementation for bitwise_or() function."""
 
@@ -267,13 +279,9 @@ def dpnp_bitwise_or(x1, x2, out=None, order="K"):
     x2_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x2)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = BinaryElementwiseFunc(
-        "bitwise_or",
-        ti._bitwise_or_result_type,
-        ti._bitwise_or,
-        _bitwise_or_docstring_,
+    res_usm = bitwise_or_func(
+        x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
@@ -303,6 +311,14 @@ Returns:
 """
 
 
+bitwise_xor_func = BinaryElementwiseFunc(
+    "bitwise_xor",
+    ti._bitwise_xor_result_type,
+    ti._bitwise_xor,
+    _bitwise_xor_docstring_,
+)
+
+
 def dpnp_bitwise_xor(x1, x2, out=None, order="K"):
     """Invokes bitwise_xor() from dpctl.tensor implementation for bitwise_xor() function."""
 
@@ -311,13 +327,9 @@ def dpnp_bitwise_xor(x1, x2, out=None, order="K"):
     x2_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x2)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = BinaryElementwiseFunc(
-        "bitwise_xor",
-        ti._bitwise_xor_result_type,
-        ti._bitwise_xor,
-        _bitwise_xor_docstring_,
+    res_usm = bitwise_xor_func(
+        x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
@@ -393,33 +405,35 @@ Return:
 """
 
 
+def _call_cos(src, dst, sycl_queue, depends=None):
+    """A callback to register in UnaryElementwiseFunc class of dpctl.tensor"""
+
+    if depends is None:
+        depends = []
+
+    if vmi._mkl_cos_to_call(sycl_queue, src, dst):
+        # call pybind11 extension for cos() function from OneMKL VM
+        return vmi._cos(sycl_queue, src, dst, depends)
+    return ti._cos(src, dst, sycl_queue, depends)
+
+
+cos_func = UnaryElementwiseFunc(
+    "cos", ti._cos_result_type, _call_cos, _cos_docstring
+)
+
+
 def dpnp_cos(x, out=None, order="K"):
     """
     Invokes cos() function from pybind11 extension of OneMKL VM if possible.
 
     Otherwise fully relies on dpctl.tensor implementation for cos() function.
-
     """
-
-    def _call_cos(src, dst, sycl_queue, depends=None):
-        """A callback to register in UnaryElementwiseFunc class of dpctl.tensor"""
-
-        if depends is None:
-            depends = []
-
-        if vmi._mkl_cos_to_call(sycl_queue, src, dst):
-            # call pybind11 extension for cos() function from OneMKL VM
-            return vmi._cos(sycl_queue, src, dst, depends)
-        return ti._cos(src, dst, sycl_queue, depends)
 
     # dpctl.tensor only works with usm_ndarray
     x1_usm = dpnp.get_usm_ndarray(x)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = UnaryElementwiseFunc(
-        "cos", ti._cos_result_type, _call_cos, _cos_docstring
-    )
-    res_usm = func(x1_usm, out=out_usm, order=order)
+    res_usm = cos_func(x1_usm, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
@@ -447,57 +461,62 @@ Returns:
 """
 
 
+def _call_divide(src1, src2, dst, sycl_queue, depends=None):
+    """A callback to register in BinaryElementwiseFunc class of dpctl.tensor"""
+
+    if depends is None:
+        depends = []
+
+    if vmi._mkl_div_to_call(sycl_queue, src1, src2, dst):
+        # call pybind11 extension for div() function from OneMKL VM
+        return vmi._div(sycl_queue, src1, src2, dst, depends)
+    return ti._divide(src1, src2, dst, sycl_queue, depends)
+
+
+def _call_divide_inplace(lhs, rhs, sycl_queue, depends=None):
+    """In place workaround until dpctl.tensor provides the functionality."""
+
+    if depends is None:
+        depends = []
+
+    # allocate temporary memory for out array
+    out = dpt.empty_like(lhs, dtype=dpnp.result_type(lhs.dtype, rhs.dtype))
+
+    # call a general callback
+    div_ht_, div_ev_ = _call_divide(lhs, rhs, out, sycl_queue, depends)
+
+    # store the result into left input array and return events
+    cp_ht_, cp_ev_ = ti._copy_usm_ndarray_into_usm_ndarray(
+        src=out, dst=lhs, sycl_queue=sycl_queue, depends=[div_ev_]
+    )
+    dpctl.SyclEvent.wait_for([div_ht_])
+    return (cp_ht_, cp_ev_)
+
+
+divide_func = BinaryElementwiseFunc(
+    "divide",
+    ti._divide_result_type,
+    _call_divide,
+    _divide_docstring_,
+    _call_divide_inplace,
+)
+
+
 def dpnp_divide(x1, x2, out=None, order="K"):
     """
     Invokes div() function from pybind11 extension of OneMKL VM if possible.
 
     Otherwise fully relies on dpctl.tensor implementation for divide() function.
-
     """
-
-    def _call_divide(src1, src2, dst, sycl_queue, depends=None):
-        """A callback to register in BinaryElementwiseFunc class of dpctl.tensor"""
-
-        if depends is None:
-            depends = []
-
-        if vmi._mkl_div_to_call(sycl_queue, src1, src2, dst):
-            # call pybind11 extension for div() function from OneMKL VM
-            return vmi._div(sycl_queue, src1, src2, dst, depends)
-        return ti._divide(src1, src2, dst, sycl_queue, depends)
-
-    def _call_divide_inplace(lhs, rhs, sycl_queue, depends=None):
-        """In place workaround until dpctl.tensor provides the functionality."""
-
-        if depends is None:
-            depends = []
-
-        # allocate temporary memory for out array
-        out = dpt.empty_like(lhs, dtype=dpnp.result_type(lhs.dtype, rhs.dtype))
-
-        # call a general callback
-        div_ht_, div_ev_ = _call_divide(lhs, rhs, out, sycl_queue, depends)
-
-        # store the result into left input array and return events
-        cp_ht_, cp_ev_ = ti._copy_usm_ndarray_into_usm_ndarray(
-            src=out, dst=lhs, sycl_queue=sycl_queue, depends=[div_ev_]
-        )
-        dpctl.SyclEvent.wait_for([div_ht_])
-        return (cp_ht_, cp_ev_)
 
     # dpctl.tensor only works with usm_ndarray or scalar
     x1_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x1)
     x2_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x2)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = BinaryElementwiseFunc(
-        "divide",
-        ti._divide_result_type,
-        _call_divide,
-        _divide_docstring_,
-        _call_divide_inplace,
+    res_usm = divide_func(
+        x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
@@ -525,6 +544,11 @@ Returns:
 """
 
 
+equal_func = BinaryElementwiseFunc(
+    "equal", ti._equal_result_type, ti._equal, _equal_docstring_
+)
+
+
 def dpnp_equal(x1, x2, out=None, order="K"):
     """Invokes equal() from dpctl.tensor implementation for equal() function."""
 
@@ -533,10 +557,9 @@ def dpnp_equal(x1, x2, out=None, order="K"):
     x2_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x2)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = BinaryElementwiseFunc(
-        "equal", ti._equal_result_type, ti._equal, _equal_docstring_
+    res_usm = equal_func(
+        x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
@@ -617,6 +640,14 @@ Returns:
 """
 
 
+floor_divide_func = BinaryElementwiseFunc(
+    "floor_divide",
+    ti._floor_divide_result_type,
+    ti._floor_divide,
+    _floor_divide_docstring_,
+)
+
+
 def dpnp_floor_divide(x1, x2, out=None, order="K"):
     """Invokes floor_divide() from dpctl.tensor implementation for floor_divide() function."""
 
@@ -625,13 +656,9 @@ def dpnp_floor_divide(x1, x2, out=None, order="K"):
     x2_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x2)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = BinaryElementwiseFunc(
-        "floor_divide",
-        ti._floor_divide_result_type,
-        ti._floor_divide,
-        _floor_divide_docstring_,
+    res_usm = floor_divide_func(
+        x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
@@ -659,6 +686,11 @@ Returns:
 """
 
 
+greater_func = BinaryElementwiseFunc(
+    "greater", ti._greater_result_type, ti._greater, _greater_docstring_
+)
+
+
 def dpnp_greater(x1, x2, out=None, order="K"):
     """Invokes greater() from dpctl.tensor implementation for greater() function."""
 
@@ -667,10 +699,9 @@ def dpnp_greater(x1, x2, out=None, order="K"):
     x2_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x2)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = BinaryElementwiseFunc(
-        "greater", ti._greater_result_type, ti._greater, _greater_docstring_
+    res_usm = greater_func(
+        x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
@@ -698,6 +729,14 @@ Returns:
 """
 
 
+greater_equal_func = BinaryElementwiseFunc(
+    "greater_equal",
+    ti._greater_equal_result_type,
+    ti._greater_equal,
+    _greater_equal_docstring_,
+)
+
+
 def dpnp_greater_equal(x1, x2, out=None, order="K"):
     """Invokes greater_equal() from dpctl.tensor implementation for greater_equal() function."""
 
@@ -706,13 +745,9 @@ def dpnp_greater_equal(x1, x2, out=None, order="K"):
     x2_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x2)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = BinaryElementwiseFunc(
-        "greater_equal",
-        ti._greater_equal_result_type,
-        ti._greater_equal,
-        _greater_equal_docstring_,
+    res_usm = greater_equal_func(
+        x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
@@ -738,6 +773,14 @@ Return:
 """
 
 
+invert_func = UnaryElementwiseFunc(
+    "invert",
+    ti._bitwise_invert_result_type,
+    ti._bitwise_invert,
+    _invert_docstring,
+)
+
+
 def dpnp_invert(x, out=None, order="K"):
     """Invokes bitwise_invert() from dpctl.tensor implementation for invert() function."""
 
@@ -745,13 +788,7 @@ def dpnp_invert(x, out=None, order="K"):
     x_usm = dpnp.get_usm_ndarray(x)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = UnaryElementwiseFunc(
-        "invert",
-        ti._bitwise_invert_result_type,
-        ti._bitwise_invert,
-        _invert_docstring,
-    )
-    res_usm = func(x_usm, out=out_usm, order=order)
+    res_usm = invert_func(x_usm, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
@@ -777,6 +814,11 @@ Returns:
 """
 
 
+isfinite_func = UnaryElementwiseFunc(
+    "isfinite", ti._isfinite_result_type, ti._isfinite, _isfinite_docstring
+)
+
+
 def dpnp_isfinite(x, out=None, order="K"):
     """Invokes isfinite() from dpctl.tensor implementation for isfinite() function."""
 
@@ -784,10 +826,7 @@ def dpnp_isfinite(x, out=None, order="K"):
     x1_usm = dpnp.get_usm_ndarray(x)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = UnaryElementwiseFunc(
-        "isfinite", ti._isfinite_result_type, ti._isfinite, _isfinite_docstring
-    )
-    res_usm = func(x1_usm, out=out_usm, order=order)
+    res_usm = isfinite_func(x1_usm, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
@@ -812,6 +851,11 @@ Returns:
 """
 
 
+isinf_func = UnaryElementwiseFunc(
+    "isinf", ti._isinf_result_type, ti._isinf, _isinf_docstring
+)
+
+
 def dpnp_isinf(x, out=None, order="K"):
     """Invokes isinf() from dpctl.tensor implementation for isinf() function."""
 
@@ -819,10 +863,7 @@ def dpnp_isinf(x, out=None, order="K"):
     x1_usm = dpnp.get_usm_ndarray(x)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = UnaryElementwiseFunc(
-        "isinf", ti._isinf_result_type, ti._isinf, _isinf_docstring
-    )
-    res_usm = func(x1_usm, out=out_usm, order=order)
+    res_usm = isinf_func(x1_usm, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
@@ -847,6 +888,11 @@ Returns:
 """
 
 
+isnan_func = UnaryElementwiseFunc(
+    "isnan", ti._isnan_result_type, ti._isnan, _isnan_docstring
+)
+
+
 def dpnp_isnan(x, out=None, order="K"):
     """Invokes isnan() from dpctl.tensor implementation for isnan() function."""
 
@@ -854,10 +900,7 @@ def dpnp_isnan(x, out=None, order="K"):
     x1_usm = dpnp.get_usm_ndarray(x)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = UnaryElementwiseFunc(
-        "isnan", ti._isnan_result_type, ti._isnan, _isnan_docstring
-    )
-    res_usm = func(x1_usm, out=out_usm, order=order)
+    res_usm = isnan_func(x1_usm, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
@@ -887,6 +930,14 @@ Returns:
 """
 
 
+leftt_shift_func = BinaryElementwiseFunc(
+    "bitwise_leftt_shift",
+    ti._bitwise_left_shift_result_type,
+    ti._bitwise_left_shift,
+    _left_shift_docstring_,
+)
+
+
 def dpnp_left_shift(x1, x2, out=None, order="K"):
     """Invokes bitwise_left_shift() from dpctl.tensor implementation for left_shift() function."""
 
@@ -895,13 +946,9 @@ def dpnp_left_shift(x1, x2, out=None, order="K"):
     x2_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x2)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = BinaryElementwiseFunc(
-        "bitwise_leftt_shift",
-        ti._bitwise_left_shift_result_type,
-        ti._bitwise_left_shift,
-        _left_shift_docstring_,
+    res_usm = leftt_shift_func(
+        x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
@@ -929,6 +976,11 @@ Returns:
 """
 
 
+less_func = BinaryElementwiseFunc(
+    "less", ti._less_result_type, ti._less, _less_docstring_
+)
+
+
 def dpnp_less(x1, x2, out=None, order="K"):
     """Invokes less() from dpctl.tensor implementation for less() function."""
 
@@ -937,10 +989,9 @@ def dpnp_less(x1, x2, out=None, order="K"):
     x2_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x2)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = BinaryElementwiseFunc(
-        "less", ti._less_result_type, ti._less, _less_docstring_
+    res_usm = less_func(
+        x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
@@ -968,6 +1019,14 @@ Returns:
 """
 
 
+less_equal_func = BinaryElementwiseFunc(
+    "less_equal",
+    ti._less_equal_result_type,
+    ti._less_equal,
+    _less_equal_docstring_,
+)
+
+
 def dpnp_less_equal(x1, x2, out=None, order="K"):
     """Invokes less_equal() from dpctl.tensor implementation for less_equal() function."""
 
@@ -976,13 +1035,9 @@ def dpnp_less_equal(x1, x2, out=None, order="K"):
     x2_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x2)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = BinaryElementwiseFunc(
-        "less_equal",
-        ti._less_equal_result_type,
-        ti._less_equal,
-        _less_equal_docstring_,
+    res_usm = less_equal_func(
+        x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
@@ -1004,33 +1059,35 @@ Return:
 """
 
 
+def _call_log(src, dst, sycl_queue, depends=None):
+    """A callback to register in UnaryElementwiseFunc class of dpctl.tensor"""
+
+    if depends is None:
+        depends = []
+
+    if vmi._mkl_ln_to_call(sycl_queue, src, dst):
+        # call pybind11 extension for ln() function from OneMKL VM
+        return vmi._ln(sycl_queue, src, dst, depends)
+    return ti._log(src, dst, sycl_queue, depends)
+
+
+log_func = UnaryElementwiseFunc(
+    "log", ti._log_result_type, _call_log, _log_docstring
+)
+
+
 def dpnp_log(x, out=None, order="K"):
     """
     Invokes log() function from pybind11 extension of OneMKL VM if possible.
 
     Otherwise fully relies on dpctl.tensor implementation for log() function.
-
     """
-
-    def _call_log(src, dst, sycl_queue, depends=None):
-        """A callback to register in UnaryElementwiseFunc class of dpctl.tensor"""
-
-        if depends is None:
-            depends = []
-
-        if vmi._mkl_ln_to_call(sycl_queue, src, dst):
-            # call pybind11 extension for ln() function from OneMKL VM
-            return vmi._ln(sycl_queue, src, dst, depends)
-        return ti._log(src, dst, sycl_queue, depends)
 
     # dpctl.tensor only works with usm_ndarray
     x1_usm = dpnp.get_usm_ndarray(x)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = UnaryElementwiseFunc(
-        "log", ti._log_result_type, _call_log, _log_docstring
-    )
-    res_usm = func(x1_usm, out=out_usm, order=order)
+    res_usm = log_func(x1_usm, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
@@ -1057,6 +1114,14 @@ Returns:
 """
 
 
+logical_and_func = BinaryElementwiseFunc(
+    "logical_and",
+    ti._logical_and_result_type,
+    ti._logical_and,
+    _logical_and_docstring_,
+)
+
+
 def dpnp_logical_and(x1, x2, out=None, order="K"):
     """Invokes logical_and() from dpctl.tensor implementation for logical_and() function."""
 
@@ -1065,13 +1130,9 @@ def dpnp_logical_and(x1, x2, out=None, order="K"):
     x2_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x2)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = BinaryElementwiseFunc(
-        "logical_and",
-        ti._logical_and_result_type,
-        ti._logical_and,
-        _logical_and_docstring_,
+    res_usm = logical_and_func(
+        x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
@@ -1093,6 +1154,14 @@ Return:
 """
 
 
+logical_not_func = UnaryElementwiseFunc(
+    "logical_not",
+    ti._logical_not_result_type,
+    ti._logical_not,
+    _logical_not_docstring_,
+)
+
+
 def dpnp_logical_not(x, out=None, order="K"):
     """Invokes logical_not() from dpctl.tensor implementation for logical_not() function."""
 
@@ -1100,13 +1169,7 @@ def dpnp_logical_not(x, out=None, order="K"):
     x_usm = dpnp.get_usm_ndarray(x)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = UnaryElementwiseFunc(
-        "logical_not",
-        ti._logical_not_result_type,
-        ti._logical_not,
-        _logical_not_docstring_,
-    )
-    res_usm = func(x_usm, out=out_usm, order=order)
+    res_usm = logical_not_func(x_usm, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
@@ -1133,6 +1196,14 @@ Returns:
 """
 
 
+logical_or_func = BinaryElementwiseFunc(
+    "logical_or",
+    ti._logical_or_result_type,
+    ti._logical_or,
+    _logical_or_docstring_,
+)
+
+
 def dpnp_logical_or(x1, x2, out=None, order="K"):
     """Invokes logical_or() from dpctl.tensor implementation for logical_or() function."""
 
@@ -1141,13 +1212,9 @@ def dpnp_logical_or(x1, x2, out=None, order="K"):
     x2_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x2)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = BinaryElementwiseFunc(
-        "logical_or",
-        ti._logical_or_result_type,
-        ti._logical_or,
-        _logical_or_docstring_,
+    res_usm = logical_or_func(
+        x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
@@ -1173,6 +1240,13 @@ Returns:
         An array containing the element-wise logical XOR results.
 """
 
+logical_xor_func = BinaryElementwiseFunc(
+    "logical_xor",
+    ti._logical_xor_result_type,
+    ti._logical_xor,
+    _logical_xor_docstring_,
+)
+
 
 def dpnp_logical_xor(x1, x2, out=None, order="K"):
     """Invokes logical_xor() from dpctl.tensor implementation for logical_xor() function."""
@@ -1182,13 +1256,9 @@ def dpnp_logical_xor(x1, x2, out=None, order="K"):
     x2_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x2)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = BinaryElementwiseFunc(
-        "logical_xor",
-        ti._logical_xor_result_type,
-        ti._logical_xor,
-        _logical_xor_docstring_,
+    res_usm = logical_xor_func(
+        x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
@@ -1264,6 +1334,13 @@ Returns:
         The data type of the returned array is determined by the Type Promotion Rules.
 """
 
+not_equal_func = BinaryElementwiseFunc(
+    "not_equal",
+    ti._not_equal_result_type,
+    ti._not_equal,
+    _not_equal_docstring_,
+)
+
 
 def dpnp_not_equal(x1, x2, out=None, order="K"):
     """Invokes not_equal() from dpctl.tensor implementation for not_equal() function."""
@@ -1273,13 +1350,9 @@ def dpnp_not_equal(x1, x2, out=None, order="K"):
     x2_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x2)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = BinaryElementwiseFunc(
-        "not_equal",
-        ti._not_equal_result_type,
-        ti._not_equal,
-        _not_equal_docstring_,
+    res_usm = not_equal_func(
+        x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
@@ -1351,6 +1424,14 @@ Returns:
 """
 
 
+right_shift_func = BinaryElementwiseFunc(
+    "bitwise_right_shift",
+    ti._bitwise_right_shift_result_type,
+    ti._bitwise_right_shift,
+    _right_shift_docstring_,
+)
+
+
 def dpnp_right_shift(x1, x2, out=None, order="K"):
     """Invokes bitwise_right_shift() from dpctl.tensor implementation for right_shift() function."""
 
@@ -1359,13 +1440,9 @@ def dpnp_right_shift(x1, x2, out=None, order="K"):
     x2_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x2)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = BinaryElementwiseFunc(
-        "bitwise_right_shift",
-        ti._bitwise_right_shift_result_type,
-        ti._bitwise_right_shift,
-        _right_shift_docstring_,
+    res_usm = right_shift_func(
+        x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    res_usm = func(x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
@@ -1388,33 +1465,35 @@ Return:
 """
 
 
+def _call_sin(src, dst, sycl_queue, depends=None):
+    """A callback to register in UnaryElementwiseFunc class of dpctl.tensor"""
+
+    if depends is None:
+        depends = []
+
+    if vmi._mkl_sin_to_call(sycl_queue, src, dst):
+        # call pybind11 extension for sin() function from OneMKL VM
+        return vmi._sin(sycl_queue, src, dst, depends)
+    return ti._sin(src, dst, sycl_queue, depends)
+
+
+sin_func = UnaryElementwiseFunc(
+    "sin", ti._sin_result_type, _call_sin, _sin_docstring
+)
+
+
 def dpnp_sin(x, out=None, order="K"):
     """
     Invokes sin() function from pybind11 extension of OneMKL VM if possible.
 
     Otherwise fully relies on dpctl.tensor implementation for sin() function.
-
     """
-
-    def _call_sin(src, dst, sycl_queue, depends=None):
-        """A callback to register in UnaryElementwiseFunc class of dpctl.tensor"""
-
-        if depends is None:
-            depends = []
-
-        if vmi._mkl_sin_to_call(sycl_queue, src, dst):
-            # call pybind11 extension for sin() function from OneMKL VM
-            return vmi._sin(sycl_queue, src, dst, depends)
-        return ti._sin(src, dst, sycl_queue, depends)
 
     # dpctl.tensor only works with usm_ndarray
     x1_usm = dpnp.get_usm_ndarray(x)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = UnaryElementwiseFunc(
-        "sin", ti._sin_result_type, _call_sin, _sin_docstring
-    )
-    res_usm = func(x1_usm, out=out_usm, order=order)
+    res_usm = sin_func(x1_usm, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
@@ -1436,36 +1515,38 @@ Return:
 """
 
 
+def _call_sqrt(src, dst, sycl_queue, depends=None):
+    """A callback to register in UnaryElementwiseFunc class of dpctl.tensor"""
+
+    if depends is None:
+        depends = []
+
+    if vmi._mkl_sqrt_to_call(sycl_queue, src, dst):
+        # call pybind11 extension for sqrt() function from OneMKL VM
+        return vmi._sqrt(sycl_queue, src, dst, depends)
+    return ti._sqrt(src, dst, sycl_queue, depends)
+
+
+sqrt_func = UnaryElementwiseFunc(
+    "sqrt",
+    ti._sqrt_result_type,
+    _call_sqrt,
+    _sqrt_docstring_,
+)
+
+
 def dpnp_sqrt(x, out=None, order="K"):
     """
     Invokes sqrt() function from pybind11 extension of OneMKL VM if possible.
 
     Otherwise fully relies on dpctl.tensor implementation for sqrt() function.
-
     """
-
-    def _call_sqrt(src, dst, sycl_queue, depends=None):
-        """A callback to register in UnaryElementwiseFunc class of dpctl.tensor"""
-
-        if depends is None:
-            depends = []
-
-        if vmi._mkl_sqrt_to_call(sycl_queue, src, dst):
-            # call pybind11 extension for sqrt() function from OneMKL VM
-            return vmi._sqrt(sycl_queue, src, dst, depends)
-        return ti._sqrt(src, dst, sycl_queue, depends)
 
     # dpctl.tensor only works with usm_ndarray or scalar
     x_usm = dpnp.get_usm_ndarray(x)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = UnaryElementwiseFunc(
-        "sqrt",
-        ti._sqrt_result_type,
-        _call_sqrt,
-        _sqrt_docstring_,
-    )
-    res_usm = func(x_usm, out=out_usm, order=order)
+    res_usm = sqrt_func(x_usm, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
@@ -1487,36 +1568,38 @@ Return:
 """
 
 
+def _call_square(src, dst, sycl_queue, depends=None):
+    """A callback to register in UnaryElementwiseFunc class of dpctl.tensor"""
+
+    if depends is None:
+        depends = []
+
+    if vmi._mkl_sqr_to_call(sycl_queue, src, dst):
+        # call pybind11 extension for sqr() function from OneMKL VM
+        return vmi._sqr(sycl_queue, src, dst, depends)
+    return ti._square(src, dst, sycl_queue, depends)
+
+
+square_func = UnaryElementwiseFunc(
+    "square",
+    ti._square_result_type,
+    _call_square,
+    _square_docstring_,
+)
+
+
 def dpnp_square(x, out=None, order="K"):
     """
     Invokes sqr() function from pybind11 extension of OneMKL VM if possible.
 
     Otherwise fully relies on dpctl.tensor implementation for square() function.
-
     """
-
-    def _call_square(src, dst, sycl_queue, depends=None):
-        """A callback to register in UnaryElementwiseFunc class of dpctl.tensor"""
-
-        if depends is None:
-            depends = []
-
-        if vmi._mkl_sqr_to_call(sycl_queue, src, dst):
-            # call pybind11 extension for sqr() function from OneMKL VM
-            return vmi._sqr(sycl_queue, src, dst, depends)
-        return ti._square(src, dst, sycl_queue, depends)
 
     # dpctl.tensor only works with usm_ndarray or scalar
     x_usm = dpnp.get_usm_ndarray(x)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    func = UnaryElementwiseFunc(
-        "square",
-        ti._square_result_type,
-        _call_square,
-        _square_docstring_,
-    )
-    res_usm = func(x_usm, out=out_usm, order=order)
+    res_usm = square_func(x_usm, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -772,7 +772,6 @@ class TestAdd:
     @pytest.mark.parametrize(
         "dtype", get_all_dtypes(no_bool=True, no_none=True)
     )
-    @pytest.mark.skip("mute unttil in-place support in dpctl is done")
     def test_inplace_strided_out(self, dtype):
         size = 21
 
@@ -862,7 +861,6 @@ class TestMultiply:
     @pytest.mark.parametrize(
         "dtype", get_all_dtypes(no_bool=True, no_none=True)
     )
-    @pytest.mark.skip("mute unttil in-place support in dpctl is done")
     def test_inplace_strided_out(self, dtype):
         size = 21
 

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -10,7 +10,7 @@ list_of_usm_types = ["device", "shared", "host"]
 
 @pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
 @pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
-def test_coerced_usm_types_sum(usm_type_x, usm_type_y):
+def test_coerced_usm_types_add(usm_type_x, usm_type_y):
     x = dp.arange(1000, usm_type=usm_type_x)
     y = dp.arange(1000, usm_type=usm_type_y)
 


### PR DESCRIPTION
In this PR, we create Unary/BinaryElementwisefunc during module import in `dpnp/dpnp_algo/dpnp_elementwise_common.py`.

In addition, we modify the implementation of `dpnp.add`, `dpnp.multiply`, and `dpnp.subtract`. These functions now invoke `oneapi::mkl::vm::add`,  `oneapi::mkl::vm::multiply`, and `oneapi::mkl::vm::subtract` from pybind11 extension of OneMKL VM, respectivelt, if possible or uses `dpctl.tensor` implementation if not.


- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
