### PR TITLE
Mute unstable `test_array_creation_cross_device` test

### DIFF
--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -166,6 +166,7 @@ def test_array_creation_follow_device(func, args, kwargs, device):
     assert_sycl_queue_equal(y.sycl_queue, x.sycl_queue)
 
 
+@pytest.mark.skip("muted until the issue reported by SAT-5969 is resolved")
 @pytest.mark.parametrize(
     "func, args, kwargs",
     [


### PR DESCRIPTION
The `test_array_creation_cross_device` test is unstable and sporadically fails.
Th PR proposes to temporary mute it until the issue is resolved.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
