### PR TITLE
in place divide and floor_divide

### DIFF
--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -1071,7 +1071,7 @@ class TestAdd:
 
 
 class TestDivide:
-    @pytest.mark.parametrize("dtype", get_float_dtypes() + get_complex_dtypes())
+    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
     def test_divide(self, dtype):
         array1_data = numpy.arange(10)
         array2_data = numpy.arange(5, 15)
@@ -1088,12 +1088,11 @@ class TestDivide:
         np_array2 = numpy.array(array2_data, dtype=dtype)
         expected = numpy.divide(np_array1, np_array2, out=out)
 
-        tol = 1e-07
-        assert_allclose(expected, result, rtol=tol, atol=tol)
-        assert_allclose(out, dp_out, rtol=tol, atol=tol)
+        assert_dtype_allclose(result, expected)
+        assert_dtype_allclose(dp_out, out)
 
     @pytest.mark.usefixtures("suppress_divide_invalid_numpy_warnings")
-    @pytest.mark.parametrize("dtype", get_float_dtypes() + get_complex_dtypes())
+    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
     def test_out_dtypes(self, dtype):
         size = 10
 
@@ -1115,12 +1114,10 @@ class TestDivide:
             dp_out = dpnp.empty(size, dtype=dtype)
 
         result = dpnp.divide(dp_array1, dp_array2, out=dp_out)
-
-        tol = 1e-07
-        assert_allclose(expected, result, rtol=tol, atol=tol)
+        assert_dtype_allclose(result, expected)
 
     @pytest.mark.usefixtures("suppress_divide_invalid_numpy_warnings")
-    @pytest.mark.parametrize("dtype", get_float_dtypes() + get_complex_dtypes())
+    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
     def test_out_overlap(self, dtype):
         size = 15
         # DPNP
@@ -1131,10 +1128,9 @@ class TestDivide:
         np_a = numpy.arange(2 * size, dtype=dtype)
         numpy.divide(np_a[size::], np_a[::2], out=np_a[:size:])
 
-        tol = 1e-07
-        assert_allclose(np_a, dp_a, rtol=tol, atol=tol)
+        assert_dtype_allclose(dp_a, np_a)
 
-    @pytest.mark.parametrize("dtype", get_float_dtypes() + get_complex_dtypes())
+    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
     def test_inplace_strided_out(self, dtype):
         size = 21
 

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -1070,9 +1070,9 @@ class TestAdd:
         assert_raises(TypeError, numpy.add, a.asnumpy(), 2, out)
 
 
-class TestHypot:
-    @pytest.mark.parametrize("dtype", get_float_dtypes())
-    def test_hypot(self, dtype):
+class TestDivide:
+    @pytest.mark.parametrize("dtype", get_float_dtypes() + get_complex_dtypes())
+    def test_divide(self, dtype):
         array1_data = numpy.arange(10)
         array2_data = numpy.arange(5, 15)
         out = numpy.empty(10, dtype=dtype)
@@ -1081,55 +1081,70 @@ class TestHypot:
         dp_array1 = dpnp.array(array1_data, dtype=dtype)
         dp_array2 = dpnp.array(array2_data, dtype=dtype)
         dp_out = dpnp.array(out, dtype=dtype)
-        result = dpnp.hypot(dp_array1, dp_array2, out=dp_out)
+        result = dpnp.divide(dp_array1, dp_array2, out=dp_out)
 
         # original
         np_array1 = numpy.array(array1_data, dtype=dtype)
         np_array2 = numpy.array(array2_data, dtype=dtype)
-        expected = numpy.hypot(np_array1, np_array2, out=out)
+        expected = numpy.divide(np_array1, np_array2, out=out)
 
-        assert_allclose(expected, result)
-        assert_allclose(out, dp_out)
+        tol = 1e-07
+        assert_allclose(expected, result, rtol=tol, atol=tol)
+        assert_allclose(out, dp_out, rtol=tol, atol=tol)
 
-    @pytest.mark.parametrize("dtype", get_float_dtypes())
+    @pytest.mark.usefixtures("suppress_divide_invalid_numpy_warnings")
+    @pytest.mark.parametrize("dtype", get_float_dtypes() + get_complex_dtypes())
     def test_out_dtypes(self, dtype):
         size = 10
 
         np_array1 = numpy.arange(size, 2 * size, dtype=dtype)
         np_array2 = numpy.arange(size, dtype=dtype)
-        np_out = numpy.empty(size, dtype=numpy.float32)
-        expected = numpy.hypot(np_array1, np_array2, out=np_out)
+        np_out = numpy.empty(size, dtype=numpy.complex64)
+        expected = numpy.divide(np_array1, np_array2, out=np_out)
 
         dp_array1 = dpnp.arange(size, 2 * size, dtype=dtype)
         dp_array2 = dpnp.arange(size, dtype=dtype)
 
-        dp_out = dpnp.empty(size, dtype=dpnp.float32)
-        if dtype != dpnp.float32:
+        dp_out = dpnp.empty(size, dtype=dpnp.complex64)
+        if dtype != dpnp.complex64:
             # dtype of out mismatches types of input arrays
             with pytest.raises(TypeError):
-                dpnp.hypot(dp_array1, dp_array2, out=dp_out)
+                dpnp.divide(dp_array1, dp_array2, out=dp_out)
 
             # allocate new out with expected type
             dp_out = dpnp.empty(size, dtype=dtype)
 
-        result = dpnp.hypot(dp_array1, dp_array2, out=dp_out)
+        result = dpnp.divide(dp_array1, dp_array2, out=dp_out)
 
-        tol = numpy.finfo(numpy.float32).resolution
+        tol = 1e-07
         assert_allclose(expected, result, rtol=tol, atol=tol)
 
-    @pytest.mark.parametrize("dtype", get_float_dtypes())
+    @pytest.mark.usefixtures("suppress_divide_invalid_numpy_warnings")
+    @pytest.mark.parametrize("dtype", get_float_dtypes() + get_complex_dtypes())
     def test_out_overlap(self, dtype):
         size = 15
         # DPNP
         dp_a = dpnp.arange(2 * size, dtype=dtype)
-        dpnp.hypot(dp_a[size::], dp_a[::2], out=dp_a[:size:])
+        dpnp.divide(dp_a[size::], dp_a[::2], out=dp_a[:size:])
 
         # original
         np_a = numpy.arange(2 * size, dtype=dtype)
-        numpy.hypot(np_a[size::], np_a[::2], out=np_a[:size:])
+        numpy.divide(np_a[size::], np_a[::2], out=np_a[:size:])
 
-        tol = numpy.finfo(numpy.float32).resolution
+        tol = 1e-07
         assert_allclose(np_a, dp_a, rtol=tol, atol=tol)
+
+    @pytest.mark.parametrize("dtype", get_float_dtypes() + get_complex_dtypes())
+    def test_inplace_strided_out(self, dtype):
+        size = 21
+
+        np_a = numpy.arange(size, dtype=dtype)
+        np_a[::3] /= 4
+
+        dp_a = dpnp.arange(size, dtype=dtype)
+        dp_a[::3] /= 4
+
+        assert_allclose(dp_a, np_a)
 
     @pytest.mark.parametrize(
         "shape", [(0,), (15,), (2, 2)], ids=["(0,)", "(15, )", "(2,2)"]
@@ -1140,7 +1155,7 @@ class TestHypot:
         dp_out = dpnp.empty(shape)
 
         with pytest.raises(ValueError):
-            dpnp.hypot(dp_array1, dp_array2, out=dp_out)
+            dpnp.divide(dp_array1, dp_array2, out=dp_out)
 
     @pytest.mark.parametrize(
         "out",
@@ -1150,8 +1165,8 @@ class TestHypot:
     def test_invalid_out(self, out):
         a = dpnp.arange(10)
 
-        assert_raises(TypeError, dpnp.hypot, a, 2, out)
-        assert_raises(TypeError, numpy.hypot, a.asnumpy(), 2, out)
+        assert_raises(TypeError, dpnp.divide, a, 2, out)
+        assert_raises(TypeError, numpy.divide, a.asnumpy(), 2, out)
 
 
 class TestFmax:
@@ -1314,6 +1329,90 @@ class TestFmin:
 
         assert_raises(TypeError, dpnp.fmin, a, 2, out)
         assert_raises(TypeError, numpy.fmin, a.asnumpy(), 2, out)
+
+
+class TestHypot:
+    @pytest.mark.parametrize("dtype", get_float_dtypes())
+    def test_hypot(self, dtype):
+        array1_data = numpy.arange(10)
+        array2_data = numpy.arange(5, 15)
+        out = numpy.empty(10, dtype=dtype)
+
+        # DPNP
+        dp_array1 = dpnp.array(array1_data, dtype=dtype)
+        dp_array2 = dpnp.array(array2_data, dtype=dtype)
+        dp_out = dpnp.array(out, dtype=dtype)
+        result = dpnp.hypot(dp_array1, dp_array2, out=dp_out)
+
+        # original
+        np_array1 = numpy.array(array1_data, dtype=dtype)
+        np_array2 = numpy.array(array2_data, dtype=dtype)
+        expected = numpy.hypot(np_array1, np_array2, out=out)
+
+        assert_allclose(expected, result)
+        assert_allclose(out, dp_out)
+
+    @pytest.mark.parametrize("dtype", get_float_dtypes())
+    def test_out_dtypes(self, dtype):
+        size = 10
+
+        np_array1 = numpy.arange(size, 2 * size, dtype=dtype)
+        np_array2 = numpy.arange(size, dtype=dtype)
+        np_out = numpy.empty(size, dtype=numpy.float32)
+        expected = numpy.hypot(np_array1, np_array2, out=np_out)
+
+        dp_array1 = dpnp.arange(size, 2 * size, dtype=dtype)
+        dp_array2 = dpnp.arange(size, dtype=dtype)
+
+        dp_out = dpnp.empty(size, dtype=dpnp.float32)
+        if dtype != dpnp.float32:
+            # dtype of out mismatches types of input arrays
+            with pytest.raises(TypeError):
+                dpnp.hypot(dp_array1, dp_array2, out=dp_out)
+
+            # allocate new out with expected type
+            dp_out = dpnp.empty(size, dtype=dtype)
+
+        result = dpnp.hypot(dp_array1, dp_array2, out=dp_out)
+
+        tol = numpy.finfo(numpy.float32).resolution
+        assert_allclose(expected, result, rtol=tol, atol=tol)
+
+    @pytest.mark.parametrize("dtype", get_float_dtypes())
+    def test_out_overlap(self, dtype):
+        size = 15
+        # DPNP
+        dp_a = dpnp.arange(2 * size, dtype=dtype)
+        dpnp.hypot(dp_a[size::], dp_a[::2], out=dp_a[:size:])
+
+        # original
+        np_a = numpy.arange(2 * size, dtype=dtype)
+        numpy.hypot(np_a[size::], np_a[::2], out=np_a[:size:])
+
+        tol = numpy.finfo(numpy.float32).resolution
+        assert_allclose(np_a, dp_a, rtol=tol, atol=tol)
+
+    @pytest.mark.parametrize(
+        "shape", [(0,), (15,), (2, 2)], ids=["(0,)", "(15, )", "(2,2)"]
+    )
+    def test_invalid_shape(self, shape):
+        dp_array1 = dpnp.arange(10)
+        dp_array2 = dpnp.arange(5, 15)
+        dp_out = dpnp.empty(shape)
+
+        with pytest.raises(ValueError):
+            dpnp.hypot(dp_array1, dp_array2, out=dp_out)
+
+    @pytest.mark.parametrize(
+        "out",
+        [4, (), [], (3, 7), [2, 4]],
+        ids=["4", "()", "[]", "(3, 7)", "[2, 4]"],
+    )
+    def test_invalid_out(self, out):
+        a = dpnp.arange(10)
+
+        assert_raises(TypeError, dpnp.hypot, a, 2, out)
+        assert_raises(TypeError, numpy.hypot, a.asnumpy(), 2, out)
 
 
 class TestMaximum:

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -1165,7 +1165,7 @@ class TestDivide:
         assert_raises(TypeError, numpy.divide, a.asnumpy(), 2, out)
 
 
-class TestFloordivide:
+class TestFloorDivide:
     @pytest.mark.parametrize(
         "dtype", get_all_dtypes(no_bool=True, no_none=True, no_complex=True)
     )


### PR DESCRIPTION
Dedicated kernels are implemented in `dpctl` for in-place division and floor division [#1431](https://github.com/IntelPython/dpctl/pull/1431)

In this PR, this feature is added for `dpnp.divide` and `dpnp.floor_divide`.
New tests are written for them.

UPDATE: 
With recent updates in `dpctl` ([#1463](https://github.com/IntelPython/dpctl/pull/1463)), the usage of in-place operator are automatically incorporated in `dpnp`. This PR now only updates the relevant tests.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
