### PR TITLE
Add dpnp.linalg.solve() function

### DIFF
--- a/dpnp/backend/extensions/lapack/CMakeLists.txt
+++ b/dpnp/backend/extensions/lapack/CMakeLists.txt
@@ -29,6 +29,7 @@ pybind11_add_module(${python_module_name} MODULE
     lapack_py.cpp
     heevd.cpp
     syevd.cpp
+    gesv.cpp
 )
 
 if (WIN32)

--- a/dpnp/backend/extensions/lapack/gesv.cpp
+++ b/dpnp/backend/extensions/lapack/gesv.cpp
@@ -1,0 +1,236 @@
+//*****************************************************************************
+// Copyright (c) 2023, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//*****************************************************************************
+
+#include <pybind11/pybind11.h>
+
+// dpctl tensor headers
+#include "utils/memory_overlap.hpp"
+#include "utils/type_utils.hpp"
+
+#include "gesv.hpp"
+#include "types_matrix.hpp"
+
+#include "dpnp_utils.hpp"
+
+namespace dpnp
+{
+namespace backend
+{
+namespace ext
+{
+namespace lapack
+{
+namespace mkl_lapack = oneapi::mkl::lapack;
+namespace py = pybind11;
+namespace type_utils = dpctl::tensor::type_utils;
+
+typedef sycl::event (*gesv_impl_fn_ptr_t)(sycl::queue,
+                                          const std::int64_t,
+                                          const std::int64_t,
+                                          char *,
+                                          std::int64_t,
+                                          std::int64_t *,
+                                          char *,
+                                          std::int64_t,
+                                          std::vector<sycl::event> &,
+                                          const std::vector<sycl::event> &);
+
+static gesv_impl_fn_ptr_t gesv_dispatch_vector[dpctl_td_ns::num_types];
+
+template <typename T>
+static sycl::event gesv_impl(sycl::queue exec_q,
+                             const std::int64_t n,
+                             const std::int64_t nrhs,
+                             char *in_a,
+                             std::int64_t lda,
+                             std::int64_t *ipiv,
+                             char *in_b,
+                             std::int64_t ldb,
+                             std::vector<sycl::event> &host_task_events,
+                             const std::vector<sycl::event> &depends)
+{
+    type_utils::validate_type_for_device<T>(exec_q);
+
+    T *a = reinterpret_cast<T *>(in_a);
+    T *b = reinterpret_cast<T *>(in_b);
+
+    const std::int64_t scratchpad_size =
+        mkl_lapack::gesv_scratchpad_size<T>(exec_q, n, nrhs, lda, ldb);
+    T *scratchpad = nullptr;
+
+    std::stringstream error_msg;
+    std::int64_t info = 0;
+
+    sycl::event gesv_event;
+    try {
+        scratchpad = sycl::malloc_device<T>(scratchpad_size, exec_q);
+
+        gesv_event = mkl_lapack::gesv(
+            exec_q,
+            n,    // The order of the matrix A (0 ≤ n).
+            nrhs, // The number of right-hand sides B (0 ≤ nrhs).
+            a,    // Pointer to the square coefficient matrix A (n x n).
+            lda,  // The leading dimension of a, must be at least max(1, n).
+            ipiv, // The pivot indices that define the permutation matrix P;
+                  // row i of the matrix was interchanged with row ipiv(i),
+                  // must be at least max(1, n).
+            b,    // Pointer to the right hand side matrix B (n x nrhs).
+            ldb,  // The leading dimension of b, must be at least max(1, n).
+            scratchpad, // Pointer to scratchpad memory to be used by MKL
+                        // routine for storing intermediate results.
+            scratchpad_size, depends);
+    } catch (mkl_lapack::exception const &e) {
+        error_msg
+            << "Unexpected MKL exception caught during gesv() call:\nreason: "
+            << e.what() << "\ninfo: " << e.info();
+        info = e.info();
+    } catch (sycl::exception const &e) {
+        error_msg << "Unexpected SYCL exception caught during gesv() call:\n"
+                  << e.what();
+        info = -1;
+    }
+
+    if (info != 0) // an unexected error occurs
+    {
+        if (scratchpad != nullptr) {
+            sycl::free(scratchpad, exec_q);
+        }
+        throw std::runtime_error(error_msg.str());
+    }
+
+    sycl::event clean_up_event = exec_q.submit([&](sycl::handler &cgh) {
+        cgh.depends_on(gesv_event);
+        auto ctx = exec_q.get_context();
+        cgh.host_task([ctx, scratchpad]() { sycl::free(scratchpad, ctx); });
+    });
+    host_task_events.push_back(clean_up_event);
+
+    return gesv_event;
+}
+
+sycl::event gesv(sycl::queue exec_q,
+                 dpctl::tensor::usm_ndarray coeff_matrix,
+                 dpctl::tensor::usm_ndarray hand_sides,
+                 const std::vector<sycl::event> &depends)
+{
+    // check ndim hand_sides
+
+    const py::ssize_t *coeff_matrix_shape = coeff_matrix.get_shape_raw();
+    const py::ssize_t *hand_sides_shape = hand_sides.get_shape_raw();
+
+    if (coeff_matrix_shape[0] != coeff_matrix_shape[1]) {
+        throw py::value_error("The input coefficients array must be square ");
+    }
+
+    // elif check shape coeff_matrix and hand_sides
+
+    // check compatibility of execution queue and allocation queue
+    if (!dpctl::utils::queues_are_compatible(exec_q,
+                                             {coeff_matrix, hand_sides})) {
+        throw py::value_error(
+            "Execution queue is not compatible with allocation queues");
+    }
+
+    auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
+    if (overlap(coeff_matrix, hand_sides)) {
+        throw py::value_error("Arrays with coefficients and hand sides are "
+                              "overlapping segments of memory");
+    }
+
+    bool is_coeff_matrix_f_contig = coeff_matrix.is_f_contiguous();
+    bool is_hand_sides_c_contig = hand_sides.is_c_contiguous();
+    if (!is_coeff_matrix_f_contig) {
+        throw py::value_error("An array with coefficients "
+                              "must be F-contiguous");
+    }
+    else if (!is_hand_sides_c_contig) {
+        throw py::value_error(
+            "An array with the output solutions of the coefﬁcient matrix"
+            "must be C-contiguous");
+    }
+
+    auto array_types = dpctl_td_ns::usm_ndarray_types();
+    int coeff_matrix_type_id =
+        array_types.typenum_to_lookup_id(coeff_matrix.get_typenum());
+    int hand_sides_type_id =
+        array_types.typenum_to_lookup_id(hand_sides.get_typenum());
+
+    if (coeff_matrix_type_id != hand_sides_type_id) {
+        throw py::value_error(
+            "Types of coefficients and hand sides are missmatched");
+    }
+
+    gesv_impl_fn_ptr_t gesv_fn = gesv_dispatch_vector[coeff_matrix_type_id];
+    if (gesv_fn == nullptr) {
+        throw py::value_error("No gesv implementation defined for a type of "
+                              "coefﬁcient matrix and hand sides");
+    }
+
+    char *coeff_matrix_data = coeff_matrix.get_data();
+    char *hand_sides_data = hand_sides.get_data();
+
+    const std::int64_t n = coeff_matrix_shape[0];
+    const std::int64_t nrhs = hand_sides_shape[0];
+    const std::int64_t m = hand_sides_shape[0];
+
+    const std::int64_t lda = std::max<size_t>(1UL, n);
+    const std::int64_t ldb = std::max<size_t>(1UL, m);
+
+    std::vector<std::int64_t> ipiv(n);
+    std::int64_t *d_ipiv = sycl::malloc_device<std::int64_t>(n, exec_q);
+
+    std::vector<sycl::event> host_task_events;
+    sycl::event gesv_ev =
+        gesv_fn(exec_q, n, nrhs, coeff_matrix_data, lda, d_ipiv,
+                hand_sides_data, ldb, host_task_events, depends);
+
+    return gesv_ev;
+}
+
+template <typename fnT, typename T>
+struct GesvContigFactory
+{
+    fnT get()
+    {
+        if constexpr (types::GesvTypePairSupportFactory<T>::is_defined) {
+            return gesv_impl<T>;
+        }
+        else {
+            return nullptr;
+        }
+    }
+};
+
+void init_gesv_dispatch_vector(void)
+{
+    dpctl_td_ns::DispatchVectorBuilder<gesv_impl_fn_ptr_t, GesvContigFactory,
+                                       dpctl_td_ns::num_types>
+        contig;
+    contig.populate_dispatch_vector(gesv_dispatch_vector);
+}
+} // namespace lapack
+} // namespace ext
+} // namespace backend
+} // namespace dpnp

--- a/dpnp/backend/extensions/lapack/gesv.cpp
+++ b/dpnp/backend/extensions/lapack/gesv.cpp
@@ -135,7 +135,13 @@ sycl::event gesv(sycl::queue exec_q,
                  dpctl::tensor::usm_ndarray hand_sides,
                  const std::vector<sycl::event> &depends)
 {
-    // check ndim hand_sides
+    const int coeff_matrix_nd = coeff_matrix.get_ndim();
+
+    if (coeff_matrix_nd != 2) {
+        throw py::value_error(
+            "Unexpected ndim=" + std::to_string(coeff_matrix_nd) +
+            " of an input array with coefficients");
+    }
 
     const py::ssize_t *coeff_matrix_shape = coeff_matrix.get_shape_raw();
     const py::ssize_t *hand_sides_shape = hand_sides.get_shape_raw();
@@ -160,15 +166,9 @@ sycl::event gesv(sycl::queue exec_q,
     }
 
     bool is_coeff_matrix_f_contig = coeff_matrix.is_f_contiguous();
-    bool is_hand_sides_c_contig = hand_sides.is_c_contiguous();
     if (!is_coeff_matrix_f_contig) {
         throw py::value_error("An array with coefficients "
                               "must be F-contiguous");
-    }
-    else if (!is_hand_sides_c_contig) {
-        throw py::value_error(
-            "An array with the output solutions of the coefﬁcient matrix"
-            "must be C-contiguous");
     }
 
     auto array_types = dpctl_td_ns::usm_ndarray_types();

--- a/dpnp/backend/extensions/lapack/gesv.hpp
+++ b/dpnp/backend/extensions/lapack/gesv.hpp
@@ -1,0 +1,50 @@
+//*****************************************************************************
+// Copyright (c) 2023, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//*****************************************************************************
+
+#pragma once
+
+#include <CL/sycl.hpp>
+#include <oneapi/mkl.hpp>
+
+#include <dpctl4pybind11.hpp>
+
+namespace dpnp
+{
+namespace backend
+{
+namespace ext
+{
+namespace lapack
+{
+extern sycl::event gesv(sycl::queue exec_q,
+                        dpctl::tensor::usm_ndarray coeff_matrix,
+                        dpctl::tensor::usm_ndarray hand_sides,
+                        const std::vector<sycl::event> &depends);
+
+extern void init_gesv_dispatch_vector(void);
+} // namespace lapack
+} // namespace ext
+} // namespace backend
+} // namespace dpnp

--- a/dpnp/backend/extensions/lapack/lapack_py.cpp
+++ b/dpnp/backend/extensions/lapack/lapack_py.cpp
@@ -30,6 +30,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include "gesv.hpp"
 #include "heevd.hpp"
 #include "syevd.hpp"
 
@@ -40,6 +41,7 @@ namespace py = pybind11;
 void init_dispatch_vectors(void)
 {
     lapack_ext::init_syevd_dispatch_vector();
+    lapack_ext::init_gesv_dispatch_vector();
 }
 
 // populate dispatch tables
@@ -65,5 +67,13 @@ PYBIND11_MODULE(_lapack_impl, m)
           "the eigenvalues and eigenvectors of a real symmetric matrix",
           py::arg("sycl_queue"), py::arg("jobz"), py::arg("upper_lower"),
           py::arg("eig_vecs"), py::arg("eig_vals"),
+          py::arg("depends") = py::list());
+
+    m.def("_gesv", &lapack_ext::gesv,
+          "Call `gesv` from OneMKL LAPACK library to return "
+          "solution to the system of linear equations with a square "
+          "coefficient matrix A"
+          "and multiple right-hand sides",
+          py::arg("sycl_queue"), py::arg("coeff_matrix"), py::arg("hand_sides"),
           py::arg("depends") = py::list());
 }

--- a/dpnp/backend/extensions/lapack/types_matrix.hpp
+++ b/dpnp/backend/extensions/lapack/types_matrix.hpp
@@ -80,6 +80,32 @@ struct SyevdTypePairSupportFactory
         // fall-through
         dpctl_td_ns::NotDefinedEntry>::is_defined;
 };
+
+/**
+ * @brief A factory to define pairs of supported types for which
+ * MKL LAPACK library provides support in oneapi::mkl::lapack::gesv<T>
+ * function.
+ *
+ * @tparam T Type of array containing input matrix A and an output arrays with
+ * coefficient matrix and hand sides.
+ */
+template <typename T>
+struct GesvTypePairSupportFactory
+{
+    static constexpr bool is_defined = std::disjunction<
+        dpctl_td_ns::TypePairDefinedEntry<T, float, T, float>,
+        dpctl_td_ns::TypePairDefinedEntry<T, double, T, double>,
+        dpctl_td_ns::TypePairDefinedEntry<T,
+                                          std::complex<float>,
+                                          T,
+                                          std::complex<float>>,
+        dpctl_td_ns::TypePairDefinedEntry<T,
+                                          std::complex<double>,
+                                          T,
+                                          std::complex<double>>,
+        // fall-through
+        dpctl_td_ns::NotDefinedEntry>::is_defined;
+};
 } // namespace types
 } // namespace lapack
 } // namespace ext

--- a/dpnp/linalg/dpnp_iface_linalg.py
+++ b/dpnp/linalg/dpnp_iface_linalg.py
@@ -549,6 +549,15 @@ def solve(a, b):
     if m != n:
         raise ValueError("Last 2 dimensions of the array must be square")
 
+    if not (
+        (a.ndim == b.ndim or a.ndim == b.ndim + 1)
+        and a.shape[:-1] == b.shape[: a.ndim - 1]
+    ):
+        raise ValueError(
+            "a must have (..., M, M) shape and b must have (..., M) "
+            "or (..., M, K)"
+        )
+
     return dpnp_solve(a, b)
 
 

--- a/dpnp/linalg/dpnp_iface_linalg.py
+++ b/dpnp/linalg/dpnp_iface_linalg.py
@@ -47,7 +47,7 @@ from dpnp.dpnp_algo import *
 from dpnp.dpnp_utils import *
 from dpnp.linalg.dpnp_algo_linalg import *
 
-from .dpnp_utils_linalg import dpnp_eigh
+from .dpnp_utils_linalg import dpnp_eigh, dpnp_solve
 
 __all__ = [
     "cholesky",
@@ -62,6 +62,7 @@ __all__ = [
     "multi_dot",
     "norm",
     "qr",
+    "solve",
     "svd",
 ]
 
@@ -496,6 +497,59 @@ def qr(x1, mode="reduced"):
             return result_tup
 
     return call_origin(numpy.linalg.qr, x1, mode)
+
+
+def solve(a, b):
+    """
+    Solve a linear matrix equation, or system of linear scalar equations.
+
+    For full documentation refer to :obj:`numpy.linalg.solve`.
+
+    Returns
+    -------
+    out : {(…, M,), (…, M, K)} dpnp.ndarray
+        Solution to the system ax = b. Returned shape is identical to b.
+
+    Limitations
+    -----------
+    Parameter `a` is supported as :class:`dpnp.ndarray` or :class:`dpctl.tensor.usm_ndarray`.
+    Input array data types are limited by supported DPNP :ref:`Data types`.
+
+    See Also
+    --------
+    :obj:`dpnp.dot` : Returns the dot product of two arrays.
+
+    Examples
+    --------
+    >>> import dpnp as dp
+    >>> a = dp.array([[1, 2], [3, 5]])
+    >>> b = dp.array([1, 2])
+    >>> x = dp.linalg.solve(a, b)
+    >>> x
+    array([-1.,  1.])
+
+    """
+    if not dpnp.is_supported_array_type(a):
+        raise TypeError(
+            "An array must be any of supported type, but got {}".format(type(a))
+        )
+
+    if not dpnp.is_supported_array_type(b):
+        raise TypeError(
+            "An array must be any of supported type, but got {}".format(type(b))
+        )
+
+    if a.ndim < 2:
+        raise ValueError(
+            f"{a.ndim}-dimensional array given. Array must be "
+            "at least two-dimensional"
+        )
+
+    m, n = a.shape[-2:]
+    if m != n:
+        raise ValueError("Last 2 dimensions of the array must be square")
+
+    return dpnp_solve(a, b)
 
 
 def svd(x1, full_matrices=True, compute_uv=True, hermitian=False):

--- a/tests/third_party/cupy/linalg_tests/test_solve.py
+++ b/tests/third_party/cupy/linalg_tests/test_solve.py
@@ -1,0 +1,80 @@
+import unittest
+
+import numpy
+import pytest
+
+import dpnp as cupy
+from tests.helper import has_support_aspect64
+from tests.third_party.cupy import testing
+
+
+@testing.parameterize(
+    *testing.product(
+        {
+            "order": ["C", "F"],
+        }
+    )
+)
+class TestSolve(unittest.TestCase):
+    # TODO: add get_batched_gesv_limit
+    # def setUp(self):
+    #     if self.batched_gesv_limit is not None:
+    #         self.old_limit = get_batched_gesv_limit()
+    #         set_batched_gesv_limit(self.batched_gesv_limit)
+
+    # def tearDown(self):
+    #     if self.batched_gesv_limit is not None:
+    #         set_batched_gesv_limit(self.old_limit)
+
+    @testing.for_dtypes("ifdFD")
+    @testing.numpy_cupy_allclose(
+        atol=1e-3, contiguous_check=False, type_check=has_support_aspect64()
+    )
+    def check_x(self, a_shape, b_shape, xp, dtype):
+        a = testing.shaped_random(a_shape, xp, dtype=dtype, seed=0, scale=20)
+        b = testing.shaped_random(b_shape, xp, dtype=dtype, seed=1)
+        a = a.copy(order=self.order)
+        b = b.copy(order=self.order)
+        a_copy = a.copy()
+        b_copy = b.copy()
+        result = xp.linalg.solve(a, b)
+        numpy.testing.assert_array_equal(a_copy, a)
+        numpy.testing.assert_array_equal(b_copy, b)
+        return result
+
+    def test_solve(self):
+        self.check_x((4, 4), (4,))
+        self.check_x((5, 5), (5, 2))
+        self.check_x((2, 4, 4), (2, 4))
+        self.check_x((2, 5, 5), (2, 5, 2))
+        self.check_x((2, 3, 2, 2), (2, 3, 2))
+        self.check_x((2, 3, 3, 3), (2, 3, 3, 2))
+        self.check_x((0, 0), (0,))
+        self.check_x((0, 0), (0, 2))
+        self.check_x((0, 2, 2), (0, 2))
+        self.check_x((0, 2, 2), (0, 2, 3))
+
+    def check_shape(self, a_shape, b_shape, error_type):
+        for xp in (numpy, cupy):
+            a = xp.random.rand(*a_shape)
+            b = xp.random.rand(*b_shape)
+            with pytest.raises(error_type):
+                xp.linalg.solve(a, b)
+
+    # dpnp.linalg.solve() raises RuntimeError instead of numpy.linalg.LinAlgError
+    # @testing.numpy_cupy_allclose()
+    # def test_solve_singular_empty(self, xp):
+    #     a = xp.zeros((3, 3))  # singular
+    #     b = xp.empty((3, 0))  # nrhs = 0
+    #     # LinAlgError("Singular matrix") is not raised
+    #     return xp.linalg.solve(a, b)
+
+    # dpnp.linalg.solve() raises RuntimeError instead of numpy.linalg.LinAlgError
+    def test_invalid_shape(self):
+        # self.check_shape((2, 3), (4,), numpy.linalg.LinAlgError)
+        self.check_shape((3, 3), (2,), ValueError)
+        self.check_shape((3, 3), (2, 2), ValueError)
+        # self.check_shape((3, 3, 4), (3,), numpy.linalg.LinAlgError)
+        self.check_shape((2, 3, 3), (3,), ValueError)
+        self.check_shape((3, 3), (0,), ValueError)
+        # self.check_shape((0, 3, 4), (3,), numpy.linalg.LinAlgError)


### PR DESCRIPTION
This PR adds a missing `dpnp.linalg.solve()` function to calculate the solution to the system of linear equations with a square coefficient matrix A and multiple right-hand sides using `oneapi::mkl::lapack::gesv`
The implementation is written as a pybind11 extension above required LAPACK functions.

```
import dpnp

a = dpnp.array([[1, 2], [3, 5]])
b = dpnp.array([1,2])

dpnp.linalg.solve(a,b)
# array([-1.,  1.])
```

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
