### PR TITLE
Correct return of object type at zero copy

### DIFF
--- a/dpnp/dpnp_container.py
+++ b/dpnp/dpnp_container.py
@@ -130,7 +130,7 @@ def asarray(
         )
 
         # return x1 if dpctl returns a zero copy of x1_obj
-        if array_obj is x1_obj:
+        if array_obj is x1_obj and isinstance(x1, dpnp_array):
             return x1
 
     return dpnp_array(array_obj.shape, buffer=array_obj, order=order)

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -1,10 +1,12 @@
 import dpctl
+import dpctl.tensor as dpt
 import numpy
 import pytest
 from dpctl.utils import ExecutionPlacementError
 from numpy.testing import assert_allclose, assert_array_equal, assert_raises
 
 import dpnp
+from dpnp.dpnp_array import dpnp_array
 
 from .helper import assert_dtype_allclose, get_all_dtypes, is_win_platform
 
@@ -1074,6 +1076,23 @@ def test_array_copy(device, func, device_param, queue_param):
     result = dpnp.array(dpnp_data, **kwargs)
 
     assert_sycl_queue_equal(result.sycl_queue, dpnp_data.sycl_queue)
+
+
+@pytest.mark.parametrize(
+    "copy", [True, False, None], ids=["True", "False", "None"]
+)
+@pytest.mark.parametrize(
+    "device",
+    valid_devices,
+    ids=[device.filter_string for device in valid_devices],
+)
+def test_array_creation_from_dpctl(copy, device):
+    dpt_data = dpt.ones((3, 3), device=device)
+
+    result = dpnp.array(dpt_data, copy=copy)
+
+    assert_sycl_queue_equal(result.sycl_queue, dpt_data.sycl_queue)
+    assert isinstance(result, dpnp_array)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -1,5 +1,6 @@
 from math import prod
 
+import dpctl.tensor as dpt
 import dpctl.utils as du
 import pytest
 
@@ -178,6 +179,17 @@ def test_array_copy(func, usm_type_x, usm_type_y):
 
     assert x.usm_type == usm_type_x
     assert y.usm_type == usm_type_y
+
+
+@pytest.mark.parametrize(
+    "copy", [True, False, None], ids=["True", "False", "None"]
+)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
+def test_array_creation_from_dpctl(copy, usm_type_x):
+    x = dpt.ones((3, 3), usm_type=usm_type_x)
+    y = dp.array(x, copy=copy)
+
+    assert y.usm_type == usm_type_x
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR solves #1570 

A new condition was added to `def asarray` function by #1526 which means if `dpctl` returns a zero copy, return the input argument. 
This did not consider the case where the input argument is `usm_ndarray` so it returned `usm_ndarray` without wrapping it in `dpnp.ndarray`

This PR updates the condition to return the input argument when dpctl return a zero copy and adds tests.


- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
