### PR TITLE
Update deploy step of a job with building docs

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -7,6 +7,8 @@ on:
     types: [opened, synchronize, reopened, closed]
 
 env:
+  GITHUB_BOT_NAME: 'github-actions[bot]'
+  GITHUB_BOT_EMAIL: 'github-actions[bot]@users.noreply.github.com'
   PUBLISH_DIR: doc/_build/html/
 
 defaults:
@@ -125,21 +127,29 @@ jobs:
             working-directory: 'dpnp/backend/doc'
 
       - name: Copy backend docs
-        run: cp -r dpnp/backend/doc/html doc/_build/html/backend_doc
+        run: cp -r dpnp/backend/doc/html ${{ env.PUBLISH_DIR }}/backend_doc
 
       # https://github.com/marketplace/actions/github-pages-action
+      # The step is only used to build docs while pushing PR to "master"
       - name: Deploy docs
         if: |
-          github.event.pull_request && !github.event.pull_request.head.repo.fork  &&
-          (github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/heads/release') == true) || github.event_name == 'push' && contains(github.ref, 'refs/tags/'))
+          github.ref == 'refs/heads/master' && github.event_name == 'push' &&
+          github.event.ref == 'refs/heads/master' && github.event.repository && !github.event.repository.fork
         uses: peaceiris/actions-gh-pages@v3.9.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ${{ env.PUBLISH_DIR }}
+          keep_files: true
+          commit_message: ${{ github.event.head_commit.message }}
+          publish_branch: gh-pages
+          user_name: ${{ env.GITHUB_BOT_NAME }}
+          user_email: ${{ env.GITHUB_BOT_EMAIL }}
 
+      # The step is only used to build docs while pushing to PR branch
       - name: Publish pull-request docs
         if: |
-          github.event.pull_request && !github.event.pull_request.head.repo.fork && github.event.action != 'closed'
+          github.event_name == 'pull_request' && github.event.action != 'closed' &&
+          github.event.pull_request && !github.event.pull_request.head.repo.fork
         uses: peaceiris/actions-gh-pages@v3.9.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -147,14 +157,16 @@ jobs:
           destination_dir: ./pull/${{ github.event.number }}
           allow_empty_commit : true
           keep_files: true
-          commit_message: ${{ github.event.head_commit.message }}
+          commit_message: ${{ github.event.pull_request.title }}
           publish_branch: gh-pages
-          user_name: 'github-actions[bot]'
-          user_email: 'github-actions[bot]@users.noreply.github.com'
+          user_name: ${{ env.GITHUB_BOT_NAME }}
+          user_email: ${{ env.GITHUB_BOT_EMAIL }}
 
+      # The step is only used to build docs while pushing to PR branch
       - name: Comment with URL to published pull-request docs
         if: |
-          github.event.pull_request && !github.event.pull_request.head.repo.fork && github.event.action != 'closed'
+          github.event_name == 'pull_request' && github.event.action != 'closed' &&
+          github.event.pull_request && !github.event.pull_request.head.repo.fork
         env:
           PR_NUM: ${{ github.event.number }}
         uses: mshick/add-pr-comment@v2.8.1
@@ -163,9 +175,11 @@ jobs:
             View rendered docs @ https://intelpython.github.io/dpnp/pull/${{ env.PR_NUM }}/index.html
           allow-repeats: false
 
+  # The job is only used to build docs when PR is closed (action from PR branch)
   clean:
     if: |
-      github.event.pull_request && !github.event.pull_request.head.repo.fork && github.event.action == 'closed'
+      github.event_name == 'pull_request' && github.event.action == 'closed' &&
+      github.event.pull_request && !github.event.pull_request.head.repo.fork
 
     needs: build-and-deploy
 
@@ -185,8 +199,8 @@ jobs:
           git checkout --track tokened_docs/gh-pages
           echo `pwd`
           [ -d pull/${PR_NUM} ] && git rm -rf pull/${PR_NUM}
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config --global user.name ${{ env.GITHUB_BOT_NAME }}
+          git config --global user.email ${{ env.GITHUB_BOT_EMAIL }}
           git commit -m "Removing docs for closed pull request ${PR_NUM}"
           git push tokened_docs gh-pages
 

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -7,8 +7,12 @@ on:
     types: [opened, synchronize, reopened, closed]
 
 env:
-  GITHUB_BOT_NAME: 'github-actions[bot]'
-  GITHUB_BOT_EMAIL: 'github-actions[bot]@users.noreply.github.com'
+  GH_BOT_NAME: 'github-actions[bot]'
+  GH_BOT_EMAIL: 'github-actions[bot]@users.noreply.github.com'
+  GH_EVENT_OPEN_PR_UPSTREAM: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' &&
+                                 github.event.pull_request && !github.event.pull_request.head.repo.fork }}
+  GH_EVENT_PUSH_UPSTREAM: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' &&
+                              github.event.ref == 'refs/heads/master' && github.event.repository && !github.event.repository.fork }}
   PUBLISH_DIR: doc/_build/html/
 
 defaults:
@@ -130,11 +134,9 @@ jobs:
         run: cp -r dpnp/backend/doc/html ${{ env.PUBLISH_DIR }}/backend_doc
 
       # https://github.com/marketplace/actions/github-pages-action
-      # The step is only used to build docs while pushing PR to "master"
+      # The step is only used to build docs while pushing a PR to "master"
       - name: Deploy docs
-        if: |
-          github.ref == 'refs/heads/master' && github.event_name == 'push' &&
-          github.event.ref == 'refs/heads/master' && github.event.repository && !github.event.repository.fork
+        if: env.GH_EVENT_PUSH_UPSTREAM
         uses: peaceiris/actions-gh-pages@v3.9.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -142,14 +144,12 @@ jobs:
           keep_files: true
           commit_message: ${{ github.event.head_commit.message }}
           publish_branch: gh-pages
-          user_name: ${{ env.GITHUB_BOT_NAME }}
-          user_email: ${{ env.GITHUB_BOT_EMAIL }}
+          user_name: ${{ env.GH_BOT_NAME }}
+          user_email: ${{ env.GH_BOT_EMAIL }}
 
       # The step is only used to build docs while pushing to PR branch
       - name: Publish pull-request docs
-        if: |
-          github.event_name == 'pull_request' && github.event.action != 'closed' &&
-          github.event.pull_request && !github.event.pull_request.head.repo.fork
+        if: env.GH_EVENT_OPEN_PR_UPSTREAM
         uses: peaceiris/actions-gh-pages@v3.9.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -159,14 +159,12 @@ jobs:
           keep_files: true
           commit_message: ${{ github.event.pull_request.title }}
           publish_branch: gh-pages
-          user_name: ${{ env.GITHUB_BOT_NAME }}
-          user_email: ${{ env.GITHUB_BOT_EMAIL }}
+          user_name: ${{ env.GH_BOT_NAME }}
+          user_email: ${{ env.GH_BOT_EMAIL }}
 
       # The step is only used to build docs while pushing to PR branch
       - name: Comment with URL to published pull-request docs
-        if: |
-          github.event_name == 'pull_request' && github.event.action != 'closed' &&
-          github.event.pull_request && !github.event.pull_request.head.repo.fork
+        if: env.GH_EVENT_OPEN_PR_UPSTREAM
         env:
           PR_NUM: ${{ github.event.number }}
         uses: mshick/add-pr-comment@v2.8.1
@@ -199,8 +197,8 @@ jobs:
           git checkout --track tokened_docs/gh-pages
           echo `pwd`
           [ -d pull/${PR_NUM} ] && git rm -rf pull/${PR_NUM}
-          git config --global user.name ${{ env.GITHUB_BOT_NAME }}
-          git config --global user.email ${{ env.GITHUB_BOT_EMAIL }}
+          git config --global user.name ${{ env.GH_BOT_NAME }}
+          git config --global user.email ${{ env.GH_BOT_EMAIL }}
           git commit -m "Removing docs for closed pull request ${PR_NUM}"
           git push tokened_docs gh-pages
 


### PR DESCRIPTION
The PR closes #1620 issues.
The PR closes #1621 pull request as superseded.

A step `Deploy docs` from building docs actions was indented to only build dpnp docs when the new commit is pushed to "master" branch. But due to wrong conditions the step was triggered from pull request of PR branch when event comes with action="closed" property.

Another major issue is missing `keep_files` option enabled for the step, which leads to removal of all files from "gh-pages" branch (as a pre-step), i.e. also including generated doc files relating to another PRs (located in a special "pull" folder and which has to be removed by separate `Clean` job per each closing PR).

The PR assumes to resolve both above issues.
Additionally GitHub bot user and email is used to push on "gh-pages" branch facelessly.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
