### PR TITLE
rework implementation of diag, diagflat, vander, and ptp

### DIFF
--- a/dpnp/backend/include/dpnp_iface_fptr.hpp
+++ b/dpnp/backend/include/dpnp_iface_fptr.hpp
@@ -132,7 +132,7 @@ enum class DPNPFuncName : size_t
     DPNP_FN_DET_EXT,       /**< Used in numpy.linalg.det() impl, requires extra
                               parameters */
     DPNP_FN_DIAG,          /**< Used in numpy.diag() impl  */
-    DPNP_FN_DIAG_INDICES,     /**< Used in numpy.diag_indices() impl  */
+    DPNP_FN_DIAG_INDICES,  /**< Used in numpy.diag_indices() impl  */
     DPNP_FN_DIAG_INDICES_EXT, /**< Used in numpy.diag_indices() impl, requires
                                  extra parameters */
     DPNP_FN_DIAGONAL,         /**< Used in numpy.diagonal() impl  */
@@ -223,24 +223,24 @@ enum class DPNPFuncName : size_t
     DPNP_FN_MODF_EXT, /**< Used in numpy.modf() impl, requires extra parameters
                        */
     DPNP_FN_MULTIPLY, /**< Used in numpy.multiply() impl  */
-    DPNP_FN_MULTIPLY_EXT,  /**< Used in numpy.multiply() impl, requires extra
-                              parameters */
-    DPNP_FN_NANVAR,        /**< Used in numpy.nanvar() impl  */
-    DPNP_FN_NANVAR_EXT,    /**< Used in numpy.nanvar() impl, requires extra
-                              parameters */
-    DPNP_FN_NEGATIVE,      /**< Used in numpy.negative() impl  */
-    DPNP_FN_NONZERO,       /**< Used in numpy.nonzero() impl  */
-    DPNP_FN_ONES,          /**< Used in numpy.ones() impl */
-    DPNP_FN_ONES_LIKE,     /**< Used in numpy.ones_like() impl */
-    DPNP_FN_PARTITION,     /**< Used in numpy.partition() impl */
-    DPNP_FN_PARTITION_EXT, /**< Used in numpy.partition() impl, requires extra
-                              parameters */
-    DPNP_FN_PLACE,         /**< Used in numpy.place() impl  */
-    DPNP_FN_POWER,         /**< Used in numpy.power() impl  */
-    DPNP_FN_PROD,          /**< Used in numpy.prod() impl  */
-    DPNP_FN_PTP,           /**< Used in numpy.ptp() impl  */
-    DPNP_FN_PUT,     /**< Used in numpy.put() impl  */
-    DPNP_FN_PUT_ALONG_AXIS,     /**< Used in numpy.put_along_axis() impl  */
+    DPNP_FN_MULTIPLY_EXT,   /**< Used in numpy.multiply() impl, requires extra
+                               parameters */
+    DPNP_FN_NANVAR,         /**< Used in numpy.nanvar() impl  */
+    DPNP_FN_NANVAR_EXT,     /**< Used in numpy.nanvar() impl, requires extra
+                               parameters */
+    DPNP_FN_NEGATIVE,       /**< Used in numpy.negative() impl  */
+    DPNP_FN_NONZERO,        /**< Used in numpy.nonzero() impl  */
+    DPNP_FN_ONES,           /**< Used in numpy.ones() impl */
+    DPNP_FN_ONES_LIKE,      /**< Used in numpy.ones_like() impl */
+    DPNP_FN_PARTITION,      /**< Used in numpy.partition() impl */
+    DPNP_FN_PARTITION_EXT,  /**< Used in numpy.partition() impl, requires extra
+                               parameters */
+    DPNP_FN_PLACE,          /**< Used in numpy.place() impl  */
+    DPNP_FN_POWER,          /**< Used in numpy.power() impl  */
+    DPNP_FN_PROD,           /**< Used in numpy.prod() impl  */
+    DPNP_FN_PTP,            /**< Used in numpy.ptp() impl  */
+    DPNP_FN_PUT,            /**< Used in numpy.put() impl  */
+    DPNP_FN_PUT_ALONG_AXIS, /**< Used in numpy.put_along_axis() impl  */
     DPNP_FN_PUT_ALONG_AXIS_EXT, /**< Used in numpy.put_along_axis() impl,
                                    requires extra parameters */
     DPNP_FN_QR,                 /**< Used in numpy.linalg.qr() impl  */

--- a/dpnp/backend/include/dpnp_iface_fptr.hpp
+++ b/dpnp/backend/include/dpnp_iface_fptr.hpp
@@ -132,8 +132,6 @@ enum class DPNPFuncName : size_t
     DPNP_FN_DET_EXT,       /**< Used in numpy.linalg.det() impl, requires extra
                               parameters */
     DPNP_FN_DIAG,          /**< Used in numpy.diag() impl  */
-    DPNP_FN_DIAG_EXT, /**< Used in numpy.diag() impl, requires extra parameters
-                       */
     DPNP_FN_DIAG_INDICES,     /**< Used in numpy.diag_indices() impl  */
     DPNP_FN_DIAG_INDICES_EXT, /**< Used in numpy.diag_indices() impl, requires
                                  extra parameters */
@@ -241,7 +239,6 @@ enum class DPNPFuncName : size_t
     DPNP_FN_POWER,         /**< Used in numpy.power() impl  */
     DPNP_FN_PROD,          /**< Used in numpy.prod() impl  */
     DPNP_FN_PTP,           /**< Used in numpy.ptp() impl  */
-    DPNP_FN_PTP_EXT, /**< Used in numpy.ptp() impl, requires extra parameters */
     DPNP_FN_PUT,     /**< Used in numpy.put() impl  */
     DPNP_FN_PUT_ALONG_AXIS,     /**< Used in numpy.put_along_axis() impl  */
     DPNP_FN_PUT_ALONG_AXIS_EXT, /**< Used in numpy.put_along_axis() impl,
@@ -401,21 +398,19 @@ enum class DPNPFuncName : size_t
     DPNP_FN_TAKE,    /**< Used in numpy.take() impl  */
     DPNP_FN_TAN,     /**< Used in numpy.tan() impl  */
     DPNP_FN_TANH,    /**< Used in numpy.tanh() impl  */
-    DPNP_FN_TRANSPOSE,  /**< Used in numpy.transpose() impl  */
-    DPNP_FN_TRACE,      /**< Used in numpy.trace() impl  */
-    DPNP_FN_TRACE_EXT,  /**< Used in numpy.trace() impl, requires extra
-                           parameters */
-    DPNP_FN_TRAPZ,      /**< Used in numpy.trapz() impl  */
-    DPNP_FN_TRAPZ_EXT,  /**< Used in numpy.trapz() impl, requires extra
-                           parameters */
-    DPNP_FN_TRI,        /**< Used in numpy.tri() impl  */
-    DPNP_FN_TRIL,       /**< Used in numpy.tril() impl  */
-    DPNP_FN_TRIU,       /**< Used in numpy.triu() impl  */
-    DPNP_FN_TRUNC,      /**< Used in numpy.trunc() impl  */
-    DPNP_FN_VANDER,     /**< Used in numpy.vander() impl  */
-    DPNP_FN_VANDER_EXT, /**< Used in numpy.vander() impl, requires extra
-                           parameters */
-    DPNP_FN_VAR,        /**< Used in numpy.var() impl  */
+    DPNP_FN_TRANSPOSE, /**< Used in numpy.transpose() impl  */
+    DPNP_FN_TRACE,     /**< Used in numpy.trace() impl  */
+    DPNP_FN_TRACE_EXT, /**< Used in numpy.trace() impl, requires extra
+                          parameters */
+    DPNP_FN_TRAPZ,     /**< Used in numpy.trapz() impl  */
+    DPNP_FN_TRAPZ_EXT, /**< Used in numpy.trapz() impl, requires extra
+                          parameters */
+    DPNP_FN_TRI,       /**< Used in numpy.tri() impl  */
+    DPNP_FN_TRIL,      /**< Used in numpy.tril() impl  */
+    DPNP_FN_TRIU,      /**< Used in numpy.triu() impl  */
+    DPNP_FN_TRUNC,     /**< Used in numpy.trunc() impl  */
+    DPNP_FN_VANDER,    /**< Used in numpy.vander() impl  */
+    DPNP_FN_VAR,       /**< Used in numpy.var() impl  */
     DPNP_FN_VAR_EXT, /**< Used in numpy.var() impl, requires extra parameters */
     DPNP_FN_ZEROS,   /**< Used in numpy.zeros() impl */
     DPNP_FN_ZEROS_LIKE, /**< Used in numpy.zeros_like() impl */

--- a/dpnp/backend/kernels/dpnp_krnl_arraycreation.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_arraycreation.cpp
@@ -201,18 +201,6 @@ void (*dpnp_diag_default_c)(void *,
                             const size_t) = dpnp_diag_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef (*dpnp_diag_ext_c)(DPCTLSyclQueueRef,
-                                     void *,
-                                     void *,
-                                     const int,
-                                     shape_elem_type *,
-                                     shape_elem_type *,
-                                     const size_t,
-                                     const size_t,
-                                     const DPCTLEventVectorRef) =
-    dpnp_diag_c<_DataType>;
-
-template <typename _DataType>
 DPCTLSyclEventRef dpnp_eye_c(DPCTLSyclQueueRef q_ref,
                              void *result1,
                              int k,
@@ -569,23 +557,6 @@ void (*dpnp_ptp_default_c)(void *,
                            const shape_elem_type *,
                            const size_t) = dpnp_ptp_c<_DataType>;
 
-template <typename _DataType>
-DPCTLSyclEventRef (*dpnp_ptp_ext_c)(DPCTLSyclQueueRef,
-                                    void *,
-                                    const size_t,
-                                    const size_t,
-                                    const shape_elem_type *,
-                                    const shape_elem_type *,
-                                    const void *,
-                                    const size_t,
-                                    const size_t,
-                                    const shape_elem_type *,
-                                    const shape_elem_type *,
-                                    const shape_elem_type *,
-                                    const size_t,
-                                    const DPCTLEventVectorRef) =
-    dpnp_ptp_c<_DataType>;
-
 template <typename _DataType_input, typename _DataType_output>
 DPCTLSyclEventRef dpnp_vander_c(DPCTLSyclQueueRef q_ref,
                                 const void *array1_in,
@@ -671,16 +642,6 @@ void (*dpnp_vander_default_c)(const void *,
                               const size_t,
                               const size_t,
                               const int) =
-    dpnp_vander_c<_DataType_input, _DataType_output>;
-
-template <typename _DataType_input, typename _DataType_output>
-DPCTLSyclEventRef (*dpnp_vander_ext_c)(DPCTLSyclQueueRef,
-                                       const void *,
-                                       void *,
-                                       const size_t,
-                                       const size_t,
-                                       const int,
-                                       const DPCTLEventVectorRef) =
     dpnp_vander_c<_DataType_input, _DataType_output>;
 
 template <typename _DataType, typename _ResultType>
@@ -1192,15 +1153,6 @@ void func_map_init_arraycreation(func_map_t &fmap)
     fmap[DPNPFuncName::DPNP_FN_DIAG][eft_DBL][eft_DBL] = {
         eft_DBL, (void *)dpnp_diag_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_DIAG_EXT][eft_INT][eft_INT] = {
-        eft_INT, (void *)dpnp_diag_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_DIAG_EXT][eft_LNG][eft_LNG] = {
-        eft_LNG, (void *)dpnp_diag_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_DIAG_EXT][eft_FLT][eft_FLT] = {
-        eft_FLT, (void *)dpnp_diag_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_DIAG_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void *)dpnp_diag_ext_c<double>};
-
     fmap[DPNPFuncName::DPNP_FN_EYE][eft_INT][eft_INT] = {
         eft_INT, (void *)dpnp_eye_default_c<int32_t>};
     fmap[DPNPFuncName::DPNP_FN_EYE][eft_LNG][eft_LNG] = {
@@ -1284,15 +1236,6 @@ void func_map_init_arraycreation(func_map_t &fmap)
     fmap[DPNPFuncName::DPNP_FN_PTP][eft_DBL][eft_DBL] = {
         eft_DBL, (void *)dpnp_ptp_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_PTP_EXT][eft_INT][eft_INT] = {
-        eft_INT, (void *)dpnp_ptp_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_PTP_EXT][eft_LNG][eft_LNG] = {
-        eft_LNG, (void *)dpnp_ptp_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_PTP_EXT][eft_FLT][eft_FLT] = {
-        eft_FLT, (void *)dpnp_ptp_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_PTP_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void *)dpnp_ptp_ext_c<double>};
-
     fmap[DPNPFuncName::DPNP_FN_VANDER][eft_INT][eft_INT] = {
         eft_LNG, (void *)dpnp_vander_default_c<int32_t, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_VANDER][eft_LNG][eft_LNG] = {
@@ -1307,23 +1250,6 @@ void func_map_init_arraycreation(func_map_t &fmap)
         eft_C128,
         (void *)
             dpnp_vander_default_c<std::complex<double>, std::complex<double>>};
-
-    fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_INT][eft_INT] = {
-        eft_LNG, (void *)dpnp_vander_ext_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_LNG][eft_LNG] = {
-        eft_LNG, (void *)dpnp_vander_ext_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_FLT][eft_FLT] = {
-        eft_FLT, (void *)dpnp_vander_ext_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void *)dpnp_vander_ext_c<double, double>};
-    fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_BLN][eft_BLN] = {
-        eft_LNG, (void *)dpnp_vander_ext_c<bool, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_C64][eft_C64] = {
-        eft_C64,
-        (void *)dpnp_vander_ext_c<std::complex<float>, std::complex<float>>};
-    fmap[DPNPFuncName::DPNP_FN_VANDER_EXT][eft_C128][eft_C128] = {
-        eft_C128,
-        (void *)dpnp_vander_ext_c<std::complex<double>, std::complex<double>>};
 
     fmap[DPNPFuncName::DPNP_FN_TRACE][eft_INT][eft_INT] = {
         eft_INT, (void *)dpnp_trace_default_c<int32_t, int32_t>};

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -64,8 +64,6 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_DEGREES_EXT
         DPNP_FN_DET
         DPNP_FN_DET_EXT
-        DPNP_FN_DIAG
-        DPNP_FN_DIAG_EXT
         DPNP_FN_DIAG_INDICES
         DPNP_FN_DIAG_INDICES_EXT
         DPNP_FN_DIAGONAL
@@ -120,8 +118,6 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_PARTITION
         DPNP_FN_PARTITION_EXT
         DPNP_FN_PLACE
-        DPNP_FN_PTP
-        DPNP_FN_PTP_EXT
         DPNP_FN_QR
         DPNP_FN_QR_EXT
         DPNP_FN_RADIANS
@@ -218,8 +214,6 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_TRIL_EXT
         DPNP_FN_TRIU
         DPNP_FN_TRIU_EXT
-        DPNP_FN_VANDER
-        DPNP_FN_VANDER_EXT
         DPNP_FN_VAR
         DPNP_FN_VAR_EXT
         DPNP_FN_ZEROS

--- a/dpnp/dpnp_algo/dpnp_algo_arraycreation.pxi
+++ b/dpnp/dpnp_algo/dpnp_algo_arraycreation.pxi
@@ -37,10 +37,7 @@ and the rest of the library
 
 __all__ += [
     "dpnp_copy",
-    "dpnp_diag",
-    "dpnp_ptp",
     "dpnp_trace",
-    "dpnp_vander",
 ]
 
 
@@ -88,136 +85,6 @@ cpdef utils.dpnp_descriptor dpnp_copy(utils.dpnp_descriptor x1):
     return call_fptr_1in_1out_strides(DPNP_FN_COPY_EXT, x1)
 
 
-cpdef utils.dpnp_descriptor dpnp_diag(utils.dpnp_descriptor v, int k):
-    cdef shape_type_c input_shape = v.shape
-    cdef shape_type_c result_shape
-
-    if v.ndim == 1:
-        n = v.shape[0] + abs(k)
-
-        result_shape = (n, n)
-    else:
-        n = min(v.shape[0], v.shape[0] + k, v.shape[1], v.shape[1] - k)
-        if n < 0:
-            n = 0
-
-        result_shape = (n, )
-
-    v_obj = v.get_array()
-
-    result_obj = dpnp_container.zeros(result_shape, dtype=v.dtype, device=v_obj.sycl_device)
-    cdef utils.dpnp_descriptor result = dpnp_descriptor(result_obj)
-
-    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(v.dtype)
-
-    cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_DIAG_EXT, param1_type, param1_type)
-
-    result_sycl_queue = result.get_array().sycl_queue
-
-    cdef c_dpctl.SyclQueue q = <c_dpctl.SyclQueue> result_sycl_queue
-    cdef c_dpctl.DPCTLSyclQueueRef q_ref = q.get_queue_ref()
-
-    cdef custom_1in_1out_func_ptr_t func = <custom_1in_1out_func_ptr_t > kernel_data.ptr
-
-    cdef c_dpctl.DPCTLSyclEventRef event_ref = func(q_ref,
-                                                    v.get_data(),
-                                                    result.get_data(),
-                                                    k,
-                                                    input_shape.data(),
-                                                    result_shape.data(),
-                                                    v.ndim,
-                                                    result.ndim,
-                                                    NULL)  # dep_events_ref
-
-    with nogil: c_dpctl.DPCTLEvent_WaitAndThrow(event_ref)
-    c_dpctl.DPCTLEvent_Delete(event_ref)
-
-    return result
-
-
-cpdef dpnp_ptp(utils.dpnp_descriptor arr, axis=None):
-    cdef shape_type_c shape_arr = arr.shape
-    cdef shape_type_c output_shape
-    if axis is None:
-        axis_ = axis
-        output_shape = (1,)
-    else:
-        if isinstance(axis, int):
-            if axis < 0:
-                axis_ = tuple([arr.ndim - axis])
-            else:
-                axis_ = tuple([axis])
-        else:
-            _axis_ = []
-            for i in range(len(axis)):
-                if axis[i] < 0:
-                    _axis_.append(arr.ndim - axis[i])
-                else:
-                    _axis_.append(axis[i])
-            axis_ = tuple(_axis_)
-
-        out_shape = []
-        ind = 0
-        for id, shape_axis in enumerate(shape_arr):
-            if id not in axis_:
-                out_shape.append(shape_axis)
-        output_shape = tuple(out_shape)
-
-    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(arr.dtype)
-
-    cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_PTP_EXT, param1_type, param1_type)
-
-    arr_obj = arr.get_array()
-
-    cdef utils.dpnp_descriptor result = utils.create_output_descriptor(output_shape,
-                                                                       kernel_data.return_type,
-                                                                       None,
-                                                                       device=arr_obj.sycl_device,
-                                                                       usm_type=arr_obj.usm_type,
-                                                                       sycl_queue=arr_obj.sycl_queue)
-
-    cdef shape_type_c axis1
-    cdef Py_ssize_t axis_size = 0
-    cdef shape_type_c axis2 = axis1
-    if axis_ is not None:
-        axis1 = axis_
-        axis2.reserve(len(axis1))
-        for shape_it in axis1:
-            if shape_it < 0:
-                raise ValueError("DPNP dparray::__init__(): Negative values in 'shape' are not allowed")
-            axis2.push_back(shape_it)
-        axis_size = len(axis1)
-
-    cdef shape_type_c result_strides = utils.strides_to_vector(result.strides, result.shape)
-    cdef shape_type_c arr_strides = utils.strides_to_vector(arr.strides, arr.shape)
-
-    result_sycl_queue = result.get_array().sycl_queue
-
-    cdef c_dpctl.SyclQueue q = <c_dpctl.SyclQueue> result_sycl_queue
-    cdef c_dpctl.DPCTLSyclQueueRef q_ref = q.get_queue_ref()
-
-    cdef custom_arraycreation_1in_1out_func_ptr_t func = <custom_arraycreation_1in_1out_func_ptr_t > kernel_data.ptr
-    cdef c_dpctl.DPCTLSyclEventRef event_ref = func(q_ref,
-                                                    result.get_data(),
-                                                    result.size,
-                                                    result.ndim,
-                                                    output_shape.data(),
-                                                    result_strides.data(),
-                                                    arr.get_data(),
-                                                    arr.size,
-                                                    arr.ndim,
-                                                    shape_arr.data(),
-                                                    arr_strides.data(),
-                                                    axis2.data(),
-                                                    axis_size,
-                                                    NULL)  # dep_events_ref
-
-    with nogil: c_dpctl.DPCTLEvent_WaitAndThrow(event_ref)
-    c_dpctl.DPCTLEvent_Delete(event_ref)
-
-    return result
-
-
 cpdef utils.dpnp_descriptor dpnp_trace(utils.dpnp_descriptor arr, offset=0, axis1=0, axis2=1, dtype=None, out=None):
     if dtype is None:
         dtype_ = arr.dtype
@@ -256,41 +123,6 @@ cpdef utils.dpnp_descriptor dpnp_trace(utils.dpnp_descriptor arr, offset=0, axis
                                                     result.get_data(),
                                                     diagonal_shape.data(),
                                                     diagonal_ndim,
-                                                    NULL)  # dep_events_ref
-
-    with nogil: c_dpctl.DPCTLEvent_WaitAndThrow(event_ref)
-    c_dpctl.DPCTLEvent_Delete(event_ref)
-
-    return result
-
-
-cpdef utils.dpnp_descriptor dpnp_vander(utils.dpnp_descriptor x1, int N, int increasing):
-    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(x1.dtype)
-    cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_VANDER_EXT, param1_type, DPNP_FT_NONE)
-
-    x1_obj = x1.get_array()
-
-    # create result array with type given by FPTR data
-    cdef shape_type_c result_shape = (x1.size, N)
-    cdef utils.dpnp_descriptor result = utils.create_output_descriptor(result_shape,
-                                                                       kernel_data.return_type,
-                                                                       None,
-                                                                       device=x1_obj.sycl_device,
-                                                                       usm_type=x1_obj.usm_type,
-                                                                       sycl_queue=x1_obj.sycl_queue)
-
-    result_sycl_queue = result.get_array().sycl_queue
-
-    cdef c_dpctl.SyclQueue q = <c_dpctl.SyclQueue> result_sycl_queue
-    cdef c_dpctl.DPCTLSyclQueueRef q_ref = q.get_queue_ref()
-
-    cdef ftpr_custom_vander_1in_1out_t func = <ftpr_custom_vander_1in_1out_t > kernel_data.ptr
-    cdef c_dpctl.DPCTLSyclEventRef event_ref = func(q_ref,
-                                                    x1.get_data(),
-                                                    result.get_data(),
-                                                    x1.size,
-                                                    N,
-                                                    increasing,
                                                     NULL)  # dep_events_ref
 
     with nogil: c_dpctl.DPCTLEvent_WaitAndThrow(event_ref)

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -1039,7 +1039,30 @@ class dpnp_array:
 
         return dpnp.prod(self, axis, dtype, out, keepdims, initial, where)
 
-    # 'ptp'
+    def ptp(
+        self,
+        axis=None,
+        out=None,
+        keepdims=numpy._NoValue,
+        device=None,
+        usm_type=None,
+        sycl_queue=None,
+    ):
+        """
+        Range of values (maximum - minimum) along an axis.
+
+        For full documentation refer to :obj:`numpy.ptp`.
+        """
+
+        return dpnp.ptp(
+            self,
+            axis=axis,
+            out=out,
+            keepdims=keepdims,
+            device=device,
+            usm_type=usm_type,
+            sycl_queue=sycl_queue,
+        )
 
     def put(self, indices, vals, /, *, axis=None, mode="wrap"):
         """

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -1039,31 +1039,6 @@ class dpnp_array:
 
         return dpnp.prod(self, axis, dtype, out, keepdims, initial, where)
 
-    def ptp(
-        self,
-        axis=None,
-        out=None,
-        keepdims=numpy._NoValue,
-        device=None,
-        usm_type=None,
-        sycl_queue=None,
-    ):
-        """
-        Range of values (maximum - minimum) along an axis.
-
-        For full documentation refer to :obj:`numpy.ptp`.
-        """
-
-        return dpnp.ptp(
-            self,
-            axis=axis,
-            out=out,
-            keepdims=keepdims,
-            device=device,
-            usm_type=usm_type,
-            sycl_queue=sycl_queue,
-        )
-
     def put(self, indices, vals, /, *, axis=None, mode="wrap"):
         """
         Puts values of an array into another array along a given axis.

--- a/dpnp/dpnp_container.py
+++ b/dpnp/dpnp_container.py
@@ -218,6 +218,7 @@ def full(
 ):
     """Validate input parameters before passing them into `dpctl.tensor` module"""
     dpu.validate_usm_type(usm_type, allow_none=True)
+
     sycl_queue_normalized = dpnp.get_normalized_queue_device(
         fill_value, sycl_queue=sycl_queue, device=device
     )

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -86,7 +86,6 @@ __all__ = [
     "ogrid",
     "ones",
     "ones_like",
-    "ptp",
     "trace",
     "tri",
     "tril",
@@ -1647,69 +1646,6 @@ def ones_like(
         )
 
     return call_origin(numpy.ones_like, x1, dtype, order, subok, shape)
-
-
-def ptp(
-    arr,
-    /,
-    axis=None,
-    out=None,
-    keepdims=numpy._NoValue,
-    *,
-    device=None,
-    usm_type=None,
-    sycl_queue=None,
-):
-    """
-    Range of values (maximum - minimum) along an axis.
-
-    For full documentation refer to :obj:`numpy.ptp`.
-
-    Returns
-    -------
-    ptp : dpnp.ndarray
-        The range of a given array.
-
-    Limitations
-    -----------
-    Input array is supported as :class:`dpnp.dpnp_array` or :class:`dpctl.tensor.usm_ndarray`.
-    Parameters `out` and `keepdims` are supported only with default values.
-    Otherwise the function will be executed sequentially on CPU.
-
-    Examples
-    --------
-    >>> import dpnp as np
-    >>> x = np.array([[4, 9, 2, 10],[6, 9, 7, 12]])
-    >>> np.ptp(x, axis=1)
-    array([8, 6])
-
-    >>> np.ptp(x, axis=0)
-    array([2, 0, 5, 2])
-
-    >>> np.ptp(x)
-    array(10)
-    """
-    if not isinstance(arr, (dpnp.ndarray, dpt.usm_ndarray)):
-        pass
-    elif axis is not None and not isinstance(axis, int):
-        pass
-    elif out is not None:
-        pass
-    elif keepdims is not numpy._NoValue:
-        pass
-    else:
-        max_array = dpnp.max(arr, axis=axis)
-        min_array = dpnp.min(arr, axis=axis)
-
-        _usm_type = arr.usm_type if usm_type is None else usm_type
-        _sycl_queue = dpnp.get_normalized_queue_device(
-            arr, sycl_queue=sycl_queue, device=device
-        )
-        return dpnp.array(
-            max_array - min_array, usm_type=_usm_type, sycl_queue=_sycl_queue
-        )
-
-    return call_origin(numpy.ptp, arr, axis, out, keepdims)
 
 
 def trace(x1, offset=0, axis1=0, axis2=1, dtype=None, out=None):

--- a/dpnp/dpnp_iface_statistics.py
+++ b/dpnp/dpnp_iface_statistics.py
@@ -713,7 +713,6 @@ def ptp(
     Limitations
     -----------
     Input array is supported as :class:`dpnp.dpnp_array` or :class:`dpctl.tensor.usm_ndarray`.
-    Otherwise the function will be executed sequentially on CPU.
 
     Examples
     --------
@@ -730,16 +729,11 @@ def ptp(
 
     """
 
-    if not isinstance(a, (dpnp.ndarray, dpt.usm_ndarray)):
-        pass
-    else:
-        return dpnp.subtract(
-            dpnp.max(a, axis=axis, keepdims=keepdims),
-            dpnp.min(a, axis=axis, keepdims=keepdims),
-            out=out,
-        )
-
-    return call_origin(numpy.ptp, a, axis, out, keepdims)
+    return dpnp.subtract(
+        dpnp.max(a, axis=axis, keepdims=keepdims, out=out),
+        dpnp.min(a, axis=axis, keepdims=keepdims),
+        out=out,
+    )
 
 
 def nanvar(x1, axis=None, dtype=None, out=None, ddof=0, keepdims=False):

--- a/dpnp/dpnp_iface_statistics.py
+++ b/dpnp/dpnp_iface_statistics.py
@@ -60,6 +60,7 @@ __all__ = [
     "mean",
     "median",
     "min",
+    "ptp",
     "nanvar",
     "std",
     "var",
@@ -690,6 +691,55 @@ def min(a, axis=None, out=None, keepdims=False, initial=None, where=True):
             dpnp.copyto(out, result, casting="safe")
 
             return out
+
+
+def ptp(
+    a,
+    /,
+    axis=None,
+    out=None,
+    keepdims=False,
+):
+    """
+    Range of values (maximum - minimum) along an axis.
+
+    For full documentation refer to :obj:`numpy.ptp`.
+
+    Returns
+    -------
+    ptp : dpnp.ndarray
+        The range of a given array.
+
+    Limitations
+    -----------
+    Input array is supported as :class:`dpnp.dpnp_array` or :class:`dpctl.tensor.usm_ndarray`.
+    Otherwise the function will be executed sequentially on CPU.
+
+    Examples
+    --------
+    >>> import dpnp as np
+    >>> x = np.array([[4, 9, 2, 10],[6, 9, 7, 12]])
+    >>> np.ptp(x, axis=1)
+    array([8, 6])
+
+    >>> np.ptp(x, axis=0)
+    array([2, 0, 5, 2])
+
+    >>> np.ptp(x)
+    array(10)
+
+    """
+
+    if not isinstance(a, (dpnp.ndarray, dpt.usm_ndarray)):
+        pass
+    else:
+        return dpnp.subtract(
+            dpnp.max(a, axis=axis, keepdims=keepdims),
+            dpnp.min(a, axis=axis, keepdims=keepdims),
+            out=out,
+        )
+
+    return call_origin(numpy.ptp, a, axis, out, keepdims)
 
 
 def nanvar(x1, axis=None, dtype=None, out=None, ddof=0, keepdims=False):

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -155,11 +155,6 @@ tests/third_party/cupy/creation_tests/test_basic.py::TestBasic::test_ones_like_s
 tests/third_party/cupy/creation_tests/test_basic.py::TestBasic::test_zeros_like_subok
 tests/third_party/cupy/creation_tests/test_basic.py::TestBasic::test_zeros_strides
 
-tests/third_party/cupy/creation_tests/test_matrix.py::TestMatrix::test_diag_construction_from_list
-tests/third_party/cupy/creation_tests/test_matrix.py::TestMatrix::test_diag_construction_from_tuple
-tests/third_party/cupy/creation_tests/test_matrix.py::TestMatrix::test_diag_extraction_from_nested_list
-tests/third_party/cupy/creation_tests/test_matrix.py::TestMatrix::test_diag_extraction_from_nested_tuple
-
 tests/third_party/cupy/creation_tests/test_ranges.py::TestMeshgrid_param_0_{copy=False, indexing='xy', sparse=False}::test_meshgrid0
 tests/third_party/cupy/creation_tests/test_ranges.py::TestMeshgrid_param_0_{copy=False, indexing='xy', sparse=False}::test_meshgrid1
 tests/third_party/cupy/creation_tests/test_ranges.py::TestMeshgrid_param_0_{copy=False, indexing='xy', sparse=False}::test_meshgrid2

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -118,18 +118,6 @@ tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayFlatte
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayFlatten::test_flatten_order_copied
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayFlatten::test_flatten_order_transposed
 
-tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_all
-tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_all_keepdims
-tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_axis0
-tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_axis1
-tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_axis2
-tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_axis_large
-tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_multiple_axes
-tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_multiple_axes_keepdims
-tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_nan
-tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_nan_imag
-tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_nan_real
-
 tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestCubReduction_param_0_{order='C', shape=(10,)}::test_cub_max
 tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestCubReduction_param_0_{order='C', shape=(10,)}::test_cub_min
 tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestCubReduction_param_1_{order='C', shape=(10, 20)}::test_cub_max

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -109,7 +109,6 @@ tests/third_party/cupy/core_tests/test_ndarray_conversion.py::TestNdarrayToBytes
 tests/third_party/cupy/core_tests/test_ndarray_conversion.py::TestNdarrayToBytes_param_3_{order='C', shape=(2, 3)}::test_item
 tests/third_party/cupy/core_tests/test_ndarray_conversion.py::TestNdarrayToBytes_param_4_{order='F', shape=(2, 3)}::test_item
 
-tests/third_party/cupy/creation_tests/test_matrix.py::TestMatrix::test_diag_construction
 tests/third_party/cupy/creation_tests/test_matrix.py::TestMatrix::test_diag_construction_from_list
 tests/third_party/cupy/creation_tests/test_matrix.py::TestMatrix::test_diag_construction_from_tuple
 tests/third_party/cupy/creation_tests/test_matrix.py::TestMatrix::test_diag_extraction_from_nested_list
@@ -200,14 +199,6 @@ tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayFlatte
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayFlatten::test_flatten_order_copied
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayFlatten::test_flatten_order_transposed
 
-tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_all
-tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_all_keepdims
-tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_axis0
-tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_axis1
-tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_axis2
-tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_axis_large
-tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_multiple_axes
-tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_multiple_axes_keepdims
 tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_nan
 tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_nan_imag
 tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_nan_real

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -199,9 +199,7 @@ tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayFlatte
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayFlatten::test_flatten_order_copied
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayFlatten::test_flatten_order_transposed
 
-tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_nan
-tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_nan_imag
-tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_nan_real
+
 
 tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestCubReduction_param_0_{order='C', shape=(10,)}::test_cub_max
 tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestCubReduction_param_0_{order='C', shape=(10,)}::test_cub_min

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -109,11 +109,6 @@ tests/third_party/cupy/core_tests/test_ndarray_conversion.py::TestNdarrayToBytes
 tests/third_party/cupy/core_tests/test_ndarray_conversion.py::TestNdarrayToBytes_param_3_{order='C', shape=(2, 3)}::test_item
 tests/third_party/cupy/core_tests/test_ndarray_conversion.py::TestNdarrayToBytes_param_4_{order='F', shape=(2, 3)}::test_item
 
-tests/third_party/cupy/creation_tests/test_matrix.py::TestMatrix::test_diag_construction_from_list
-tests/third_party/cupy/creation_tests/test_matrix.py::TestMatrix::test_diag_construction_from_tuple
-tests/third_party/cupy/creation_tests/test_matrix.py::TestMatrix::test_diag_extraction_from_nested_list
-tests/third_party/cupy/creation_tests/test_matrix.py::TestMatrix::test_diag_extraction_from_nested_tuple
-
 tests/third_party/cupy/indexing_tests/test_insert.py::TestFillDiagonal_param_4_{shape=(3, 3), val=(2,), wrap=True}::test_1darray
 tests/third_party/cupy/indexing_tests/test_insert.py::TestFillDiagonal_param_4_{shape=(3, 3), val=(2,), wrap=True}::test_fill_diagonal
 tests/third_party/cupy/indexing_tests/test_insert.py::TestFillDiagonal_param_5_{shape=(3, 3), val=(2,), wrap=False}::test_1darray

--- a/tests/test_arraycreation.py
+++ b/tests/test_arraycreation.py
@@ -125,6 +125,36 @@ def test_diag(v, k):
     assert_array_equal(expected, result)
 
 
+@pytest.mark.parametrize(
+    "axis",
+    [None, 0, 1],
+    ids=["None", "0", "1"],
+)
+@pytest.mark.parametrize(
+    "v",
+    [
+        [[0, 0], [0, 0]],
+        [[1, 2], [1, 2]],
+        [[1, 2], [3, 4]],
+        [[0, 1, 2], [3, 4, 5], [6, 7, 8]],
+        [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]],
+    ],
+    ids=[
+        "[[0, 0], [0, 0]]",
+        "[[1, 2], [1, 2]]",
+        "[[1, 2], [3, 4]]",
+        "[[0, 1, 2], [3, 4, 5], [6, 7, 8]]",
+        "[[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]",
+    ],
+)
+def test_ptp(v, axis):
+    a = numpy.array(v)
+    ia = dpnp.array(a)
+    expected = numpy.ptp(a, axis)
+    result = dpnp.ptp(ia, axis)
+    assert_array_equal(expected, result)
+
+
 @pytest.mark.parametrize("N", [0, 1, 2, 3], ids=["0", "1", "2", "3"])
 @pytest.mark.parametrize(
     "M", [None, 0, 1, 2, 3], ids=["None", "0", "1", "2", "3"]
@@ -426,12 +456,16 @@ def test_triu_size_null(k):
 @pytest.mark.parametrize("n", [0, 1, 4, None], ids=["0", "1", "4", "None"])
 @pytest.mark.parametrize("increase", [True, False], ids=["True", "False"])
 def test_vander(array, dtype, n, increase):
-    create_array = lambda xp: xp.array(array, dtype=dtype)
+    if dtype in [dpnp.complex64, dpnp.complex128] and array == [0, 3, 5]:
+        pytest.skip(
+            "dpnp.power(dpnp.array(complex(0,0)), dpnp.array(0)) returns nan+nanj while it should be 1+0j"
+        )
     vander_func = lambda xp, x: xp.vander(x, N=n, increasing=increase)
 
     a_np = numpy.array(array, dtype=dtype)
     a_dpnp = dpnp.array(array, dtype=dtype)
-    assert_array_equal(vander_func(numpy, a_np), vander_func(dpnp, a_dpnp))
+
+    assert_allclose(vander_func(numpy, a_np), vander_func(dpnp, a_dpnp))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_arraycreation.py
+++ b/tests/test_arraycreation.py
@@ -117,41 +117,40 @@ def test_arange(start, stop, step, dtype):
         "[[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]",
     ],
 )
-def test_diag(v, k):
+def test_diag_diagflat(v, k):
     a = numpy.array(v)
     ia = dpnp.array(a)
     expected = numpy.diag(a, k)
     result = dpnp.diag(ia, k)
     assert_array_equal(expected, result)
 
+    expected = numpy.diagflat(a, k)
+    result = dpnp.diagflat(ia, k)
+    assert_array_equal(expected, result)
+
 
 @pytest.mark.parametrize(
-    "axis",
-    [None, 0, 1],
-    ids=["None", "0", "1"],
-)
-@pytest.mark.parametrize(
-    "v",
+    "seq",
     [
-        [[0, 0], [0, 0]],
-        [[1, 2], [1, 2]],
-        [[1, 2], [3, 4]],
+        [0, 1, 2, 3, 4],
+        (0, 1, 2, 3, 4),
         [[0, 1, 2], [3, 4, 5], [6, 7, 8]],
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]],
     ],
     ids=[
-        "[[0, 0], [0, 0]]",
-        "[[1, 2], [1, 2]]",
-        "[[1, 2], [3, 4]]",
+        "[0, 1, 2, 3, 4]",
+        "(0, 1, 2, 3, 4)",
         "[[0, 1, 2], [3, 4, 5], [6, 7, 8]]",
         "[[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]",
     ],
 )
-def test_ptp(v, axis):
-    a = numpy.array(v)
-    ia = dpnp.array(a)
-    expected = numpy.ptp(a, axis)
-    result = dpnp.ptp(ia, axis)
+def test_diag_diagflat_seq(seq):
+    expected = numpy.diag(seq)
+    result = dpnp.diag(seq)
+    assert_array_equal(expected, result)
+
+    expected = numpy.diagflat(seq)
+    result = dpnp.diagflat(seq)
     assert_array_equal(expected, result)
 
 
@@ -458,7 +457,7 @@ def test_triu_size_null(k):
 def test_vander(array, dtype, n, increase):
     if dtype in [dpnp.complex64, dpnp.complex128] and array == [0, 3, 5]:
         pytest.skip(
-            "dpnp.power(dpnp.array(complex(0,0)), dpnp.array(0)) returns nan+nanj while it should be 1+0j"
+            "per array API dpnp.power(complex(0,0)), 0) returns nan+nanj while NumPy returns 1+0j"
         )
     vander_func = lambda xp, x: xp.vander(x, N=n, increasing=increase)
 
@@ -466,6 +465,16 @@ def test_vander(array, dtype, n, increase):
     a_dpnp = dpnp.array(array, dtype=dtype)
 
     assert_allclose(vander_func(numpy, a_np), vander_func(dpnp, a_dpnp))
+
+
+@pytest.mark.parametrize(
+    "sequence",
+    [[1, 2, 3, 4], (1, 2, 3, 4)],
+    ids=["[1, 2, 3, 4]", "(1, 2, 3, 4)"],
+)
+def test_vander_seq(sequence):
+    vander_func = lambda xp, x: xp.vander(x)
+    assert_allclose(vander_func(numpy, sequence), vander_func(dpnp, sequence))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_arraycreation.py
+++ b/tests/test_arraycreation.py
@@ -91,6 +91,7 @@ def test_arange(start, stop, step, dtype):
         assert_array_equal(exp_array, res_array)
 
 
+@pytest.mark.parametrize("func", ["diag", "diagflat"])
 @pytest.mark.parametrize(
     "k",
     [-6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6],
@@ -117,18 +118,22 @@ def test_arange(start, stop, step, dtype):
         "[[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]",
     ],
 )
-def test_diag_diagflat(v, k):
+def test_diag_diagflat(func, v, k):
     a = numpy.array(v)
     ia = dpnp.array(a)
-    expected = numpy.diag(a, k)
-    result = dpnp.diag(ia, k)
-    assert_array_equal(expected, result)
-
-    expected = numpy.diagflat(a, k)
-    result = dpnp.diagflat(ia, k)
+    expected = getattr(numpy, func)(a, k)
+    result = getattr(dpnp, func)(ia, k)
     assert_array_equal(expected, result)
 
 
+@pytest.mark.parametrize("func", ["diag", "diagflat"])
+def test_diag_diagflat_raise_error(func):
+    ia = dpnp.array([0, 1, 2, 3, 4])
+    with pytest.raises(TypeError):
+        getattr(dpnp, func)(ia, k=2.0)
+
+
+@pytest.mark.parametrize("func", ["diag", "diagflat"])
 @pytest.mark.parametrize(
     "seq",
     [
@@ -144,13 +149,9 @@ def test_diag_diagflat(v, k):
         "[[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]",
     ],
 )
-def test_diag_diagflat_seq(seq):
-    expected = numpy.diag(seq)
-    result = dpnp.diag(seq)
-    assert_array_equal(expected, result)
-
-    expected = numpy.diagflat(seq)
-    result = dpnp.diagflat(seq)
+def test_diag_diagflat_seq(func, seq):
+    expected = getattr(numpy, func)(seq)
+    result = getattr(dpnp, func)(seq)
     assert_array_equal(expected, result)
 
 
@@ -465,6 +466,16 @@ def test_vander(array, dtype, n, increase):
     a_dpnp = dpnp.array(array, dtype=dtype)
 
     assert_allclose(vander_func(numpy, a_np), vander_func(dpnp, a_dpnp))
+
+
+def test_vander_raise_error():
+    a = dpnp.array([1, 2, 3, 4])
+    with pytest.raises(TypeError):
+        dpnp.vander(a, N=1.0)
+
+    a = dpnp.array([[1, 2], [3, 4]])
+    with pytest.raises(ValueError):
+        dpnp.vander(a)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -1,7 +1,10 @@
 import dpctl.tensor as dpt
 import numpy
 import pytest
-from numpy.testing import assert_allclose
+from numpy.testing import (
+    assert_allclose,
+    assert_array_equal,
+)
 
 import dpnp
 
@@ -190,3 +193,64 @@ def test_cov_1D_rowvar(dtype):
     a = dpnp.array([[0, 1, 2]], dtype=dtype)
     b = numpy.array([[0, 1, 2]], dtype=dtype)
     assert_allclose(numpy.cov(b, rowvar=False), dpnp.cov(a, rowvar=False))
+
+
+@pytest.mark.parametrize(
+    "axis",
+    [None, 0, 1],
+    ids=["None", "0", "1"],
+)
+@pytest.mark.parametrize(
+    "v",
+    [
+        [[0, 0], [0, 0]],
+        [[1, 2], [1, 2]],
+        [[1, 2], [3, 4]],
+        [[0, 1, 2], [3, 4, 5], [6, 7, 8]],
+        [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]],
+    ],
+    ids=[
+        "[[0, 0], [0, 0]]",
+        "[[1, 2], [1, 2]]",
+        "[[1, 2], [3, 4]]",
+        "[[0, 1, 2], [3, 4, 5], [6, 7, 8]]",
+        "[[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]",
+    ],
+)
+def test_ptp(v, axis):
+    a = numpy.array(v)
+    ia = dpnp.array(a)
+    expected = numpy.ptp(a, axis)
+    result = dpnp.ptp(ia, axis)
+    assert_array_equal(expected, result)
+
+
+@pytest.mark.parametrize(
+    "axis",
+    [None, 0, 1],
+    ids=["None", "0", "1"],
+)
+@pytest.mark.parametrize(
+    "v",
+    [
+        [[0, 0], [0, 0]],
+        [[1, 2], [1, 2]],
+        [[1, 2], [3, 4]],
+        [[0, 1, 2], [3, 4, 5], [6, 7, 8]],
+        [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]],
+    ],
+    ids=[
+        "[[0, 0], [0, 0]]",
+        "[[1, 2], [1, 2]]",
+        "[[1, 2], [3, 4]]",
+        "[[0, 1, 2], [3, 4, 5], [6, 7, 8]]",
+        "[[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]",
+    ],
+)
+def test_ptp_out(v, axis):
+    a = numpy.array(v)
+    ia = dpnp.array(a)
+    expected = numpy.ptp(a, axis)
+    result = dpnp.array(numpy.empty_like(expected))
+    dpnp.ptp(ia, axis, out=result)
+    assert_array_equal(expected, result)

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -199,13 +199,11 @@ def test_array_creation_follow_device_logspace_base(device):
     assert_sycl_queue_equal(y.sycl_queue, x.sycl_queue)
 
 
-@pytest.mark.skip("muted until the issue reported by SAT-5969 is resolved")
 @pytest.mark.parametrize(
     "func, args, kwargs",
     [
         pytest.param("diag", ["x0"], {}),
         pytest.param("diagflat", ["x0"], {}),
-        pytest.param("ptp", ["x0"], {"axis": 0}),
     ],
 )
 @pytest.mark.parametrize(
@@ -226,6 +224,7 @@ def test_array_creation_follow_device_2d_array(func, args, kwargs, device):
     assert_sycl_queue_equal(y.sycl_queue, x.sycl_queue)
 
 
+@pytest.mark.skip("muted until the issue reported by SAT-5969 is resolved")
 @pytest.mark.parametrize(
     "func, args, kwargs",
     [
@@ -276,7 +275,6 @@ def test_array_creation_cross_device(func, args, kwargs, device_x, device_y):
     [
         pytest.param("diag", ["x0"], {}),
         pytest.param("diagflat", ["x0"], {}),
-        pytest.param("ptp", ["x0"], {"axis": 0}),
     ],
 )
 @pytest.mark.parametrize(
@@ -375,6 +373,7 @@ def test_meshgrid(device_x, device_y):
         pytest.param("negative", [1.0, 0.0, -1.0]),
         pytest.param("positive", [1.0, 0.0, -1.0]),
         pytest.param("prod", [1.0, 2.0]),
+        pytest.param("ptp", [1.0, 2.0, 4.0, 7.0]),
         pytest.param(
             "real", [complex(1.0, 2.0), complex(3.0, 4.0), complex(5.0, 6.0)]
         ),

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -270,6 +270,7 @@ def test_array_creation_cross_device(func, args, kwargs, device_x, device_y):
     assert_sycl_queue_equal(y.sycl_queue, x.to_device(device_y).sycl_queue)
 
 
+@pytest.mark.skip("muted until the issue reported by SAT-5969 is resolved")
 @pytest.mark.parametrize(
     "func, args, kwargs",
     [

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -152,13 +152,10 @@ def test_empty_like(device_x, device_y):
         pytest.param("ones_like", ["x0"], {}),
         pytest.param("tril", ["x0.reshape((2,2))"], {}),
         pytest.param("triu", ["x0.reshape((2,2))"], {}),
-<<<<<<< HEAD
-        pytest.param("zeros_like", ["x0"], {}),
-=======
         pytest.param("linspace", ["x0", "4", "4"], {}),
         pytest.param("linspace", ["1", "x0", "4"], {}),
         pytest.param("vander", ["x0"], {}),
->>>>>>> rework implementation of diag, diagflat, vander, and ptp
+        pytest.param("zeros_like", ["x0"], {}),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -141,6 +141,7 @@ def test_empty_like(device_x, device_y):
 @pytest.mark.parametrize(
     "func, args, kwargs",
     [
+        pytest.param("diag", ["x0"], {}),
         pytest.param("full_like", ["x0"], {"fill_value": 5}),
         pytest.param("geomspace", ["x0[0:3]", "8", "4"], {}),
         pytest.param("geomspace", ["1", "x0[2:4]", "4"], {}),
@@ -151,7 +152,13 @@ def test_empty_like(device_x, device_y):
         pytest.param("ones_like", ["x0"], {}),
         pytest.param("tril", ["x0.reshape((2,2))"], {}),
         pytest.param("triu", ["x0.reshape((2,2))"], {}),
+<<<<<<< HEAD
         pytest.param("zeros_like", ["x0"], {}),
+=======
+        pytest.param("linspace", ["x0", "4", "4"], {}),
+        pytest.param("linspace", ["1", "x0", "4"], {}),
+        pytest.param("vander", ["x0"], {}),
+>>>>>>> rework implementation of diag, diagflat, vander, and ptp
     ],
 )
 @pytest.mark.parametrize(
@@ -196,11 +203,40 @@ def test_array_creation_follow_device_logspace_base(device):
 @pytest.mark.parametrize(
     "func, args, kwargs",
     [
+        pytest.param("diag", ["x0"], {}),
+        pytest.param("diagflat", ["x0"], {}),
+        pytest.param("ptp", ["x0"], {"axis": 0}),
+    ],
+)
+@pytest.mark.parametrize(
+    "device",
+    valid_devices,
+    ids=[device.filter_string for device in valid_devices],
+)
+def test_array_creation_follow_device_2d_array(func, args, kwargs, device):
+    x_orig = numpy.arange(9).reshape(3, 3)
+    numpy_args = [eval(val, {"x0": x_orig}) for val in args]
+    y_orig = getattr(numpy, func)(*numpy_args, **kwargs)
+
+    x = dpnp.arange(9, device=device).reshape(3, 3)
+    dpnp_args = [eval(val, {"x0": x}) for val in args]
+
+    y = getattr(dpnp, func)(*dpnp_args, **kwargs)
+    assert_allclose(y_orig, y)
+    assert_sycl_queue_equal(y.sycl_queue, x.sycl_queue)
+
+
+@pytest.mark.parametrize(
+    "func, args, kwargs",
+    [
+        pytest.param("diag", ["x0"], {}),
+        pytest.param("full", ["10", "x0[3]"], {}),
         pytest.param("full_like", ["x0"], {"fill_value": 5}),
         pytest.param("ones_like", ["x0"], {}),
         pytest.param("zeros_like", ["x0"], {}),
         pytest.param("linspace", ["x0", "4", "4"], {}),
         pytest.param("linspace", ["1", "x0", "4"], {}),
+        pytest.param("vander", ["x0"], {}),
     ],
 )
 @pytest.mark.parametrize(
@@ -214,7 +250,7 @@ def test_array_creation_follow_device_logspace_base(device):
     ids=[device.filter_string for device in valid_devices],
 )
 def test_array_creation_cross_device(func, args, kwargs, device_x, device_y):
-    if func is "linspace" and is_win_platform():
+    if func == "linspace" and is_win_platform():
         pytest.skip("CPU driver experiences an instability on Windows.")
 
     x_orig = numpy.array([1, 2, 3, 4])
@@ -225,8 +261,52 @@ def test_array_creation_cross_device(func, args, kwargs, device_x, device_y):
     dpnp_args = [eval(val, {"x0": x}) for val in args]
 
     dpnp_kwargs = dict(kwargs)
-    dpnp_kwargs["device"] = device_y
+    y = getattr(dpnp, func)(*dpnp_args, **dpnp_kwargs)
+    assert_sycl_queue_equal(y.sycl_queue, x.sycl_queue)
 
+    dpnp_kwargs["device"] = device_y
+    y = getattr(dpnp, func)(*dpnp_args, **dpnp_kwargs)
+    assert_allclose(y_orig, y)
+
+    assert_sycl_queue_equal(y.sycl_queue, x.to_device(device_y).sycl_queue)
+
+
+@pytest.mark.parametrize(
+    "func, args, kwargs",
+    [
+        pytest.param("diag", ["x0"], {}),
+        pytest.param("diagflat", ["x0"], {}),
+        pytest.param("ptp", ["x0"], {"axis": 0}),
+    ],
+)
+@pytest.mark.parametrize(
+    "device_x",
+    valid_devices,
+    ids=[device.filter_string for device in valid_devices],
+)
+@pytest.mark.parametrize(
+    "device_y",
+    valid_devices,
+    ids=[device.filter_string for device in valid_devices],
+)
+def test_array_creation_cross_device_2d_array(
+    func, args, kwargs, device_x, device_y
+):
+    if func == "linspace" and is_win_platform():
+        pytest.skip("CPU driver experiences an instability on Windows.")
+
+    x_orig = numpy.arange(9).reshape(3, 3)
+    numpy_args = [eval(val, {"x0": x_orig}) for val in args]
+    y_orig = getattr(numpy, func)(*numpy_args, **kwargs)
+
+    x = dpnp.arange(9, device=device_x).reshape(3, 3)
+    dpnp_args = [eval(val, {"x0": x}) for val in args]
+
+    dpnp_kwargs = dict(kwargs)
+    y = getattr(dpnp, func)(*dpnp_args, **dpnp_kwargs)
+    assert_sycl_queue_equal(y.sycl_queue, x.sycl_queue)
+
+    dpnp_kwargs["device"] = device_y
     y = getattr(dpnp, func)(*dpnp_args, **dpnp_kwargs)
     assert_allclose(y_orig, y)
 

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -179,7 +179,6 @@ def test_array_creation_from_1d_array(func, args, usm_type_x, usm_type_y):
     [
         pytest.param("diag", ["x0"]),
         pytest.param("diagflat", ["x0"]),
-        pytest.param("ptp", ["x0", "0"]),
     ],
 )
 @pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
@@ -403,6 +402,7 @@ def test_meshgrid(usm_type_x, usm_type_y):
         pytest.param("positive", [1.0, 0.0, -1.0]),
         pytest.param("prod", [1.0, 2.0]),
         pytest.param("proj", [complex(1.0, 2.0), complex(dp.inf, -1.0)]),
+        pytest.param("ptp", [1.0, 2.0, 4.0, 7.0]),
         pytest.param(
             "real", [complex(1.0, 2.0), complex(3.0, 4.0), complex(5.0, 6.0)]
         ),

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -140,25 +140,19 @@ def test_coerced_usm_types_power(usm_type_x, usm_type_y):
 @pytest.mark.parametrize(
     "func, args",
     [
-<<<<<<< HEAD
-        pytest.param("empty_like", ["x0"]),
-=======
         pytest.param("diag", ["x0"]),
->>>>>>> rework implementation of diag, diagflat, vander, and ptp
+        pytest.param("empty_like", ["x0"]),
         pytest.param("full", ["10", "x0[3]"]),
         pytest.param("full_like", ["x0", "4"]),
         pytest.param("geomspace", ["x0[0:3]", "8", "4"]),
         pytest.param("geomspace", ["1", "x0[3:5]", "4"]),
         pytest.param("linspace", ["x0[0:2]", "8", "4"]),
         pytest.param("linspace", ["0", "x0[3:5]", "4"]),
-<<<<<<< HEAD
         pytest.param("logspace", ["x0[0:2]", "8", "4"]),
         pytest.param("logspace", ["0", "x0[3:5]", "4"]),
         pytest.param("ones_like", ["x0"]),
-        pytest.param("zeros_like", ["x0"]),
-=======
         pytest.param("vander", ["x0"]),
->>>>>>> rework implementation of diag, diagflat, vander, and ptp
+        pytest.param("zeros_like", ["x0"]),
     ],
 )
 @pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -140,23 +140,52 @@ def test_coerced_usm_types_power(usm_type_x, usm_type_y):
 @pytest.mark.parametrize(
     "func, args",
     [
+<<<<<<< HEAD
         pytest.param("empty_like", ["x0"]),
+=======
+        pytest.param("diag", ["x0"]),
+>>>>>>> rework implementation of diag, diagflat, vander, and ptp
         pytest.param("full", ["10", "x0[3]"]),
         pytest.param("full_like", ["x0", "4"]),
         pytest.param("geomspace", ["x0[0:3]", "8", "4"]),
         pytest.param("geomspace", ["1", "x0[3:5]", "4"]),
         pytest.param("linspace", ["x0[0:2]", "8", "4"]),
         pytest.param("linspace", ["0", "x0[3:5]", "4"]),
+<<<<<<< HEAD
         pytest.param("logspace", ["x0[0:2]", "8", "4"]),
         pytest.param("logspace", ["0", "x0[3:5]", "4"]),
         pytest.param("ones_like", ["x0"]),
         pytest.param("zeros_like", ["x0"]),
+=======
+        pytest.param("vander", ["x0"]),
+>>>>>>> rework implementation of diag, diagflat, vander, and ptp
     ],
 )
 @pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
 @pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
-def test_array_creation_from_an_array(func, args, usm_type_x, usm_type_y):
+def test_array_creation_from_1d_array(func, args, usm_type_x, usm_type_y):
     x0 = dp.full(10, 3, usm_type=usm_type_x)
+    new_args = [eval(val, {"x0": x0}) for val in args]
+
+    x = getattr(dp, func)(*new_args)
+    y = getattr(dp, func)(*new_args, usm_type=usm_type_y)
+
+    assert x.usm_type == usm_type_x
+    assert y.usm_type == usm_type_y
+
+
+@pytest.mark.parametrize(
+    "func, args",
+    [
+        pytest.param("diag", ["x0"]),
+        pytest.param("diagflat", ["x0"]),
+        pytest.param("ptp", ["x0", "0"]),
+    ],
+)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+def test_array_creation_from_2d_array(func, args, usm_type_x, usm_type_y):
+    x0 = dp.arange(25, usm_type=usm_type_x).reshape(5, 5)
     new_args = [eval(val, {"x0": x0}) for val in args]
 
     x = getattr(dp, func)(*new_args)

--- a/tests/third_party/cupy/core_tests/test_ndarray_reduction.py
+++ b/tests/third_party/cupy/core_tests/test_ndarray_reduction.py
@@ -9,7 +9,6 @@ import dpnp as cupy
 from tests.third_party.cupy import testing
 
 
-@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @testing.gpu
 class TestArrayReduction(unittest.TestCase):
     @testing.for_all_dtypes()
@@ -149,70 +148,70 @@ class TestArrayReduction(unittest.TestCase):
     @testing.numpy_cupy_allclose()
     def test_ptp_all(self, xp, dtype):
         a = testing.shaped_random((2, 3), xp, dtype)
-        return a.ptp()
+        return xp.ptp(a)
 
     @testing.with_requires("numpy>=1.15")
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose()
     def test_ptp_all_keepdims(self, xp, dtype):
         a = testing.shaped_random((2, 3), xp, dtype)
-        return a.ptp(keepdims=True)
+        return xp.ptp(a, keepdims=True)
 
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose()
     def test_ptp_axis_large(self, xp, dtype):
         a = testing.shaped_random((3, 1000), xp, dtype)
-        return a.ptp(axis=0)
+        return xp.ptp(a, axis=0)
 
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose()
     def test_ptp_axis0(self, xp, dtype):
         a = testing.shaped_random((2, 3, 4), xp, dtype)
-        return a.ptp(axis=0)
+        return xp.ptp(a, axis=0)
 
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose()
     def test_ptp_axis1(self, xp, dtype):
         a = testing.shaped_random((2, 3, 4), xp, dtype)
-        return a.ptp(axis=1)
+        return xp.ptp(a, axis=1)
 
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose()
     def test_ptp_axis2(self, xp, dtype):
         a = testing.shaped_random((2, 3, 4), xp, dtype)
-        return a.ptp(axis=2)
+        return xp.ptp(a, axis=2)
 
     @testing.with_requires("numpy>=1.15")
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose()
     def test_ptp_multiple_axes(self, xp, dtype):
         a = testing.shaped_random((2, 3, 4), xp, dtype)
-        return a.ptp(axis=(1, 2))
+        return xp.ptp(a, axis=(1, 2))
 
     @testing.with_requires("numpy>=1.15")
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose()
     def test_ptp_multiple_axes_keepdims(self, xp, dtype):
         a = testing.shaped_random((2, 3, 4), xp, dtype)
-        return a.ptp(axis=(1, 2), keepdims=True)
+        return xp.ptp(a, axis=(1, 2), keepdims=True)
 
     @testing.for_float_dtypes()
     @testing.numpy_cupy_allclose()
     def test_ptp_nan(self, xp, dtype):
         a = xp.array([float("nan"), 1, -1], dtype)
-        return a.ptp()
+        return xp.ptp(a)
 
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose()
     def test_ptp_nan_real(self, xp, dtype):
         a = xp.array([float("nan"), 1, -1], dtype)
-        return a.ptp()
+        return xp.ptp(a)
 
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose()
     def test_ptp_nan_imag(self, xp, dtype):
         a = xp.array([float("nan") * 1.0j, 1.0j, -1.0j], dtype)
-        return a.ptp()
+        return xp.ptp(a)
 
 
 @testing.parameterize(

--- a/tests/third_party/cupy/core_tests/test_ndarray_reduction.py
+++ b/tests/third_party/cupy/core_tests/test_ndarray_reduction.py
@@ -10,207 +10,220 @@ from tests.third_party.cupy import testing
 
 
 @testing.gpu
+@testing.parameterize(
+    *testing.product(
+        {
+            "order": ("C", "F"),
+        }
+    )
+)
 class TestArrayReduction(unittest.TestCase):
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_max_all(self, xp, dtype):
-        a = testing.shaped_random((2, 3), xp, dtype)
+        a = testing.shaped_random((2, 3), xp, dtype, order=self.order)
         return a.max()
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_max_all_keepdims(self, xp, dtype):
-        a = testing.shaped_random((2, 3), xp, dtype)
+        a = testing.shaped_random((2, 3), xp, dtype, order=self.order)
         return a.max(keepdims=True)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_max_axis_large(self, xp, dtype):
-        a = testing.shaped_random((3, 1000), xp, dtype)
+        a = testing.shaped_random((3, 1000), xp, dtype, order=self.order)
         return a.max(axis=0)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_max_axis0(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return a.max(axis=0)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_max_axis1(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return a.max(axis=1)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_max_axis2(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return a.max(axis=2)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_max_multiple_axes(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return a.max(axis=(1, 2))
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_max_multiple_axes_keepdims(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return a.max(axis=(1, 2), keepdims=True)
 
     @testing.for_float_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_max_nan(self, xp, dtype):
-        a = xp.array([float("nan"), 1, -1], dtype)
+        a = xp.array([float("nan"), 1, -1], dtype, order=self.order)
         return a.max()
 
     @testing.for_complex_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_max_nan_real(self, xp, dtype):
-        a = xp.array([float("nan"), 1, -1], dtype)
+        a = xp.array([float("nan"), 1, -1], dtype, order=self.order)
         return a.max()
 
     @testing.for_complex_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_max_nan_imag(self, xp, dtype):
-        a = xp.array([float("nan") * 1.0j, 1.0j, -1.0j], dtype)
+        a = xp.array(
+            [float("nan") * 1.0j, 1.0j, -1.0j], dtype, order=self.order
+        )
         return a.max()
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_min_all(self, xp, dtype):
-        a = testing.shaped_random((2, 3), xp, dtype)
+        a = testing.shaped_random((2, 3), xp, dtype, order=self.order)
         return a.min()
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_min_all_keepdims(self, xp, dtype):
-        a = testing.shaped_random((2, 3), xp, dtype)
+        a = testing.shaped_random((2, 3), xp, dtype, order=self.order)
         return a.min(keepdims=True)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_min_axis_large(self, xp, dtype):
-        a = testing.shaped_random((3, 1000), xp, dtype)
+        a = testing.shaped_random((3, 1000), xp, dtype, order=self.order)
         return a.min(axis=0)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_min_axis0(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return a.min(axis=0)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_min_axis1(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return a.min(axis=1)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_min_axis2(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return a.min(axis=2)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_min_multiple_axes(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return a.min(axis=(1, 2))
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_min_multiple_axes_keepdims(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return a.min(axis=(1, 2), keepdims=True)
 
     @testing.for_float_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_min_nan(self, xp, dtype):
-        a = xp.array([float("nan"), 1, -1], dtype)
+        a = xp.array([float("nan"), 1, -1], dtype, order=self.order)
         return a.min()
 
     @testing.for_complex_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_min_nan_real(self, xp, dtype):
-        a = xp.array([float("nan"), 1, -1], dtype)
+        a = xp.array([float("nan"), 1, -1], dtype, order=self.order)
         return a.min()
 
     @testing.for_complex_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_min_nan_imag(self, xp, dtype):
-        a = xp.array([float("nan") * 1.0j, 1.0j, -1.0j], dtype)
+        a = xp.array(
+            [float("nan") * 1.0j, 1.0j, -1.0j], dtype, order=self.order
+        )
         return a.min()
 
     # skip bool: numpy's ptp raises a TypeError on bool inputs
     @testing.for_all_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_ptp_all(self, xp, dtype):
-        a = testing.shaped_random((2, 3), xp, dtype)
+        a = testing.shaped_random((2, 3), xp, dtype, order=self.order)
         return xp.ptp(a)
 
     @testing.with_requires("numpy>=1.15")
     @testing.for_all_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_ptp_all_keepdims(self, xp, dtype):
-        a = testing.shaped_random((2, 3), xp, dtype)
+        a = testing.shaped_random((2, 3), xp, dtype, order=self.order)
         return xp.ptp(a, keepdims=True)
 
     @testing.for_all_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_ptp_axis_large(self, xp, dtype):
-        a = testing.shaped_random((3, 1000), xp, dtype)
+        a = testing.shaped_random((3, 1000), xp, dtype, order=self.order)
         return xp.ptp(a, axis=0)
 
     @testing.for_all_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_ptp_axis0(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return xp.ptp(a, axis=0)
 
     @testing.for_all_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_ptp_axis1(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return xp.ptp(a, axis=1)
 
     @testing.for_all_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_ptp_axis2(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return xp.ptp(a, axis=2)
 
     @testing.with_requires("numpy>=1.15")
     @testing.for_all_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_ptp_multiple_axes(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return xp.ptp(a, axis=(1, 2))
 
     @testing.with_requires("numpy>=1.15")
     @testing.for_all_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_ptp_multiple_axes_keepdims(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return xp.ptp(a, axis=(1, 2), keepdims=True)
 
     @testing.for_float_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_ptp_nan(self, xp, dtype):
-        a = xp.array([float("nan"), 1, -1], dtype)
+        a = xp.array([float("nan"), 1, -1], dtype, order=self.order)
         return xp.ptp(a)
 
     @testing.for_complex_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_ptp_nan_real(self, xp, dtype):
-        a = xp.array([float("nan"), 1, -1], dtype)
+        a = xp.array([float("nan"), 1, -1], dtype, order=self.order)
         return xp.ptp(a)
 
     @testing.for_complex_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_ptp_nan_imag(self, xp, dtype):
-        a = xp.array([float("nan") * 1.0j, 1.0j, -1.0j], dtype)
+        a = xp.array(
+            [float("nan") * 1.0j, 1.0j, -1.0j], dtype, order=self.order
+        )
         return xp.ptp(a)
 
 

--- a/tests/third_party/cupy/creation_tests/test_matrix.py
+++ b/tests/third_party/cupy/creation_tests/test_matrix.py
@@ -59,19 +59,16 @@ class TestMatrix(unittest.TestCase):
         self.assertIsInstance(r, xp.ndarray)
         return r
 
-    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_diag_scaler(self):
         for xp in (numpy, cupy):
             with pytest.raises(ValueError):
                 xp.diag(1)
 
-    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_diag_0dim(self):
         for xp in (numpy, cupy):
             with pytest.raises(ValueError):
                 xp.diag(xp.zeros(()))
 
-    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_diag_3dim(self):
         for xp in (numpy, cupy):
             with pytest.raises(ValueError):
@@ -92,17 +89,14 @@ class TestMatrix(unittest.TestCase):
         a = testing.shaped_arange((3, 3), xp)
         return xp.diagflat(a, -2)
 
-    @pytest.mark.skip("Scalar input is not supported")
     @testing.numpy_cupy_array_equal()
     def test_diagflat_from_scalar(self, xp):
         return xp.diagflat(3)
 
-    @pytest.mark.skip("Scalar input is not supported")
     @testing.numpy_cupy_array_equal()
     def test_diagflat_from_scalar_with_k0(self, xp):
         return xp.diagflat(3, 0)
 
-    @pytest.mark.skip("Scalar input is not supported")
     @testing.numpy_cupy_array_equal()
     def test_diagflat_from_scalar_with_k1(self, xp):
         return xp.diagflat(3, 1)
@@ -183,3 +177,41 @@ class TestTriLowerAndUpper(unittest.TestCase):
     def test_triu_posi(self, xp, dtype):
         m = testing.shaped_arange(self.shape, xp, dtype)
         return xp.triu(m, k=1)
+
+
+@testing.parameterize(
+    *testing.product({"N": [None, 0, 1, 2, 3], "increasing": [False, True]})
+)
+class TestVander(unittest.TestCase):
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose(type_check=False)
+    def test_vander(self, xp, dtype):
+        a = testing.shaped_arange((3,), xp, dtype=dtype)
+        return xp.vander(a, N=self.N, increasing=self.increasing)
+
+    @testing.numpy_cupy_allclose()
+    def test_vander_array_like_list(self, xp):
+        a = [0, 1, 2, 3, 4, 5, 6]
+        return xp.vander(a, N=self.N, increasing=self.increasing)
+
+    @testing.numpy_cupy_allclose()
+    def test_vander_array_like_tuple(self, xp):
+        a = (0, 1, 2, 3, 4, 5, 6)
+        return xp.vander(a, N=self.N, increasing=self.increasing)
+
+    def test_vander_scalar(self):
+        for xp in (numpy, cupy):
+            with pytest.raises(ValueError):
+                xp.vander(1, N=self.N, increasing=self.increasing)
+
+    def test_vander_0dim(self):
+        for xp in (numpy, cupy):
+            a = xp.zeros(())
+            with pytest.raises(ValueError):
+                xp.vander(a, N=self.N, increasing=self.increasing)
+
+    def test_vander_2dim(self):
+        for xp in (numpy, cupy):
+            m = xp.zeros((2, 2))
+            with pytest.raises(ValueError):
+                xp.vander(m, N=self.N, increasing=self.increasing)


### PR DESCRIPTION
In this PR, `device`, `usm_type`, and `sycl_queue` keywords are added to `dpnp.diag`, `dpnp.diagflat`, `dpnp.ptp` and `dpnp.vander`.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
