### PR TITLE
fix cholesky for 0-D array

### DIFF
--- a/dpnp/backend/kernels/dpnp_krnl_linalg.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_linalg.cpp
@@ -47,6 +47,9 @@ DPCTLSyclEventRef dpnp_cholesky_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
+    if (!data_size) {
+        return event_ref;
+    }
     sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     sycl::event event;

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -61,6 +61,25 @@ def test_cholesky(array):
 
 
 @pytest.mark.parametrize(
+    "shape",
+    [
+        (0, 0),
+        (3, 0, 0),
+    ],
+    ids=[
+        "(0, 0)",
+        "(3, 0, 0)",
+    ],
+)
+def test_cholesky_0D(shape):
+    a = numpy.empty(shape)
+    ia = inp.array(a)
+    result = inp.linalg.cholesky(ia)
+    expected = numpy.linalg.cholesky(a)
+    assert_array_equal(expected, result)
+
+
+@pytest.mark.parametrize(
     "arr",
     [[[1, 0, -1], [0, 1, 0], [1, 0, 1]], [[1, 2, 3], [4, 5, 6], [7, 8, 9]]],
     ids=[


### PR DESCRIPTION
In this PR, `dpnp.linalg.cholesky` is modified to work with zero-dimensional arrays.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
