### PR TITLE
Added dependency on min required dpctl version while installing in build docs env

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Install dpnp dependencies
         run: |
-          conda install numpy"<1.24" dpctl mkl-devel-dpcpp onedpl-devel tbb-devel dpcpp_linux-64 \
+          conda install numpy"<1.24" dpctl">=0.15.0" mkl-devel-dpcpp onedpl-devel tbb-devel dpcpp_linux-64 \
               cmake cython pytest ninja scikit-build sysroot_linux-64">=2.28" ${{ env.CHANNELS }}
 
       - name: Install cuPy dependencies


### PR DESCRIPTION
The PR proposes to explicitly state a dependency on minimum required `dpctl` version while installing in build docs environment, since it's aligned with `dpnp` dependencies listed in `host` section of `meta.yaml`.
Prior the change, conda might install dpctl of older version which causes an issue.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
