### PR TITLE
utilize new functionality of dpctl for in-place operators

### DIFF
--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -188,7 +188,10 @@ class dpnp_array:
     def __float__(self):
         return self._array_obj.__float__()
 
-    # '__floordiv__',
+    def __floordiv__(self, other):
+        """Return self//value."""
+        return dpnp.floor_divide(self, other)
+
     # '__format__',
 
     def __ge__(self, other):
@@ -227,7 +230,10 @@ class dpnp_array:
         dpnp.bitwise_and(self, other, out=self)
         return self
 
-    # '__ifloordiv__',
+    def __ifloordiv__(self, other):
+        """Return self//=value."""
+        dpnp.floor_divide(self, other, out=self)
+        return self
 
     def __ilshift__(self, other):
         """Return self<<=value."""
@@ -235,7 +241,11 @@ class dpnp_array:
         return self
 
     # '__imatmul__',
-    # '__imod__',
+
+    def __imod__(self, other):
+        """Return self%=value."""
+        dpnp.remainder(self, other, out=self)
+        return self
 
     def __imul__(self, other):
         """Return self*=value."""
@@ -345,7 +355,8 @@ class dpnp_array:
     def __repr__(self):
         return dpt.usm_ndarray_repr(self._array_obj, prefix="array")
 
-    # '__rfloordiv__',
+    def __rfloordiv__(self, other):
+        return dpnp.floor_divide(self, other)
 
     def __rlshift__(self, other):
         return dpnp.left_shift(other, self)

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -901,6 +901,14 @@ def floor_divide(
 
     >>> np.floor_divide(np.array([1., 2., 3., 4.]), 2.5)
     array([ 0.,  0.,  1.,  1.])
+
+    The ``//`` operator can be used as a shorthand for ``floor_divide`` on
+    :class:`dpnp.ndarray`.
+
+    >>> x1 = np.array([1., 2., 3., 4.])
+    >>> x1 // 2.5
+    array([0., 0., 1., 1.])
+
     """
 
     return check_nd_call_func(

--- a/tests/test_bitwise.py
+++ b/tests/test_bitwise.py
@@ -67,8 +67,6 @@ class TestBitwise:
         )
         assert_array_equal(dp_a & dp_b, np_a & np_b)
 
-        """
-        TODO: unmute once dpctl support that
         if (
             not (inp.isscalar(dp_a) or inp.isscalar(dp_b))
             and dp_a.shape == dp_b.shape
@@ -76,7 +74,6 @@ class TestBitwise:
             dp_a &= dp_b
             np_a &= np_b
             assert_array_equal(dp_a, np_a)
-        """
 
     def test_bitwise_or(self, lhs, rhs, dtype):
         dp_a, dp_b, np_a, np_b = self._test_binary_int(
@@ -84,8 +81,6 @@ class TestBitwise:
         )
         assert_array_equal(dp_a | dp_b, np_a | np_b)
 
-        """
-        TODO: unmute once dpctl support that
         if (
             not (inp.isscalar(dp_a) or inp.isscalar(dp_b))
             and dp_a.shape == dp_b.shape
@@ -93,7 +88,6 @@ class TestBitwise:
             dp_a |= dp_b
             np_a |= np_b
             assert_array_equal(dp_a, np_a)
-        """
 
     def test_bitwise_xor(self, lhs, rhs, dtype):
         dp_a, dp_b, np_a, np_b = self._test_binary_int(
@@ -101,8 +95,6 @@ class TestBitwise:
         )
         assert_array_equal(dp_a ^ dp_b, np_a ^ np_b)
 
-        """
-        TODO: unmute once dpctl support that
         if (
             not (inp.isscalar(dp_a) or inp.isscalar(dp_b))
             and dp_a.shape == dp_b.shape
@@ -110,7 +102,6 @@ class TestBitwise:
             dp_a ^= dp_b
             np_a ^= np_b
             assert_array_equal(dp_a, np_a)
-        """
 
     def test_invert(self, lhs, rhs, dtype):
         dp_a, np_a = self._test_unary_int("invert", lhs, dtype)
@@ -122,8 +113,6 @@ class TestBitwise:
         )
         assert_array_equal(dp_a << dp_b, np_a << np_b)
 
-        """
-        TODO: unmute once dpctl support that
         if (
             not (inp.isscalar(dp_a) or inp.isscalar(dp_b))
             and dp_a.shape == dp_b.shape
@@ -131,7 +120,6 @@ class TestBitwise:
             dp_a <<= dp_b
             np_a <<= np_b
             assert_array_equal(dp_a, np_a)
-        """
 
     def test_right_shift(self, lhs, rhs, dtype):
         dp_a, dp_b, np_a, np_b = self._test_binary_int(
@@ -139,8 +127,6 @@ class TestBitwise:
         )
         assert_array_equal(dp_a >> dp_b, np_a >> np_b)
 
-        """
-        TODO: unmute once dpctl support that
         if (
             not (inp.isscalar(dp_a) or inp.isscalar(dp_b))
             and dp_a.shape == dp_b.shape
@@ -148,4 +134,3 @@ class TestBitwise:
             dp_a >>= dp_b
             np_a >>= np_b
             assert_array_equal(dp_a, np_a)
-        """

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -1177,3 +1177,31 @@ class TestMean:
         result = dp_array.mean()
         expected = np_array.mean()
         assert_allclose(expected, result)
+
+
+@pytest.mark.parametrize(
+    "dtype", get_all_dtypes(no_bool=True, no_none=True, no_complex=True)
+)
+def test_inplace_remainder(dtype):
+    size = 21
+    np_a = numpy.arange(size, dtype=dtype)
+    dp_a = dpnp.arange(size, dtype=dtype)
+
+    np_a %= 4
+    dp_a %= 4
+
+    assert_allclose(dp_a, np_a)
+
+
+@pytest.mark.parametrize(
+    "dtype", get_all_dtypes(no_bool=True, no_none=True, no_complex=True)
+)
+def test_inplace_floor_divide(dtype):
+    size = 21
+    np_a = numpy.arange(size, dtype=dtype)
+    dp_a = dpnp.arange(size, dtype=dtype)
+
+    np_a //= 4
+    dp_a //= 4
+
+    assert_allclose(dp_a, np_a)

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -83,11 +83,34 @@ def test_coerced_usm_types_remainder(usm_type_x, usm_type_y):
     y = dp.arange(100, usm_type=usm_type_y).reshape(10, 10)
     y = y.T + 1
 
+    z = 100 % y
+    z = y % 7
     z = x % y
 
     # inplace remainder
     z %= y
     z %= 5
+
+    assert x.usm_type == usm_type_x
+    assert y.usm_type == usm_type_y
+    assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
+
+
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+def test_coerced_usm_types_floor_divide(usm_type_x, usm_type_y):
+    x = dp.arange(100, usm_type=usm_type_x).reshape(10, 10)
+    y = dp.arange(100, usm_type=usm_type_y).reshape(10, 10)
+    x = x + 1.5
+    y = y.T + 0.5
+
+    z = 3.4 // y
+    z = y // 2.7
+    z = x // y
+
+    # inplace floor_divide
+    z //= y
+    z //= 2.5
 
     assert x.usm_type == usm_type_x
     assert y.usm_type == usm_type_y

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -85,6 +85,10 @@ def test_coerced_usm_types_remainder(usm_type_x, usm_type_y):
 
     z = x % y
 
+    # inplace remainder
+    z %= y
+    z %= 5
+
     assert x.usm_type == usm_type_x
     assert y.usm_type == usm_type_y
     assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])


### PR DESCRIPTION
Since `usm_ndarray` in-place arithmetic operators is fully enabled in `dpctl` [#1352](https://github.com/IntelPython/dpctl/pull/1352), `dpnp` is updated to use the newly added features.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
