### PR TITLE
identity and tri with device keywords

### DIFF
--- a/dpnp/backend/include/dpnp_iface_fptr.hpp
+++ b/dpnp/backend/include/dpnp_iface_fptr.hpp
@@ -204,8 +204,6 @@ enum class DPNPFuncName : size_t
                                   extra parameters */
     DPNP_FN_HYPOT,             /**< Used in numpy.hypot() impl  */
     DPNP_FN_IDENTITY,          /**< Used in numpy.identity() impl  */
-    DPNP_FN_IDENTITY_EXT, /**< Used in numpy.identity() impl, requires extra
-                             parameters  */
     DPNP_FN_INITVAL, /**< Used in numpy ones, ones_like, zeros, zeros_like impls
                       */
     DPNP_FN_INITVAL_EXT, /**< Used in numpy ones, ones_like, zeros, zeros_like
@@ -438,19 +436,18 @@ enum class DPNPFuncName : size_t
     DPNP_FN_TAKE,    /**< Used in numpy.take() impl  */
     DPNP_FN_TAN,     /**< Used in numpy.tan() impl  */
     DPNP_FN_TANH,    /**< Used in numpy.tanh() impl  */
-    DPNP_FN_TRANSPOSE, /**< Used in numpy.transpose() impl  */
-    DPNP_FN_TRACE,     /**< Used in numpy.trace() impl  */
-    DPNP_FN_TRACE_EXT, /**< Used in numpy.trace() impl, requires extra
-                          parameters */
-    DPNP_FN_TRAPZ,     /**< Used in numpy.trapz() impl  */
-    DPNP_FN_TRAPZ_EXT, /**< Used in numpy.trapz() impl, requires extra
-                          parameters */
-    DPNP_FN_TRI,       /**< Used in numpy.tri() impl  */
-    DPNP_FN_TRI_EXT, /**< Used in numpy.tri() impl, requires extra parameters */
-    DPNP_FN_TRIL,    /**< Used in numpy.tril() impl  */
-    DPNP_FN_TRIU,    /**< Used in numpy.triu() impl  */
-    DPNP_FN_TRUNC,   /**< Used in numpy.trunc() impl  */
-    DPNP_FN_VANDER,  /**< Used in numpy.vander() impl  */
+    DPNP_FN_TRANSPOSE,  /**< Used in numpy.transpose() impl  */
+    DPNP_FN_TRACE,      /**< Used in numpy.trace() impl  */
+    DPNP_FN_TRACE_EXT,  /**< Used in numpy.trace() impl, requires extra
+                           parameters */
+    DPNP_FN_TRAPZ,      /**< Used in numpy.trapz() impl  */
+    DPNP_FN_TRAPZ_EXT,  /**< Used in numpy.trapz() impl, requires extra
+                           parameters */
+    DPNP_FN_TRI,        /**< Used in numpy.tri() impl  */
+    DPNP_FN_TRIL,       /**< Used in numpy.tril() impl  */
+    DPNP_FN_TRIU,       /**< Used in numpy.triu() impl  */
+    DPNP_FN_TRUNC,      /**< Used in numpy.trunc() impl  */
+    DPNP_FN_VANDER,     /**< Used in numpy.vander() impl  */
     DPNP_FN_VANDER_EXT, /**< Used in numpy.vander() impl, requires extra
                            parameters */
     DPNP_FN_VAR,        /**< Used in numpy.var() impl  */

--- a/dpnp/backend/kernels/dpnp_krnl_arraycreation.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_arraycreation.cpp
@@ -393,13 +393,6 @@ void (*dpnp_identity_default_c)(void *,
                                 const size_t) = dpnp_identity_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef (*dpnp_identity_ext_c)(DPCTLSyclQueueRef,
-                                         void *,
-                                         const size_t,
-                                         const DPCTLEventVectorRef) =
-    dpnp_identity_c<_DataType>;
-
-template <typename _DataType>
 class dpnp_ones_c_kernel;
 
 template <typename _DataType>
@@ -852,15 +845,6 @@ void (*dpnp_tri_default_c)(void *, const size_t, const size_t, const int) =
     dpnp_tri_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef (*dpnp_tri_ext_c)(DPCTLSyclQueueRef,
-                                    void *,
-                                    const size_t,
-                                    const size_t,
-                                    const int,
-                                    const DPCTLEventVectorRef) =
-    dpnp_tri_c<_DataType>;
-
-template <typename _DataType>
 DPCTLSyclEventRef dpnp_tril_c(DPCTLSyclQueueRef q_ref,
                               void *array_in,
                               void *result1,
@@ -1265,21 +1249,6 @@ void func_map_init_arraycreation(func_map_t &fmap)
     fmap[DPNPFuncName::DPNP_FN_IDENTITY][eft_C128][eft_C128] = {
         eft_C128, (void *)dpnp_identity_default_c<std::complex<double>>};
 
-    fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_INT][eft_INT] = {
-        eft_INT, (void *)dpnp_identity_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_LNG][eft_LNG] = {
-        eft_LNG, (void *)dpnp_identity_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_FLT][eft_FLT] = {
-        eft_FLT, (void *)dpnp_identity_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void *)dpnp_identity_ext_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_BLN][eft_BLN] = {
-        eft_BLN, (void *)dpnp_identity_ext_c<bool>};
-    fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_C64][eft_C64] = {
-        eft_C64, (void *)dpnp_identity_ext_c<std::complex<float>>};
-    fmap[DPNPFuncName::DPNP_FN_IDENTITY_EXT][eft_C128][eft_C128] = {
-        eft_C128, (void *)dpnp_identity_ext_c<std::complex<double>>};
-
     fmap[DPNPFuncName::DPNP_FN_ONES][eft_INT][eft_INT] = {
         eft_INT, (void *)dpnp_ones_default_c<int32_t>};
     fmap[DPNPFuncName::DPNP_FN_ONES][eft_LNG][eft_LNG] = {
@@ -1430,15 +1399,6 @@ void func_map_init_arraycreation(func_map_t &fmap)
         eft_FLT, (void *)dpnp_tri_default_c<float>};
     fmap[DPNPFuncName::DPNP_FN_TRI][eft_DBL][eft_DBL] = {
         eft_DBL, (void *)dpnp_tri_default_c<double>};
-
-    fmap[DPNPFuncName::DPNP_FN_TRI_EXT][eft_INT][eft_INT] = {
-        eft_INT, (void *)dpnp_tri_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRI_EXT][eft_LNG][eft_LNG] = {
-        eft_LNG, (void *)dpnp_tri_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRI_EXT][eft_FLT][eft_FLT] = {
-        eft_FLT, (void *)dpnp_tri_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_TRI_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void *)dpnp_tri_ext_c<double>};
 
     fmap[DPNPFuncName::DPNP_FN_TRIL][eft_INT][eft_INT] = {
         eft_INT, (void *)dpnp_tril_default_c<int32_t>};

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -108,8 +108,6 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_FMOD_EXT
         DPNP_FN_FULL
         DPNP_FN_FULL_LIKE
-        DPNP_FN_IDENTITY
-        DPNP_FN_IDENTITY_EXT
         DPNP_FN_INV
         DPNP_FN_INV_EXT
         DPNP_FN_KRON
@@ -242,8 +240,6 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_TRANSPOSE
         DPNP_FN_TRAPZ
         DPNP_FN_TRAPZ_EXT
-        DPNP_FN_TRI
-        DPNP_FN_TRI_EXT
         DPNP_FN_TRIL
         DPNP_FN_TRIL_EXT
         DPNP_FN_TRIU

--- a/dpnp/dpnp_algo/dpnp_algo_arraycreation.pxi
+++ b/dpnp/dpnp_algo/dpnp_algo_arraycreation.pxi
@@ -39,12 +39,10 @@ __all__ += [
     "dpnp_copy",
     "dpnp_diag",
     "dpnp_geomspace",
-    "dpnp_identity",
     "dpnp_linspace",
     "dpnp_logspace",
     "dpnp_ptp",
     "dpnp_trace",
-    "dpnp_tri",
     "dpnp_vander",
 ]
 
@@ -164,28 +162,6 @@ cpdef utils.dpnp_descriptor dpnp_geomspace(start, stop, num, endpoint, dtype, ax
         result.get_pyobj()[0] = start
         if endpoint and result.size > 1:
             result.get_pyobj()[result.size - 1] = stop
-
-    return result
-
-
-cpdef utils.dpnp_descriptor dpnp_identity(n, result_dtype):
-    cdef DPNPFuncType dtype_in = dpnp_dtype_to_DPNPFuncType(result_dtype)
-
-    cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_IDENTITY_EXT, dtype_in, DPNP_FT_NONE)
-
-    cdef shape_type_c shape_in = (n, n)
-    cdef utils.dpnp_descriptor result = utils.create_output_descriptor(shape_in, kernel_data.return_type, None)
-
-    result_sycl_queue = result.get_array().sycl_queue
-
-    cdef c_dpctl.SyclQueue q = <c_dpctl.SyclQueue> result_sycl_queue
-    cdef c_dpctl.DPCTLSyclQueueRef q_ref = q.get_queue_ref()
-
-    cdef fptr_1out_t func = <fptr_1out_t > kernel_data.ptr
-    cdef c_dpctl.DPCTLSyclEventRef event_ref = func(q_ref, result.get_data(), n, NULL)
-
-    with nogil: c_dpctl.DPCTLEvent_WaitAndThrow(event_ref)
-    c_dpctl.DPCTLEvent_Delete(event_ref)
 
     return result
 
@@ -394,32 +370,6 @@ cpdef utils.dpnp_descriptor dpnp_trace(utils.dpnp_descriptor arr, offset=0, axis
                                                     diagonal_shape.data(),
                                                     diagonal_ndim,
                                                     NULL)  # dep_events_ref
-
-    with nogil: c_dpctl.DPCTLEvent_WaitAndThrow(event_ref)
-    c_dpctl.DPCTLEvent_Delete(event_ref)
-
-    return result
-
-
-cpdef utils.dpnp_descriptor dpnp_tri(N, M=None, k=0, dtype=dpnp.float):
-    if M is None:
-        M = N
-
-    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(dtype)
-
-    cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_TRI_EXT, param1_type, param1_type)
-
-    cdef shape_type_c shape_in = (N, M)
-    cdef utils.dpnp_descriptor result = utils.create_output_descriptor(shape_in, kernel_data.return_type, None)
-
-    result_sycl_queue = result.get_array().sycl_queue
-
-    cdef c_dpctl.SyclQueue q = <c_dpctl.SyclQueue> result_sycl_queue
-    cdef c_dpctl.DPCTLSyclQueueRef q_ref = q.get_queue_ref()
-
-    cdef custom_indexing_1out_func_ptr_t func = <custom_indexing_1out_func_ptr_t > kernel_data.ptr
-
-    cdef c_dpctl.DPCTLSyclEventRef event_ref = func(q_ref, result.get_data(), N, M, k, NULL)
 
     with nogil: c_dpctl.DPCTLEvent_WaitAndThrow(event_ref)
     c_dpctl.DPCTLEvent_Delete(event_ref)

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -90,6 +90,21 @@ __all__ = [
     "zeros_like",
 ]
 
+i1 = numpy.iinfo(numpy.int8)
+i2 = numpy.iinfo(numpy.int16)
+i4 = numpy.iinfo(numpy.int32)
+
+
+def _min_int(low, high):
+    """Get small int that fits the range"""
+    if high <= i1.max and low >= i1.min:
+        return numpy.int8
+    if high <= i2.max and low >= i2.min:
+        return numpy.int16
+    if high <= i4.max and low >= i4.min:
+        return numpy.int32
+    return numpy.int64
+
 
 def arange(
     start,
@@ -115,7 +130,7 @@ def arange(
 
     Limitations
     -----------
-    Parameter ``like`` is supported only with default value ``None``.
+    Parameter `like` is supported only with default value ``None``.
     Otherwise the function will be executed sequentially on CPU.
 
     See Also
@@ -668,8 +683,8 @@ def empty(
 
     Limitations
     -----------
-    Parameter ``order`` is supported only with values ``"C"`` and ``"F"``.
-    Parameter ``like`` is supported only with default value ``None``.
+    Parameter `order` is supported only with values ``"C"`` and ``"F"``.
+    Parameter `like` is supported only with default value ``None``.
     Otherwise the function will be executed sequentially on CPU.
 
     See Also
@@ -724,9 +739,9 @@ def empty_like(
 
     Limitations
     -----------
-    Parameter ``x1`` is supported as :class:`dpnp.dpnp_array` or :class:`dpctl.tensor.usm_ndarray`
-    Parameter ``order`` is supported with values ``"C"`` or ``"F"``.
-    Parameter ``subok`` is supported only with default value ``False``.
+    Parameter `x1` is supported as :class:`dpnp.dpnp_array` or :class:`dpctl.tensor.usm_ndarray`
+    Parameter `order` is supported with values ``"C"`` or ``"F"``.
+    Parameter `subok` is supported only with default value ``False``.
     Otherwise the function will be executed sequentially on CPU.
 
     See Also
@@ -790,8 +805,8 @@ def eye(
 
     Limitations
     -----------
-    Parameter ``order`` is supported only with values ``"C"`` and ``"F"``.
-    Parameter ``like`` is supported only with default value ``None``.
+    Parameter `order` is supported only with values ``"C"`` and ``"F"``.
+    Parameter `like` is supported only with default value ``None``.
     Otherwise the function will be executed sequentially on CPU.
 
     """
@@ -916,8 +931,8 @@ def full(
 
     Limitations
     -----------
-    Parameter ``order`` is supported only with values ``"C"`` and ``"F"``.
-    Parameter ``like`` is supported only with default value ``None``.
+    Parameter `order` is supported only with values ``"C"`` and ``"F"``.
+    Parameter `like` is supported only with default value ``None``.
     Otherwise the function will be executed sequentially on CPU.
 
     See Also
@@ -973,9 +988,9 @@ def full_like(
 
     Limitations
     -----------
-    Parameter ``x1`` is supported as :class:`dpnp.dpnp_array` or :class:`dpctl.tensor.usm_ndarray`
-    Parameter ``order`` is supported only with values ``"C"`` and ``"F"``.
-    Parameter ``subok`` is supported only with default value ``False``.
+    Parameter `x1` is supported as :class:`dpnp.dpnp_array` or :class:`dpctl.tensor.usm_ndarray`
+    Parameter `order` is supported only with values ``"C"`` and ``"F"``.
+    Parameter `subok` is supported only with default value ``False``.
     Otherwise the function will be executed sequentially on CPU.
 
     See Also
@@ -1061,7 +1076,9 @@ def geomspace(start, stop, num=50, endpoint=True, dtype=None, axis=0):
     return call_origin(numpy.geomspace, start, stop, num, endpoint, dtype, axis)
 
 
-def identity(n, dtype=None, *, like=None):
+def identity(
+    n, dtype=None, *, device=None, usm_type="device", sycl_queue=None, like=None
+):
     """
     Return the identity array.
 
@@ -1069,9 +1086,22 @@ def identity(n, dtype=None, *, like=None):
 
     For full documentation refer to :obj:`numpy.identity`.
 
+    Returns
+    -------
+    out : dpnp.ndarray
+        `n` x `n` array with its main diagonal set to one,
+        and all other elements 0.
+
     Limitations
     -----------
-    Parameter ``like`` is currently not supported .
+    Parameter `like` is currently not supported.
+    Otherwise the function will be executed sequentially on CPU.
+
+    See Also
+    --------
+    :obj:`dpnp.eye` : Return a 2-D array with ones on the diagonal and zeros elsewhere.
+    :obj:`dpnp.ones` : Return a new array setting values to one.
+    :obj:`dpnp.diag` : Return diagonal 2-D array from an input 1-D array.
 
     Examples
     --------
@@ -1086,11 +1116,16 @@ def identity(n, dtype=None, *, like=None):
         if like is not None:
             pass
         elif n < 0:
-            pass
+            raise ValueError("negative dimensions are not allowed")
         else:
             _dtype = dpnp.default_float_type() if dtype is None else dtype
-            return dpnp_identity(n, _dtype).get_pyobj()
-
+            return dpnp.eye(
+                n,
+                dtype=_dtype,
+                device=device,
+                usm_type=usm_type,
+                sycl_queue=sycl_queue,
+            )
     return call_origin(numpy.identity, n, dtype=dtype, like=like)
 
 
@@ -1115,8 +1150,8 @@ def linspace(
 
     Limitations
     -----------
-    Parameter ``axis`` is supported only with default value ``0``.
-    Parameter ``retstep`` is supported only with default value ``False``.
+    Parameter `axis` is supported only with default value ``0``.
+    Parameter `retstep` is supported only with default value ``False``.
     Otherwise the function will be executed sequentially on CPU.
 
     See Also
@@ -1198,7 +1233,7 @@ def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None, axis=0):
 
     Limitations
     -----------
-    Parameter ``axis`` is supported only with default value ``0``.
+    Parameter `axis` is supported only with default value ``0``.
 
     See Also
     --------
@@ -1252,8 +1287,8 @@ def meshgrid(*xi, copy=True, sparse=False, indexing="xy"):
     Limitations
     -----------
     Each array instance from `xi` is supported as either :class:`dpnp.dpnp_array` or :class:`dpctl.tensor.usm_ndarray`.
-    Parameter ``copy`` is supported only with default value ``True``.
-    Parameter ``sparse`` is supported only with default value ``False``.
+    Parameter `copy` is supported only with default value ``True``.
+    Parameter `sparse` is supported only with default value ``False``.
     Otherwise the function will be executed sequentially on CPU.
 
     Examples
@@ -1379,8 +1414,8 @@ def ones(
 
     Limitations
     -----------
-    Parameter ``order`` is supported only with values ``"C"`` and ``"F"``.
-    Parameter ``like`` is supported only with default value ``None``.
+    Parameter `order` is supported only with values ``"C"`` and ``"F"``.
+    Parameter `like` is supported only with default value ``None``.
     Otherwise the function will be executed sequentially on CPU.
 
     See Also
@@ -1439,9 +1474,9 @@ def ones_like(
 
     Limitations
     -----------
-    Parameter ``x1`` is supported as :class:`dpnp.dpnp_array` or :class:`dpctl.tensor.usm_ndarray`
-    Parameter ``order`` is supported with values ``"C"`` or ``"F"``.
-    Parameter ``subok`` is supported only with default value ``False``.
+    Parameter `x1` is supported as :class:`dpnp.dpnp_array` or :class:`dpctl.tensor.usm_ndarray`
+    Parameter `order` is supported with values ``"C"`` or ``"F"``.
+    Parameter `subok` is supported only with default value ``False``.
     Otherwise the function will be executed sequentially on CPU.
 
     See Also
@@ -1523,7 +1558,7 @@ def trace(x1, offset=0, axis1=0, axis2=1, dtype=None, out=None):
     Limitations
     -----------
     Input array is supported as :obj:`dpnp.ndarray`.
-    Parameters ``axis1``, ``axis2``, ``out`` and ``dtype`` are supported only with default values.
+    Parameters `axis1`, `axis2`, `out` and `dtype` are supported only with default values.
     """
 
     x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
@@ -1546,11 +1581,36 @@ def trace(x1, offset=0, axis1=0, axis2=1, dtype=None, out=None):
     return call_origin(numpy.trace, x1, offset, axis1, axis2, dtype, out)
 
 
-def tri(N, M=None, k=0, dtype=dpnp.float, **kwargs):
+def tri(
+    N,
+    M=None,
+    k=0,
+    dtype=dpnp.float,
+    device=None,
+    usm_type="device",
+    sycl_queue=None,
+    **kwargs,
+):
     """
     An array with ones at and below the given diagonal and zeros elsewhere.
 
     For full documentation refer to :obj:`numpy.tri`.
+
+    Returns
+    -------
+    out : ndarray of shape (N, M)
+        Array with its lower triangle filled with ones and zeros elsewhere.
+
+    Limitations
+    -----------
+    Parameter `M`, `N`, and `k` are only supported as integer data type.
+    Keyword argument `kwargs` is currently unsupported.
+    Otherwise the function will be executed sequentially on CPU.
+
+    See Also
+    --------
+    :obj:`dpnp.tril` : Return lower triangle of an array.
+    :obj:`dpnp.triu` : Return upper triangle of an array.
 
     Examples
     --------
@@ -1572,11 +1632,7 @@ def tri(N, M=None, k=0, dtype=dpnp.float, **kwargs):
             pass
         elif not isinstance(N, int):
             pass
-        elif N < 0:
-            pass
         elif M is not None and not isinstance(M, int):
-            pass
-        elif M is not None and M < 0:
             pass
         elif not isinstance(k, int):
             pass
@@ -1586,7 +1642,31 @@ def tri(N, M=None, k=0, dtype=dpnp.float, **kwargs):
                 if dtype in (dpnp.float, None)
                 else dtype
             )
-            return dpnp_tri(N, M, k, _dtype).get_pyobj()
+            if M is None:
+                M = N
+
+            m = dpnp.greater_equal(
+                dpnp.arange(
+                    N,
+                    dtype=_min_int(0, N),
+                    device=device,
+                    usm_type=usm_type,
+                    sycl_queue=sycl_queue,
+                )[:, dpnp.newaxis],
+                dpnp.arange(
+                    -k,
+                    M - k,
+                    dtype=_min_int(-k, M - k),
+                    device=device,
+                    usm_type=usm_type,
+                    sycl_queue=sycl_queue,
+                ),
+            )
+
+            # Avoid making a copy if the requested type is already bool
+            m = m.astype(_dtype, copy=False)
+
+            return m
 
     return call_origin(numpy.tri, N, M, k, dtype, **kwargs)
 
@@ -1737,8 +1817,8 @@ def zeros(
 
     Limitations
     -----------
-    Parameter ``order`` is supported only with values ``"C"`` and ``"F"``.
-    Parameter ``like`` is supported only with default value ``None``.
+    Parameter `order` is supported only with values ``"C"`` and ``"F"``.
+    Parameter `like` is supported only with default value ``None``.
     Otherwise the function will be executed sequentially on CPU.
 
     See Also
@@ -1796,9 +1876,9 @@ def zeros_like(
 
     Limitations
     -----------
-    Parameter ``x1`` is supported as :class:`dpnp.dpnp_array` or :class:`dpctl.tensor.usm_ndarray`
-    Parameter ``order`` is supported with values ``"C"`` or ``"F"``.
-    Parameter ``subok`` is supported only with default value ``False``.
+    Parameter `x1` is supported as :class:`dpnp.dpnp_array` or :class:`dpctl.tensor.usm_ndarray`
+    Parameter `order` is supported with values ``"C"`` or ``"F"``.
+    Parameter `subok` is supported only with default value ``False``.
     Otherwise the function will be executed sequentially on CPU.
 
     See Also

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -90,21 +90,6 @@ __all__ = [
     "zeros_like",
 ]
 
-i1 = numpy.iinfo(numpy.int8)
-i2 = numpy.iinfo(numpy.int16)
-i4 = numpy.iinfo(numpy.int32)
-
-
-def _min_int(low, high):
-    """Get small int that fits the range"""
-    if high <= i1.max and low >= i1.min:
-        return numpy.int8
-    if high <= i2.max and low >= i2.min:
-        return numpy.int16
-    if high <= i4.max and low >= i4.min:
-        return numpy.int32
-    return numpy.int64
-
 
 def arange(
     start,
@@ -1632,7 +1617,11 @@ def tri(
             pass
         elif not isinstance(N, int):
             pass
+        elif N < 0:
+            pass
         elif M is not None and not isinstance(M, int):
+            pass
+        elif M is not None and M < 0:
             pass
         elif not isinstance(k, int):
             pass
@@ -1645,28 +1634,14 @@ def tri(
             if M is None:
                 M = N
 
-            m = dpnp.greater_equal(
-                dpnp.arange(
-                    N,
-                    dtype=_min_int(0, N),
-                    device=device,
-                    usm_type=usm_type,
-                    sycl_queue=sycl_queue,
-                )[:, dpnp.newaxis],
-                dpnp.arange(
-                    -k,
-                    M - k,
-                    dtype=_min_int(-k, M - k),
-                    device=device,
-                    usm_type=usm_type,
-                    sycl_queue=sycl_queue,
-                ),
+            m = dpnp.ones(
+                (N, M),
+                dtype=_dtype,
+                device=device,
+                usm_type=usm_type,
+                sycl_queue=sycl_queue,
             )
-
-            # Avoid making a copy if the requested type is already bool
-            m = m.astype(_dtype, copy=False)
-
-            return m
+            return dpnp.tril(m, k=k)
 
     return call_origin(numpy.tri, N, M, k, dtype, **kwargs)
 

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -1223,7 +1223,7 @@ def stack(arrays, /, *, axis=0, out=None, dtype=None, **kwargs):
     or :class:`dpctl.tensor.usm_ndarray`. Otherwise ``TypeError`` exception
     will be raised.
     Parameters `out` and `dtype` are supported with default value.
-    Keyword argument ``kwargs`` is currently unsupported.
+    Keyword argument `kwargs` is currently unsupported.
     Otherwise the function will be executed sequentially on CPU.
 
     See Also

--- a/tests/test_arraycreation.py
+++ b/tests/test_arraycreation.py
@@ -292,11 +292,9 @@ def test_trace(array, offset, type, dtype):
     assert_array_equal(trace_func(dpnp, ia), trace_func(numpy, a))
 
 
+@pytest.mark.parametrize("N", [0, 1, 2, 3, 4], ids=["0", "1", "2", "3", "4"])
 @pytest.mark.parametrize(
-    "N", [-1, 0, 1, 2, 3, 4], ids=["-1", "0", "1", "2", "3", "4"]
-)
-@pytest.mark.parametrize(
-    "M", [-1, None, 0, 1, 2, 3, 4], ids=["-1", "None", "0", "1", "2", "3", "4"]
+    "M", [None, 0, 1, 2, 3, 4], ids=["None", "0", "1", "2", "3", "4"]
 )
 @pytest.mark.parametrize(
     "k",
@@ -307,7 +305,6 @@ def test_trace(array, offset, type, dtype):
 def test_tri(N, M, k, dtype):
     func = lambda xp: xp.tri(N, M, k, dtype=dtype)
     assert_array_equal(func(dpnp), func(numpy))
-    assert func(dpnp).shape == func(numpy).shape
 
 
 def test_tri_default_dtype():

--- a/tests/test_arraycreation.py
+++ b/tests/test_arraycreation.py
@@ -292,17 +292,22 @@ def test_trace(array, offset, type, dtype):
     assert_array_equal(trace_func(dpnp, ia), trace_func(numpy, a))
 
 
-@pytest.mark.parametrize("N", [0, 1, 2, 3, 4], ids=["0", "1", "2", "3", "4"])
-@pytest.mark.parametrize("M", [0, 1, 2, 3, 4], ids=["0", "1", "2", "3", "4"])
+@pytest.mark.parametrize(
+    "N", [-1, 0, 1, 2, 3, 4], ids=["-1", "0", "1", "2", "3", "4"]
+)
+@pytest.mark.parametrize(
+    "M", [-1, None, 0, 1, 2, 3, 4], ids=["-1", "None", "0", "1", "2", "3", "4"]
+)
 @pytest.mark.parametrize(
     "k",
     [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5],
     ids=["-5", "-4", "-3", "-2", "-1", "0", "1", "2", "3", "4", "5"],
 )
-@pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True))
+@pytest.mark.parametrize("dtype", get_all_dtypes())
 def test_tri(N, M, k, dtype):
     func = lambda xp: xp.tri(N, M, k, dtype=dtype)
     assert_array_equal(func(dpnp), func(numpy))
+    assert func(dpnp).shape == func(numpy).shape
 
 
 def test_tri_default_dtype():

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -85,8 +85,10 @@ def vvsort(val, vec, size, xp):
         pytest.param("arange", [-25.7], {"stop": 10**8, "step": 15}),
         pytest.param("full", [(2, 2)], {"fill_value": 5}),
         pytest.param("eye", [4, 2], {}),
+        pytest.param("identity", [4], {}),
         pytest.param("linspace", [0, 4, 8], {}),
         pytest.param("ones", [(2, 2)], {}),
+        pytest.param("tri", [3, 5, 2], {}),
         pytest.param("zeros", [(2, 2)], {}),
     ],
 )


### PR DESCRIPTION
In this PR, `device`, `usm_type`, and `sycl_queue` keywords are added to `dpnp.tri` and `dpnp.identity`.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
