### PR TITLE
Modify the tests to align them with the changes in dpctl

### DIFF
--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -633,7 +633,7 @@ class TestCeil:
         dp_array = dpnp.arange(10, dtype=dtype)
         dp_out = dpnp.empty(shape, dtype=dtype)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpnp.ceil(dp_array, out=dp_out)
 
 
@@ -673,7 +673,7 @@ class TestFloor:
         dp_array = dpnp.arange(10, dtype=dtype)
         dp_out = dpnp.empty(shape, dtype=dtype)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpnp.floor(dp_array, out=dp_out)
 
 
@@ -713,7 +713,7 @@ class TestTrunc:
         dp_array = dpnp.arange(10, dtype=dtype)
         dp_out = dpnp.empty(shape, dtype=dtype)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpnp.trunc(dp_array, out=dp_out)
 
 
@@ -765,9 +765,15 @@ class TestAdd:
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     def test_out_overlap(self, dtype):
         size = 1 if dtype == dpnp.bool else 15
+        # DPNP
         dp_a = dpnp.arange(2 * size, dtype=dtype)
-        with pytest.raises(TypeError):
-            dpnp.add(dp_a[size::], dp_a[::2], out=dp_a[:size:])
+        dpnp.add(dp_a[size::], dp_a[::2], out=dp_a[:size:])
+
+        # original
+        np_a = numpy.arange(2 * size, dtype=dtype)
+        numpy.add(np_a[size::], np_a[::2], out=np_a[:size:])
+
+        assert_allclose(np_a, dp_a)
 
     @pytest.mark.parametrize(
         "dtype", get_all_dtypes(no_bool=True, no_none=True)
@@ -791,7 +797,7 @@ class TestAdd:
         dp_array2 = dpnp.arange(5, 15)
         dp_out = dpnp.empty(shape)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpnp.add(dp_array1, dp_array2, out=dp_out)
 
     @pytest.mark.parametrize(
@@ -854,9 +860,15 @@ class TestMultiply:
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     def test_out_overlap(self, dtype):
         size = 1 if dtype == dpnp.bool else 15
+        # DPNP
         dp_a = dpnp.arange(2 * size, dtype=dtype)
-        with pytest.raises(TypeError):
-            dpnp.multiply(dp_a[size::], dp_a[::2], out=dp_a[:size:])
+        dpnp.multiply(dp_a[size::], dp_a[::2], out=dp_a[:size:])
+
+        # original
+        np_a = numpy.arange(2 * size, dtype=dtype)
+        numpy.multiply(np_a[size::], np_a[::2], out=np_a[:size:])
+
+        assert_allclose(np_a, dp_a)
 
     @pytest.mark.parametrize(
         "dtype", get_all_dtypes(no_bool=True, no_none=True)
@@ -880,7 +892,7 @@ class TestMultiply:
         dp_array2 = dpnp.arange(5, 15)
         dp_out = dpnp.empty(shape)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpnp.multiply(dp_array1, dp_array2, out=dp_out)
 
     @pytest.mark.parametrize(

--- a/tests/test_umath.py
+++ b/tests/test_umath.py
@@ -171,7 +171,7 @@ class TestSin:
         dp_array = dpnp.arange(10)
         dp_out = dpnp.empty(shape, dtype=dp_array.dtype)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpnp.sin(dp_array, out=dp_out)
 
 
@@ -254,7 +254,7 @@ class TestCos:
         dp_array = dpnp.arange(10)
         dp_out = dpnp.empty(shape, dtype=dp_array.dtype)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpnp.cos(dp_array, out=dp_out)
 
 
@@ -337,7 +337,7 @@ class TestsLog:
         dp_array = dpnp.arange(10)
         dp_out = dpnp.empty(shape, dtype=dp_array.dtype)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpnp.log(dp_array, out=dp_out)
 
 
@@ -613,7 +613,7 @@ class TestSqrt:
         dp_array = dpnp.arange(10, dtype=dpnp.float32)
         dp_out = dpnp.empty(shape, dtype=dpnp.float32)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpnp.sqrt(dp_array, out=dp_out)
 
     @pytest.mark.parametrize(
@@ -675,7 +675,7 @@ class TestSquare:
         dp_array = dpnp.arange(10, dtype=dpnp.float32)
         dp_out = dpnp.empty(shape, dtype=dpnp.float32)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpnp.square(dp_array, out=dp_out)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Due to the new updates in elementwise function of `dpctl` [#1352](https://github.com/IntelPython/dpctl/pull/1352), the tests in `dpnp` are updated to align them with the changes in `dpctl`.
The changes in `dpctl` include:
1) raise `ValueError` when, there is shape inconsistency between input(s) and output
2) Memory overlap between inputs and output is allowed

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
