### PR TITLE
Do not build dpnp for Python 3.8

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -43,7 +43,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11']
+        python: ['3.9', '3.10', '3.11']
         os: [ubuntu-20.04, windows-latest]
 
     runs-on: ${{ matrix.os }}
@@ -120,7 +120,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11']
+        python: ['3.9', '3.10', '3.11']
         os: [ubuntu-20.04, ubuntu-latest]
 
     continue-on-error: true
@@ -221,7 +221,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11']
+        python: ['3.9', '3.10', '3.11']
 
     continue-on-error: true
 
@@ -353,7 +353,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11']
+        python: ['3.9', '3.10', '3.11']
         os: [ubuntu-20.04, windows-latest]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The PR proposes to stop building conda packages of `dpnp` for Python 3.8.

The similar change is going to be implemented by `dpctl` in [gh-1363](https://github.com/IntelPython/dpctl/pull/1363).
And so the PR intends to align the build matrix with `dpctl`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
