### PR TITLE
re-write dpnp.abs

### DIFF
--- a/dpnp/backend/extensions/vm/abs.hpp
+++ b/dpnp/backend/extensions/vm/abs.hpp
@@ -1,0 +1,78 @@
+//*****************************************************************************
+// Copyright (c) 2023, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//*****************************************************************************
+
+#pragma once
+
+#include <CL/sycl.hpp>
+
+#include "common.hpp"
+#include "types_matrix.hpp"
+
+namespace dpnp
+{
+namespace backend
+{
+namespace ext
+{
+namespace vm
+{
+template <typename T>
+sycl::event abs_contig_impl(sycl::queue exec_q,
+                            const std::int64_t n,
+                            const char *in_a,
+                            char *out_y,
+                            const std::vector<sycl::event> &depends)
+{
+    type_utils::validate_type_for_device<T>(exec_q);
+
+    const T *a = reinterpret_cast<const T *>(in_a);
+    T *y = reinterpret_cast<T *>(out_y);
+
+    return mkl_vm::abs(exec_q,
+                       n, // number of elements to be calculated
+                       a, // pointer `a` containing input vector of size n
+                       y, // pointer `y` to the output vector of size n
+                       depends);
+}
+
+template <typename fnT, typename T>
+struct AbsContigFactory
+{
+    fnT get()
+    {
+        if constexpr (std::is_same_v<
+                          typename types::AbsOutputType<T>::value_type, void>)
+        {
+            return nullptr;
+        }
+        else {
+            return abs_contig_impl<T>;
+        }
+    }
+};
+} // namespace vm
+} // namespace ext
+} // namespace backend
+} // namespace dpnp

--- a/dpnp/backend/extensions/vm/types_matrix.hpp
+++ b/dpnp/backend/extensions/vm/types_matrix.hpp
@@ -53,6 +53,8 @@ template <typename T>
 struct AbsOutputType
 {
     using value_type = typename std::disjunction<
+        // TODO: Add complex type here after updating the dispatching to allow
+        // output type to be different than input
         dpctl_td_ns::TypeMapResultEntry<T, double>,
         dpctl_td_ns::TypeMapResultEntry<T, float>,
         dpctl_td_ns::DefaultResultEntry<void>>::result_type;

--- a/dpnp/backend/extensions/vm/types_matrix.hpp
+++ b/dpnp/backend/extensions/vm/types_matrix.hpp
@@ -45,6 +45,21 @@ namespace types
 {
 /**
  * @brief A factory to define pairs of supported types for which
+ * MKL VM library provides support in oneapi::mkl::vm::abs<T> function.
+ *
+ * @tparam T Type of input vector `a` and of result vector `y`.
+ */
+template <typename T>
+struct AbsOutputType
+{
+    using value_type = typename std::disjunction<
+        dpctl_td_ns::TypeMapResultEntry<T, double>,
+        dpctl_td_ns::TypeMapResultEntry<T, float>,
+        dpctl_td_ns::DefaultResultEntry<void>>::result_type;
+};
+
+/**
+ * @brief A factory to define pairs of supported types for which
  * MKL VM library provides support in oneapi::mkl::vm::acos<T> function.
  *
  * @tparam T Type of input vector `a` and of result vector `y`.

--- a/dpnp/backend/extensions/vm/vm_py.cpp
+++ b/dpnp/backend/extensions/vm/vm_py.cpp
@@ -114,7 +114,7 @@ PYBIND11_MODULE(_vm_impl, m)
         };
         m.def("_abs", abs_pyapi,
               "Call `abs` function from OneMKL VM library to compute "
-              "the absolute of vector elements",
+              "the absolute value of vector elements",
               py::arg("sycl_queue"), py::arg("src"), py::arg("dst"),
               py::arg("depends") = py::list());
 

--- a/dpnp/backend/include/dpnp_iface_fptr.hpp
+++ b/dpnp/backend/include/dpnp_iface_fptr.hpp
@@ -58,11 +58,9 @@
  */
 enum class DPNPFuncName : size_t
 {
-    DPNP_FN_NONE,         /**< Very first element of the enumeration */
-    DPNP_FN_ABSOLUTE,     /**< Used in numpy.absolute() impl  */
-    DPNP_FN_ABSOLUTE_EXT, /**< Used in numpy.absolute() impl, requires extra
-                             parameters */
-    DPNP_FN_ADD,          /**< Used in numpy.add() impl  */
+    DPNP_FN_NONE,     /**< Very first element of the enumeration */
+    DPNP_FN_ABSOLUTE, /**< Used in numpy.absolute() impl  */
+    DPNP_FN_ADD,      /**< Used in numpy.add() impl  */
     DPNP_FN_ADD_EXT, /**< Used in numpy.add() impl, requires extra parameters */
     DPNP_FN_ALL,     /**< Used in numpy.all() impl  */
     DPNP_FN_ALLCLOSE,     /**< Used in numpy.allclose() impl  */

--- a/dpnp/backend/kernels/dpnp_krnl_mathematical.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_mathematical.cpp
@@ -216,14 +216,6 @@ template <typename _DataType>
 void (*dpnp_elemwise_absolute_default_c)(const void *, void *, size_t) =
     dpnp_elemwise_absolute_c<_DataType>;
 
-template <typename _DataType_input, typename _DataType_output = _DataType_input>
-DPCTLSyclEventRef (*dpnp_elemwise_absolute_ext_c)(DPCTLSyclQueueRef,
-                                                  const void *,
-                                                  void *,
-                                                  size_t,
-                                                  const DPCTLEventVectorRef) =
-    dpnp_elemwise_absolute_c<_DataType_input, _DataType_output>;
-
 template <typename _DataType_output,
           typename _DataType_input1,
           typename _DataType_input2>
@@ -1150,21 +1142,6 @@ void func_map_init_mathematical(func_map_t &fmap)
         eft_FLT, (void *)dpnp_elemwise_absolute_default_c<float>};
     fmap[DPNPFuncName::DPNP_FN_ABSOLUTE][eft_DBL][eft_DBL] = {
         eft_DBL, (void *)dpnp_elemwise_absolute_default_c<double>};
-
-    fmap[DPNPFuncName::DPNP_FN_ABSOLUTE_EXT][eft_INT][eft_INT] = {
-        eft_INT, (void *)dpnp_elemwise_absolute_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_ABSOLUTE_EXT][eft_LNG][eft_LNG] = {
-        eft_LNG, (void *)dpnp_elemwise_absolute_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_ABSOLUTE_EXT][eft_FLT][eft_FLT] = {
-        eft_FLT, (void *)dpnp_elemwise_absolute_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_ABSOLUTE_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void *)dpnp_elemwise_absolute_ext_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_ABSOLUTE_EXT][eft_C64][eft_C64] = {
-        eft_FLT,
-        (void *)dpnp_elemwise_absolute_ext_c<std::complex<float>, float>};
-    fmap[DPNPFuncName::DPNP_FN_ABSOLUTE_EXT][eft_C128][eft_C128] = {
-        eft_DBL,
-        (void *)dpnp_elemwise_absolute_ext_c<std::complex<double>, double>};
 
     fmap[DPNPFuncName::DPNP_FN_AROUND][eft_INT][eft_INT] = {
         eft_INT, (void *)dpnp_around_default_c<int32_t>};

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -33,8 +33,6 @@ from dpnp.dpnp_utils.dpnp_algo_utils cimport dpnp_descriptor
 
 cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this namespace for Enum import
     cdef enum DPNPFuncName "DPNPFuncName":
-        DPNP_FN_ABSOLUTE
-        DPNP_FN_ABSOLUTE_EXT
         DPNP_FN_ALLCLOSE
         DPNP_FN_ALLCLOSE_EXT
         DPNP_FN_ARANGE

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -50,6 +50,7 @@ from dpnp.dpnp_array import dpnp_array
 from .dpnp_algo import *
 from .dpnp_algo.dpnp_elementwise_common import (
     check_nd_call_func,
+    dpnp_abs,
     dpnp_add,
     dpnp_ceil,
     dpnp_conj,
@@ -126,7 +127,17 @@ __all__ = [
 ]
 
 
-def abs(*args, **kwargs):
+def abs(
+    x,
+    /,
+    out=None,
+    *,
+    order="K",
+    where=True,
+    dtype=None,
+    subok=True,
+    **kwargs,
+):
     """
     Calculate the absolute value element-wise.
 
@@ -140,22 +151,37 @@ def abs(*args, **kwargs):
     --------
     >>> import dpnp as np
     >>> a = np.array([-1.2, 1.2])
-    >>> result = np.abs(a)
-    >>> [x for x in result]
-    [1.2, 1.2]
+    >>> np.abs(a)
+    array([1.2, 1.2])
 
     """
 
-    return dpnp.absolute(*args, **kwargs)
+    return dpnp.absolute(
+        x,
+        out,
+        order="K",
+        where=where,
+        dtype=dtype,
+        subok=subok,
+        **kwargs,
+    )
 
 
-def absolute(x, /, out=None, *, where=True, dtype=None, subok=True, **kwargs):
+def absolute(
+    x,
+    /,
+    out=None,
+    *,
+    order="K",
+    where=True,
+    dtype=None,
+    subok=True,
+    **kwargs,
+):
     """
     Calculate the absolute value element-wise.
 
     For full documentation refer to :obj:`numpy.absolute`.
-
-    .. seealso:: :obj:`dpnp.abs` : Calculate the absolute value element-wise.
 
     Returns
     -------
@@ -170,44 +196,27 @@ def absolute(x, /, out=None, *, where=True, dtype=None, subok=True, **kwargs):
     Otherwise the function will be executed sequentially on CPU.
     Input array data types are limited by supported DPNP :ref:`Data types`.
 
+    See Also
+    --------
+    :obj:`dpnp.abs` : is a shorthand for this function..
+    :obj:`dpnp.fabs` : Calculate the absolute value element-wise excluding complex types.
+
     Examples
     --------
     >>> import dpnp as dp
     >>> a = dp.array([-1.2, 1.2])
-    >>> result = dp.absolute(a)
-    >>> [x for x in result]
-    [1.2, 1.2]
+    >>> dp.absolute(a)
+    array([1.2, 1.2])
 
     """
 
-    if out is not None:
-        pass
-    elif where is not True:
-        pass
-    elif dtype is not None:
-        pass
-    elif subok is not True:
-        pass
-    elif dpnp.isscalar(x):
-        pass
-    else:
-        x_desc = dpnp.get_dpnp_descriptor(x, copy_when_nondefault_queue=False)
-        if x_desc:
-            if x_desc.dtype == dpnp.bool:
-                # return a copy of input array "x"
-                return dpnp.array(
-                    x,
-                    dtype=x.dtype,
-                    sycl_queue=x.sycl_queue,
-                    usm_type=x.usm_type,
-                )
-            return dpnp_absolute(x_desc).get_pyobj()
-
-    return call_origin(
+    return check_nd_call_func(
         numpy.absolute,
+        dpnp_abs,
         x,
         out=out,
         where=where,
+        order=order,
         dtype=dtype,
         subok=subok,
         **kwargs,

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -127,46 +127,6 @@ __all__ = [
 ]
 
 
-def abs(
-    x,
-    /,
-    out=None,
-    *,
-    order="K",
-    where=True,
-    dtype=None,
-    subok=True,
-    **kwargs,
-):
-    """
-    Calculate the absolute value element-wise.
-
-    For full documentation refer to :obj:`numpy.absolute`.
-
-    Notes
-    -----
-    :obj:`dpnp.abs` is a shorthand for :obj:`dpnp.absolute`.
-
-    Examples
-    --------
-    >>> import dpnp as np
-    >>> a = np.array([-1.2, 1.2])
-    >>> np.abs(a)
-    array([1.2, 1.2])
-
-    """
-
-    return dpnp.absolute(
-        x,
-        out,
-        order="K",
-        where=where,
-        dtype=dtype,
-        subok=subok,
-        **kwargs,
-    )
-
-
 def absolute(
     x,
     /,
@@ -198,15 +158,22 @@ def absolute(
 
     See Also
     --------
-    :obj:`dpnp.abs` : is a shorthand for this function..
     :obj:`dpnp.fabs` : Calculate the absolute value element-wise excluding complex types.
+
+    Notes
+    -----
+    ``dpnp.abs`` is a shorthand for this function.
 
     Examples
     --------
-    >>> import dpnp as dp
-    >>> a = dp.array([-1.2, 1.2])
-    >>> dp.absolute(a)
+    >>> import dpnp as np
+    >>> a = np.array([-1.2, 1.2])
+    >>> np.absolute(a)
     array([1.2, 1.2])
+
+    >>> a = np.array(1.2 + 1j)
+    >>> np.absolute(a)
+    array(1.5620499351813308)
 
     """
 
@@ -221,6 +188,9 @@ def absolute(
         subok=subok,
         **kwargs,
     )
+
+
+abs = absolute
 
 
 def add(
@@ -835,7 +805,7 @@ def fabs(x1, **kwargs):
 
     See Also
     --------
-    :obj:`dpnp.abs` : Calculate the absolute value element-wise.
+    :obj:`dpnp.absolute` : Calculate the absolute value element-wise.
 
     Examples
     --------
@@ -2152,7 +2122,7 @@ def proj(
 
     See Also
     --------
-    :obj:`dpnp.abs` : Returns the magnitude of a complex number, element-wise.
+    :obj:`dpnp.absolute` : Returns the magnitude of a complex number, element-wise.
     :obj:`dpnp.conj` : Return the complex conjugate, element-wise.
 
     Examples

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -498,7 +498,6 @@ tests/third_party/cupy/math_tests/test_floating.py::TestFloating::test_nextafter
 
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_clip_min_max_none
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_external_clip4
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_absolute_negative
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_fmax_nan
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_fmin_nan
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -633,7 +633,6 @@ tests/third_party/cupy/math_tests/test_floating.py::TestFloating::test_nextafter
 
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_clip_min_max_none
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_external_clip4
-tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_absolute_negative
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_fmax_nan
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_fmin_nan
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -325,6 +325,7 @@ def test_meshgrid(usm_type_x, usm_type_y):
 @pytest.mark.parametrize(
     "func,data",
     [
+        pytest.param("abs", [-1.2, 1.2]),
         pytest.param("arccos", [-0.5, 0.0, 0.5]),
         pytest.param("arccosh", [1.5, 3.5, 5.0]),
         pytest.param("arcsin", [-0.5, 0.0, 0.5]),


### PR DESCRIPTION
The PR changes the implementation of `dpnp.abs`. This function now invokes `oneapi::mkl::vm` implementation from pybind11 extension of OneMKL VM if possible or uses `dpctl.tensor.abs` implementation if not.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
