### PR TITLE
fix `dpnp.linalg.qr` and `dpnp.linalg.det` functions

### DIFF
--- a/dpnp/backend/kernels/dpnp_krnl_linalg.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_linalg.cpp
@@ -612,6 +612,9 @@ DPCTLSyclEventRef dpnp_qr_c(DPCTLSyclQueueRef q_ref,
     (void)dep_event_vec_ref;
 
     DPCTLSyclEventRef event_ref = nullptr;
+    if (!size_m || !size_n) {
+        return event_ref;
+    }
     sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
     sycl::event event;

--- a/dpnp/linalg/dpnp_algo_linalg.pyx
+++ b/dpnp/linalg/dpnp_algo_linalg.pyx
@@ -142,15 +142,9 @@ cpdef object dpnp_cond(object input, object p):
 cpdef utils.dpnp_descriptor dpnp_det(utils.dpnp_descriptor input):
     cdef shape_type_c input_shape = input.shape
     cdef size_t n = input.shape[-1]
-    cdef size_t size_out = 1
+    cdef shape_type_c result_shape = (1,)
     if input.ndim != 2:
-        output_shape = tuple((list(input.shape))[:-2])
-        for i in range(len(output_shape)):
-            size_out *= output_shape[i]
-
-    cdef shape_type_c result_shape = (size_out,)
-    if size_out > 1:
-        result_shape = output_shape
+        result_shape = tuple((list(input.shape))[:-2])
 
     cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(input.dtype)
 

--- a/dpnp/linalg/dpnp_iface_linalg.py
+++ b/dpnp/linalg/dpnp_iface_linalg.py
@@ -159,7 +159,9 @@ def det(input):
 
     x1_desc = dpnp.get_dpnp_descriptor(input, copy_when_nondefault_queue=False)
     if x1_desc:
-        if x1_desc.shape[-1] == x1_desc.shape[-2]:
+        if x1_desc.ndim < 2:
+            pass
+        elif x1_desc.shape[-1] == x1_desc.shape[-2]:
             result_obj = dpnp_det(x1_desc).get_pyobj()
             result = dpnp.convert_single_elem_array_to_scalar(result_obj)
 

--- a/dpnp/linalg/dpnp_iface_linalg.py
+++ b/dpnp/linalg/dpnp_iface_linalg.py
@@ -488,7 +488,9 @@ def qr(x1, mode="reduced"):
 
     x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
     if x1_desc:
-        if mode != "reduced":
+        if x1_desc.ndim != 2:
+            pass
+        elif mode != "reduced":
             pass
         else:
             result_tup = dpnp_qr(x1_desc, mode)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -130,7 +130,7 @@ def test_det(array):
 
 @pytest.mark.usefixtures("allow_fall_back_on_numpy")
 def test_det_empty():
-    a = numpy.empty((0,0,2,2), dtype=numpy.float32)
+    a = numpy.empty((0, 0, 2, 2), dtype=numpy.float32)
     ia = inp.array(a)
 
     np_det = numpy.linalg.det(a)
@@ -139,9 +139,9 @@ def test_det_empty():
     assert dpnp_det.dtype == np_det.dtype
     assert dpnp_det.shape == np_det.shape
 
-    assert_allclose(np_det,dpnp_det)
+    assert_allclose(np_det, dpnp_det)
 
-    
+
 @pytest.mark.parametrize("type", get_all_dtypes(no_bool=True, no_complex=True))
 @pytest.mark.parametrize("size", [2, 4, 8, 16, 300])
 def test_eig_arange(type, size):
@@ -425,7 +425,7 @@ def test_qr(type, shape, mode):
 
 @pytest.mark.usefixtures("allow_fall_back_on_numpy")
 def test_qr_not_2D():
-    a = numpy.arange(12, dtype=numpy.float32).reshape((3,2,2))
+    a = numpy.arange(12, dtype=numpy.float32).reshape((3, 2, 2))
     ia = inp.array(a)
 
     np_q, np_r = numpy.linalg.qr(a)
@@ -436,9 +436,9 @@ def test_qr_not_2D():
     assert dpnp_q.shape == np_q.shape
     assert dpnp_r.shape == np_r.shape
 
-    assert_allclose(ia,inp.matmul(dpnp_q, dpnp_r))
+    assert_allclose(ia, inp.matmul(dpnp_q, dpnp_r))
 
-    a = numpy.empty((0,3,2), dtype=numpy.float32)
+    a = numpy.empty((0, 3, 2), dtype=numpy.float32)
     ia = inp.array(a)
 
     np_q, np_r = numpy.linalg.qr(a)
@@ -449,7 +449,7 @@ def test_qr_not_2D():
     assert dpnp_q.shape == np_q.shape
     assert dpnp_r.shape == np_r.shape
 
-    assert_allclose(ia,inp.matmul(dpnp_q, dpnp_r))
+    assert_allclose(ia, inp.matmul(dpnp_q, dpnp_r))
 
 
 @pytest.mark.parametrize("type", get_all_dtypes(no_bool=True, no_complex=True))

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -128,6 +128,20 @@ def test_det(array):
     assert_allclose(expected, result)
 
 
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
+def test_det_empty():
+    a = numpy.empty((0,0,2,2), dtype=numpy.float32)
+    ia = inp.array(a)
+
+    np_det = numpy.linalg.det(a)
+    dpnp_det = inp.linalg.det(ia)
+
+    assert dpnp_det.dtype == np_det.dtype
+    assert dpnp_det.shape == np_det.shape
+
+    assert_allclose(np_det,dpnp_det)
+
+    
 @pytest.mark.parametrize("type", get_all_dtypes(no_bool=True, no_complex=True))
 @pytest.mark.parametrize("size", [2, 4, 8, 16, 300])
 def test_eig_arange(type, size):
@@ -388,7 +402,7 @@ def test_qr(type, shape, mode):
     # check decomposition
     assert_allclose(
         ia,
-        numpy.dot(inp.asnumpy(dpnp_q), inp.asnumpy(dpnp_r)),
+        inp.dot(dpnp_q, dpnp_r),
         rtol=tol,
         atol=tol,
     )
@@ -407,6 +421,35 @@ def test_qr(type, shape, mode):
             )
 
     assert_allclose(dpnp_r, np_r, rtol=tol, atol=tol)
+
+
+@pytest.mark.usefixtures("allow_fall_back_on_numpy")
+def test_qr_not_2D():
+    a = numpy.arange(12, dtype=numpy.float32).reshape((3,2,2))
+    ia = inp.array(a)
+
+    np_q, np_r = numpy.linalg.qr(a)
+    dpnp_q, dpnp_r = inp.linalg.qr(ia)
+
+    assert dpnp_q.dtype == np_q.dtype
+    assert dpnp_r.dtype == np_r.dtype
+    assert dpnp_q.shape == np_q.shape
+    assert dpnp_r.shape == np_r.shape
+
+    assert_allclose(ia,inp.matmul(dpnp_q, dpnp_r))
+
+    a = numpy.empty((0,3,2), dtype=numpy.float32)
+    ia = inp.array(a)
+
+    np_q, np_r = numpy.linalg.qr(a)
+    dpnp_q, dpnp_r = inp.linalg.qr(ia)
+
+    assert dpnp_q.dtype == np_q.dtype
+    assert dpnp_r.dtype == np_r.dtype
+    assert dpnp_q.shape == np_q.shape
+    assert dpnp_r.shape == np_r.shape
+
+    assert_allclose(ia,inp.matmul(dpnp_q, dpnp_r))
 
 
 @pytest.mark.parametrize("type", get_all_dtypes(no_bool=True, no_complex=True))

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -358,8 +358,8 @@ def test_norm3(array, ord, axis):
 @pytest.mark.parametrize("type", get_all_dtypes(no_bool=True, no_complex=True))
 @pytest.mark.parametrize(
     "shape",
-    [(2, 2), (3, 4), (5, 3), (16, 16)],
-    ids=["(2,2)", "(3,4)", "(5,3)", "(16,16)"],
+    [(2, 2), (3, 4), (5, 3), (16, 16), (0, 0), (0, 2), (2, 0)],
+    ids=["(2,2)", "(3,4)", "(5,3)", "(16,16)", "(0,0)", "(0,2)", "(2,0)"],
 )
 @pytest.mark.parametrize(
     "mode", ["complete", "reduced"], ids=["complete", "reduced"]


### PR DESCRIPTION
`dpnp.linalg.qr` is updated to take care of the cases where input array is not 2-D.
`dpnp.linalg.det` is updated to take care of the cases where input array is an empty array.


- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
