### PR TITLE
Conversion from raw to multi_ptr should be done with address_space_cast

### DIFF
--- a/dpnp/backend/kernels/dpnp_krnl_logic.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_logic.cpp
@@ -537,12 +537,20 @@ DPCTLSyclEventRef (*dpnp_any_ext_c)(DPCTLSyclQueueRef,
                                                                                \
                 if (start + static_cast<size_t>(vec_sz) * max_sg_size <        \
                     result_size) {                                             \
-                    sycl::vec<_DataType_input1, vec_sz> x1 = sg.load<vec_sz>(  \
-                        sycl::multi_ptr<_DataType_input1, global_space>(       \
-                            &input1_data[start]));                             \
-                    sycl::vec<_DataType_input2, vec_sz> x2 = sg.load<vec_sz>(  \
-                        sycl::multi_ptr<_DataType_input2, global_space>(       \
-                            &input2_data[start]));                             \
+                    auto input1_multi_ptr = sycl::address_space_cast<          \
+                        sycl::access::address_space::global_space,             \
+                        sycl::access::decorated::yes>(&input1_data[start]);    \
+                    auto input2_multi_ptr = sycl::address_space_cast<          \
+                        sycl::access::address_space::global_space,             \
+                        sycl::access::decorated::yes>(&input2_data[start]);    \
+                    auto result_multi_ptr = sycl::address_space_cast<          \
+                        sycl::access::address_space::global_space,             \
+                        sycl::access::decorated::yes>(&result[start]);         \
+                                                                               \
+                    sycl::vec<_DataType_input1, vec_sz> x1 =                   \
+                        sg.load<vec_sz>(input1_multi_ptr);                     \
+                    sycl::vec<_DataType_input2, vec_sz> x2 =                   \
+                        sg.load<vec_sz>(input2_multi_ptr);                     \
                     sycl::vec<bool, vec_sz> res_vec;                           \
                                                                                \
                     for (size_t k = 0; k < vec_sz; ++k) {                      \
@@ -550,9 +558,7 @@ DPCTLSyclEventRef (*dpnp_any_ext_c)(DPCTLSyclQueueRef,
                         const _DataType_input2 input2_elem = x2[k];            \
                         res_vec[k] = __operation__;                            \
                     }                                                          \
-                    sg.store<vec_sz>(                                          \
-                        sycl::multi_ptr<bool, global_space>(&result[start]),   \
-                        res_vec);                                              \
+                    sg.store<vec_sz>(result_multi_ptr, res_vec);               \
                 }                                                              \
                 else {                                                         \
                     for (size_t k = start; k < result_size; ++k) {             \


### PR DESCRIPTION
The PR proposes to implement similar fix as dpctl did in [gh-1366](https://github.com/IntelPython/dpctl/pull/1366).
It will help to adopt towards some of the changes in SYCL 2020 for `multi_ptr` which have introduced breaking changes for SYCL 1.2.1 applications moving to SYCL 2020.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
