### PR TITLE
Add type checking in `assert_dtype_allclose` for inexact dtypes

### DIFF
--- a/tests/helper.py
+++ b/tests/helper.py
@@ -7,7 +7,9 @@ from numpy.testing import assert_allclose, assert_array_equal
 import dpnp
 
 
-def assert_dtype_allclose(dpnp_arr, numpy_arr, check_type=True):
+def assert_dtype_allclose(
+    dpnp_arr, numpy_arr, check_type=True, check_only_type_kind=False
+):
     """
     Assert DPNP and NumPy array based on maximum dtype resolution of input arrays
     for floating and complex types.
@@ -23,6 +25,9 @@ def assert_dtype_allclose(dpnp_arr, numpy_arr, check_type=True):
         supports 64-bit precision floating point operations or if the numpy array's inexact
         dtype is not a double precision type.
         Otherwise, asserts equal type kinds.
+    The 'check_only_type_kind' parameter (False by default) asserts only equal type kinds
+    for all data types supported by DPNP when set to True.
+    It is effective only when 'check_type' is also set to True.
 
     """
 
@@ -38,22 +43,29 @@ def assert_dtype_allclose(dpnp_arr, numpy_arr, check_type=True):
             numpy_arr_dtype = numpy_arr.dtype
             dpnp_arr_dtype = dpnp_arr.dtype
             dpnp_arr_dev = dpnp_arr.sycl_device
-            is_np_arr_f2 = numpy_arr_dtype == numpy.float16
 
-            if is_np_arr_f2:
-                if has_support_aspect16(dpnp_arr_dev):
-                    assert dpnp_arr_dtype == numpy_arr_dtype
-            elif (
-                numpy_arr_dtype not in list_64bit_types
-                or has_support_aspect64(dpnp_arr_dev)
-            ):
-                assert dpnp_arr_dtype == numpy_arr_dtype
-            else:
+            if check_only_type_kind:
                 assert dpnp_arr_dtype.kind == numpy_arr_dtype.kind
+            else:
+                is_np_arr_f2 = numpy_arr_dtype == numpy.float16
+
+                if is_np_arr_f2:
+                    if has_support_aspect16(dpnp_arr_dev):
+                        assert dpnp_arr_dtype == numpy_arr_dtype
+                elif (
+                    numpy_arr_dtype not in list_64bit_types
+                    or has_support_aspect64(dpnp_arr_dev)
+                ):
+                    assert dpnp_arr_dtype == numpy_arr_dtype
+                else:
+                    assert dpnp_arr_dtype.kind == numpy_arr_dtype.kind
     else:
         assert_array_equal(dpnp_arr.asnumpy(), numpy_arr)
         if check_type:
-            assert dpnp_arr.dtype == numpy_arr.dtype
+            if check_only_type_kind:
+                assert dpnp_arr.dtype.kind == numpy_arr.dtype.kind
+            else:
+                assert dpnp_arr.dtype == numpy_arr.dtype
 
 
 def get_complex_dtypes(device=None):

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -40,11 +40,12 @@ def assert_dtype_allclose(dpnp_arr, numpy_arr, check_type=True):
             dpnp_arr_dev = dpnp_arr.sycl_device
             is_np_arr_f2 = numpy_arr_dtype == numpy.float16
 
-            if is_np_arr_f2 and has_support_aspect16(dpnp_arr_dev):
-                assert dpnp_arr_dtype == numpy_arr_dtype
-            elif not is_np_arr_f2 and (
-                has_support_aspect64(dpnp_arr_dev)
-                or numpy_arr_dtype not in list_64bit_types
+            if is_np_arr_f2:
+                if has_support_aspect16(dpnp_arr_dev):
+                    assert dpnp_arr_dtype == numpy_arr_dtype
+            elif (
+                numpy_arr_dtype not in list_64bit_types
+                or has_support_aspect64(dpnp_arr_dev)
             ):
                 assert dpnp_arr_dtype == numpy_arr_dtype
             else:

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -12,6 +12,9 @@ def assert_dtype_allclose(dpnp_arr, numpy_arr, check_type=True):
     Assert DPNP and NumPy array based on maximum dtype resolution of input arrays
     for floating and complex types.
     For other dtypes the assertion is based on exact matching of the arrays.
+    When 'check_type' True (default), it asserts equal dtypes for exact types
+    and either equal dtypes or kinds for inexact types, depending on the 64-bit precision
+    support of the device on which `dpnp_arr` is created.
 
     """
 
@@ -22,6 +25,11 @@ def assert_dtype_allclose(dpnp_arr, numpy_arr, check_type=True):
             numpy.finfo(numpy_arr.dtype).resolution,
         )
         assert_allclose(dpnp_arr.asnumpy(), numpy_arr, atol=tol, rtol=tol)
+        if check_type:
+            if has_support_aspect64(dpnp_arr.sycl_device):
+                assert dpnp_arr.dtype == numpy_arr.dtype
+            else:
+                assert dpnp_arr.dtype.kind == numpy_arr.dtype.kind
     else:
         assert_array_equal(dpnp_arr.asnumpy(), numpy_arr)
         if check_type:

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -23,6 +23,7 @@ def assert_dtype_allclose(dpnp_arr, numpy_arr, check_type=True):
         supports 64-bit precision floating point operations or if the numpy array's inexact
         dtype is not a double precision type.
         Otherwise, asserts equal type kinds.
+
     """
 
     list_64bit_types = [numpy.float64, numpy.complex128]

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -42,7 +42,7 @@ def assert_dtype_allclose(dpnp_arr, numpy_arr, check_type=True):
 
             if is_np_arr_f2 and has_support_aspect16(dpnp_arr_dev):
                 assert dpnp_arr_dtype == numpy_arr_dtype
-            elif is_np_arr_f2 and (
+            elif not is_np_arr_f2 and (
                 has_support_aspect64(dpnp_arr_dev)
                 or numpy_arr_dtype not in list_64bit_types
             ):

--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -16,7 +16,7 @@ def test_fft(dtype, norm):
     np_res = numpy.fft.fft(data, norm=norm)
     dpnp_res = dpnp.fft.fft(dpnp_data, norm=norm)
 
-    assert_dtype_allclose(dpnp_res, np_res)
+    assert_dtype_allclose(dpnp_res, np_res, check_only_type_kind=True)
 
 
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
@@ -29,7 +29,7 @@ def test_fft_ndim(dtype, shape, norm):
     np_res = numpy.fft.fft(np_data, norm=norm)
     dpnp_res = dpnp.fft.fft(dpnp_data, norm=norm)
 
-    assert_dtype_allclose(dpnp_res, np_res)
+    assert_dtype_allclose(dpnp_res, np_res, check_only_type_kind=True)
 
 
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
@@ -44,7 +44,7 @@ def test_fft_ifft(dtype, shape, norm):
     np_res = numpy.fft.ifft(np_data, norm=norm)
     dpnp_res = dpnp.fft.ifft(dpnp_data, norm=norm)
 
-    assert_dtype_allclose(dpnp_res, np_res)
+    assert_dtype_allclose(dpnp_res, np_res, check_only_type_kind=True)
 
 
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True))
@@ -58,7 +58,7 @@ def test_fft_rfft(dtype, shape):
     np_res = numpy.fft.rfft(np_data)
     dpnp_res = dpnp.fft.rfft(dpnp_data)
 
-    assert_dtype_allclose(dpnp_res, np_res)
+    assert_dtype_allclose(dpnp_res, np_res, check_only_type_kind=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -1105,6 +1105,7 @@ class TestDivide:
         dp_array2 = dpnp.arange(size, dtype=dtype)
 
         dp_out = dpnp.empty(size, dtype=dpnp.complex64)
+        check_dtype = True
         if dtype != dpnp.complex64:
             # dtype of out mismatches types of input arrays
             with pytest.raises(TypeError):
@@ -1112,9 +1113,11 @@ class TestDivide:
 
             # allocate new out with expected type
             dp_out = dpnp.empty(size, dtype=dtype)
+            # Set check_dtype to False as dtype does not match
+            check_dtype = False
 
         result = dpnp.divide(dp_array1, dp_array2, out=dp_out)
-        assert_dtype_allclose(result, expected)
+        assert_dtype_allclose(result, expected, check_type=check_dtype)
 
     @pytest.mark.usefixtures("suppress_divide_invalid_numpy_warnings")
     @pytest.mark.parametrize("dtype", get_float_complex_dtypes())

--- a/tests/test_sum.py
+++ b/tests/test_sum.py
@@ -28,16 +28,15 @@ def test_sum_float(dtype):
     ia = dpnp.array(a)
 
     # Flag for type check in special cases
-    # Skip dtype checks when dpnp handles float32 arrays
+    # Use only type kinds checks when dpnp handles float32 arrays
     # as `dpnp.sum()` and `numpy.sum()` return different dtypes
-    check_dtype = dtype != dpnp.float32
+    check_type_kind = dtype == dpnp.float32
     for axis in range(len(a)):
         result = dpnp.sum(ia, axis=axis)
         expected = numpy.sum(a, axis=axis)
-        assert_dtype_allclose(result, expected, check_type=check_dtype)
-        if not check_dtype:
-            # Ensure dtype kind matches when check_dtype is False
-            assert result.dtype.kind == expected.dtype.kind
+        assert_dtype_allclose(
+            result, expected, check_only_type_kind=check_type_kind
+        )
 
 
 def test_sum_int():

--- a/tests/test_sum.py
+++ b/tests/test_sum.py
@@ -27,10 +27,17 @@ def test_sum_float(dtype):
     )
     ia = dpnp.array(a)
 
+    # Flag for type check in special cases
+    # Skip dtype checks when dpnp handles float32 arrays
+    # as `dpnp.sum()` and `numpy.sum()` return different dtypes
+    check_dtype = dtype != dpnp.float32
     for axis in range(len(a)):
         result = dpnp.sum(ia, axis=axis)
         expected = numpy.sum(a, axis=axis)
-        assert_dtype_allclose(result, expected)
+        assert_dtype_allclose(result, expected, check_type=check_dtype)
+        if not check_dtype:
+            # Ensure dtype kind matches when check_dtype is False
+            assert result.dtype.kind == expected.dtype.kind
 
 
 def test_sum_int():

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -875,7 +875,7 @@ def test_fft_rfft(type, shape, device):
     np_res = numpy.fft.rfft(np_data)
     dpnp_res = dpnp.fft.rfft(dpnp_data)
 
-    assert_dtype_allclose(dpnp_res, np_res)
+    assert_dtype_allclose(dpnp_res, np_res, check_only_type_kind=True)
 
     expected_queue = dpnp_data.get_array().sycl_queue
     result_queue = dpnp_res.get_array().sycl_queue


### PR DESCRIPTION
This PR improves `assert_dtype_allclose` function by adding type checking for cases with inexact data types. 
It makes the behaviour of the function consistent with its purpose and improves the reliability of data type checking in `dpnp` functions.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
