### PR TITLE
use dpctl for trigonometric functions in dpnp

### DIFF
--- a/dpnp/backend/extensions/vm/acos.hpp
+++ b/dpnp/backend/extensions/vm/acos.hpp
@@ -1,0 +1,78 @@
+//*****************************************************************************
+// Copyright (c) 2023, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//*****************************************************************************
+
+#pragma once
+
+#include <CL/sycl.hpp>
+
+#include "common.hpp"
+#include "types_matrix.hpp"
+
+namespace dpnp
+{
+namespace backend
+{
+namespace ext
+{
+namespace vm
+{
+template <typename T>
+sycl::event acos_contig_impl(sycl::queue exec_q,
+                             const std::int64_t n,
+                             const char *in_a,
+                             char *out_y,
+                             const std::vector<sycl::event> &depends)
+{
+    type_utils::validate_type_for_device<T>(exec_q);
+
+    const T *a = reinterpret_cast<const T *>(in_a);
+    T *y = reinterpret_cast<T *>(out_y);
+
+    return mkl_vm::acos(exec_q,
+                        n, // number of elements to be calculated
+                        a, // pointer `a` containing input vector of size n
+                        y, // pointer `y` to the output vector of size n
+                        depends);
+}
+
+template <typename fnT, typename T>
+struct AcosContigFactory
+{
+    fnT get()
+    {
+        if constexpr (std::is_same_v<
+                          typename types::AcosOutputType<T>::value_type, void>)
+        {
+            return nullptr;
+        }
+        else {
+            return acos_contig_impl<T>;
+        }
+    }
+};
+} // namespace vm
+} // namespace ext
+} // namespace backend
+} // namespace dpnp

--- a/dpnp/backend/extensions/vm/asin.hpp
+++ b/dpnp/backend/extensions/vm/asin.hpp
@@ -1,0 +1,78 @@
+//*****************************************************************************
+// Copyright (c) 2023, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//*****************************************************************************
+
+#pragma once
+
+#include <CL/sycl.hpp>
+
+#include "common.hpp"
+#include "types_matrix.hpp"
+
+namespace dpnp
+{
+namespace backend
+{
+namespace ext
+{
+namespace vm
+{
+template <typename T>
+sycl::event asin_contig_impl(sycl::queue exec_q,
+                             const std::int64_t n,
+                             const char *in_a,
+                             char *out_y,
+                             const std::vector<sycl::event> &depends)
+{
+    type_utils::validate_type_for_device<T>(exec_q);
+
+    const T *a = reinterpret_cast<const T *>(in_a);
+    T *y = reinterpret_cast<T *>(out_y);
+
+    return mkl_vm::asin(exec_q,
+                        n, // number of elements to be calculated
+                        a, // pointer `a` containing input vector of size n
+                        y, // pointer `y` to the output vector of size n
+                        depends);
+}
+
+template <typename fnT, typename T>
+struct AsinContigFactory
+{
+    fnT get()
+    {
+        if constexpr (std::is_same_v<
+                          typename types::AsinOutputType<T>::value_type, void>)
+        {
+            return nullptr;
+        }
+        else {
+            return asin_contig_impl<T>;
+        }
+    }
+};
+} // namespace vm
+} // namespace ext
+} // namespace backend
+} // namespace dpnp

--- a/dpnp/backend/extensions/vm/atan.hpp
+++ b/dpnp/backend/extensions/vm/atan.hpp
@@ -1,0 +1,78 @@
+//*****************************************************************************
+// Copyright (c) 2023, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//*****************************************************************************
+
+#pragma once
+
+#include <CL/sycl.hpp>
+
+#include "common.hpp"
+#include "types_matrix.hpp"
+
+namespace dpnp
+{
+namespace backend
+{
+namespace ext
+{
+namespace vm
+{
+template <typename T>
+sycl::event atan_contig_impl(sycl::queue exec_q,
+                             const std::int64_t n,
+                             const char *in_a,
+                             char *out_y,
+                             const std::vector<sycl::event> &depends)
+{
+    type_utils::validate_type_for_device<T>(exec_q);
+
+    const T *a = reinterpret_cast<const T *>(in_a);
+    T *y = reinterpret_cast<T *>(out_y);
+
+    return mkl_vm::atan(exec_q,
+                        n, // number of elements to be calculated
+                        a, // pointer `a` containing input vector of size n
+                        y, // pointer `y` to the output vector of size n
+                        depends);
+}
+
+template <typename fnT, typename T>
+struct AtanContigFactory
+{
+    fnT get()
+    {
+        if constexpr (std::is_same_v<
+                          typename types::AtanOutputType<T>::value_type, void>)
+        {
+            return nullptr;
+        }
+        else {
+            return atan_contig_impl<T>;
+        }
+    }
+};
+} // namespace vm
+} // namespace ext
+} // namespace backend
+} // namespace dpnp

--- a/dpnp/backend/extensions/vm/atan2.hpp
+++ b/dpnp/backend/extensions/vm/atan2.hpp
@@ -1,0 +1,81 @@
+//*****************************************************************************
+// Copyright (c) 2023, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//*****************************************************************************
+
+#pragma once
+
+#include <CL/sycl.hpp>
+
+#include "common.hpp"
+#include "types_matrix.hpp"
+
+namespace dpnp
+{
+namespace backend
+{
+namespace ext
+{
+namespace vm
+{
+template <typename T>
+sycl::event atan2_contig_impl(sycl::queue exec_q,
+                              const std::int64_t n,
+                              const char *in_a,
+                              const char *in_b,
+                              char *out_y,
+                              const std::vector<sycl::event> &depends)
+{
+    type_utils::validate_type_for_device<T>(exec_q);
+
+    const T *a = reinterpret_cast<const T *>(in_a);
+    const T *b = reinterpret_cast<const T *>(in_b);
+    T *y = reinterpret_cast<T *>(out_y);
+
+    return mkl_vm::atan2(exec_q,
+                         n, // number of elements to be calculated
+                         a, // pointer `a` containing 1st input vector of size n
+                         b, // pointer `b` containing 2nd input vector of size n
+                         y, // pointer `y` to the output vector of size n
+                         depends);
+}
+
+template <typename fnT, typename T>
+struct Atan2ContigFactory
+{
+    fnT get()
+    {
+        if constexpr (std::is_same_v<
+                          typename types::Atan2OutputType<T>::value_type, void>)
+        {
+            return nullptr;
+        }
+        else {
+            return atan2_contig_impl<T>;
+        }
+    }
+};
+} // namespace vm
+} // namespace ext
+} // namespace backend
+} // namespace dpnp

--- a/dpnp/backend/extensions/vm/tan.hpp
+++ b/dpnp/backend/extensions/vm/tan.hpp
@@ -1,0 +1,78 @@
+//*****************************************************************************
+// Copyright (c) 2023, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//*****************************************************************************
+
+#pragma once
+
+#include <CL/sycl.hpp>
+
+#include "common.hpp"
+#include "types_matrix.hpp"
+
+namespace dpnp
+{
+namespace backend
+{
+namespace ext
+{
+namespace vm
+{
+template <typename T>
+sycl::event tan_contig_impl(sycl::queue exec_q,
+                            const std::int64_t n,
+                            const char *in_a,
+                            char *out_y,
+                            const std::vector<sycl::event> &depends)
+{
+    type_utils::validate_type_for_device<T>(exec_q);
+
+    const T *a = reinterpret_cast<const T *>(in_a);
+    T *y = reinterpret_cast<T *>(out_y);
+
+    return mkl_vm::tan(exec_q,
+                       n, // number of elements to be calculated
+                       a, // pointer `a` containing input vector of size n
+                       y, // pointer `y` to the output vector of size n
+                       depends);
+}
+
+template <typename fnT, typename T>
+struct TanContigFactory
+{
+    fnT get()
+    {
+        if constexpr (std::is_same_v<
+                          typename types::TanOutputType<T>::value_type, void>)
+        {
+            return nullptr;
+        }
+        else {
+            return tan_contig_impl<T>;
+        }
+    }
+};
+} // namespace vm
+} // namespace ext
+} // namespace backend
+} // namespace dpnp

--- a/dpnp/backend/extensions/vm/types_matrix.hpp
+++ b/dpnp/backend/extensions/vm/types_matrix.hpp
@@ -45,6 +45,23 @@ namespace types
 {
 /**
  * @brief A factory to define pairs of supported types for which
+ * MKL VM library provides support in oneapi::mkl::vm::acos<T> function.
+ *
+ * @tparam T Type of input vector `a` and of result vector `y`.
+ */
+template <typename T>
+struct AcosOutputType
+{
+    using value_type = typename std::disjunction<
+        dpctl_td_ns::TypeMapResultEntry<T, std::complex<double>>,
+        dpctl_td_ns::TypeMapResultEntry<T, std::complex<float>>,
+        dpctl_td_ns::TypeMapResultEntry<T, double>,
+        dpctl_td_ns::TypeMapResultEntry<T, float>,
+        dpctl_td_ns::DefaultResultEntry<void>>::result_type;
+};
+
+/**
+ * @brief A factory to define pairs of supported types for which
  * MKL VM library provides support in oneapi::mkl::vm::add<T> function.
  *
  * @tparam T Type of input vectors `a` and `b` and of result vector `y`.
@@ -63,6 +80,55 @@ struct AddOutputType
                                               T,
                                               std::complex<float>,
                                               std::complex<float>>,
+        dpctl_td_ns::BinaryTypeMapResultEntry<T, double, T, double, double>,
+        dpctl_td_ns::BinaryTypeMapResultEntry<T, float, T, float, float>,
+        dpctl_td_ns::DefaultResultEntry<void>>::result_type;
+};
+
+/**
+ * @brief A factory to define pairs of supported types for which
+ * MKL VM library provides support in oneapi::mkl::vm::asin<T> function.
+ *
+ * @tparam T Type of input vector `a` and of result vector `y`.
+ */
+template <typename T>
+struct AsinOutputType
+{
+    using value_type = typename std::disjunction<
+        dpctl_td_ns::TypeMapResultEntry<T, std::complex<double>>,
+        dpctl_td_ns::TypeMapResultEntry<T, std::complex<float>>,
+        dpctl_td_ns::TypeMapResultEntry<T, double>,
+        dpctl_td_ns::TypeMapResultEntry<T, float>,
+        dpctl_td_ns::DefaultResultEntry<void>>::result_type;
+};
+
+/**
+ * @brief A factory to define pairs of supported types for which
+ * MKL VM library provides support in oneapi::mkl::vm::atan<T> function.
+ *
+ * @tparam T Type of input vector `a` and of result vector `y`.
+ */
+template <typename T>
+struct AtanOutputType
+{
+    using value_type = typename std::disjunction<
+        dpctl_td_ns::TypeMapResultEntry<T, std::complex<double>>,
+        dpctl_td_ns::TypeMapResultEntry<T, std::complex<float>>,
+        dpctl_td_ns::TypeMapResultEntry<T, double>,
+        dpctl_td_ns::TypeMapResultEntry<T, float>,
+        dpctl_td_ns::DefaultResultEntry<void>>::result_type;
+};
+
+/**
+ * @brief A factory to define pairs of supported types for which
+ * MKL VM library provides support in oneapi::mkl::vm::atan2<T> function.
+ *
+ * @tparam T Type of input vectors `a` and `b` and of result vector `y`.
+ */
+template <typename T>
+struct Atan2OutputType
+{
+    using value_type = typename std::disjunction<
         dpctl_td_ns::BinaryTypeMapResultEntry<T, double, T, double, double>,
         dpctl_td_ns::BinaryTypeMapResultEntry<T, float, T, float, float>,
         dpctl_td_ns::DefaultResultEntry<void>>::result_type;
@@ -110,10 +176,8 @@ template <typename T>
 struct CosOutputType
 {
     using value_type = typename std::disjunction<
-        dpctl_td_ns::
-            TypeMapResultEntry<T, std::complex<double>, std::complex<double>>,
-        dpctl_td_ns::
-            TypeMapResultEntry<T, std::complex<float>, std::complex<float>>,
+        dpctl_td_ns::TypeMapResultEntry<T, std::complex<double>>,
+        dpctl_td_ns::TypeMapResultEntry<T, std::complex<float>>,
         dpctl_td_ns::TypeMapResultEntry<T, double, double>,
         dpctl_td_ns::TypeMapResultEntry<T, float, float>,
         dpctl_td_ns::DefaultResultEntry<void>>::result_type;
@@ -253,10 +317,8 @@ template <typename T>
 struct SinOutputType
 {
     using value_type = typename std::disjunction<
-        dpctl_td_ns::
-            TypeMapResultEntry<T, std::complex<double>, std::complex<double>>,
-        dpctl_td_ns::
-            TypeMapResultEntry<T, std::complex<float>, std::complex<float>>,
+        dpctl_td_ns::TypeMapResultEntry<T, std::complex<double>>,
+        dpctl_td_ns::TypeMapResultEntry<T, std::complex<float>>,
         dpctl_td_ns::TypeMapResultEntry<T, double, double>,
         dpctl_td_ns::TypeMapResultEntry<T, float, float>,
         dpctl_td_ns::DefaultResultEntry<void>>::result_type;
@@ -318,6 +380,23 @@ struct SubOutputType
                                               std::complex<float>>,
         dpctl_td_ns::BinaryTypeMapResultEntry<T, double, T, double, double>,
         dpctl_td_ns::BinaryTypeMapResultEntry<T, float, T, float, float>,
+        dpctl_td_ns::DefaultResultEntry<void>>::result_type;
+};
+
+/**
+ * @brief A factory to define pairs of supported types for which
+ * MKL VM library provides support in oneapi::mkl::vm::tan<T> function.
+ *
+ * @tparam T Type of input vector `a` and of result vector `y`.
+ */
+template <typename T>
+struct TanOutputType
+{
+    using value_type = typename std::disjunction<
+        dpctl_td_ns::TypeMapResultEntry<T, std::complex<double>>,
+        dpctl_td_ns::TypeMapResultEntry<T, std::complex<float>>,
+        dpctl_td_ns::TypeMapResultEntry<T, double>,
+        dpctl_td_ns::TypeMapResultEntry<T, float>,
         dpctl_td_ns::DefaultResultEntry<void>>::result_type;
 };
 

--- a/dpnp/backend/extensions/vm/vm_py.cpp
+++ b/dpnp/backend/extensions/vm/vm_py.cpp
@@ -30,7 +30,11 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include "acos.hpp"
 #include "add.hpp"
+#include "asin.hpp"
+#include "atan.hpp"
+#include "atan2.hpp"
 #include "ceil.hpp"
 #include "common.hpp"
 #include "conj.hpp"
@@ -45,6 +49,7 @@
 #include "sqr.hpp"
 #include "sqrt.hpp"
 #include "sub.hpp"
+#include "tan.hpp"
 #include "trunc.hpp"
 #include "types_matrix.hpp"
 
@@ -54,7 +59,11 @@ namespace vm_ext = dpnp::backend::ext::vm;
 using vm_ext::binary_impl_fn_ptr_t;
 using vm_ext::unary_impl_fn_ptr_t;
 
+static unary_impl_fn_ptr_t acos_dispatch_vector[dpctl_td_ns::num_types];
 static binary_impl_fn_ptr_t add_dispatch_vector[dpctl_td_ns::num_types];
+static unary_impl_fn_ptr_t asin_dispatch_vector[dpctl_td_ns::num_types];
+static unary_impl_fn_ptr_t atan_dispatch_vector[dpctl_td_ns::num_types];
+static binary_impl_fn_ptr_t atan2_dispatch_vector[dpctl_td_ns::num_types];
 static unary_impl_fn_ptr_t ceil_dispatch_vector[dpctl_td_ns::num_types];
 static unary_impl_fn_ptr_t cos_dispatch_vector[dpctl_td_ns::num_types];
 static binary_impl_fn_ptr_t div_dispatch_vector[dpctl_td_ns::num_types];
@@ -68,12 +77,41 @@ static unary_impl_fn_ptr_t sin_dispatch_vector[dpctl_td_ns::num_types];
 static unary_impl_fn_ptr_t sqr_dispatch_vector[dpctl_td_ns::num_types];
 static unary_impl_fn_ptr_t sqrt_dispatch_vector[dpctl_td_ns::num_types];
 static binary_impl_fn_ptr_t sub_dispatch_vector[dpctl_td_ns::num_types];
+static unary_impl_fn_ptr_t tan_dispatch_vector[dpctl_td_ns::num_types];
 static unary_impl_fn_ptr_t trunc_dispatch_vector[dpctl_td_ns::num_types];
 
 PYBIND11_MODULE(_vm_impl, m)
 {
     using arrayT = dpctl::tensor::usm_ndarray;
     using event_vecT = std::vector<sycl::event>;
+
+    // UnaryUfunc: ==== Acos(x) ====
+    {
+        vm_ext::init_ufunc_dispatch_vector<unary_impl_fn_ptr_t,
+                                           vm_ext::AcosContigFactory>(
+            acos_dispatch_vector);
+
+        auto acos_pyapi = [&](sycl::queue exec_q, arrayT src, arrayT dst,
+                              const event_vecT &depends = {}) {
+            return vm_ext::unary_ufunc(exec_q, src, dst, depends,
+                                       acos_dispatch_vector);
+        };
+        m.def("_acos", acos_pyapi,
+              "Call `acos` function from OneMKL VM library to compute "
+              "inverse cosine of vector elements",
+              py::arg("sycl_queue"), py::arg("src"), py::arg("dst"),
+              py::arg("depends") = py::list());
+
+        auto acos_need_to_call_pyapi = [&](sycl::queue exec_q, arrayT src,
+                                           arrayT dst) {
+            return vm_ext::need_to_call_unary_ufunc(exec_q, src, dst,
+                                                    acos_dispatch_vector);
+        };
+        m.def("_mkl_acos_to_call", acos_need_to_call_pyapi,
+              "Check input arguments to answer if `acos` function from "
+              "OneMKL VM library can be used",
+              py::arg("sycl_queue"), py::arg("src"), py::arg("dst"));
+    }
 
     // BinaryUfunc: ==== Add(x1, x2) ====
     {
@@ -100,6 +138,91 @@ PYBIND11_MODULE(_vm_impl, m)
         };
         m.def("_mkl_add_to_call", add_need_to_call_pyapi,
               "Check input arguments to answer if `add` function from "
+              "OneMKL VM library can be used",
+              py::arg("sycl_queue"), py::arg("src1"), py::arg("src2"),
+              py::arg("dst"));
+    }
+
+    // UnaryUfunc: ==== Asin(x) ====
+    {
+        vm_ext::init_ufunc_dispatch_vector<unary_impl_fn_ptr_t,
+                                           vm_ext::AsinContigFactory>(
+            asin_dispatch_vector);
+
+        auto asin_pyapi = [&](sycl::queue exec_q, arrayT src, arrayT dst,
+                              const event_vecT &depends = {}) {
+            return vm_ext::unary_ufunc(exec_q, src, dst, depends,
+                                       asin_dispatch_vector);
+        };
+        m.def("_asin", asin_pyapi,
+              "Call `asin` function from OneMKL VM library to compute "
+              "inverse sine of vector elements",
+              py::arg("sycl_queue"), py::arg("src"), py::arg("dst"),
+              py::arg("depends") = py::list());
+
+        auto asin_need_to_call_pyapi = [&](sycl::queue exec_q, arrayT src,
+                                           arrayT dst) {
+            return vm_ext::need_to_call_unary_ufunc(exec_q, src, dst,
+                                                    asin_dispatch_vector);
+        };
+        m.def("_mkl_asin_to_call", asin_need_to_call_pyapi,
+              "Check input arguments to answer if `asin` function from "
+              "OneMKL VM library can be used",
+              py::arg("sycl_queue"), py::arg("src"), py::arg("dst"));
+    }
+
+    // UnaryUfunc: ==== Atan(x) ====
+    {
+        vm_ext::init_ufunc_dispatch_vector<unary_impl_fn_ptr_t,
+                                           vm_ext::AtanContigFactory>(
+            atan_dispatch_vector);
+
+        auto atan_pyapi = [&](sycl::queue exec_q, arrayT src, arrayT dst,
+                              const event_vecT &depends = {}) {
+            return vm_ext::unary_ufunc(exec_q, src, dst, depends,
+                                       atan_dispatch_vector);
+        };
+        m.def("_atan", atan_pyapi,
+              "Call `atan` function from OneMKL VM library to compute "
+              "inverse tangent of vector elements",
+              py::arg("sycl_queue"), py::arg("src"), py::arg("dst"),
+              py::arg("depends") = py::list());
+
+        auto atan_need_to_call_pyapi = [&](sycl::queue exec_q, arrayT src,
+                                           arrayT dst) {
+            return vm_ext::need_to_call_unary_ufunc(exec_q, src, dst,
+                                                    atan_dispatch_vector);
+        };
+        m.def("_mkl_atan_to_call", atan_need_to_call_pyapi,
+              "Check input arguments to answer if `atan` function from "
+              "OneMKL VM library can be used",
+              py::arg("sycl_queue"), py::arg("src"), py::arg("dst"));
+    }
+
+    // BinaryUfunc: ==== Atan2(x1, x2) ====
+    {
+        vm_ext::init_ufunc_dispatch_vector<binary_impl_fn_ptr_t,
+                                           vm_ext::Atan2ContigFactory>(
+            atan2_dispatch_vector);
+
+        auto atan2_pyapi = [&](sycl::queue exec_q, arrayT src1, arrayT src2,
+                               arrayT dst, const event_vecT &depends = {}) {
+            return vm_ext::binary_ufunc(exec_q, src1, src2, dst, depends,
+                                        atan2_dispatch_vector);
+        };
+        m.def("_atan2", atan2_pyapi,
+              "Call `atan2` function from OneMKL VM library to compute element "
+              "by element inverse tangent of `x1/x2`",
+              py::arg("sycl_queue"), py::arg("src1"), py::arg("src2"),
+              py::arg("dst"), py::arg("depends") = py::list());
+
+        auto atan2_need_to_call_pyapi = [&](sycl::queue exec_q, arrayT src1,
+                                            arrayT src2, arrayT dst) {
+            return vm_ext::need_to_call_binary_ufunc(exec_q, src1, src2, dst,
+                                                     atan2_dispatch_vector);
+        };
+        m.def("_mkl_atan2_to_call", atan2_need_to_call_pyapi,
+              "Check input arguments to answer if `atan2` function from "
               "OneMKL VM library can be used",
               py::arg("sycl_queue"), py::arg("src1"), py::arg("src2"),
               py::arg("dst"));
@@ -478,6 +601,34 @@ PYBIND11_MODULE(_vm_impl, m)
               "OneMKL VM library can be used",
               py::arg("sycl_queue"), py::arg("src1"), py::arg("src2"),
               py::arg("dst"));
+    }
+
+    // UnaryUfunc: ==== Tan(x) ====
+    {
+        vm_ext::init_ufunc_dispatch_vector<unary_impl_fn_ptr_t,
+                                           vm_ext::TanContigFactory>(
+            tan_dispatch_vector);
+
+        auto tan_pyapi = [&](sycl::queue exec_q, arrayT src, arrayT dst,
+                             const event_vecT &depends = {}) {
+            return vm_ext::unary_ufunc(exec_q, src, dst, depends,
+                                       tan_dispatch_vector);
+        };
+        m.def("_tan", tan_pyapi,
+              "Call `tan` function from OneMKL VM library to compute "
+              "tangent of vector elements",
+              py::arg("sycl_queue"), py::arg("src"), py::arg("dst"),
+              py::arg("depends") = py::list());
+
+        auto tan_need_to_call_pyapi = [&](sycl::queue exec_q, arrayT src,
+                                          arrayT dst) {
+            return vm_ext::need_to_call_unary_ufunc(exec_q, src, dst,
+                                                    tan_dispatch_vector);
+        };
+        m.def("_mkl_tan_to_call", tan_need_to_call_pyapi,
+              "Check input arguments to answer if `tan` function from "
+              "OneMKL VM library can be used",
+              py::arg("sycl_queue"), py::arg("src"), py::arg("dst"));
     }
 
     // UnaryUfunc: ==== Trunc(x) ====

--- a/dpnp/backend/include/dpnp_iface_fptr.hpp
+++ b/dpnp/backend/include/dpnp_iface_fptr.hpp
@@ -71,23 +71,15 @@ enum class DPNPFuncName : size_t
     DPNP_FN_ANY,          /**< Used in numpy.any() impl  */
     DPNP_FN_ARANGE,       /**< Used in numpy.arange() impl  */
     DPNP_FN_ARCCOS,       /**< Used in numpy.arccos() impl  */
-    DPNP_FN_ARCCOS_EXT,   /**< Used in numpy.arccos() impl, requires extra
-                             parameters */
     DPNP_FN_ARCCOSH,      /**< Used in numpy.arccosh() impl  */
     DPNP_FN_ARCCOSH_EXT,  /**< Used in numpy.arccosh() impl, requires extra
                              parameters */
     DPNP_FN_ARCSIN,       /**< Used in numpy.arcsin() impl  */
-    DPNP_FN_ARCSIN_EXT,   /**< Used in numpy.arcsin() impl, requires extra
-                             parameters */
     DPNP_FN_ARCSINH,      /**< Used in numpy.arcsinh() impl  */
     DPNP_FN_ARCSINH_EXT,  /**< Used in numpy.arcsinh() impl, requires extra
                              parameters */
     DPNP_FN_ARCTAN,       /**< Used in numpy.arctan() impl  */
-    DPNP_FN_ARCTAN_EXT,   /**< Used in numpy.arctan() impl, requires extra
-                             parameters */
     DPNP_FN_ARCTAN2,      /**< Used in numpy.arctan2() impl  */
-    DPNP_FN_ARCTAN2_EXT,  /**< Used in numpy.arctan2() impl, requires extra
-                             parameters */
     DPNP_FN_ARCTANH,      /**< Used in numpy.arctanh() impl  */
     DPNP_FN_ARCTANH_EXT,  /**< Used in numpy.arctanh() impl, requires extra
                              parameters */
@@ -458,7 +450,6 @@ enum class DPNPFuncName : size_t
                         parameters */
     DPNP_FN_TAKE,    /**< Used in numpy.take() impl  */
     DPNP_FN_TAN,     /**< Used in numpy.tan() impl  */
-    DPNP_FN_TAN_EXT, /**< Used in numpy.tan() impl, requires extra parameters */
     DPNP_FN_TANH,    /**< Used in numpy.tanh() impl  */
     DPNP_FN_TANH_EXT,  /**< Used in numpy.tanh() impl, requires extra parameters
                         */

--- a/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
@@ -233,15 +233,6 @@ static void func_map_init_elemwise_1arg_2type(func_map_t &fmap)
     fmap[DPNPFuncName::DPNP_FN_ARCCOS][eft_DBL][eft_DBL] = {
         eft_DBL, (void *)dpnp_acos_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_ARCCOS_EXT][eft_INT][eft_INT] = {
-        eft_DBL, (void *)dpnp_acos_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCCOS_EXT][eft_LNG][eft_LNG] = {
-        eft_DBL, (void *)dpnp_acos_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCCOS_EXT][eft_FLT][eft_FLT] = {
-        eft_FLT, (void *)dpnp_acos_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_ARCCOS_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void *)dpnp_acos_c_ext<double, double>};
-
     fmap[DPNPFuncName::DPNP_FN_ARCCOSH][eft_INT][eft_INT] = {
         eft_DBL, (void *)dpnp_acosh_c_default<int32_t, double>};
     fmap[DPNPFuncName::DPNP_FN_ARCCOSH][eft_LNG][eft_LNG] = {
@@ -269,15 +260,6 @@ static void func_map_init_elemwise_1arg_2type(func_map_t &fmap)
     fmap[DPNPFuncName::DPNP_FN_ARCSIN][eft_DBL][eft_DBL] = {
         eft_DBL, (void *)dpnp_asin_c_default<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_ARCSIN_EXT][eft_INT][eft_INT] = {
-        eft_DBL, (void *)dpnp_asin_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCSIN_EXT][eft_LNG][eft_LNG] = {
-        eft_DBL, (void *)dpnp_asin_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCSIN_EXT][eft_FLT][eft_FLT] = {
-        eft_FLT, (void *)dpnp_asin_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_ARCSIN_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void *)dpnp_asin_c_ext<double, double>};
-
     fmap[DPNPFuncName::DPNP_FN_ARCSINH][eft_INT][eft_INT] = {
         eft_DBL, (void *)dpnp_asinh_c_default<int32_t, double>};
     fmap[DPNPFuncName::DPNP_FN_ARCSINH][eft_LNG][eft_LNG] = {
@@ -304,15 +286,6 @@ static void func_map_init_elemwise_1arg_2type(func_map_t &fmap)
         eft_FLT, (void *)dpnp_atan_c_default<float, float>};
     fmap[DPNPFuncName::DPNP_FN_ARCTAN][eft_DBL][eft_DBL] = {
         eft_DBL, (void *)dpnp_atan_c_default<double, double>};
-
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN_EXT][eft_INT][eft_INT] = {
-        eft_DBL, (void *)dpnp_atan_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN_EXT][eft_LNG][eft_LNG] = {
-        eft_DBL, (void *)dpnp_atan_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN_EXT][eft_FLT][eft_FLT] = {
-        eft_FLT, (void *)dpnp_atan_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_ARCTAN_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void *)dpnp_atan_c_ext<double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_ARCTANH][eft_INT][eft_INT] = {
         eft_DBL, (void *)dpnp_atanh_c_default<int32_t, double>};
@@ -692,15 +665,6 @@ static void func_map_init_elemwise_1arg_2type(func_map_t &fmap)
         eft_FLT, (void *)dpnp_tan_c_default<float, float>};
     fmap[DPNPFuncName::DPNP_FN_TAN][eft_DBL][eft_DBL] = {
         eft_DBL, (void *)dpnp_tan_c_default<double, double>};
-
-    fmap[DPNPFuncName::DPNP_FN_TAN_EXT][eft_INT][eft_INT] = {
-        eft_DBL, (void *)dpnp_tan_c_ext<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TAN_EXT][eft_LNG][eft_LNG] = {
-        eft_DBL, (void *)dpnp_tan_c_ext<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TAN_EXT][eft_FLT][eft_FLT] = {
-        eft_FLT, (void *)dpnp_tan_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_TAN_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void *)dpnp_tan_c_ext<double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_TANH][eft_INT][eft_INT] = {
         eft_DBL, (void *)dpnp_tanh_c_default<int32_t, double>};
@@ -1577,19 +1541,6 @@ static void func_map_elemwise_2arg_3type_core(func_map_t &fmap)
 template <DPNPFuncType FT1, DPNPFuncType... FTs>
 static void func_map_elemwise_2arg_3type_short_core(func_map_t &fmap)
 {
-    ((fmap[DPNPFuncName::DPNP_FN_ARCTAN2_EXT][FT1][FTs] =
-          {get_floating_res_type<FT1, FTs>(),
-           (void *)dpnp_arctan2_c_ext<
-               func_type_map_t::find_type<get_floating_res_type<FT1, FTs>()>,
-               func_type_map_t::find_type<FT1>,
-               func_type_map_t::find_type<FTs>>,
-           get_floating_res_type<FT1, FTs, std::false_type>(),
-           (void *)dpnp_arctan2_c_ext<
-               func_type_map_t::find_type<
-                   get_floating_res_type<FT1, FTs, std::false_type>()>,
-               func_type_map_t::find_type<FT1>,
-               func_type_map_t::find_type<FTs>>}),
-     ...);
     ((fmap[DPNPFuncName::DPNP_FN_COPYSIGN_EXT][FT1][FTs] =
           {get_floating_res_type<FT1, FTs>(),
            (void *)dpnp_copysign_c_ext<

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -408,8 +408,6 @@ cpdef dpnp_descriptor dpnp_copy(dpnp_descriptor x1)
 """
 Mathematical functions
 """
-cpdef dpnp_descriptor dpnp_arctan2(dpnp_descriptor x1_obj, dpnp_descriptor x2_obj, object dtype=*,
-                                   dpnp_descriptor out=*, object where=*)
 cpdef dpnp_descriptor dpnp_hypot(dpnp_descriptor x1_obj, dpnp_descriptor x2_obj, object dtype=*,
                                  dpnp_descriptor out=*, object where=*)
 cpdef dpnp_descriptor dpnp_maximum(dpnp_descriptor x1_obj, dpnp_descriptor x2_obj, object dtype=*,
@@ -444,11 +442,8 @@ cpdef dpnp_descriptor dpnp_argmin(dpnp_descriptor array1)
 """
 Trigonometric functions
 """
-cpdef dpnp_descriptor dpnp_arccos(dpnp_descriptor array1)
 cpdef dpnp_descriptor dpnp_arccosh(dpnp_descriptor array1)
-cpdef dpnp_descriptor dpnp_arcsin(dpnp_descriptor array1, dpnp_descriptor out)
 cpdef dpnp_descriptor dpnp_arcsinh(dpnp_descriptor array1)
-cpdef dpnp_descriptor dpnp_arctan(dpnp_descriptor array1, dpnp_descriptor out)
 cpdef dpnp_descriptor dpnp_arctanh(dpnp_descriptor array1)
 cpdef dpnp_descriptor dpnp_cbrt(dpnp_descriptor array1)
 cpdef dpnp_descriptor dpnp_cosh(dpnp_descriptor array1)
@@ -462,5 +457,4 @@ cpdef dpnp_descriptor dpnp_log2(dpnp_descriptor array1)
 cpdef dpnp_descriptor dpnp_radians(dpnp_descriptor array1)
 cpdef dpnp_descriptor dpnp_recip(dpnp_descriptor array1)
 cpdef dpnp_descriptor dpnp_sinh(dpnp_descriptor array1)
-cpdef dpnp_descriptor dpnp_tan(dpnp_descriptor array1, dpnp_descriptor out)
 cpdef dpnp_descriptor dpnp_tanh(dpnp_descriptor array1)

--- a/dpnp/dpnp_algo/dpnp_algo_mathematical.pxi
+++ b/dpnp/dpnp_algo/dpnp_algo_mathematical.pxi
@@ -37,7 +37,6 @@ and the rest of the library
 
 __all__ += [
     "dpnp_absolute",
-    "dpnp_arctan2",
     "dpnp_copysign",
     "dpnp_cross",
     "dpnp_cumprod",
@@ -105,14 +104,6 @@ cpdef utils.dpnp_descriptor dpnp_absolute(utils.dpnp_descriptor x1):
     c_dpctl.DPCTLEvent_Delete(event_ref)
 
     return result
-
-
-cpdef utils.dpnp_descriptor dpnp_arctan2(utils.dpnp_descriptor x1_obj,
-                                         utils.dpnp_descriptor x2_obj,
-                                         object dtype=None,
-                                         utils.dpnp_descriptor out=None,
-                                         object where=True):
-    return call_fptr_2in_1out_strides(DPNP_FN_ARCTAN2_EXT, x1_obj, x2_obj, dtype, out, where, func_name="arctan2")
 
 
 cpdef utils.dpnp_descriptor dpnp_copysign(utils.dpnp_descriptor x1_obj,

--- a/dpnp/dpnp_algo/dpnp_algo_trigonometric.pxi
+++ b/dpnp/dpnp_algo/dpnp_algo_trigonometric.pxi
@@ -36,11 +36,8 @@ and the rest of the library
 # NO IMPORTs here. All imports must be placed into main "dpnp_algo.pyx" file
 
 __all__ += [
-    'dpnp_arccos',
     'dpnp_arccosh',
-    'dpnp_arcsin',
     'dpnp_arcsinh',
-    'dpnp_arctan',
     'dpnp_arctanh',
     'dpnp_cbrt',
     'dpnp_cosh',
@@ -54,30 +51,17 @@ __all__ += [
     'dpnp_radians',
     'dpnp_recip',
     'dpnp_sinh',
-    'dpnp_tan',
     'dpnp_tanh',
     'dpnp_unwrap'
 ]
-
-
-cpdef utils.dpnp_descriptor dpnp_arccos(utils.dpnp_descriptor x1):
-    return call_fptr_1in_1out_strides(DPNP_FN_ARCCOS_EXT, x1)
 
 
 cpdef utils.dpnp_descriptor dpnp_arccosh(utils.dpnp_descriptor x1):
     return call_fptr_1in_1out_strides(DPNP_FN_ARCCOSH_EXT, x1)
 
 
-cpdef utils.dpnp_descriptor dpnp_arcsin(utils.dpnp_descriptor x1, utils.dpnp_descriptor out):
-    return call_fptr_1in_1out_strides(DPNP_FN_ARCSIN_EXT, x1, dtype=None, out=out, where=True, func_name='arcsin')
-
-
 cpdef utils.dpnp_descriptor dpnp_arcsinh(utils.dpnp_descriptor x1):
     return call_fptr_1in_1out_strides(DPNP_FN_ARCSINH_EXT, x1)
-
-
-cpdef utils.dpnp_descriptor dpnp_arctan(utils.dpnp_descriptor x1, utils.dpnp_descriptor out):
-    return call_fptr_1in_1out_strides(DPNP_FN_ARCTAN_EXT, x1, dtype=None, out=out, where=True, func_name='arctan')
 
 
 cpdef utils.dpnp_descriptor dpnp_arctanh(utils.dpnp_descriptor x1):
@@ -130,10 +114,6 @@ cpdef utils.dpnp_descriptor dpnp_radians(utils.dpnp_descriptor x1):
 
 cpdef utils.dpnp_descriptor dpnp_sinh(utils.dpnp_descriptor x1):
     return call_fptr_1in_1out_strides(DPNP_FN_SINH_EXT, x1)
-
-
-cpdef utils.dpnp_descriptor dpnp_tan(utils.dpnp_descriptor x1, utils.dpnp_descriptor out):
-    return call_fptr_1in_1out_strides(DPNP_FN_TAN_EXT, x1, dtype=None, out=out, where=True, func_name='tan')
 
 
 cpdef utils.dpnp_descriptor dpnp_tanh(utils.dpnp_descriptor x1):

--- a/dpnp/dpnp_algo/dpnp_elementwise_common.py
+++ b/dpnp/dpnp_algo/dpnp_elementwise_common.py
@@ -42,7 +42,11 @@ from dpnp.dpnp_utils import call_origin
 
 __all__ = [
     "check_nd_call_func",
+    "dpnp_acos",
     "dpnp_add",
+    "dpnp_asin",
+    "dpnp_atan",
+    "dpnp_atan2",
     "dpnp_bitwise_and",
     "dpnp_bitwise_or",
     "dpnp_bitwise_xor",
@@ -81,6 +85,7 @@ __all__ = [
     "dpnp_sqrt",
     "dpnp_square",
     "dpnp_subtract",
+    "dpnp_tan",
     "dpnp_trunc",
 ]
 
@@ -151,6 +156,60 @@ def check_nd_call_func(
     )
 
 
+_acos_docstring = """
+acos(x, out=None, order='K')
+
+Computes inverse cosine for each element `x_i` for input array `x`.
+
+Args:
+    x (dpnp.ndarray):
+        Input array, expected to have numeric data type.
+    out ({None, dpnp.ndarray}, optional):
+        Output array to populate. Array must have the correct
+        shape and the expected data type.
+    order ("C","F","A","K", optional): memory layout of the new
+        output array, if parameter `out` is `None`.
+        Default: "K".
+Return:
+    dpnp.ndarray:
+        An array containing the element-wise inverse cosine, in radians
+        and in the closed interval `[-pi/2, pi/2]`. The data type
+        of the returned array is determined by the Type Promotion Rules.
+"""
+
+
+def _call_acos(src, dst, sycl_queue, depends=None):
+    """A callback to register in UnaryElementwiseFunc class of dpctl.tensor"""
+
+    if depends is None:
+        depends = []
+
+    if vmi._mkl_acos_to_call(sycl_queue, src, dst):
+        # call pybind11 extension for acos() function from OneMKL VM
+        return vmi._acos(sycl_queue, src, dst, depends)
+    return ti._acos(src, dst, sycl_queue, depends)
+
+
+acos_func = UnaryElementwiseFunc(
+    "acos", ti._acos_result_type, _call_acos, _acos_docstring
+)
+
+
+def dpnp_acos(x, out=None, order="K"):
+    """
+    Invokes acos() function from pybind11 extension of OneMKL VM if possible.
+
+    Otherwise fully relies on dpctl.tensor implementation for acos() function.
+
+    """
+    # dpctl.tensor only works with usm_ndarray
+    x1_usm = dpnp.get_usm_ndarray(x)
+    out_usm = None if out is None else dpnp.get_usm_ndarray(out)
+
+    res_usm = acos_func(x1_usm, out=out_usm, order=order)
+    return dpnp_array._create_from_usm_ndarray(res_usm)
+
+
 _add_docstring_ = """
 add(x1, x2, out=None, order="K")
 
@@ -205,6 +264,180 @@ def dpnp_add(x1, x2, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = add_func(
+        x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
+    )
+    return dpnp_array._create_from_usm_ndarray(res_usm)
+
+
+_asin_docstring = """
+asin(x, out=None, order='K')
+
+Computes inverse sine for each element `x_i` for input array `x`.
+
+Args:
+    x (dpnp.ndarray):
+        Input array, expected to have numeric data type.
+    out ({None, dpnp.ndarray}, optional):
+        Output array to populate. Array must have the correct
+        shape and the expected data type.
+    order ("C","F","A","K", optional): memory layout of the new
+        output array, if parameter `out` is `None`.
+        Default: "K".
+Return:
+    dpnp.ndarray:
+        An array containing the element-wise inverse sine, in radians
+        and in the closed interval `[-pi/2, pi/2]`. The data type
+        of the returned array is determined by the Type Promotion Rules.
+"""
+
+
+def _call_asin(src, dst, sycl_queue, depends=None):
+    """A callback to register in UnaryElementwiseFunc class of dpctl.tensor"""
+
+    if depends is None:
+        depends = []
+
+    if vmi._mkl_asin_to_call(sycl_queue, src, dst):
+        # call pybind11 extension for asin() function from OneMKL VM
+        return vmi._asin(sycl_queue, src, dst, depends)
+    return ti._asin(src, dst, sycl_queue, depends)
+
+
+asin_func = UnaryElementwiseFunc(
+    "asin", ti._asin_result_type, _call_asin, _asin_docstring
+)
+
+
+def dpnp_asin(x, out=None, order="K"):
+    """
+    Invokes asin() function from pybind11 extension of OneMKL VM if possible.
+
+    Otherwise fully relies on dpctl.tensor implementation for asin() function.
+
+    """
+    # dpctl.tensor only works with usm_ndarray
+    x1_usm = dpnp.get_usm_ndarray(x)
+    out_usm = None if out is None else dpnp.get_usm_ndarray(out)
+
+    res_usm = asin_func(x1_usm, out=out_usm, order=order)
+    return dpnp_array._create_from_usm_ndarray(res_usm)
+
+
+_atan_docstring = """
+atan(x, out=None, order='K')
+
+Computes inverse tangent for each element `x_i` for input array `x`.
+
+Args:
+    x (dpnp.ndarray):
+        Input array, expected to have numeric data type.
+    out ({None, dpnp.ndarray}, optional):
+        Output array to populate. Array must have the correct
+        shape and the expected data type.
+    order ("C","F","A","K", optional): memory layout of the new
+        output array, if parameter `out` is `None`.
+        Default: "K".
+Return:
+    dpnp.ndarray:
+        An array containing the element-wise inverse tangent, in radians
+        and in the closed interval `[-pi/2, pi/2]`. The data type
+        of the returned array is determined by the Type Promotion Rules.
+"""
+
+
+def _call_atan(src, dst, sycl_queue, depends=None):
+    """A callback to register in UnaryElementwiseFunc class of dpctl.tensor"""
+
+    if depends is None:
+        depends = []
+
+    if vmi._mkl_atan_to_call(sycl_queue, src, dst):
+        # call pybind11 extension for atan() function from OneMKL VM
+        return vmi._atan(sycl_queue, src, dst, depends)
+    return ti._atan(src, dst, sycl_queue, depends)
+
+
+atan_func = UnaryElementwiseFunc(
+    "atan", ti._atan_result_type, _call_atan, _atan_docstring
+)
+
+
+def dpnp_atan(x, out=None, order="K"):
+    """
+    Invokes atan() function from pybind11 extension of OneMKL VM if possible.
+
+    Otherwise fully relies on dpctl.tensor implementation for atan() function.
+
+    """
+    # dpctl.tensor only works with usm_ndarray
+    x1_usm = dpnp.get_usm_ndarray(x)
+    out_usm = None if out is None else dpnp.get_usm_ndarray(out)
+
+    res_usm = atan_func(x1_usm, out=out_usm, order=order)
+    return dpnp_array._create_from_usm_ndarray(res_usm)
+
+
+_atan2_docstring_ = """
+atan2(x1, x2, out=None, order="K")
+
+Calculates the inverse tangent of the quotient `x1_i/x2_i` for each element
+`x1_i` of the input array `x1` with the respective element `x2_i` of the
+input array `x2`. Each element-wise result is expressed in radians.
+
+Args:
+    x1 (dpnp.ndarray):
+        First input array, expected to have a real-valued floating-point
+        data type.
+    x2 (dpnp.ndarray):
+        Second input array, also expected to have a real-valued
+        floating-point data type.
+    out ({None, dpnp.ndarray}, optional):
+        Output array to populate.
+        Array have the correct shape and the expected data type.
+    order ("C","F","A","K", None, optional):
+        Memory layout of the newly output array, if parameter `out` is `None`.
+        Default: "K".
+Returns:
+    dpnp.ndarray:
+        An array containing the inverse tangent of the quotient `x1`/`x2`.
+        The returned array must have a real-valued floating-point data type
+        determined by Type Promotion Rules.
+"""
+
+
+def _call_atan2(src1, src2, dst, sycl_queue, depends=None):
+    """A callback to register in BinaryElementwiseFunc class of dpctl.tensor"""
+
+    if depends is None:
+        depends = []
+
+    if vmi._mkl_atan2_to_call(sycl_queue, src1, src2, dst):
+        # call pybind11 extension for atan2() function from OneMKL VM
+        return vmi._atan2(sycl_queue, src1, src2, dst, depends)
+    return ti._atan2(src1, src2, dst, sycl_queue, depends)
+
+
+atan2_func = BinaryElementwiseFunc(
+    "atan2",
+    ti._atan2_result_type,
+    _call_atan2,
+    _atan2_docstring_,
+)
+
+
+def dpnp_atan2(x1, x2, out=None, order="K"):
+    """
+    Invokes atan2() function from pybind11 extension of OneMKL VM if possible.
+
+    Otherwise fully relies on dpctl.tensor implementation for atan2() function.
+    """
+
+    # dpctl.tensor only works with usm_ndarray or scalar
+    x1_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x1)
+    x2_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x2)
+    out_usm = None if out is None else dpnp.get_usm_ndarray(out)
+
+    res_usm = atan2_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
     return dpnp_array._create_from_usm_ndarray(res_usm)
@@ -409,7 +642,9 @@ def dpnp_ceil(x, out=None, order="K"):
 
 _cos_docstring = """
 cos(x, out=None, order='K')
+
 Computes cosine for each element `x_i` for input array `x`.
+
 Args:
     x (dpnp.ndarray):
         Input array, expected to have numeric data type.
@@ -424,6 +659,38 @@ Return:
         An array containing the element-wise cosine. The data type
         of the returned array is determined by the Type Promotion Rules.
 """
+
+
+def _call_cos(src, dst, sycl_queue, depends=None):
+    """A callback to register in UnaryElementwiseFunc class of dpctl.tensor"""
+
+    if depends is None:
+        depends = []
+
+    if vmi._mkl_cos_to_call(sycl_queue, src, dst):
+        # call pybind11 extension for cos() function from OneMKL VM
+        return vmi._cos(sycl_queue, src, dst, depends)
+    return ti._cos(src, dst, sycl_queue, depends)
+
+
+cos_func = UnaryElementwiseFunc(
+    "cos", ti._cos_result_type, _call_cos, _cos_docstring
+)
+
+
+def dpnp_cos(x, out=None, order="K"):
+    """
+    Invokes cos() function from pybind11 extension of OneMKL VM if possible.
+
+    Otherwise fully relies on dpctl.tensor implementation for cos() function.
+
+    """
+    # dpctl.tensor only works with usm_ndarray
+    x1_usm = dpnp.get_usm_ndarray(x)
+    out_usm = None if out is None else dpnp.get_usm_ndarray(out)
+
+    res_usm = cos_func(x1_usm, out=out_usm, order=order)
+    return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
 _conj_docstring = """
@@ -462,36 +729,6 @@ def _call_conj(src, dst, sycl_queue, depends=None):
 conj_func = UnaryElementwiseFunc(
     "conj", ti._conj_result_type, _call_conj, _conj_docstring
 )
-
-
-def dpnp_cos(x, out=None, order="K"):
-    """
-    Invokes cos() function from pybind11 extension of OneMKL VM if possible.
-
-    Otherwise fully relies on dpctl.tensor implementation for cos() function.
-
-    """
-
-    def _call_cos(src, dst, sycl_queue, depends=None):
-        """A callback to register in UnaryElementwiseFunc class of dpctl.tensor"""
-
-        if depends is None:
-            depends = []
-
-        if vmi._mkl_cos_to_call(sycl_queue, src, dst):
-            # call pybind11 extension for cos() function from OneMKL VM
-            return vmi._cos(sycl_queue, src, dst, depends)
-        return ti._cos(src, dst, sycl_queue, depends)
-
-    # dpctl.tensor only works with usm_ndarray
-    x1_usm = dpnp.get_usm_ndarray(x)
-    out_usm = None if out is None else dpnp.get_usm_ndarray(out)
-
-    func = UnaryElementwiseFunc(
-        "cos", ti._cos_result_type, _call_cos, _cos_docstring
-    )
-    res_usm = func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
 
 
 def dpnp_conj(x, out=None, order="K"):
@@ -980,8 +1217,8 @@ Returns:
 """
 
 
-leftt_shift_func = BinaryElementwiseFunc(
-    "bitwise_leftt_shift",
+left_shift_func = BinaryElementwiseFunc(
+    "bitwise_left_shift",
     ti._bitwise_left_shift_result_type,
     ti._bitwise_left_shift,
     _left_shift_docstring_,
@@ -996,7 +1233,7 @@ def dpnp_left_shift(x1, x2, out=None, order="K"):
     x2_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x2)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
-    res_usm = leftt_shift_func(
+    res_usm = left_shift_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
     return dpnp_array._create_from_usm_ndarray(res_usm)
@@ -1789,7 +2026,9 @@ def dpnp_signbit(x, out=None, order="K"):
 
 _sin_docstring = """
 sin(x, out=None, order='K')
+
 Computes sine for each element `x_i` of input array `x`.
+
 Args:
     x (dpnp.ndarray):
         Input array, expected to have numeric data type.
@@ -2015,6 +2254,59 @@ def dpnp_subtract(x1, x2, out=None, order="K"):
     res_usm = subtract_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
+    return dpnp_array._create_from_usm_ndarray(res_usm)
+
+
+_tan_docstring = """
+tan(x, out=None, order='K')
+
+Computes tangent for each element `x_i` for input array `x`.
+
+Args:
+    x (dpnp.ndarray):
+        Input array, expected to have numeric data type.
+    out ({None, dpnp.ndarray}, optional):
+        Output array to populate. Array must have the correct
+        shape and the expected data type.
+    order ("C","F","A","K", optional): memory layout of the new
+        output array, if parameter `out` is `None`.
+        Default: "K".
+Return:
+    dpnp.ndarray:
+        An array containing the element-wise tangent. The data type
+        of the returned array is determined by the Type Promotion Rules.
+"""
+
+
+def _call_tan(src, dst, sycl_queue, depends=None):
+    """A callback to register in UnaryElementwiseFunc class of dpctl.tensor"""
+
+    if depends is None:
+        depends = []
+
+    if vmi._mkl_tan_to_call(sycl_queue, src, dst):
+        # call pybind11 extension for tan() function from OneMKL VM
+        return vmi._tan(sycl_queue, src, dst, depends)
+    return ti._tan(src, dst, sycl_queue, depends)
+
+
+tan_func = UnaryElementwiseFunc(
+    "tan", ti._tan_result_type, _call_tan, _tan_docstring
+)
+
+
+def dpnp_tan(x, out=None, order="K"):
+    """
+    Invokes tan() function from pybind11 extension of OneMKL VM if possible.
+
+    Otherwise fully relies on dpctl.tensor implementation for tan() function.
+
+    """
+    # dpctl.tensor only works with usm_ndarray
+    x1_usm = dpnp.get_usm_ndarray(x)
+    out_usm = None if out is None else dpnp.get_usm_ndarray(out)
+
+    res_usm = tan_func(x1_usm, out=out_usm, order=order)
     return dpnp_array._create_from_usm_ndarray(res_usm)
 
 

--- a/dpnp/dpnp_iface_trigonometric.py
+++ b/dpnp/dpnp_iface_trigonometric.py
@@ -48,11 +48,16 @@ from dpnp.dpnp_utils import *
 
 from .dpnp_algo.dpnp_elementwise_common import (
     check_nd_call_func,
+    dpnp_acos,
+    dpnp_asin,
+    dpnp_atan,
+    dpnp_atan2,
     dpnp_cos,
     dpnp_log,
     dpnp_sin,
     dpnp_sqrt,
     dpnp_square,
+    dpnp_tan,
 )
 
 __all__ = [
@@ -89,45 +94,67 @@ __all__ = [
 ]
 
 
-def arccos(x1):
+def arccos(
+    x,
+    /,
+    out=None,
+    *,
+    order="K",
+    where=True,
+    dtype=None,
+    subok=True,
+    **kwargs,
+):
     """
     Trigonometric inverse cosine, element-wise.
 
     For full documentation refer to :obj:`numpy.arccos`.
 
+    Returns
+    -------
+    out : dpnp.ndarray
+        The inverse cosine of each element of `x`.
+
     Limitations
     -----------
-    Input array is supported as :class:`dpnp.ndarray`.
+    Parameter `x` is only supported as either :class:`dpnp.ndarray` or :class:`dpctl.tensor.usm_ndarray`.
+    Parameters `where`, `dtype` and `subok` are supported with their default values.
+    Keyword argument `kwargs` is currently unsupported.
+    Otherwise the function will be executed sequentially on CPU.
     Input array data types are limited by supported DPNP :ref:`Data types`.
 
     See Also
     --------
-    :obj:`dpnp.cos` : Cosine element-wise.
+    :obj:`dpnp.cos` : Trigonometric cosine, element-wise.
     :obj:`dpnp.arctan` : Trigonometric inverse tangent, element-wise.
-    :obj:`dpnp.arcsin` : Inverse sine, element-wise.
+    :obj:`dpnp.arcsin` : Trigonometric inverse sine, element-wise.
+    :obj:`dpnp.arccosh` : Hyperbolic inverse cosine, element-wise.
 
     Examples
     --------
     >>> import dpnp as np
     >>> x = np.array([1, -1])
-    >>> out = np.arccos(x)
-    >>> [i for i in out]
-    [0.0,  3.14159265]
+    >>> np.arccos(x)
+    array([0.0,  3.14159265])
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(
-        x1, copy_when_strides=False, copy_when_nondefault_queue=False
+    return check_nd_call_func(
+        numpy.arccos,
+        dpnp_acos,
+        x,
+        out=out,
+        where=where,
+        order=order,
+        dtype=dtype,
+        subok=subok,
+        **kwargs,
     )
-    if x1_desc:
-        return dpnp_arccos(x1_desc).get_pyobj()
-
-    return call_origin(numpy.arccos, x1, **kwargs)
 
 
 def arccosh(x1):
     """
-    Trigonometric inverse hyperbolic cosine, element-wise.
+    Inverse hyperbolic cosine, element-wise.
 
     For full documentation refer to :obj:`numpy.arccosh`.
 
@@ -163,50 +190,62 @@ def arccosh(x1):
     return call_origin(numpy.arccosh, x1, **kwargs)
 
 
-def arcsin(x1, out=None, **kwargs):
+def arcsin(
+    x,
+    /,
+    out=None,
+    *,
+    order="K",
+    where=True,
+    dtype=None,
+    subok=True,
+    **kwargs,
+):
     """
     Inverse sine, element-wise.
 
     For full documentation refer to :obj:`numpy.arcsin`.
 
+    Returns
+    -------
+    out : dpnp.ndarray
+        The inverse sine of each element of `x`.
+
     Limitations
     -----------
-    Input array is supported as :class:`dpnp.ndarray`.
+    Parameter `x` is only supported as either :class:`dpnp.ndarray` or :class:`dpctl.tensor.usm_ndarray`.
+    Parameters `where`, `dtype` and `subok` are supported with their default values.
     Keyword argument `kwargs` is currently unsupported.
+    Otherwise the function will be executed sequentially on CPU.
     Input array data types are limited by supported DPNP :ref:`Data types`.
 
     See Also
     --------
     :obj:`dpnp.sin` : Trigonometric sine, element-wise.
-    :obj:`dpnp.cos` : Cosine element-wise.
-    :obj:`dpnp.arccos` : Trigonometric inverse cosine, element-wise.
-    :obj:`dpnp.tan` : Compute tangent element-wise.
     :obj:`dpnp.arctan` : Trigonometric inverse tangent, element-wise.
-    :obj:`dpnp.arctan2` : Element-wise arc tangent of ``x1/x2``
-                          choosing the quadrant correctly.
+    :obj:`dpnp.arccos` : Trigonometric inverse cosine, element-wise.
+    :obj:`dpnp.arcsinh` : Hyperbolic inverse sine, element-wise.
 
     Examples
     --------
     >>> import dpnp as np
     >>> x = np.array([0, 1, -1])
-    >>> out = np.arcsin(x)
-    >>> [i for i in out]
-    [0.0, 1.5707963267948966, -1.5707963267948966]
+    >>> np.arcsin(x)
+    array([0.0, 1.5707963267948966, -1.5707963267948966])
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(
-        x1, copy_when_strides=False, copy_when_nondefault_queue=False
+    return check_nd_call_func(
+        numpy.arcsin,
+        dpnp_asin,
+        x,
+        out=out,
+        where=where,
+        order=order,
+        dtype=dtype,
+        subok=subok,
+        **kwargs,
     )
-    if x1_desc:
-        out_desc = (
-            dpnp.get_dpnp_descriptor(out, copy_when_nondefault_queue=False)
-            if out is not None
-            else None
-        )
-        return dpnp_arcsin(x1_desc, out_desc).get_pyobj()
-
-    return call_origin(numpy.arcsin, x1, out=out, **kwargs)
 
 
 def arcsinh(x1):
@@ -239,51 +278,143 @@ def arcsinh(x1):
     return call_origin(numpy.arcsinh, x1, **kwargs)
 
 
-def arctan(x1, out=None, **kwargs):
+def arctan(
+    x,
+    /,
+    out=None,
+    *,
+    order="K",
+    where=True,
+    dtype=None,
+    subok=True,
+    **kwargs,
+):
     """
     Trigonometric inverse tangent, element-wise.
 
     For full documentation refer to :obj:`numpy.arctan`.
 
+    Returns
+    -------
+    out : dpnp.ndarray
+        The inverse tangent of each element of `x`.
+
     Limitations
     -----------
-    Input array is supported as :class:`dpnp.ndarray`.
+    Parameter `x` is only supported as either :class:`dpnp.ndarray` or :class:`dpctl.tensor.usm_ndarray`.
+    Parameters `where`, `dtype` and `subok` are supported with their default values.
     Keyword argument `kwargs` is currently unsupported.
+    Otherwise the function will be executed sequentially on CPU.
     Input array data types are limited by supported DPNP :ref:`Data types`.
 
     See Also
     --------
-    :obj:`dpnp.arctan2` : Element-wise arc tangent of ``x1/x2``
-                          choosing the quadrant correctly.
+    :obj:`dpnp.arctan2` : Element-wise arc tangent of `x1/x2` choosing the quadrant correctly.
     :obj:`dpnp.angle` : Argument of complex values.
+    :obj:`dpnp.tan` : Trigonometric tangent, element-wise.
+    :obj:`dpnp.arcsin` : Trigonometric inverse sine, element-wise.
+    :obj:`dpnp.arccos` : Trigonometric inverse cosine, element-wise.
+    :obj:`dpnp.arctanh` : Inverse hyperbolic tangent, element-wise.
 
     Examples
     --------
     >>> import dpnp as np
     >>> x = np.array([0, 1])
-    >>> out = np.arctan(x)
-    >>> [i for i in out]
-    [0.0, 0.78539816]
+    >>> np.arctan(x)
+    array([0.0, 0.78539816])
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(
-        x1, copy_when_strides=False, copy_when_nondefault_queue=False
+    return check_nd_call_func(
+        numpy.arctan,
+        dpnp_atan,
+        x,
+        out=out,
+        where=where,
+        order=order,
+        dtype=dtype,
+        subok=subok,
+        **kwargs,
     )
-    if x1_desc:
-        out_desc = (
-            dpnp.get_dpnp_descriptor(out, copy_when_nondefault_queue=False)
-            if out is not None
-            else None
-        )
-        return dpnp_arctan(x1_desc, out_desc).get_pyobj()
 
-    return call_origin(numpy.arctan, x1, out=out, **kwargs)
+
+def arctan2(
+    x1,
+    x2,
+    /,
+    out=None,
+    *,
+    where=True,
+    order="K",
+    dtype=None,
+    subok=True,
+    **kwargs,
+):
+    """
+    Element-wise arc tangent of `x1/x2` choosing the quadrant correctly.
+
+    For full documentation refer to :obj:`numpy.arctan2`.
+
+    Returns
+    -------
+    out : dpnp.ndarray
+        The inverse tangent of `x1/x2`, element-wise.
+
+    Limitations
+    -----------
+    Parameters `x1` and `x2` are supported as either scalar, :class:`dpnp.ndarray`
+    or :class:`dpctl.tensor.usm_ndarray`, but both `x1` and `x2` can not be scalars at the same time.
+    Parameters `where`, `dtype` and `subok` are supported with their default values.
+    Keyword arguments `kwargs` are currently unsupported.
+    Otherwise the function will be executed sequentially on CPU.
+    Input array data types are limited by supported DPNP :ref:`Data types`.
+
+    See Also
+    --------
+    :obj:`dpnp.arctan` : Trigonometric inverse tangent, element-wise.
+    :obj:`dpnp.tan` : Compute tangent element-wise.
+    :obj:`dpnp.angle` : Return the angle of the complex argument.
+    :obj:`dpnp.arcsin` : Trigonometric inverse sine, element-wise.
+    :obj:`dpnp.arccos` : Trigonometric inverse cosine, element-wise.
+    :obj:`dpnp.arctanh` : Inverse hyperbolic tangent, element-wise.
+
+    Examples
+    --------
+    >>> import dpnp as np
+    >>> x1 = np.array([1., -1.])
+    >>> x2 = np.array([0., 0.])
+    >>> np.arctan2(x1, x2)
+    array([1.57079633, -1.57079633])
+
+    >>> x1 = np.array([0., 0., np.inf])
+    >>> x2 = np.array([+0., -0., np.inf])
+    >>> np.arctan2(x1, x2)
+    array([0.0 , 3.14159265, 0.78539816])
+
+    >>> x1 = np.array([-1, +1, +1, -1])
+    >>> x2 = np.array([-1, -1, +1, +1])
+    >>> np.arctan2(x1, x2) * 180 / np.pi
+    array([-135.,  -45.,   45.,  135.])
+
+    """
+
+    return check_nd_call_func(
+        numpy.arctan2,
+        dpnp_atan2,
+        x1,
+        x2,
+        out=out,
+        where=where,
+        order=order,
+        dtype=dtype,
+        subok=subok,
+        **kwargs,
+    )
 
 
 def arctanh(x1):
     """
-    Trigonometric hyperbolic inverse tangent, element-wise.
+    Hyperbolic inverse tangent, element-wise.
 
     For full documentation refer to :obj:`numpy.arctanh`.
 
@@ -341,76 +472,6 @@ def cbrt(x1):
     return call_origin(numpy.cbrt, x1, **kwargs)
 
 
-def arctan2(x1, x2, dtype=None, out=None, where=True, **kwargs):
-    """
-    Element-wise arc tangent of ``x1/x2`` choosing the quadrant correctly.
-
-    For full documentation refer to :obj:`numpy.arctan2`.
-
-    Limitations
-    -----------
-    Parameters `x1` and `x2` are supported as either :obj:`dpnp.ndarray` or scalar.
-    Parameters `dtype`, `out` and `where` are supported with their default values.
-    Keyword argument `kwargs` is currently unsupported.
-    Otherwise the function will be executed sequentially on CPU.
-    Input array data types are limited by supported DPNP :ref:`Data types`.
-
-    See Also
-    --------
-    :obj:`dpnp.arctan` : Trigonometric inverse tangent, element-wise.
-    :obj:`dpnp.tan` : Compute tangent element-wise.
-    :obj:`dpnp.angle` : Return the angle of the complex argument.
-
-    Examples
-    --------
-    >>> import dpnp as np
-    >>> x1 = np.array([1., -1.])
-    >>> x2 = np.array([0., 0.])
-    >>> out = np.arctan2(x1, x2)
-    >>> [i for i in out]
-    [1.57079633, -1.57079633]
-
-    """
-
-    x1_is_scalar = dpnp.isscalar(x1)
-    x2_is_scalar = dpnp.isscalar(x2)
-    x1_desc = dpnp.get_dpnp_descriptor(
-        x1, copy_when_strides=False, copy_when_nondefault_queue=False
-    )
-    x2_desc = dpnp.get_dpnp_descriptor(
-        x2, copy_when_strides=False, copy_when_nondefault_queue=False
-    )
-
-    if x1_desc and x2_desc and not kwargs:
-        if not x1_desc and not x1_is_scalar:
-            pass
-        elif not x2_desc and not x2_is_scalar:
-            pass
-        elif x1_is_scalar and x2_is_scalar:
-            pass
-        elif x1_desc and x1_desc.ndim == 0:
-            pass
-        elif x2_desc and x2_desc.ndim == 0:
-            pass
-        elif dtype is not None:
-            pass
-        elif not where:
-            pass
-        else:
-            out_desc = (
-                dpnp.get_dpnp_descriptor(out, copy_when_nondefault_queue=False)
-                if out is not None
-                else None
-            )
-            return dpnp_arctan2(
-                x1_desc, x2_desc, dtype, out_desc, where
-            ).get_pyobj()
-
-    return call_origin(
-        numpy.arctan2, x1, x2, dtype=dtype, out=out, where=where, **kwargs
-    )
-
-
 def cos(
     x,
     /,
@@ -440,6 +501,13 @@ def cos(
     Otherwise the function will be executed sequentially on CPU.
     Input array data types are limited by supported DPNP :ref:`Data types`.
 
+    See Also
+    --------
+    :obj:`dpnp.arccos` : Trigonometric inverse cosine, element-wise.
+    :obj:`dpnp.sin` : Trigonometric sine, element-wise.
+    :obj:`dpnp.tan` : Trigonometric tangent, element-wise.
+    :obj:`dpnp.cosh` : Hyperbolic cosine, element-wise.
+
     Examples
     --------
     >>> import dpnp as np
@@ -464,7 +532,7 @@ def cos(
 
 def cosh(x1):
     """
-    Trigonometric hyperbolic cosine, element-wise.
+    Hyperbolic cosine, element-wise.
 
     For full documentation refer to :obj:`numpy.cosh`.
 
@@ -546,7 +614,7 @@ def degrees(x1):
 
 def exp(x1, out=None, **kwargs):
     """
-    Trigonometric exponent, element-wise.
+    Calculate the exponential, element-wise.
 
     For full documentation refer to :obj:`numpy.exp`.
 
@@ -586,7 +654,7 @@ def exp(x1, out=None, **kwargs):
 
 def exp2(x1):
     """
-    Trigonometric exponent2, element-wise.
+    Calculate `2**p` for all `p` in the input array.
 
     For full documentation refer to :obj:`numpy.exp2`.
 
@@ -621,7 +689,7 @@ def exp2(x1):
 
 def expm1(x1):
     """
-    Trigonometric exponent minus 1, element-wise.
+    Return the exponential of the input array minus one, element-wise.
 
     For full documentation refer to :obj:`numpy.expm1`.
 
@@ -810,7 +878,7 @@ def log(
 
 def log10(x1):
     """
-    Trigonometric logarithm, element-wise.
+    Return the base 10 logarithm of the input array, element-wise.
 
     For full documentation refer to :obj:`numpy.log10`.
 
@@ -840,7 +908,7 @@ def log10(x1):
 
 def log1p(x1):
     """
-    Trigonometric logarithm, element-wise.
+    Return the natural logarithm of one plus the input array, element-wise.
 
     For full documentation refer to :obj:`numpy.log1p`.
 
@@ -874,7 +942,7 @@ def log1p(x1):
 
 def log2(x1):
     """
-    Trigonometric logarithm, element-wise.
+    Return the base 2 logarithm of the input array, element-wise.
 
     For full documentation refer to :obj:`numpy.log2`.
 
@@ -1025,9 +1093,10 @@ def sin(
 
     See Also
     --------
-    :obj:`dpnp.arcsin` : Inverse sine, element-wise.
+    :obj:`dpnp.arcsin` : Trigonometric inverse sine, element-wise.
+    :obj:`dpnp.cos` : Trigonometric cosine, element-wise.
+    :obj:`dpnp.tan` : Trigonometric tangent, element-wise.
     :obj:`dpnp.sinh` : Hyperbolic sine, element-wise.
-    :obj:`dpnp.cos` : Cosine element-wise.
 
     Examples
     --------
@@ -1053,7 +1122,7 @@ def sin(
 
 def sinh(x1):
     """
-    Trigonometric hyperbolic sine, element-wise.
+    Hyperbolic sine, element-wise.
 
     For full documentation refer to :obj:`numpy.sinh`.
 
@@ -1202,40 +1271,62 @@ def square(
     )
 
 
-def tan(x1, out=None, **kwargs):
+def tan(
+    x,
+    /,
+    out=None,
+    *,
+    order="K",
+    where=True,
+    dtype=None,
+    subok=True,
+    **kwargs,
+):
     """
-    Compute tangent element-wise.
+    Trigonometric tangent, element-wise.
 
     For full documentation refer to :obj:`numpy.tan`.
 
+    Returns
+    -------
+    out : dpnp.ndarray
+        The tangent of each element of `x`.
+
     Limitations
     -----------
-    Input array is supported as :class:`dpnp.ndarray`.
+    Parameter `x` is only supported as either :class:`dpnp.ndarray` or :class:`dpctl.tensor.usm_ndarray`.
+    Parameters `where`, `dtype` and `subok` are supported with their default values.
     Keyword argument `kwargs` is currently unsupported.
+    Otherwise the function will be executed sequentially on CPU.
     Input array data types are limited by supported DPNP :ref:`Data types`.
+
+    See Also
+    --------
+    :obj:`dpnp.arctan` : Trigonometric inverse tangent, element-wise.
+    :obj:`dpnp.sin` : Trigonometric sine, element-wise.
+    :obj:`dpnp.cos` : Trigonometric cosine, element-wise.
+    :obj:`dpnp.tanh` : Hyperbolic tangent, element-wise.
 
     Examples
     --------
     >>> import dpnp as np
     >>> x = np.array([-np.pi, np.pi/2, np.pi])
-    >>> out = np.tan(x)
-    >>> [i for i in out]
-    [1.22460635e-16, 1.63317787e+16, -1.22460635e-16]
+    >>> np.tan(x)
+    array([1.22460635e-16, 1.63317787e+16, -1.22460635e-16])
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(
-        x1, copy_when_strides=False, copy_when_nondefault_queue=False
+    return check_nd_call_func(
+        numpy.tan,
+        dpnp_tan,
+        x,
+        out=out,
+        where=where,
+        order=order,
+        dtype=dtype,
+        subok=subok,
+        **kwargs,
     )
-    if x1_desc:
-        out_desc = (
-            dpnp.get_dpnp_descriptor(out, copy_when_nondefault_queue=False)
-            if out is not None
-            else None
-        )
-        return dpnp_tan(x1_desc, out_desc).get_pyobj()
-
-    return call_origin(numpy.tan, x1, out=out, **kwargs)
 
 
 def tanh(x1):

--- a/tests/skipped_tests_gpu_no_fp64.tbl
+++ b/tests/skipped_tests_gpu_no_fp64.tbl
@@ -78,8 +78,8 @@ tests/test_strides.py::test_strides_tan[(10,)-None]
 
 tests/test_sycl_queue.py::test_array_creation[opencl:gpu:0-arange-arg0-kwargs0]
 tests/test_sycl_queue.py::test_array_creation[level_zero:gpu:0-arange-arg0-kwargs0]
-tests/test_sycl_queue.py::test_1in_1out[opencl:gpu:0-gradient-data10]
-tests/test_sycl_queue.py::test_1in_1out[level_zero:gpu:0-gradient-data10]
+tests/test_sycl_queue.py::test_1in_1out[opencl:gpu:0-gradient-data14]
+tests/test_sycl_queue.py::test_1in_1out[level_zero:gpu:0-gradient-data14]
 tests/test_sycl_queue.py::test_eig[opencl:gpu:0]
 tests/test_sycl_queue.py::test_eig[level_zero:gpu:0]
 tests/test_sycl_queue.py::test_eigh[opencl:gpu:0]
@@ -778,14 +778,9 @@ tests/third_party/cupy/math_tests/test_sumprod.py::TestNansumNanprodLong_param_3
 tests/third_party/cupy/math_tests/test_sumprod.py::TestNansumNanprodLong_param_31_{axis=1, func='nanprod', keepdims=False, shape=(20, 30, 40), transpose_axes=False}::test_nansum_axis_transposed
 tests/third_party/cupy/math_tests/test_sumprod.py::TestDiff::test_diff_2dim_with_scalar_append
 
-tests/third_party/cupy/math_tests/test_trigonometric.py::TestTrigonometric::test_arccos
-tests/third_party/cupy/math_tests/test_trigonometric.py::TestTrigonometric::test_arcsin
-tests/third_party/cupy/math_tests/test_trigonometric.py::TestTrigonometric::test_arctan
-tests/third_party/cupy/math_tests/test_trigonometric.py::TestTrigonometric::test_arctan2
 tests/third_party/cupy/math_tests/test_trigonometric.py::TestTrigonometric::test_deg2rad
 tests/third_party/cupy/math_tests/test_trigonometric.py::TestTrigonometric::test_hypot
 tests/third_party/cupy/math_tests/test_trigonometric.py::TestTrigonometric::test_rad2deg
-tests/third_party/cupy/math_tests/test_trigonometric.py::TestTrigonometric::test_tan
 
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_6_{a_shape=(3, 2), b_shape=(3, 2), shape=(4, 3, 2)}::test_beta
 tests/third_party/cupy/random_tests/test_distributions.py::TestDistributionsBeta_param_7_{a_shape=(3, 2), b_shape=(3, 2), shape=(3, 2)}::test_beta

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -225,8 +225,14 @@ def test_meshgrid(device_x, device_y):
     "func,data",
     [
         pytest.param("abs", [-1.2, 1.2]),
+        pytest.param("arccos", [-0.5, 0.0, 0.5]),
+        pytest.param("arcsin", [-0.5, 0.0, 0.5]),
+        pytest.param("arctan", [-1.0, 0.0, 1.0]),
         pytest.param("ceil", [-1.7, -1.5, -0.2, 0.2, 1.5, 1.7, 2.0]),
         pytest.param("conjugate", [[1.0 + 1.0j, 0.0], [0.0, 1.0 + 1.0j]]),
+        pytest.param(
+            "cos", [-dpnp.pi / 2, -dpnp.pi / 4, 0.0, dpnp.pi / 4, dpnp.pi / 2]
+        ),
         pytest.param("copy", [1.0, 2.0, 3.0]),
         pytest.param("cumprod", [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
         pytest.param("cumsum", [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
@@ -243,8 +249,14 @@ def test_meshgrid(device_x, device_y):
         pytest.param("prod", [1.0, 2.0]),
         pytest.param("sign", [-5.0, 0.0, 4.5]),
         pytest.param("signbit", [-5.0, 0.0, 4.5]),
+        pytest.param(
+            "sin", [-dpnp.pi / 2, -dpnp.pi / 4, 0.0, dpnp.pi / 4, dpnp.pi / 2]
+        ),
         pytest.param("sqrt", [1.0, 3.0, 9.0]),
         pytest.param("sum", [1.0, 2.0]),
+        pytest.param(
+            "tan", [-dpnp.pi / 2, -dpnp.pi / 4, 0.0, dpnp.pi / 4, dpnp.pi / 2]
+        ),
         pytest.param("trapz", [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]),
         pytest.param("trunc", [-1.7, -1.5, -0.2, 0.2, 1.5, 1.7, 2.0]),
     ],
@@ -255,13 +267,13 @@ def test_meshgrid(device_x, device_y):
     ids=[device.filter_string for device in valid_devices],
 )
 def test_1in_1out(func, data, device):
-    x_orig = numpy.array(data)
-    expected = getattr(numpy, func)(x_orig)
-
     x = dpnp.array(data, device=device)
     result = getattr(dpnp, func)(x)
 
-    assert_allclose(result, expected)
+    x_orig = dpnp.asnumpy(x)
+    expected = getattr(numpy, func)(x_orig)
+
+    assert_allclose(result, expected, rtol=2e-07)
 
     expected_queue = x.get_array().sycl_queue
     result_queue = result.get_array().sycl_queue
@@ -310,6 +322,11 @@ def test_proj(device):
             "allclose",
             [1.0, dpnp.inf, -dpnp.inf],
             [1.0, dpnp.inf, -dpnp.inf],
+        ),
+        pytest.param(
+            "arctan2",
+            [[-1, +1, +1, -1]],
+            [[-1, -1, +1, +1]],
         ),
         pytest.param("copysign", [0.0, 1.0, 2.0], [-1.0, 0.0, 1.0]),
         pytest.param("cross", [1.0, 2.0, 3.0], [4.0, 5.0, 6.0]),

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -275,14 +275,26 @@ def test_meshgrid(usm_type_x, usm_type_y):
 @pytest.mark.parametrize(
     "func,data",
     [
+        pytest.param("arccos", [-0.5, 0.0, 0.5]),
+        pytest.param("arcsin", [-0.5, 0.0, 0.5]),
+        pytest.param("arctan", [-1.0, 0.0, 1.0]),
         pytest.param("ceil", [-1.7, -1.5, -0.2, 0.2, 1.5, 1.7, 2.0]),
         pytest.param("conjugate", [[1.0 + 1.0j, 0.0], [0.0, 1.0 + 1.0j]]),
+        pytest.param(
+            "cos", [-dp.pi / 2, -dp.pi / 4, 0.0, dp.pi / 4, dp.pi / 2]
+        ),
         pytest.param("floor", [-1.7, -1.5, -0.2, 0.2, 1.5, 1.7, 2.0]),
         pytest.param("negative", [1.0, 0.0, -1.0]),
         pytest.param("proj", [complex(1.0, 2.0), complex(dp.inf, -1.0)]),
         pytest.param("sign", [-5.0, 0.0, 4.5]),
         pytest.param("signbit", [-5.0, 0.0, 4.5]),
+        pytest.param(
+            "sin", [-dp.pi / 2, -dp.pi / 4, 0.0, dp.pi / 4, dp.pi / 2]
+        ),
         pytest.param("sqrt", [1.0, 3.0, 9.0]),
+        pytest.param(
+            "tan", [-dp.pi / 2, -dp.pi / 4, 0.0, dp.pi / 4, dp.pi / 2]
+        ),
         pytest.param("trunc", [-1.7, -1.5, -0.2, 0.2, 1.5, 1.7, 2.0]),
     ],
 )
@@ -301,6 +313,11 @@ def test_1in_1out(func, data, usm_type):
             "allclose",
             [[1.2, -0.0], [-7, 2.34567]],
             [[1.2, 0.0], [-7, 2.34567]],
+        ),
+        pytest.param(
+            "arctan2",
+            [[-1, +1, +1, -1]],
+            [[-1, -1, +1, +1]],
         ),
         pytest.param(
             "dot",

--- a/tests/third_party/cupy/math_tests/test_trigonometric.py
+++ b/tests/third_party/cupy/math_tests/test_trigonometric.py
@@ -1,17 +1,18 @@
 import unittest
 
+from tests.helper import has_support_aspect64
 from tests.third_party.cupy import testing
 
 
 class TestTrigonometric(unittest.TestCase):
     @testing.for_all_dtypes(no_complex=True)
-    @testing.numpy_cupy_allclose(atol=1e-5, type_check=False)
+    @testing.numpy_cupy_allclose(atol=1e-5, type_check=has_support_aspect64())
     def check_unary(self, name, xp, dtype):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return getattr(xp, name)(a)
 
     @testing.for_all_dtypes(no_complex=True)
-    @testing.numpy_cupy_allclose(atol=1e-5)
+    @testing.numpy_cupy_allclose(atol=1e-5, type_check=has_support_aspect64())
     def check_binary(self, name, xp, dtype):
         a = testing.shaped_arange((2, 3), xp, dtype)
         b = testing.shaped_reverse_arange((2, 3), xp, dtype)


### PR DESCRIPTION
The PR changes the implementation of `dpnp.arccos`, `dpnp.arcsin`, `dpnp.arctan`, `dpnp.arctan2`, and `dpnp.tan`. These functions now invoke `oneapi::mkl::vm` implementation from pybind11 extension of OneMKL VM if possible or uses `dpctl.tensor` implementation if not.	
 
- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
