### PR TITLE
Pin DPC++ compiler to 2023.2 for coverage run to work around a crash in 2024.0

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -423,7 +423,7 @@ jobs:
         run: conda install anaconda-client
 
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.5.2
         with:
           repository: IntelPython/devops-tools
           fetch-depth: 0

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -42,8 +42,10 @@ jobs:
 
       - name: Install dpnp dependencies
         run: |
+          # use DPC++ compiler 2023.2 to work around an issue with crash
           conda install cython llvm cmake">=3.21" scikit-build ninja pytest pytest-cov coverage[toml] \
-              dpctl dpcpp_linux-64 sysroot_linux-64">=2.28" mkl-devel-dpcpp tbb-devel onedpl-devel ${{ env.CHANNELS }}
+              dpctl dpcpp_linux-64"=2023.2" sysroot_linux-64">=2.28" mkl-devel-dpcpp tbb-devel"=2021.10" \
+              onedpl-devel ${{ env.CHANNELS }}
 
       - name: Conda info
         run: |


### PR DESCRIPTION
The build with enabled coverage profiling is terminating with stack dump when using DPC++ 2024.0 compiler.
The PR proposes to temporary use DPC++ 2023.2 for coverage run until the issue is resolved.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
