### PR TITLE
Temporary mute tests for dpnp.sum

### DIFF
--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -1203,6 +1203,9 @@ def test_sum_empty_out(dtype):
 @pytest.mark.parametrize("transpose", [True, False])
 @pytest.mark.parametrize("keepdims", [True, False])
 def test_sum(shape, dtype_in, dtype_out, transpose, keepdims):
+    if transpose and shape in [(1, 2, 3), (3, 3, 3)]:
+        pytest.skip("muted due to issue dpctl-1391")
+
     size = numpy.prod(shape)
     a_np = numpy.arange(size).astype(dtype_in).reshape(shape)
     a = dpnp.asarray(a_np)

--- a/tests/third_party/cupy/math_tests/test_sumprod.py
+++ b/tests/third_party/cupy/math_tests/test_sumprod.py
@@ -117,6 +117,7 @@ class TestSumprod(unittest.TestCase):
         else:
             return a.sum(axis=1)
 
+    @pytest.mark.skip("muted due to issue dpctl-1391")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_sum_axis_transposed(self, xp, dtype):
@@ -127,6 +128,7 @@ class TestSumprod(unittest.TestCase):
         else:
             return a.sum(axis=1)
 
+    @pytest.mark.skip("muted due to issue dpctl-1391")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_sum_axis_transposed2(self, xp, dtype):


### PR DESCRIPTION
The PR is intended to temporary mute tests for `dpnp.sum` which are failing due to dpctl issue [#1391](https://github.com/IntelPython/dpctl/issues/1391)

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
