### PR TITLE
implement dpnp.max and dpnp.min using dpctl.tensor functions

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -13,6 +13,7 @@ env:
   # TODO: to add test_arraymanipulation.py back to the scope once crash on Windows is gone
   TEST_SCOPE: >-
       test_arraycreation.py
+      test_amin_amax.py
       test_dot.py
       test_dparray.py
       test_copy.py

--- a/dpnp/backend/include/dpnp_iface_fptr.hpp
+++ b/dpnp/backend/include/dpnp_iface_fptr.hpp
@@ -212,20 +212,18 @@ enum class DPNPFuncName : size_t
     DPNP_FN_MATRIX_RANK_EXT, /**< Used in numpy.linalg.matrix_rank() impl,
                                 requires extra parameters */
     DPNP_FN_MAX,             /**< Used in numpy.max() impl  */
-    DPNP_FN_MAX_EXT, /**< Used in numpy.max() impl, requires extra parameters */
-    DPNP_FN_MAXIMUM, /**< Used in numpy.fmax() impl  */
-    DPNP_FN_MAXIMUM_EXT, /**< Used in numpy.fmax() impl , requires extra
-                            parameters */
-    DPNP_FN_MEAN,        /**< Used in numpy.mean() impl  */
-    DPNP_FN_MEDIAN,      /**< Used in numpy.median() impl  */
-    DPNP_FN_MEDIAN_EXT,  /**< Used in numpy.median() impl, requires extra
-                            parameters */
-    DPNP_FN_MIN,         /**< Used in numpy.min() impl  */
-    DPNP_FN_MIN_EXT, /**< Used in numpy.min() impl, requires extra parameters */
-    DPNP_FN_MINIMUM, /**< Used in numpy.fmin() impl  */
-    DPNP_FN_MINIMUM_EXT, /**< Used in numpy.fmax() impl, requires extra
-                            parameters */
-    DPNP_FN_MODF,        /**< Used in numpy.modf() impl  */
+    DPNP_FN_MAXIMUM,         /**< Used in numpy.fmax() impl  */
+    DPNP_FN_MAXIMUM_EXT,     /**< Used in numpy.fmax() impl , requires extra
+                                parameters */
+    DPNP_FN_MEAN,            /**< Used in numpy.mean() impl  */
+    DPNP_FN_MEDIAN,          /**< Used in numpy.median() impl  */
+    DPNP_FN_MEDIAN_EXT,      /**< Used in numpy.median() impl, requires extra
+                                parameters */
+    DPNP_FN_MIN,             /**< Used in numpy.min() impl  */
+    DPNP_FN_MINIMUM,         /**< Used in numpy.fmin() impl  */
+    DPNP_FN_MINIMUM_EXT,     /**< Used in numpy.fmax() impl, requires extra
+                                parameters */
+    DPNP_FN_MODF,            /**< Used in numpy.modf() impl  */
     DPNP_FN_MODF_EXT, /**< Used in numpy.modf() impl, requires extra parameters
                        */
     DPNP_FN_MULTIPLY, /**< Used in numpy.multiply() impl  */

--- a/dpnp/backend/kernels/dpnp_krnl_statistics.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_statistics.cpp
@@ -503,18 +503,6 @@ void (*dpnp_max_default_c)(void *,
                            const shape_elem_type *,
                            size_t) = dpnp_max_c<_DataType>;
 
-template <typename _DataType>
-DPCTLSyclEventRef (*dpnp_max_ext_c)(DPCTLSyclQueueRef,
-                                    void *,
-                                    void *,
-                                    const size_t,
-                                    const shape_elem_type *,
-                                    size_t,
-                                    const shape_elem_type *,
-                                    size_t,
-                                    const DPCTLEventVectorRef) =
-    dpnp_max_c<_DataType>;
-
 template <typename _DataType, typename _ResultType>
 DPCTLSyclEventRef dpnp_mean_c(DPCTLSyclQueueRef q_ref,
                               void *array1_in,
@@ -886,18 +874,6 @@ void (*dpnp_min_default_c)(void *,
                            size_t,
                            const shape_elem_type *,
                            size_t) = dpnp_min_c<_DataType>;
-
-template <typename _DataType>
-DPCTLSyclEventRef (*dpnp_min_ext_c)(DPCTLSyclQueueRef,
-                                    void *,
-                                    void *,
-                                    const size_t,
-                                    const shape_elem_type *,
-                                    size_t,
-                                    const shape_elem_type *,
-                                    size_t,
-                                    const DPCTLEventVectorRef) =
-    dpnp_min_c<_DataType>;
 
 template <typename _DataType>
 DPCTLSyclEventRef dpnp_nanvar_c(DPCTLSyclQueueRef q_ref,
@@ -1283,15 +1259,6 @@ void func_map_init_statistics(func_map_t &fmap)
     fmap[DPNPFuncName::DPNP_FN_MAX][eft_DBL][eft_DBL] = {
         eft_DBL, (void *)dpnp_max_default_c<double>};
 
-    fmap[DPNPFuncName::DPNP_FN_MAX_EXT][eft_INT][eft_INT] = {
-        eft_INT, (void *)dpnp_max_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MAX_EXT][eft_LNG][eft_LNG] = {
-        eft_LNG, (void *)dpnp_max_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MAX_EXT][eft_FLT][eft_FLT] = {
-        eft_FLT, (void *)dpnp_max_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_MAX_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void *)dpnp_max_ext_c<double>};
-
     fmap[DPNPFuncName::DPNP_FN_MEAN][eft_INT][eft_INT] = {
         eft_DBL, (void *)dpnp_mean_default_c<int32_t, double>};
     fmap[DPNPFuncName::DPNP_FN_MEAN][eft_LNG][eft_LNG] = {
@@ -1339,15 +1306,6 @@ void func_map_init_statistics(func_map_t &fmap)
         eft_FLT, (void *)dpnp_min_default_c<float>};
     fmap[DPNPFuncName::DPNP_FN_MIN][eft_DBL][eft_DBL] = {
         eft_DBL, (void *)dpnp_min_default_c<double>};
-
-    fmap[DPNPFuncName::DPNP_FN_MIN_EXT][eft_INT][eft_INT] = {
-        eft_INT, (void *)dpnp_min_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_MIN_EXT][eft_LNG][eft_LNG] = {
-        eft_LNG, (void *)dpnp_min_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_MIN_EXT][eft_FLT][eft_FLT] = {
-        eft_FLT, (void *)dpnp_min_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_MIN_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void *)dpnp_min_ext_c<double>};
 
     fmap[DPNPFuncName::DPNP_FN_NANVAR][eft_INT][eft_INT] = {
         eft_INT, (void *)dpnp_nanvar_default_c<int32_t>};

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -106,14 +106,10 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_MATMUL_EXT
         DPNP_FN_MATRIX_RANK
         DPNP_FN_MATRIX_RANK_EXT
-        DPNP_FN_MAX
-        DPNP_FN_MAX_EXT
         DPNP_FN_MAXIMUM
         DPNP_FN_MAXIMUM_EXT
         DPNP_FN_MEDIAN
         DPNP_FN_MEDIAN_EXT
-        DPNP_FN_MIN
-        DPNP_FN_MIN_EXT
         DPNP_FN_MINIMUM
         DPNP_FN_MINIMUM_EXT
         DPNP_FN_MODF
@@ -367,12 +363,6 @@ cpdef dpnp_descriptor dpnp_fmin(dpnp_descriptor x1_obj, dpnp_descriptor x2_obj, 
 Array manipulation routines
 """
 cpdef dpnp_descriptor dpnp_repeat(dpnp_descriptor array1, repeats, axes=*)
-
-
-"""
-Statistics functions
-"""
-cpdef dpnp_descriptor dpnp_min(dpnp_descriptor a, axis)
 
 
 """

--- a/dpnp/dpnp_algo/dpnp_elementwise_common.py
+++ b/dpnp/dpnp_algo/dpnp_elementwise_common.py
@@ -1,5 +1,3 @@
-# cython: language_level=3
-# distutils: language = c++
 # -*- coding: utf-8 -*-
 # *****************************************************************************
 # Copyright (c) 2023, Intel Corporation

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -25,7 +25,6 @@
 # *****************************************************************************
 
 import dpctl.tensor as dpt
-import numpy
 
 import dpnp
 
@@ -939,9 +938,9 @@ class dpnp_array:
         self,
         axis=None,
         out=None,
-        keepdims=numpy._NoValue,
-        initial=numpy._NoValue,
-        where=numpy._NoValue,
+        keepdims=False,
+        initial=None,
+        where=True,
     ):
         """Return the maximum along an axis."""
 
@@ -956,9 +955,9 @@ class dpnp_array:
         self,
         axis=None,
         out=None,
-        keepdims=numpy._NoValue,
-        initial=numpy._NoValue,
-        where=numpy._NoValue,
+        keepdims=False,
+        initial=None,
+        where=True,
     ):
         """Return the minimum along a given axis."""
 

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -942,7 +942,11 @@ class dpnp_array:
         initial=None,
         where=True,
     ):
-        """Return the maximum along an axis."""
+        """
+        Return the maximum along an axis.
+
+        Refer to :obj:`dpnp.max` for full documentation.
+        """
 
         return dpnp.max(self, axis, out, keepdims, initial, where)
 
@@ -959,7 +963,11 @@ class dpnp_array:
         initial=None,
         where=True,
     ):
-        """Return the minimum along a given axis."""
+        """
+        Return the minimum along a given axis.
+
+        Refer to :obj:`dpnp.min` for full documentation.
+        """
 
         return dpnp.min(self, axis, out, keepdims, initial, where)
 

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -1401,9 +1401,9 @@ def maximum(
     :obj:`dpnp.fmax` : Element-wise maximum of two arrays, ignores NaNs.
     :obj:`dpnp.amax` : The maximum value of an array along a given axis, propagates NaNs.
     :obj:`dpnp.nanmax` : The maximum value of an array along a given axis, ignores NaNs.
-    :obj:`dpnp.fmin` : Element-wise minimum of two arrays, ignores NaNs.
-    :obj:`dpnp.amix` : The minimum value of an array along a given axis, propagates NaNs.
-    :obj:`dpnp.nanmix` : The minimum value of an array along a given axis, ignores NaNs.
+    :obj:`dpnp.fmax` : Element-wise maximum of two arrays, ignores NaNs.
+    :obj:`dpnp.amax` : The maximum value of an array along a given axis, propagates NaNs.
+    :obj:`dpnp.nanmax` : The maximum value of an array along a given axis, ignores NaNs.
 
     Examples
     --------
@@ -1480,9 +1480,9 @@ def minimum(
     :obj:`dpnp.fmin` : Element-wise minimum of two arrays, ignores NaNs.
     :obj:`dpnp.amin` : The minimum value of an array along a given axis, propagates NaNs.
     :obj:`dpnp.nanmin` : The minimum value of an array along a given axis, ignores NaNs.
-    :obj:`dpnp.fmax` : Element-wise maximum of two arrays, ignores NaNs.
-    :obj:`dpnp.amax` : The maximum value of an array along a given axis, propagates NaNs.
-    :obj:`dpnp.nanmax` : The maximum value of an array along a given axis, ignores NaNs.
+    :obj:`dpnp.fmin` : Element-wise minimum of two arrays, ignores NaNs.
+    :obj:`dpnp.amin` : The minimum value of an array along a given axis, propagates NaNs.
+    :obj:`dpnp.nanmin` : The minimum value of an array along a given axis, ignores NaNs.
 
     Examples
     --------

--- a/dpnp/dpnp_iface_statistics.py
+++ b/dpnp/dpnp_iface_statistics.py
@@ -414,14 +414,14 @@ def max(a, axis=None, out=None, keepdims=False, initial=None, where=True):
             axis = (axis,) if isinstance(axis, int) else axis
             for i in range(a.ndim):
                 if a.shape[i] == 0:
-                    if i not in axis:
-                        indices = [i for i in range(a.ndim) if i not in axis]
-                        res_shape = tuple([a.shape[i] for i in indices])
-                        result = dpnp.empty(res_shape, dtype=a.dtype)
-                    else:
+                    if axis is None or i in axis:
                         raise ValueError(
                             "reduction does not support zero-size arrays"
                         )
+                    else:
+                        indices = [i for i in range(a.ndim) if i not in axis]
+                        res_shape = tuple([a.shape[i] for i in indices])
+                        result = dpnp.empty(res_shape, dtype=a.dtype)
         else:
             result = dpnp_array._create_from_usm_ndarray(
                 dpt.max(dpt_array, axis=axis, keepdims=keepdims)
@@ -658,14 +658,14 @@ def min(a, axis=None, out=None, keepdims=False, initial=None, where=True):
             # TODO: get rid of this if condition when dpctl supports it
             for i in range(a.ndim):
                 if a.shape[i] == 0:
-                    if i not in axis:
-                        indices = [i for i in range(a.ndim) if i not in axis]
-                        res_shape = tuple([a.shape[i] for i in indices])
-                        result = dpnp.empty(res_shape, dtype=a.dtype)
-                    else:
+                    if axis is None or i in axis:
                         raise ValueError(
                             "reduction does not support zero-size arrays"
                         )
+                    else:
+                        indices = [i for i in range(a.ndim) if i not in axis]
+                        res_shape = tuple([a.shape[i] for i in indices])
+                        result = dpnp.empty(res_shape, dtype=a.dtype)
         else:
             result = dpnp_array._create_from_usm_ndarray(
                 dpt.min(dpt_array, axis=axis, keepdims=keepdims)

--- a/dpnp/dpnp_iface_statistics.py
+++ b/dpnp/dpnp_iface_statistics.py
@@ -363,9 +363,9 @@ def max(a, axis=None, out=None, keepdims=False, initial=None, where=True):
 
     Limitations
     -----------
-    Input array `a` is only supported as either :class:`dpnp.ndarray` or :class:`dpctl.tensor.usm_ndarray`.
-    Parameters `out`, `where`, and `initial` are supported only with their default values.
-    Otherwise the function will be executed sequentially on CPU.
+    Input and output arrays are only supported as either :class:`dpnp.ndarray` or :class:`dpctl.tensor.usm_ndarray`.
+    Parameters `where`, and `initial` are supported only with their default values.
+    Otherwise ``NotImplementedError`` exception will be raised.
     Input array data types are limited by supported DPNP :ref:`Data types`.
 
     See Also
@@ -400,16 +400,17 @@ def max(a, axis=None, out=None, keepdims=False, initial=None, where=True):
 
     if initial is not None:
         raise NotImplementedError(
-            "initial keyword arguemnts is only supported by its default value."
+            "initial keyword arguemnt is only supported by its default value."
         )
     elif where is not True:
         raise NotImplementedError(
-            "where keyword arguemnts is only supported by its default values."
+            "where keyword arguemnt is only supported by its default value."
         )
     else:
         dpt_array = dpnp.get_usm_ndarray(a)
         if dpt_array.size == 0:
             # TODO: get rid of this if condition when dpctl supports it
+            axis = (axis,) if isinstance(axis, int) else axis
             for i in range(a.ndim):
                 if a.shape[i] == 0:
                     if i not in axis:
@@ -431,21 +432,17 @@ def max(a, axis=None, out=None, keepdims=False, initial=None, where=True):
                 raise ValueError(
                     f"Output array of shape {result.shape} is needed, got {out.shape}."
                 )
-            elif out.dtype != result.dtype:
-                raise ValueError(
-                    f"Output array of type {result.dtype} is needed, got {out.dtype}."
-                )
             elif not isinstance(out, dpnp_array):
                 if isinstance(out, dpt.usm_ndarray):
-                    out = dpnp.array(out)
+                    out = dpnp_array._create_from_usm_ndarray(out)
                 else:
-                    raise ValueError(
-                        "An array must be any of supported type, but got {}".format(
+                    raise TypeError(
+                        "Output array must be any of supported type, but got {}".format(
                             type(out)
                         )
                     )
 
-            dpnp.copyto(out, result)
+            dpnp.copyto(out, result, casting="safe")
 
             return out
 
@@ -610,9 +607,9 @@ def min(a, axis=None, out=None, keepdims=False, initial=None, where=True):
 
     Limitations
     -----------
-    Input array `a` is only supported as either :class:`dpnp.ndarray` or :class:`dpctl.tensor.usm_ndarray`.
-    Parameters `out`, `where`, and `initial` are supported only with their default values.
-    Otherwise the function will be executed sequentially on CPU.
+    Input and output arrays are only supported as either :class:`dpnp.ndarray` or :class:`dpctl.tensor.usm_ndarray`.
+    Parameters `where`, and `initial` are supported only with their default values.
+    Otherwise ``NotImplementedError`` exception will be raised.
     Input array data types are limited by supported DPNP :ref:`Data types`.
 
     See Also
@@ -647,11 +644,11 @@ def min(a, axis=None, out=None, keepdims=False, initial=None, where=True):
 
     if initial is not None:
         raise NotImplementedError(
-            "initial keyword arguemnts is only supported by its default value."
+            "initial keyword arguemnt is only supported by its default value."
         )
     elif where is not True:
         raise NotImplementedError(
-            "where keyword arguemnts is only supported by its default values."
+            "where keyword arguemnt is only supported by its default values."
         )
     else:
         dpt_array = dpnp.get_usm_ndarray(a)
@@ -678,21 +675,17 @@ def min(a, axis=None, out=None, keepdims=False, initial=None, where=True):
                 raise ValueError(
                     f"Output array of shape {result.shape} is needed, got {out.shape}."
                 )
-            elif out.dtype != result.dtype:
-                raise ValueError(
-                    f"Output array of type {result.dtype} is needed, got {out.dtype}."
-                )
             elif not isinstance(out, dpnp_array):
                 if isinstance(out, dpt.usm_ndarray):
-                    out = dpnp.array(out)
+                    out = dpnp_array._create_from_usm_ndarray(out)
                 else:
-                    raise ValueError(
-                        "An array must be any of supported type, but got {}".format(
+                    raise TypeError(
+                        "Output array must be any of supported type, but got {}".format(
                             type(out)
                         )
                     )
 
-            dpnp.copyto(out, result)
+            dpnp.copyto(out, result, casting="safe")
 
             return out
 

--- a/dpnp/dpnp_iface_statistics.py
+++ b/dpnp/dpnp_iface_statistics.py
@@ -363,14 +363,15 @@ def max(a, axis=None, out=None, keepdims=False, initial=None, where=True):
 
     Limitations
     -----------
-    Input and output arrays are only supported as either :class:`dpnp.ndarray` or :class:`dpctl.tensor.usm_ndarray`.
+    Input and output arrays are only supported as either :class:`dpnp.ndarray`
+    or :class:`dpctl.tensor.usm_ndarray`.
     Parameters `where`, and `initial` are supported only with their default values.
     Otherwise ``NotImplementedError`` exception will be raised.
     Input array data types are limited by supported DPNP :ref:`Data types`.
 
     See Also
     --------
-    :obj:`dpnp.min` : Return tha minimum of an array.
+    :obj:`dpnp.min` : Return the minimum of an array.
     :obj:`dpnp.maximum` : Element-wise maximum of two arrays, propagates NaNs.
     :obj:`dpnp.fmax` : Element-wise maximum of two arrays, ignores NaNs.
     :obj:`dpnp.amax` : The maximum value of an array along a given axis, propagates NaNs.
@@ -400,11 +401,11 @@ def max(a, axis=None, out=None, keepdims=False, initial=None, where=True):
 
     if initial is not None:
         raise NotImplementedError(
-            "initial keyword arguemnt is only supported by its default value."
+            "initial keyword argument is only supported by its default value."
         )
     elif where is not True:
         raise NotImplementedError(
-            "where keyword arguemnt is only supported by its default value."
+            "where keyword argument is only supported by its default value."
         )
     else:
         dpt_array = dpnp.get_usm_ndarray(a)
@@ -607,14 +608,15 @@ def min(a, axis=None, out=None, keepdims=False, initial=None, where=True):
 
     Limitations
     -----------
-    Input and output arrays are only supported as either :class:`dpnp.ndarray` or :class:`dpctl.tensor.usm_ndarray`.
+    Input and output arrays are only supported as either :class:`dpnp.ndarray`
+    or :class:`dpctl.tensor.usm_ndarray`.
     Parameters `where`, and `initial` are supported only with their default values.
     Otherwise ``NotImplementedError`` exception will be raised.
     Input array data types are limited by supported DPNP :ref:`Data types`.
 
     See Also
     --------
-    :obj:`dpnp.max` : Return tha maximum of an array.
+    :obj:`dpnp.max` : Return the maximum of an array.
     :obj:`dpnp.minimum` : Element-wise minimum of two arrays, propagates NaNs.
     :obj:`dpnp.fmin` : Element-wise minimum of two arrays, ignores NaNs.
     :obj:`dpnp.amin` : The minimum value of an array along a given axis, propagates NaNs.
@@ -644,11 +646,11 @@ def min(a, axis=None, out=None, keepdims=False, initial=None, where=True):
 
     if initial is not None:
         raise NotImplementedError(
-            "initial keyword arguemnt is only supported by its default value."
+            "initial keyword argument is only supported by its default value."
         )
     elif where is not True:
         raise NotImplementedError(
-            "where keyword arguemnt is only supported by its default values."
+            "where keyword argument is only supported by its default values."
         )
     else:
         dpt_array = dpnp.get_usm_ndarray(a)

--- a/dpnp/dpnp_iface_statistics.py
+++ b/dpnp/dpnp_iface_statistics.py
@@ -1,5 +1,3 @@
-# cython: language_level=3
-# distutils: language = c++
 # -*- coding: utf-8 -*-
 # *****************************************************************************
 # Copyright (c) 2016-2023, Intel Corporation
@@ -352,69 +350,65 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
     )
 
 
-def max(x1, axis=None, out=None, keepdims=False, initial=None, where=True):
+def max(a, axis=None, out=None, keepdims=False, initial=None, where=True):
     """
     Return the maximum of an array or maximum along an axis.
 
+    Returns
+    -------
+    out : dpnp.ndarray
+        Maximum of `a`.
+
     Limitations
     -----------
-    Input array is supported as :obj:`dpnp.ndarray`.
+    Input array `a` is only supported as either :class:`dpnp.ndarray` or :class:`dpctl.tensor.usm_ndarray`.
+    Parameters `out`, `where`, and `initial` are supported only with their default values.
     Otherwise the function will be executed sequentially on CPU.
-    Parameter `out` is supported only with default value ``None``.
     Input array data types are limited by supported DPNP :ref:`Data types`.
+
+    See Also
+    --------
+    :obj:`dpnp.min` : Return tha minimum of an array.
+    :obj:`dpnp.maximum` : Element-wise maximum of two arrays, propagates NaNs.
+    :obj:`dpnp.fmax` : Element-wise maximum of two arrays, ignores NaNs.
+    :obj:`dpnp.amax` : The maximum value of an array along a given axis, propagates NaNs.
+    :obj:`dpnp.nanmax` : The maximum value of an array along a given axis, ignores NaNs.
 
     Examples
     --------
     >>> import dpnp as np
     >>> a = np.arange(4).reshape((2,2))
-    >>> a.shape
-    (2, 2)
-    >>> [i for i in a]
-    [0, 1, 2, 3]
+    >>> a
+    array([[0, 1],
+           [2, 3]])
     >>> np.max(a)
-    3
+    array(3)
+
+    >>> np.max(a, axis=0)   # Maxima along the first axis
+    array([2, 3])
+    >>> np.max(a, axis=1)   # Maxima along the second axis
+    array([1, 3])
+
+    >>> b = np.arange(5, dtype=float)
+    >>> b[2] = np.NaN
+    >>> np.max(b)
+    array(nan)
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
-    if x1_desc:
-        # Negative values in 'shape' are not allowed in input array
-        # 306-322 check on negative and duplicate axis
-        isaxis = True
-        if axis is not None:
-            if dpnp.isscalar(axis):
-                if axis < 0:
-                    isaxis = False
-            else:
-                for val in axis:
-                    if val < 0:
-                        isaxis = False
-                        break
-                if isaxis:
-                    for i in range(len(axis)):
-                        for j in range(len(axis)):
-                            if i != j:
-                                if axis[i] == axis[j]:
-                                    isaxis = False
-                                    break
+    if out is not None:
+        pass
+    elif initial is not None:
+        pass
+    elif where is not True:
+        pass
+    else:
+        dpt_array = dpnp.get_usm_ndarray(a)
+        return dpnp_array._create_from_usm_ndarray(
+            dpt.max(dpt_array, axis=axis, keepdims=keepdims)
+        )
 
-        if not isaxis:
-            pass
-        elif out is not None:
-            pass
-        elif keepdims:
-            pass
-        elif initial is not None:
-            pass
-        elif where is not True:
-            pass
-        else:
-            result_obj = dpnp_max(x1_desc, axis).get_pyobj()
-            result = dpnp.convert_single_elem_array_to_scalar(result_obj)
-
-            return result
-
-    return call_origin(numpy.max, x1, axis, out, keepdims, initial, where)
+    return call_origin(numpy.max, a, axis, out, keepdims, initial, where)
 
 
 def mean(x, /, *, axis=None, dtype=None, keepdims=False, out=None, where=True):
@@ -564,47 +558,67 @@ def median(x1, axis=None, out=None, overwrite_input=False, keepdims=False):
     return call_origin(numpy.median, x1, axis, out, overwrite_input, keepdims)
 
 
-def min(x1, axis=None, out=None, keepdims=False, initial=None, where=True):
+def min(a, axis=None, out=None, keepdims=False, initial=None, where=True):
     """
-    Return the minimum along a given axis.
+    Return the minimum of an array or maximum along an axis.
+
+    For full documentation refer to :obj:`numpy.min`.
+
+    Returns
+    -------
+    out : dpnp.ndarray
+        Minimum of `a`.
 
     Limitations
     -----------
-    Input array is supported as :obj:`dpnp.ndarray`.
+    Input array `a` is only supported as either :class:`dpnp.ndarray` or :class:`dpctl.tensor.usm_ndarray`.
+    Parameters `out`, `where`, and `initial` are supported only with their default values.
     Otherwise the function will be executed sequentially on CPU.
-    Parameter `out` is supported only with default value ``None``.
     Input array data types are limited by supported DPNP :ref:`Data types`.
+
+    See Also
+    --------
+    :obj:`dpnp.max` : Return tha maximum of an array.
+    :obj:`dpnp.minimum` : Element-wise minimum of two arrays, propagates NaNs.
+    :obj:`dpnp.fmin` : Element-wise minimum of two arrays, ignores NaNs.
+    :obj:`dpnp.amin` : The minimum value of an array along a given axis, propagates NaNs.
+    :obj:`dpnp.nanmin` : The minimum value of an array along a given axis, ignores NaNs.
 
     Examples
     --------
     >>> import dpnp as np
     >>> a = np.arange(4).reshape((2,2))
-    >>> a.shape
-    (2, 2)
-    >>> [i for i in a]
-    [0, 1, 2, 3]
+    >>> a
+    array([[0, 1],
+           [2, 3]])
     >>> np.min(a)
-    0
+    array(0)
+
+    >>> np.min(a, axis=0)   # Minima along the first axis
+    array([0, 1])
+    >>> np.min(a, axis=1)   # Minima along the second axis
+    array([0, 2])
+
+    >>> b = np.arange(5, dtype=float)
+    >>> b[2] = np.NaN
+    >>> np.min(b)
+    array(nan)
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
-    if x1_desc:
-        if out is not None:
-            pass
-        elif keepdims:
-            pass
-        elif initial is not None:
-            pass
-        elif where is not True:
-            pass
-        else:
-            result_obj = dpnp_min(x1_desc, axis).get_pyobj()
-            result = dpnp.convert_single_elem_array_to_scalar(result_obj)
+    if out is not None:
+        pass
+    elif initial is not None:
+        pass
+    elif where is not True:
+        pass
+    else:
+        dpt_array = dpnp.get_usm_ndarray(a)
+        return dpnp_array._create_from_usm_ndarray(
+            dpt.min(dpt_array, axis=axis, keepdims=keepdims)
+        )
 
-            return result
-
-    return call_origin(numpy.min, x1, axis, out, keepdims, initial, where)
+    return call_origin(numpy.min, a, axis, out, keepdims, initial, where)
 
 
 def nanvar(x1, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
@@ -619,7 +633,7 @@ def nanvar(x1, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
     Parameter `axis` is supported only with default value ``None``.
     Parameter `dtype` is supported only with default value ``None``.
     Parameter `out` is supported only with default value ``None``.
-    Parameter `keepdims` is supported only with default value ``numpy._NoValue``.
+    Parameter `keepdims` is supported only with default value ``False``.
     Otherwise the function will be executed sequentially on CPU.
     """
 
@@ -665,7 +679,7 @@ def std(x1, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
     Parameter `axis` is supported only with default value ``None``.
     Parameter `dtype` is supported only with default value ``None``.
     Parameter `out` is supported only with default value ``None``.
-    Parameter `keepdims` is supported only with default value ``numpy._NoValue``.
+    Parameter `keepdims` is supported only with default value ``False``.
     Otherwise the function will be executed sequentially on CPU.
     Input array data types are limited by supported DPNP :ref:`Data types`.
 
@@ -723,7 +737,7 @@ def var(x1, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
     Parameter `axis` is supported only with default value ``None``.
     Parameter `dtype` is supported only with default value ``None``.
     Parameter `out` is supported only with default value ``None``.
-    Parameter `keepdims` is supported only with default value ``numpy._NoValue``.
+    Parameter `keepdims` is supported only with default value ``False``.
     Otherwise the function will be executed sequentially on CPU.
     Input array data types are limited by supported DPNP :ref:`Data types`.
 

--- a/dpnp/dpnp_iface_statistics.py
+++ b/dpnp/dpnp_iface_statistics.py
@@ -354,6 +354,8 @@ def max(a, axis=None, out=None, keepdims=False, initial=None, where=True):
     """
     Return the maximum of an array or maximum along an axis.
 
+    For full documentation refer to :obj:`numpy.max`.
+
     Returns
     -------
     out : dpnp.ndarray
@@ -396,19 +398,56 @@ def max(a, axis=None, out=None, keepdims=False, initial=None, where=True):
 
     """
 
-    if out is not None:
-        pass
-    elif initial is not None:
-        pass
+    if initial is not None:
+        raise NotImplementedError(
+            "initial keyword arguemnts is only supported by its default value."
+        )
     elif where is not True:
-        pass
+        raise NotImplementedError(
+            "where keyword arguemnts is only supported by its default values."
+        )
     else:
         dpt_array = dpnp.get_usm_ndarray(a)
-        return dpnp_array._create_from_usm_ndarray(
-            dpt.max(dpt_array, axis=axis, keepdims=keepdims)
-        )
+        if dpt_array.size == 0:
+            # TODO: get rid of this if condition when dpctl supports it
+            for i in range(a.ndim):
+                if a.shape[i] == 0:
+                    if i not in axis:
+                        indices = [i for i in range(a.ndim) if i not in axis]
+                        res_shape = tuple([a.shape[i] for i in indices])
+                        result = dpnp.empty(res_shape, dtype=a.dtype)
+                    else:
+                        raise ValueError(
+                            "reduction does not support zero-size arrays"
+                        )
+        else:
+            result = dpnp_array._create_from_usm_ndarray(
+                dpt.max(dpt_array, axis=axis, keepdims=keepdims)
+            )
+        if out is None:
+            return result
+        else:
+            if out.shape != result.shape:
+                raise ValueError(
+                    f"Output array of shape {result.shape} is needed, got {out.shape}."
+                )
+            elif out.dtype != result.dtype:
+                raise ValueError(
+                    f"Output array of type {result.dtype} is needed, got {out.dtype}."
+                )
+            elif not isinstance(out, dpnp_array):
+                if isinstance(out, dpt.usm_ndarray):
+                    out = dpnp.array(out)
+                else:
+                    raise ValueError(
+                        "An array must be any of supported type, but got {}".format(
+                            type(out)
+                        )
+                    )
 
-    return call_origin(numpy.max, a, axis, out, keepdims, initial, where)
+            dpnp.copyto(out, result)
+
+            return out
 
 
 def mean(x, /, *, axis=None, dtype=None, keepdims=False, out=None, where=True):
@@ -606,19 +645,56 @@ def min(a, axis=None, out=None, keepdims=False, initial=None, where=True):
 
     """
 
-    if out is not None:
-        pass
-    elif initial is not None:
-        pass
+    if initial is not None:
+        raise NotImplementedError(
+            "initial keyword arguemnts is only supported by its default value."
+        )
     elif where is not True:
-        pass
+        raise NotImplementedError(
+            "where keyword arguemnts is only supported by its default values."
+        )
     else:
         dpt_array = dpnp.get_usm_ndarray(a)
-        return dpnp_array._create_from_usm_ndarray(
-            dpt.min(dpt_array, axis=axis, keepdims=keepdims)
-        )
+        if dpt_array.size == 0:
+            # TODO: get rid of this if condition when dpctl supports it
+            for i in range(a.ndim):
+                if a.shape[i] == 0:
+                    if i not in axis:
+                        indices = [i for i in range(a.ndim) if i not in axis]
+                        res_shape = tuple([a.shape[i] for i in indices])
+                        result = dpnp.empty(res_shape, dtype=a.dtype)
+                    else:
+                        raise ValueError(
+                            "reduction does not support zero-size arrays"
+                        )
+        else:
+            result = dpnp_array._create_from_usm_ndarray(
+                dpt.min(dpt_array, axis=axis, keepdims=keepdims)
+            )
+        if out is None:
+            return result
+        else:
+            if out.shape != result.shape:
+                raise ValueError(
+                    f"Output array of shape {result.shape} is needed, got {out.shape}."
+                )
+            elif out.dtype != result.dtype:
+                raise ValueError(
+                    f"Output array of type {result.dtype} is needed, got {out.dtype}."
+                )
+            elif not isinstance(out, dpnp_array):
+                if isinstance(out, dpt.usm_ndarray):
+                    out = dpnp.array(out)
+                else:
+                    raise ValueError(
+                        "An array must be any of supported type, but got {}".format(
+                            type(out)
+                        )
+                    )
 
-    return call_origin(numpy.min, a, axis, out, keepdims, initial, where)
+            dpnp.copyto(out, result)
+
+            return out
 
 
 def nanvar(x1, axis=None, dtype=None, out=None, ddof=0, keepdims=False):

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -118,7 +118,6 @@ tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayFlatte
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayFlatten::test_flatten_order_copied
 tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py::TestArrayFlatten::test_flatten_order_transposed
 
-tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_min_nan
 tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_all
 tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_all_keepdims
 tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestArrayReduction::test_ptp_axis0
@@ -796,14 +795,10 @@ tests/third_party/cupy/random_tests/test_sample.py::TestMultinomial_param_4_{siz
 tests/third_party/cupy/random_tests/test_sample.py::TestRandint2::test_bound_float1
 tests/third_party/cupy/random_tests/test_sample.py::TestRandint2::test_goodness_of_fit
 tests/third_party/cupy/random_tests/test_sample.py::TestRandint2::test_goodness_of_fit_2
-
 tests/third_party/cupy/random_tests/test_sample.py::TestRandomIntegers2::test_bound_1
 tests/third_party/cupy/random_tests/test_sample.py::TestRandomIntegers2::test_bound_2
 tests/third_party/cupy/random_tests/test_sample.py::TestRandomIntegers2::test_goodness_of_fit
 tests/third_party/cupy/random_tests/test_sample.py::TestRandomIntegers2::test_goodness_of_fit_2
-tests/third_party/cupy/random_tests/test_sample.py::TestRandomIntegers::test_high_is_none
-tests/third_party/cupy/random_tests/test_sample.py::TestRandomIntegers::test_normal
-tests/third_party/cupy/random_tests/test_sample.py::TestRandomIntegers::test_size_is_not_none
 
 tests/third_party/cupy/sorting_tests/test_search.py::TestArgMinMaxDtype_param_0_{func='argmin', is_module=True, shape=(3, 4)}::test_argminmax_dtype
 tests/third_party/cupy/sorting_tests/test_search.py::TestArgMinMaxDtype_param_1_{func='argmin', is_module=True, shape=()}::test_argminmax_dtype

--- a/tests/test_amin_amax.py
+++ b/tests/test_amin_amax.py
@@ -7,7 +7,7 @@ import dpnp
 from .helper import get_all_dtypes
 
 
-@pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True))
+@pytest.mark.parametrize("dtype", get_all_dtypes())
 def test_amax(dtype):
     a = numpy.array(
         [
@@ -25,7 +25,7 @@ def test_amax(dtype):
         assert_allclose(expected, result)
 
 
-@pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True))
+@pytest.mark.parametrize("dtype", get_all_dtypes())
 def test_amin(dtype):
     a = numpy.array(
         [
@@ -55,8 +55,7 @@ def _get_min_max_input(type, shape):
     return a.reshape(shape)
 
 
-@pytest.mark.usefixtures("allow_fall_back_on_numpy")
-@pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True))
+@pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
 @pytest.mark.parametrize(
     "shape", [(4,), (2, 3), (4, 5, 6)], ids=["(4,)", "(2,3)", "(4,5,6)"]
 )
@@ -74,8 +73,7 @@ def test_amax_diff_shape(dtype, shape):
     numpy.testing.assert_array_equal(dpnp_res, np_res)
 
 
-@pytest.mark.usefixtures("allow_fall_back_on_numpy")
-@pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True))
+@pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
 @pytest.mark.parametrize(
     "shape", [(4,), (2, 3), (4, 5, 6)], ids=["(4,)", "(2,3)", "(4,5,6)"]
 )

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -1,3 +1,4 @@
+import dpctl.tensor as dpt
 import numpy
 import pytest
 from numpy.testing import assert_allclose
@@ -61,26 +62,43 @@ def test_max_min_bool(axis, keepdims):
     assert_allclose(dpnp_res, np_res)
 
 
-@pytest.mark.parametrize("axis", [None, 0, 1, -1, 2, -2, (1, 2), (0, -2)])
-@pytest.mark.parametrize("keepdims", [False, True])
-@pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
-def test_max_min_out(axis, keepdims, dtype):
-    a = numpy.arange(768, dtype=dtype).reshape((4, 4, 6, 8))
+def test_max_min_out():
+    a = numpy.arange(6).reshape((2, 3))
     ia = dpnp.array(a)
 
-    np_res = numpy.max(a, axis=axis, keepdims=keepdims)
+    np_res = numpy.max(a, axis=0)
     dpnp_res = dpnp.array(numpy.empty_like(np_res))
-    dpnp.max(ia, axis=axis, keepdims=keepdims, out=dpnp_res)
-
-    assert dpnp_res.shape == np_res.shape
+    dpnp.max(ia, axis=0, out=dpnp_res)
     assert_allclose(dpnp_res, np_res)
 
-    np_res = numpy.min(a, axis=axis, keepdims=keepdims)
-    dpnp_res = dpnp.array(numpy.empty_like(np_res))
-    dpnp.min(ia, axis=axis, keepdims=keepdims, out=dpnp_res)
-
-    assert dpnp_res.shape == np_res.shape
+    dpnp_res = dpt.asarray(numpy.empty_like(np_res))
+    dpnp.max(ia, axis=0, out=dpnp_res)
     assert_allclose(dpnp_res, np_res)
+
+    dpnp_res = numpy.empty_like(np_res)
+    with pytest.raises(TypeError):
+        dpnp.max(ia, axis=0, out=dpnp_res)
+
+    dpnp_res = dpnp.array(numpy.empty((2, 3)))
+    with pytest.raises(ValueError):
+        dpnp.max(ia, axis=0, out=dpnp_res)
+
+    np_res = numpy.min(a, axis=0)
+    dpnp_res = dpnp.array(numpy.empty_like(np_res))
+    dpnp.min(ia, axis=0, out=dpnp_res)
+    assert_allclose(dpnp_res, np_res)
+
+    dpnp_res = dpt.asarray(numpy.empty_like(np_res))
+    dpnp.min(ia, axis=0, out=dpnp_res)
+    assert_allclose(dpnp_res, np_res)
+
+    dpnp_res = numpy.empty_like(np_res)
+    with pytest.raises(TypeError):
+        dpnp.min(ia, axis=0, out=dpnp_res)
+
+    dpnp_res = dpnp.array(numpy.empty((2, 3)))
+    with pytest.raises(ValueError):
+        dpnp.min(ia, axis=0, out=dpnp_res)
 
 
 def test_max_min_NotImplemented():
@@ -94,7 +112,7 @@ def test_max_min_NotImplemented():
     with pytest.raises(NotImplementedError):
         dpnp.min(ia, where=False)
     with pytest.raises(NotImplementedError):
-        dpnp.max(ia, initial=6)
+        dpnp.min(ia, initial=6)
 
 
 @pytest.mark.usefixtures("allow_fall_back_on_numpy")

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -22,97 +22,67 @@ def test_median(dtype, size):
     assert_allclose(dpnp_res, np_res)
 
 
+@pytest.mark.parametrize("func", ["max", "min"])
 @pytest.mark.parametrize("axis", [None, 0, 1, -1, 2, -2, (1, 2), (0, -2)])
 @pytest.mark.parametrize("keepdims", [False, True])
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
-def test_max_min(axis, keepdims, dtype):
+def test_max_min(func, axis, keepdims, dtype):
     a = numpy.arange(768, dtype=dtype).reshape((4, 4, 6, 8))
     ia = dpnp.array(a)
 
-    np_res = numpy.max(a, axis=axis, keepdims=keepdims)
-    dpnp_res = dpnp.max(ia, axis=axis, keepdims=keepdims)
-
-    assert dpnp_res.shape == np_res.shape
-    assert_allclose(dpnp_res, np_res)
-
-    np_res = numpy.min(a, axis=axis, keepdims=keepdims)
-    dpnp_res = dpnp.min(ia, axis=axis, keepdims=keepdims)
+    np_res = getattr(numpy, func)(a, axis=axis, keepdims=keepdims)
+    dpnp_res = getattr(dpnp, func)(ia, axis=axis, keepdims=keepdims)
 
     assert dpnp_res.shape == np_res.shape
     assert_allclose(dpnp_res, np_res)
 
 
+@pytest.mark.parametrize("func", ["max", "min"])
 @pytest.mark.parametrize("axis", [None, 0, 1, -1])
 @pytest.mark.parametrize("keepdims", [False, True])
-def test_max_min_bool(axis, keepdims):
+def test_max_min_bool(func, axis, keepdims):
     a = numpy.arange(2, dtype=dpnp.bool)
     a = numpy.tile(a, (2, 2))
     ia = dpnp.array(a)
 
-    np_res = numpy.max(a, axis=axis, keepdims=keepdims)
-    dpnp_res = dpnp.max(ia, axis=axis, keepdims=keepdims)
-
-    assert dpnp_res.shape == np_res.shape
-    assert_allclose(dpnp_res, np_res)
-
-    np_res = numpy.min(a, axis=axis, keepdims=keepdims)
-    dpnp_res = dpnp.min(ia, axis=axis, keepdims=keepdims)
+    np_res = getattr(numpy, func)(a, axis=axis, keepdims=keepdims)
+    dpnp_res = getattr(dpnp, func)(ia, axis=axis, keepdims=keepdims)
 
     assert dpnp_res.shape == np_res.shape
     assert_allclose(dpnp_res, np_res)
 
 
-def test_max_min_out():
+@pytest.mark.parametrize("func", ["max", "min"])
+def test_max_min_out(func):
     a = numpy.arange(6).reshape((2, 3))
     ia = dpnp.array(a)
 
-    np_res = numpy.max(a, axis=0)
+    np_res = getattr(numpy, func)(a, axis=0)
     dpnp_res = dpnp.array(numpy.empty_like(np_res))
-    dpnp.max(ia, axis=0, out=dpnp_res)
+    getattr(dpnp, func)(ia, axis=0, out=dpnp_res)
     assert_allclose(dpnp_res, np_res)
 
     dpnp_res = dpt.asarray(numpy.empty_like(np_res))
-    dpnp.max(ia, axis=0, out=dpnp_res)
+    getattr(dpnp, func)(ia, axis=0, out=dpnp_res)
     assert_allclose(dpnp_res, np_res)
 
     dpnp_res = numpy.empty_like(np_res)
     with pytest.raises(TypeError):
-        dpnp.max(ia, axis=0, out=dpnp_res)
+        getattr(dpnp, func)(ia, axis=0, out=dpnp_res)
 
     dpnp_res = dpnp.array(numpy.empty((2, 3)))
     with pytest.raises(ValueError):
-        dpnp.max(ia, axis=0, out=dpnp_res)
-
-    np_res = numpy.min(a, axis=0)
-    dpnp_res = dpnp.array(numpy.empty_like(np_res))
-    dpnp.min(ia, axis=0, out=dpnp_res)
-    assert_allclose(dpnp_res, np_res)
-
-    dpnp_res = dpt.asarray(numpy.empty_like(np_res))
-    dpnp.min(ia, axis=0, out=dpnp_res)
-    assert_allclose(dpnp_res, np_res)
-
-    dpnp_res = numpy.empty_like(np_res)
-    with pytest.raises(TypeError):
-        dpnp.min(ia, axis=0, out=dpnp_res)
-
-    dpnp_res = dpnp.array(numpy.empty((2, 3)))
-    with pytest.raises(ValueError):
-        dpnp.min(ia, axis=0, out=dpnp_res)
+        getattr(dpnp, func)(ia, axis=0, out=dpnp_res)
 
 
-def test_max_min_NotImplemented():
+@pytest.mark.parametrize("func", ["max", "min"])
+def test_max_min_NotImplemented(func):
     ia = dpnp.arange(5)
 
     with pytest.raises(NotImplementedError):
-        dpnp.max(ia, where=False)
+        getattr(dpnp, func)(ia, where=False)
     with pytest.raises(NotImplementedError):
-        dpnp.max(ia, initial=6)
-
-    with pytest.raises(NotImplementedError):
-        dpnp.min(ia, where=False)
-    with pytest.raises(NotImplementedError):
-        dpnp.min(ia, initial=6)
+        getattr(dpnp, func)(ia, initial=6)
 
 
 @pytest.mark.usefixtures("allow_fall_back_on_numpy")

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -21,18 +21,23 @@ def test_median(dtype, size):
     assert_allclose(dpnp_res, np_res)
 
 
-@pytest.mark.usefixtures("allow_fall_back_on_numpy")
-@pytest.mark.parametrize("axis", [0, 1, -1, 2, -2, (1, 2), (0, -2)])
-@pytest.mark.parametrize(
-    "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
-)
-def test_max(axis, dtype):
+@pytest.mark.parametrize("axis", [None, 0, 1, -1, 2, -2, (1, 2), (0, -2)])
+@pytest.mark.parametrize("keepdims", [False, True])
+@pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True, no_bool=True))
+def test_max_min(axis, keepdims, dtype):
     a = numpy.arange(768, dtype=dtype).reshape((4, 4, 6, 8))
     ia = dpnp.array(a)
 
-    np_res = numpy.max(a, axis=axis)
-    dpnp_res = dpnp.max(ia, axis=axis)
+    np_res = numpy.max(a, axis=axis, keepdims=keepdims)
+    dpnp_res = dpnp.max(ia, axis=axis, keepdims=keepdims)
 
+    assert dpnp_res.shape == np_res.shape
+    assert_allclose(dpnp_res, np_res)
+
+    np_res = numpy.min(a, axis=axis, keepdims=keepdims)
+    dpnp_res = dpnp.min(ia, axis=axis, keepdims=keepdims)
+
+    assert dpnp_res.shape == np_res.shape
     assert_allclose(dpnp_res, np_res)
 
 

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -23,7 +23,7 @@ def test_median(dtype, size):
 
 @pytest.mark.parametrize("axis", [None, 0, 1, -1, 2, -2, (1, 2), (0, -2)])
 @pytest.mark.parametrize("keepdims", [False, True])
-@pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True, no_bool=True))
+@pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
 def test_max_min(axis, keepdims, dtype):
     a = numpy.arange(768, dtype=dtype).reshape((4, 4, 6, 8))
     ia = dpnp.array(a)
@@ -39,6 +39,62 @@ def test_max_min(axis, keepdims, dtype):
 
     assert dpnp_res.shape == np_res.shape
     assert_allclose(dpnp_res, np_res)
+
+
+@pytest.mark.parametrize("axis", [None, 0, 1, -1])
+@pytest.mark.parametrize("keepdims", [False, True])
+def test_max_min_bool(axis, keepdims):
+    a = numpy.arange(2, dtype=dpnp.bool)
+    a = numpy.tile(a, (2, 2))
+    ia = dpnp.array(a)
+
+    np_res = numpy.max(a, axis=axis, keepdims=keepdims)
+    dpnp_res = dpnp.max(ia, axis=axis, keepdims=keepdims)
+
+    assert dpnp_res.shape == np_res.shape
+    assert_allclose(dpnp_res, np_res)
+
+    np_res = numpy.min(a, axis=axis, keepdims=keepdims)
+    dpnp_res = dpnp.min(ia, axis=axis, keepdims=keepdims)
+
+    assert dpnp_res.shape == np_res.shape
+    assert_allclose(dpnp_res, np_res)
+
+
+@pytest.mark.parametrize("axis", [None, 0, 1, -1, 2, -2, (1, 2), (0, -2)])
+@pytest.mark.parametrize("keepdims", [False, True])
+@pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
+def test_max_min_out(axis, keepdims, dtype):
+    a = numpy.arange(768, dtype=dtype).reshape((4, 4, 6, 8))
+    ia = dpnp.array(a)
+
+    np_res = numpy.max(a, axis=axis, keepdims=keepdims)
+    dpnp_res = dpnp.array(numpy.empty_like(np_res))
+    dpnp.max(ia, axis=axis, keepdims=keepdims, out=dpnp_res)
+
+    assert dpnp_res.shape == np_res.shape
+    assert_allclose(dpnp_res, np_res)
+
+    np_res = numpy.min(a, axis=axis, keepdims=keepdims)
+    dpnp_res = dpnp.array(numpy.empty_like(np_res))
+    dpnp.min(ia, axis=axis, keepdims=keepdims, out=dpnp_res)
+
+    assert dpnp_res.shape == np_res.shape
+    assert_allclose(dpnp_res, np_res)
+
+
+def test_max_min_NotImplemented():
+    ia = dpnp.arange(5)
+
+    with pytest.raises(NotImplementedError):
+        dpnp.max(ia, where=False)
+    with pytest.raises(NotImplementedError):
+        dpnp.max(ia, initial=6)
+
+    with pytest.raises(NotImplementedError):
+        dpnp.min(ia, where=False)
+    with pytest.raises(NotImplementedError):
+        dpnp.max(ia, initial=6)
 
 
 @pytest.mark.usefixtures("allow_fall_back_on_numpy")

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -260,6 +260,8 @@ def test_meshgrid(device_x, device_y):
         pytest.param("log10", [1.0, 2.0, 4.0, 7.0]),
         pytest.param("log1p", [1.0e-10, 1.0, 2.0, 4.0, 7.0]),
         pytest.param("log2", [1.0, 2.0, 4.0, 7.0]),
+        pytest.param("max", [1.0, 2.0, 4.0, 7.0]),
+        pytest.param("min", [1.0, 2.0, 4.0, 7.0]),
         pytest.param("nancumprod", [1.0, dpnp.nan]),
         pytest.param("nancumsum", [1.0, dpnp.nan]),
         pytest.param("nanprod", [1.0, dpnp.nan]),

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -350,6 +350,8 @@ def test_meshgrid(usm_type_x, usm_type_y):
         pytest.param("log1p", [1.0e-10, 1.0, 2.0, 4.0, 7.0]),
         pytest.param("log2", [1.0, 2.0, 4.0, 7.0]),
         pytest.param("nanprod", [1.0, 2.0, dp.nan]),
+        pytest.param("max", [1.0, 2.0, 4.0, 7.0]),
+        pytest.param("min", [1.0, 2.0, 4.0, 7.0]),
         pytest.param("negative", [1.0, 0.0, -1.0]),
         pytest.param("positive", [1.0, 0.0, -1.0]),
         pytest.param("prod", [1.0, 2.0]),


### PR DESCRIPTION
In this PR, `dpnp.max` and `dpnp.min` are implemented using their `dpctl.tensor` counterparts.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
