### PR TITLE
Allow different output type than input type when dispatching

### DIFF
--- a/dpnp/backend/extensions/vm/abs.hpp
+++ b/dpnp/backend/extensions/vm/abs.hpp
@@ -48,7 +48,8 @@ sycl::event abs_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::AbsOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::abs(exec_q,
                        n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/acos.hpp
+++ b/dpnp/backend/extensions/vm/acos.hpp
@@ -48,7 +48,8 @@ sycl::event acos_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::AcosOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::acos(exec_q,
                         n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/acosh.hpp
+++ b/dpnp/backend/extensions/vm/acosh.hpp
@@ -48,7 +48,8 @@ sycl::event acosh_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::AcoshOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::acosh(exec_q,
                          n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/add.hpp
+++ b/dpnp/backend/extensions/vm/add.hpp
@@ -50,7 +50,8 @@ sycl::event add_contig_impl(sycl::queue exec_q,
 
     const T *a = reinterpret_cast<const T *>(in_a);
     const T *b = reinterpret_cast<const T *>(in_b);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::AddOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::add(exec_q,
                        n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/asin.hpp
+++ b/dpnp/backend/extensions/vm/asin.hpp
@@ -48,7 +48,8 @@ sycl::event asin_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::AsinOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::asin(exec_q,
                         n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/asinh.hpp
+++ b/dpnp/backend/extensions/vm/asinh.hpp
@@ -48,7 +48,8 @@ sycl::event asinh_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::AsinhOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::asinh(exec_q,
                          n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/atan.hpp
+++ b/dpnp/backend/extensions/vm/atan.hpp
@@ -48,7 +48,8 @@ sycl::event atan_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::AtanOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::atan(exec_q,
                         n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/atan2.hpp
+++ b/dpnp/backend/extensions/vm/atan2.hpp
@@ -50,7 +50,8 @@ sycl::event atan2_contig_impl(sycl::queue exec_q,
 
     const T *a = reinterpret_cast<const T *>(in_a);
     const T *b = reinterpret_cast<const T *>(in_b);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::Atan2OutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::atan2(exec_q,
                          n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/atanh.hpp
+++ b/dpnp/backend/extensions/vm/atanh.hpp
@@ -48,7 +48,8 @@ sycl::event atanh_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::AtanhOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::atanh(exec_q,
                          n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/ceil.hpp
+++ b/dpnp/backend/extensions/vm/ceil.hpp
@@ -48,7 +48,8 @@ sycl::event ceil_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::CeilOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::ceil(exec_q,
                         n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/conj.hpp
+++ b/dpnp/backend/extensions/vm/conj.hpp
@@ -48,7 +48,8 @@ sycl::event conj_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::ConjOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::conj(exec_q,
                         n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/cos.hpp
+++ b/dpnp/backend/extensions/vm/cos.hpp
@@ -48,7 +48,8 @@ sycl::event cos_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::CosOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::cos(exec_q,
                        n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/cosh.hpp
+++ b/dpnp/backend/extensions/vm/cosh.hpp
@@ -48,7 +48,8 @@ sycl::event cosh_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::CoshOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::cosh(exec_q,
                         n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/div.hpp
+++ b/dpnp/backend/extensions/vm/div.hpp
@@ -50,7 +50,8 @@ sycl::event div_contig_impl(sycl::queue exec_q,
 
     const T *a = reinterpret_cast<const T *>(in_a);
     const T *b = reinterpret_cast<const T *>(in_b);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::DivOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::div(exec_q,
                        n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/exp.hpp
+++ b/dpnp/backend/extensions/vm/exp.hpp
@@ -48,7 +48,8 @@ sycl::event exp_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::ExpOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::exp(exec_q,
                        n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/expm1.hpp
+++ b/dpnp/backend/extensions/vm/expm1.hpp
@@ -48,7 +48,8 @@ sycl::event expm1_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::Expm1OutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::expm1(exec_q,
                          n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/floor.hpp
+++ b/dpnp/backend/extensions/vm/floor.hpp
@@ -48,7 +48,8 @@ sycl::event floor_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::FloorOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::floor(exec_q,
                          n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/hypot.hpp
+++ b/dpnp/backend/extensions/vm/hypot.hpp
@@ -50,7 +50,8 @@ sycl::event hypot_contig_impl(sycl::queue exec_q,
 
     const T *a = reinterpret_cast<const T *>(in_a);
     const T *b = reinterpret_cast<const T *>(in_b);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::HypotOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::hypot(exec_q,
                          n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/ln.hpp
+++ b/dpnp/backend/extensions/vm/ln.hpp
@@ -48,7 +48,8 @@ sycl::event ln_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::LnOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::ln(exec_q,
                       n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/log10.hpp
+++ b/dpnp/backend/extensions/vm/log10.hpp
@@ -48,7 +48,8 @@ sycl::event log10_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::Log10OutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::log10(exec_q,
                          n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/log1p.hpp
+++ b/dpnp/backend/extensions/vm/log1p.hpp
@@ -48,7 +48,8 @@ sycl::event log1p_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::Log1pOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::log1p(exec_q,
                          n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/log2.hpp
+++ b/dpnp/backend/extensions/vm/log2.hpp
@@ -48,7 +48,8 @@ sycl::event log2_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::Log2OutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::log2(exec_q,
                         n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/mul.hpp
+++ b/dpnp/backend/extensions/vm/mul.hpp
@@ -50,7 +50,8 @@ sycl::event mul_contig_impl(sycl::queue exec_q,
 
     const T *a = reinterpret_cast<const T *>(in_a);
     const T *b = reinterpret_cast<const T *>(in_b);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::MulOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::mul(exec_q,
                        n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/pow.hpp
+++ b/dpnp/backend/extensions/vm/pow.hpp
@@ -50,7 +50,8 @@ sycl::event pow_contig_impl(sycl::queue exec_q,
 
     const T *a = reinterpret_cast<const T *>(in_a);
     const T *b = reinterpret_cast<const T *>(in_b);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::PowOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::pow(exec_q,
                        n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/round.hpp
+++ b/dpnp/backend/extensions/vm/round.hpp
@@ -48,7 +48,8 @@ sycl::event round_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::RoundOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::rint(exec_q,
                         n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/sin.hpp
+++ b/dpnp/backend/extensions/vm/sin.hpp
@@ -48,7 +48,8 @@ sycl::event sin_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::SinOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::sin(exec_q,
                        n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/sinh.hpp
+++ b/dpnp/backend/extensions/vm/sinh.hpp
@@ -48,7 +48,8 @@ sycl::event sinh_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::SinhOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::sinh(exec_q,
                         n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/sqr.hpp
+++ b/dpnp/backend/extensions/vm/sqr.hpp
@@ -48,7 +48,8 @@ sycl::event sqr_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::SqrOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::sqr(exec_q,
                        n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/sqrt.hpp
+++ b/dpnp/backend/extensions/vm/sqrt.hpp
@@ -48,7 +48,8 @@ sycl::event sqrt_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::SqrtOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::sqrt(exec_q,
                         n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/sub.hpp
+++ b/dpnp/backend/extensions/vm/sub.hpp
@@ -50,7 +50,8 @@ sycl::event sub_contig_impl(sycl::queue exec_q,
 
     const T *a = reinterpret_cast<const T *>(in_a);
     const T *b = reinterpret_cast<const T *>(in_b);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::SubOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::sub(exec_q,
                        n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/tan.hpp
+++ b/dpnp/backend/extensions/vm/tan.hpp
@@ -48,7 +48,8 @@ sycl::event tan_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::TanOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::tan(exec_q,
                        n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/tanh.hpp
+++ b/dpnp/backend/extensions/vm/tanh.hpp
@@ -48,7 +48,8 @@ sycl::event tanh_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::TanhOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::tanh(exec_q,
                         n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/trunc.hpp
+++ b/dpnp/backend/extensions/vm/trunc.hpp
@@ -48,7 +48,8 @@ sycl::event trunc_contig_impl(sycl::queue exec_q,
     type_utils::validate_type_for_device<T>(exec_q);
 
     const T *a = reinterpret_cast<const T *>(in_a);
-    T *y = reinterpret_cast<T *>(out_y);
+    using resTy = typename types::TruncOutputType<T>::value_type;
+    resTy *y = reinterpret_cast<resTy *>(out_y);
 
     return mkl_vm::trunc(exec_q,
                          n, // number of elements to be calculated

--- a/dpnp/backend/extensions/vm/types_matrix.hpp
+++ b/dpnp/backend/extensions/vm/types_matrix.hpp
@@ -53,8 +53,8 @@ template <typename T>
 struct AbsOutputType
 {
     using value_type = typename std::disjunction<
-        // TODO: Add complex type here after updating the dispatching to allow
-        // output type to be different than input
+        dpctl_td_ns::TypeMapResultEntry<T, std::complex<double>, double>,
+        dpctl_td_ns::TypeMapResultEntry<T, std::complex<float>, float>,
         dpctl_td_ns::TypeMapResultEntry<T, double>,
         dpctl_td_ns::TypeMapResultEntry<T, float>,
         dpctl_td_ns::DefaultResultEntry<void>>::result_type;


### PR DESCRIPTION
In this PR, dispatching for elementwise functions is modified to allow the output type to be different than input type.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
