### PR TITLE
Pinned DPC++ and MKL to release versions

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -14,14 +14,14 @@ requirements:
       - ninja
       - git
       - dpctl >=0.15.0
-      - mkl-devel-dpcpp {{ environ.get('MKL_VER', '>=2023.2.0') }}
+      - mkl-devel-dpcpp {{ environ.get('MKL_VER', '>=2024.0.0') }}
       - onedpl-devel
       - tbb-devel
       - wheel
       - scikit-build
     build:
       - {{ compiler('cxx') }}
-      - {{ compiler('dpcpp') }}  >=2023.2.0  # [not osx]
+      - {{ compiler('dpcpp') }}  >=2024.0.0  # [not osx]
       - sysroot_linux-64 >=2.28 # [linux]
     run:
       - python


### PR DESCRIPTION
The PR is about to pin versions of DPC++ and OneMKL components to release ones in `meta.yaml` file.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
