### PR TITLE
remove skip test

### DIFF
--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -1049,7 +1049,7 @@ def repeat(a, repeats, axis=None):
     >>> np.repeat(x, 4)
     array([3, 3, 3, 3])
 
-    >>> x = np.array([[1,2], [3,4]])
+    >>> x = np.array([[1, 2], [3, 4]])
     >>> np.repeat(x, 2)
     array([1, 1, 2, 2, 3, 3, 4, 4])
     >>> np.repeat(x, 3, axis=1)

--- a/tests/third_party/cupy/statistics_tests/test_meanvar.py
+++ b/tests/third_party/cupy/statistics_tests/test_meanvar.py
@@ -181,8 +181,6 @@ class TestMeanVar(unittest.TestCase):
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-06)
     def test_mean_all_float32_dtype(self, xp, dtype):
-        if dtype == xp.int32:
-            pytest.skip("skip until issue #1468 is solved in dpctl")
         a = xp.full((2, 3, 4), 123456789, dtype=dtype)
         return xp.mean(a, dtype=numpy.float32)
 


### PR DESCRIPTION
A skip test is removed since `dpctl` [issue #1468](https://github.com/IntelPython/dpctl/issues/1468) is resolved by `dpctl` [PR #1470](https://github.com/IntelPython/dpctl/pull/1470).

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
