### PR TITLE
Redesign `dpnp.put_along_axis` and `dpnp.take_along_axis` thorough existing calls

### DIFF
--- a/dpnp/backend/include/dpnp_iface_fptr.hpp
+++ b/dpnp/backend/include/dpnp_iface_fptr.hpp
@@ -231,21 +231,19 @@ enum class DPNPFuncName : size_t
     DPNP_FN_PTP,            /**< Used in numpy.ptp() impl  */
     DPNP_FN_PUT,            /**< Used in numpy.put() impl  */
     DPNP_FN_PUT_ALONG_AXIS, /**< Used in numpy.put_along_axis() impl  */
-    DPNP_FN_PUT_ALONG_AXIS_EXT, /**< Used in numpy.put_along_axis() impl,
-                                   requires extra parameters */
-    DPNP_FN_QR,                 /**< Used in numpy.linalg.qr() impl  */
-    DPNP_FN_QR_EXT,       /**< Used in numpy.linalg.qr() impl, requires extra
-                             parameters */
-    DPNP_FN_RADIANS,      /**< Used in numpy.radians() impl  */
-    DPNP_FN_RADIANS_EXT,  /**< Used in numpy.radians() impl, requires extra
-                             parameters */
-    DPNP_FN_REMAINDER,    /**< Used in numpy.remainder() impl  */
-    DPNP_FN_RECIP,        /**< Used in numpy.recip() impl  */
-    DPNP_FN_RECIP_EXT,    /**< Used in numpy.recip() impl, requires extra
-                             parameters */
-    DPNP_FN_REPEAT,       /**< Used in numpy.repeat() impl  */
-    DPNP_FN_RIGHT_SHIFT,  /**< Used in numpy.right_shift() impl  */
-    DPNP_FN_RNG_BETA,     /**< Used in numpy.random.beta() impl  */
+    DPNP_FN_QR,             /**< Used in numpy.linalg.qr() impl  */
+    DPNP_FN_QR_EXT,         /**< Used in numpy.linalg.qr() impl, requires extra
+                               parameters */
+    DPNP_FN_RADIANS,        /**< Used in numpy.radians() impl  */
+    DPNP_FN_RADIANS_EXT,    /**< Used in numpy.radians() impl, requires extra
+                               parameters */
+    DPNP_FN_REMAINDER,      /**< Used in numpy.remainder() impl  */
+    DPNP_FN_RECIP,          /**< Used in numpy.recip() impl  */
+    DPNP_FN_RECIP_EXT,      /**< Used in numpy.recip() impl, requires extra
+                               parameters */
+    DPNP_FN_REPEAT,         /**< Used in numpy.repeat() impl  */
+    DPNP_FN_RIGHT_SHIFT,    /**< Used in numpy.right_shift() impl  */
+    DPNP_FN_RNG_BETA,       /**< Used in numpy.random.beta() impl  */
     DPNP_FN_RNG_BETA_EXT, /**< Used in numpy.random.beta() impl, requires extra
                              parameters */
     DPNP_FN_RNG_BINOMIAL, /**< Used in numpy.random.binomial() impl  */

--- a/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
@@ -796,19 +796,6 @@ void (*dpnp_put_along_axis_default_c)(void *,
                                       size_t) =
     dpnp_put_along_axis_c<_DataType>;
 
-template <typename _DataType>
-DPCTLSyclEventRef (*dpnp_put_along_axis_ext_c)(DPCTLSyclQueueRef,
-                                               void *,
-                                               long *,
-                                               void *,
-                                               size_t,
-                                               const shape_elem_type *,
-                                               size_t,
-                                               size_t,
-                                               size_t,
-                                               const DPCTLEventVectorRef) =
-    dpnp_put_along_axis_c<_DataType>;
-
 template <typename _DataType, typename _IndecesType>
 class dpnp_take_c_kernel;
 
@@ -1004,15 +991,6 @@ void func_map_init_indexing_func(func_map_t &fmap)
         eft_FLT, (void *)dpnp_put_along_axis_default_c<float>};
     fmap[DPNPFuncName::DPNP_FN_PUT_ALONG_AXIS][eft_DBL][eft_DBL] = {
         eft_DBL, (void *)dpnp_put_along_axis_default_c<double>};
-
-    fmap[DPNPFuncName::DPNP_FN_PUT_ALONG_AXIS_EXT][eft_INT][eft_INT] = {
-        eft_INT, (void *)dpnp_put_along_axis_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_PUT_ALONG_AXIS_EXT][eft_LNG][eft_LNG] = {
-        eft_LNG, (void *)dpnp_put_along_axis_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_PUT_ALONG_AXIS_EXT][eft_FLT][eft_FLT] = {
-        eft_FLT, (void *)dpnp_put_along_axis_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_PUT_ALONG_AXIS_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void *)dpnp_put_along_axis_ext_c<double>};
 
     fmap[DPNPFuncName::DPNP_FN_TAKE][eft_BLN][eft_INT] = {
         eft_BLN, (void *)dpnp_take_default_c<bool, int32_t>};

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -156,8 +156,6 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_RNG_POISSON_EXT
         DPNP_FN_RNG_POWER
         DPNP_FN_RNG_POWER_EXT
-        DPNP_FN_PUT_ALONG_AXIS
-        DPNP_FN_PUT_ALONG_AXIS_EXT
         DPNP_FN_RNG_RAYLEIGH
         DPNP_FN_RNG_RAYLEIGH_EXT
         DPNP_FN_RNG_SHUFFLE

--- a/dpnp/dpnp_algo/dpnp_algo_indexing.pxi
+++ b/dpnp/dpnp_algo/dpnp_algo_indexing.pxi
@@ -41,10 +41,8 @@ __all__ += [
     "dpnp_diagonal",
     "dpnp_fill_diagonal",
     "dpnp_indices",
-    "dpnp_put_along_axis",
     "dpnp_putmask",
     "dpnp_select",
-    "dpnp_take_along_axis",
     "dpnp_tril_indices",
     "dpnp_tril_indices_from",
     "dpnp_triu_indices",
@@ -69,16 +67,6 @@ ctypedef c_dpctl.DPCTLSyclEventRef(*custom_indexing_2in_1out_func_ptr_t_)(c_dpct
 ctypedef c_dpctl.DPCTLSyclEventRef(*custom_indexing_2in_func_ptr_t)(c_dpctl.DPCTLSyclQueueRef,
                                                                     void *, void * , shape_elem_type * , const size_t,
                                                                     const c_dpctl.DPCTLEventVectorRef)
-ctypedef c_dpctl.DPCTLSyclEventRef(*custom_indexing_3in_with_axis_func_ptr_t)(c_dpctl.DPCTLSyclQueueRef,
-                                                                              void * ,
-                                                                              void * ,
-                                                                              void * ,
-                                                                              const size_t,
-                                                                              shape_elem_type * ,
-                                                                              const size_t,
-                                                                              const size_t,
-                                                                              const size_t,
-                                                                              const c_dpctl.DPCTLEventVectorRef)
 
 
 cpdef utils.dpnp_descriptor dpnp_choose(utils.dpnp_descriptor x1, list choices1):
@@ -283,35 +271,6 @@ cpdef object dpnp_indices(dimensions):
     return dpnp_result
 
 
-cpdef dpnp_put_along_axis(dpnp_descriptor arr, dpnp_descriptor indices, dpnp_descriptor values, int axis):
-    cdef shape_type_c arr_shape = arr.shape
-    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(arr.dtype)
-
-    cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_PUT_ALONG_AXIS_EXT, param1_type, param1_type)
-
-    utils.get_common_usm_allocation(arr, indices)  # check USM allocation is common
-    _, _, result_sycl_queue = utils.get_common_usm_allocation(arr, values)
-
-    cdef c_dpctl.SyclQueue q = <c_dpctl.SyclQueue> result_sycl_queue
-    cdef c_dpctl.DPCTLSyclQueueRef q_ref = q.get_queue_ref()
-
-    cdef custom_indexing_3in_with_axis_func_ptr_t func = <custom_indexing_3in_with_axis_func_ptr_t > kernel_data.ptr
-
-    cdef c_dpctl.DPCTLSyclEventRef event_ref = func(q_ref,
-                                                    arr.get_data(),
-                                                    indices.get_data(),
-                                                    values.get_data(),
-                                                    axis,
-                                                    arr_shape.data(),
-                                                    arr.ndim,
-                                                    indices.size,
-                                                    values.size,
-                                                    NULL)  # dep_events_ref
-
-    with nogil: c_dpctl.DPCTLEvent_WaitAndThrow(event_ref)
-    c_dpctl.DPCTLEvent_Delete(event_ref)
-
-
 cpdef dpnp_putmask(utils.dpnp_descriptor arr, utils.dpnp_descriptor mask, utils.dpnp_descriptor values):
     cdef int values_size = values.size
 
@@ -339,94 +298,6 @@ cpdef utils.dpnp_descriptor dpnp_select(list condlist, list choicelist, default)
         res_array.get_pyobj()[ind] = val
 
     return res_array
-
-
-cpdef object dpnp_take_along_axis(object arr, object indices, int axis):
-    cdef long size_arr = arr.size
-    cdef shape_type_c shape_arr = arr.shape
-    cdef shape_type_c output_shape
-    cdef long size_indices = indices.size
-    res_type = arr.dtype
-
-    if axis != arr.ndim - 1:
-        res_shape_list = list(shape_arr)
-        res_shape_list[axis] = 1
-        res_shape = tuple(res_shape_list)
-
-        output_shape = (0,) * (len(shape_arr) - 1)
-        ind = 0
-        for id, shape_axis in enumerate(shape_arr):
-            if id != axis:
-                output_shape[ind] = shape_axis
-                ind += 1
-
-        prod = 1
-        for i in range(len(output_shape)):
-            if output_shape[i] != 0:
-                prod *= output_shape[i]
-
-        result_array = dpnp.empty((prod, ), dtype=res_type)
-        ind_array = [None] * prod
-        arr_shape_offsets = [None] * len(shape_arr)
-        acc = 1
-
-        for i in range(len(shape_arr)):
-            ind = len(shape_arr) - 1 - i
-            arr_shape_offsets[ind] = acc
-            acc *= shape_arr[ind]
-
-        output_shape_offsets = [None] * len(shape_arr)
-        acc = 1
-
-        for i in range(len(output_shape)):
-            ind = len(output_shape) - 1 - i
-            output_shape_offsets[ind] = acc
-            acc *= output_shape[ind]
-            result_offsets = arr_shape_offsets[:]  # need copy. not a reference
-        result_offsets[axis] = 0
-
-        for source_idx in range(size_arr):
-
-            # reconstruct x,y,z from linear source_idx
-            xyz = []
-            remainder = source_idx
-            for i in arr_shape_offsets:
-                quotient, remainder = divmod(remainder, i)
-                xyz.append(quotient)
-
-            # extract result axis
-            result_axis = []
-            for idx, offset in enumerate(xyz):
-                if idx != axis:
-                    result_axis.append(offset)
-
-            # Construct result offset
-            result_offset = 0
-            for i, result_axis_val in enumerate(result_axis):
-                result_offset += (output_shape_offsets[i] * result_axis_val)
-
-            arr_elem = arr.item(source_idx)
-            if ind_array[result_offset] is None:
-                ind_array[result_offset] = 0
-            else:
-                ind_array[result_offset] += 1
-
-            if ind_array[result_offset] % size_indices == indices.item(result_offset % size_indices):
-                result_array[result_offset] = arr_elem
-
-        dpnp_result_array = dpnp.reshape(result_array, res_shape)
-        return dpnp_result_array
-
-    else:
-        result_array = utils_py.create_output_descriptor_py(shape_arr, res_type, None).get_pyobj()
-
-        result_array_flatiter = result_array.flat
-
-        for i in range(size_arr):
-            ind = size_indices * (i // size_indices) + indices.item(i % size_indices)
-            result_array_flatiter[i] = arr.item(ind)
-
-        return result_array
 
 
 cpdef tuple dpnp_tril_indices(n, k=0, m=None):

--- a/dpnp/dpnp_iface.py
+++ b/dpnp/dpnp_iface.py
@@ -58,6 +58,7 @@ __all__ = [
     "array_equal",
     "asnumpy",
     "astype",
+    "check_supported_arrays_type",
     "convert_single_elem_array_to_scalar",
     "default_float_type",
     "dpnp_queue_initialize",
@@ -201,6 +202,45 @@ def astype(x1, dtype, order="K", casting="unsafe", copy=True):
         return x1
 
     return dpnp_array._create_from_usm_ndarray(array_obj)
+
+
+def check_supported_arrays_type(*arrays, scalar_type=False):
+    """
+    Return ``True`` if each array has either type of scalar,
+    :class:`dpnp.ndarray` or :class:`dpctl.tensor.usm_ndarray`.
+    But if any array has unsupported type, ``TypeError`` will be raised.
+
+    Parameters
+    ----------
+    arrays : {dpnp_array, usm_ndarray}
+        Input arrays to check for supported types.
+    scalar_type : {bool}, optional
+        A scalar type is also considered as supported if flag is True.
+
+    Returns
+    -------
+    out : bool
+        ``True`` if each type of input `arrays` is supported type,
+        ``False`` otherwise.
+
+    Raises
+    ------
+    TypeError
+        If any input array from `arrays` is of unsupported array type.
+
+    """
+
+    for a in arrays:
+        if not (
+            (scalar_type or is_supported_array_type(a))
+            and is_supported_array_or_scalar(a)
+        ):
+            raise TypeError(
+                "An array must be any of supported type, but got {}".format(
+                    type(a)
+                )
+            )
+    return True
 
 
 def convert_single_elem_array_to_scalar(obj, keepdims=False):

--- a/dpnp/dpnp_iface.py
+++ b/dpnp/dpnp_iface.py
@@ -231,15 +231,12 @@ def check_supported_arrays_type(*arrays, scalar_type=False):
     """
 
     for a in arrays:
-        if not (
-            (scalar_type or is_supported_array_type(a))
-            and is_supported_array_or_scalar(a)
-        ):
-            raise TypeError(
-                "An array must be any of supported type, but got {}".format(
-                    type(a)
-                )
-            )
+        if scalar_type and dpnp.isscalar(a) or is_supported_array_type(a):
+            continue
+
+        raise TypeError(
+            "An array must be any of supported type, but got {}".format(type(a))
+        )
     return True
 
 

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -799,10 +799,7 @@ def fliplr(m):
 
     """
 
-    if not dpnp.is_supported_array_type(m):
-        raise TypeError(
-            "An array must be any of supported type, but got {}".format(type(m))
-        )
+    dpnp.check_supported_arrays_type(m)
 
     if m.ndim < 2:
         raise ValueError(f"Input must be >= 2-d, but got {m.ndim}")
@@ -857,10 +854,7 @@ def flipud(m):
 
     """
 
-    if not dpnp.is_supported_array_type(m):
-        raise TypeError(
-            "An array must be any of supported type, but got {}".format(type(m))
-        )
+    dpnp.check_supported_arrays_type(m)
 
     if m.ndim < 1:
         raise ValueError(f"Input must be >= 1-d, but got {m.ndim}")

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -2103,10 +2103,9 @@ def prod(
 
     """
 
-    dpnp.check_supported_arrays_type(a)
-
     # Product reduction for complex output are known to fail for Gen9 with 2024.0 compiler
     # TODO: get rid of this temporary work around when OneAPI 2024.1 is released
+    dpnp.check_supported_arrays_type(a)
     _dtypes = (a.dtype, dtype)
     _any_complex = any(
         dpnp.issubdtype(dt, dpnp.complexfloating) for dt in _dtypes

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -1785,15 +1785,12 @@ def nanprod(
 
     """
 
-    if dpnp.is_supported_array_or_scalar(a):
-        if issubclass(a.dtype.type, dpnp.inexact):
-            mask = dpnp.isnan(a)
-            a = dpnp.array(a, copy=True)
-            dpnp.copyto(a, 1, where=mask)
-    else:
-        raise TypeError(
-            "An array must be any of supported type, but got {}".format(type(a))
-        )
+    dpnp.check_supported_arrays_type(a)
+
+    if issubclass(a.dtype.type, dpnp.inexact):
+        mask = dpnp.isnan(a)
+        a = dpnp.array(a, copy=True)
+        dpnp.copyto(a, 1, where=mask)
 
     return dpnp.prod(
         a,
@@ -2106,12 +2103,10 @@ def prod(
 
     """
 
+    dpnp.check_supported_arrays_type(a)
+
     # Product reduction for complex output are known to fail for Gen9 with 2024.0 compiler
     # TODO: get rid of this temporary work around when OneAPI 2024.1 is released
-    if not isinstance(a, (dpnp_array, dpt.usm_ndarray)):
-        raise TypeError(
-            "An array must be any of supported type, but got {}".format(type(a))
-        )
     _dtypes = (a.dtype, dtype)
     _any_complex = any(
         dpnp.issubdtype(dt, dpnp.complexfloating) for dt in _dtypes

--- a/dpnp/linalg/dpnp_iface_linalg.py
+++ b/dpnp/linalg/dpnp_iface_linalg.py
@@ -233,13 +233,10 @@ def eigh(a, UPLO="L"):
 
     """
 
+    dpnp.check_supported_arrays_type(a)
+
     if UPLO not in ("L", "U"):
         raise ValueError("UPLO argument must be 'L' or 'U'")
-
-    if not dpnp.is_supported_array_type(a):
-        raise TypeError(
-            "An array must be any of supported type, but got {}".format(type(a))
-        )
 
     if a.ndim < 2:
         raise ValueError(

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -28,6 +28,14 @@ def assert_dtype_allclose(dpnp_arr, numpy_arr, check_type=True):
             assert dpnp_arr.dtype == numpy_arr.dtype
 
 
+def get_integer_dtypes():
+    """
+    Build a list of integer types supported by DPNP.
+    """
+
+    return [dpnp.int32, dpnp.int64]
+
+
 def get_complex_dtypes(device=None):
     """
     Build a list of complex types supported by DPNP based on device capabilities.
@@ -83,7 +91,7 @@ def get_all_dtypes(
     dtypes = [dpnp.bool] if not no_bool else []
 
     # add integer types
-    dtypes.extend([dpnp.int32, dpnp.int64])
+    dtypes.extend(get_integer_dtypes())
 
     # add floating types
     dtypes.extend(get_float_dtypes(no_float16=no_float16, device=dev))

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -1,10 +1,32 @@
+import functools
+
 import numpy
 import pytest
-from numpy.testing import assert_, assert_array_equal, assert_equal
+from numpy.testing import (
+    assert_,
+    assert_array_equal,
+    assert_equal,
+    assert_raises,
+)
 
 import dpnp
 
-from .helper import get_all_dtypes
+from .helper import get_all_dtypes, get_integer_dtypes
+
+
+def _add_keepdims(func):
+    """
+    Hack in keepdims behavior into a function taking an axis.
+    """
+
+    @functools.wraps(func)
+    def wrapped(a, axis, **kwargs):
+        res = func(a, axis=axis, **kwargs)
+        if axis is None:
+            axis = 0  # res is now 0d and we can insert this anywhere
+        return dpnp.expand_dims(res, axis=axis)
+
+    return wrapped
 
 
 class TestIndexing:
@@ -61,6 +83,168 @@ class TestIndexing:
         slices = (slice(None), dpnp.array([0, 1, 2, 3]))
         arr[slices] = 10
         assert_array_equal(arr, 10.0)
+
+
+class TestPutAlongAxis:
+    @pytest.mark.parametrize(
+        "arr_dt", get_all_dtypes(no_bool=True, no_none=True)
+    )
+    @pytest.mark.parametrize("axis", list(range(2)) + [None])
+    def test_replace_max(self, arr_dt, axis):
+        a = dpnp.array([[10, 30, 20], [60, 40, 50]], dtype=arr_dt)
+
+        # replace the max with a small value
+        i_max = _add_keepdims(dpnp.argmax)(a, axis=axis)
+        dpnp.put_along_axis(a, i_max, -99, axis=axis)
+
+        # find the new minimum, which should max
+        i_min = _add_keepdims(dpnp.argmin)(a, axis=axis)
+        assert_array_equal(i_min, i_max)
+
+    @pytest.mark.parametrize(
+        "arr_dt", get_all_dtypes(no_bool=True, no_none=True)
+    )
+    @pytest.mark.parametrize("idx_dt", get_integer_dtypes())
+    @pytest.mark.parametrize("ndim", list(range(1, 4)))
+    @pytest.mark.parametrize(
+        "values",
+        [
+            777,
+            [100, 200, 300, 400],
+            (42,),
+            range(4),
+            numpy.arange(4),
+            dpnp.ones(4),
+        ],
+        ids=[
+            "scalar",
+            "list",
+            "tuple",
+            "range",
+            "numpy.ndarray",
+            "dpnp.ndarray",
+        ],
+    )
+    def test_values(self, arr_dt, idx_dt, ndim, values):
+        np_a = numpy.arange(4**ndim, dtype=arr_dt).reshape((4,) * ndim)
+        np_ai = numpy.array([3, 0, 2, 1], dtype=idx_dt).reshape(
+            (1,) * (ndim - 1) + (4,)
+        )
+
+        dp_a = dpnp.array(np_a, dtype=arr_dt)
+        dp_ai = dpnp.array(np_ai, dtype=idx_dt)
+
+        for axis in range(ndim):
+            numpy.put_along_axis(np_a, np_ai, values, axis)
+            dpnp.put_along_axis(dp_a, dp_ai, values, axis)
+            assert_array_equal(np_a, dp_a)
+
+    @pytest.mark.parametrize("arr_dt", get_all_dtypes())
+    @pytest.mark.parametrize("idx_dt", get_integer_dtypes())
+    def test_broadcast(self, arr_dt, idx_dt):
+        np_a = numpy.ones((3, 4, 1), dtype=arr_dt)
+        np_ai = numpy.arange(10, dtype=idx_dt).reshape((1, 2, 5)) % 4
+
+        dp_a = dpnp.array(np_a, dtype=arr_dt)
+        dp_ai = dpnp.array(np_ai, dtype=idx_dt)
+
+        numpy.put_along_axis(np_a, np_ai, 20, axis=1)
+        dpnp.put_along_axis(dp_a, dp_ai, 20, axis=1)
+        assert_array_equal(np_a, dp_a)
+
+
+class TestTakeAlongAxis:
+    # TODO: remove fixture once `dpnp.sort` is fully implemented
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
+    @pytest.mark.parametrize(
+        "func, argfunc, kwargs",
+        [
+            pytest.param(dpnp.sort, dpnp.argsort, {}),
+            pytest.param(
+                _add_keepdims(dpnp.min), _add_keepdims(dpnp.argmin), {}
+            ),
+            pytest.param(
+                _add_keepdims(dpnp.max), _add_keepdims(dpnp.argmax), {}
+            ),
+            # TODO: unmute, once `dpnp.argpartition` is implemented
+            # pytest.param(dpnp.partition, dpnp.argpartition, {"kth": 2}),
+        ],
+    )
+    def test_argequivalent(self, func, argfunc, kwargs):
+        a = dpnp.random.random(size=(3, 4, 5))
+
+        for axis in list(range(a.ndim)) + [None]:
+            a_func = func(a, axis=axis, **kwargs)
+            ai_func = argfunc(a, axis=axis, **kwargs)
+            assert_array_equal(
+                a_func, dpnp.take_along_axis(a, ai_func, axis=axis)
+            )
+
+    @pytest.mark.parametrize(
+        "arr_dt", get_all_dtypes(no_bool=True, no_none=True)
+    )
+    @pytest.mark.parametrize("idx_dt", get_integer_dtypes())
+    @pytest.mark.parametrize("ndim", list(range(1, 4)))
+    def test_multi_dimensions(self, arr_dt, idx_dt, ndim):
+        np_a = numpy.arange(4**ndim, dtype=arr_dt).reshape((4,) * ndim)
+        np_ai = numpy.array([3, 0, 2, 1], dtype=idx_dt).reshape(
+            (1,) * (ndim - 1) + (4,)
+        )
+
+        dp_a = dpnp.array(np_a, dtype=arr_dt)
+        dp_ai = dpnp.array(np_ai, dtype=idx_dt)
+
+        for axis in range(ndim):
+            expected = numpy.take_along_axis(np_a, np_ai, axis)
+            result = dpnp.take_along_axis(dp_a, dp_ai, axis)
+            assert_array_equal(expected, result)
+
+    @pytest.mark.parametrize("xp", [numpy, dpnp])
+    def test_invalid(self, xp):
+        a = xp.ones((10, 10))
+        ai = xp.ones((10, 2), dtype=xp.intp)
+
+        # not enough indices
+        assert_raises(ValueError, xp.take_along_axis, a, xp.array(1), axis=1)
+
+        # bool arrays not allowed
+        assert_raises(
+            IndexError, xp.take_along_axis, a, ai.astype(bool), axis=1
+        )
+
+        # float arrays not allowed
+        assert_raises(
+            IndexError, xp.take_along_axis, a, ai.astype(numpy.float32), axis=1
+        )
+
+        # invalid axis
+        assert_raises(numpy.AxisError, xp.take_along_axis, a, ai, axis=10)
+
+    @pytest.mark.parametrize("arr_dt", get_all_dtypes())
+    @pytest.mark.parametrize("idx_dt", get_integer_dtypes())
+    def test_empty(self, arr_dt, idx_dt):
+        np_a = numpy.ones((3, 4, 5), dtype=arr_dt)
+        np_ai = numpy.ones((3, 0, 5), dtype=idx_dt)
+
+        dp_a = dpnp.array(np_a, dtype=arr_dt)
+        dp_ai = dpnp.array(np_ai, dtype=idx_dt)
+
+        expected = numpy.take_along_axis(np_a, np_ai, axis=1)
+        result = dpnp.take_along_axis(dp_a, dp_ai, axis=1)
+        assert_array_equal(expected, result)
+
+    @pytest.mark.parametrize("arr_dt", get_all_dtypes())
+    @pytest.mark.parametrize("idx_dt", get_integer_dtypes())
+    def test_broadcast(self, arr_dt, idx_dt):
+        np_a = numpy.ones((3, 4, 1), dtype=arr_dt)
+        np_ai = numpy.ones((1, 2, 5), dtype=idx_dt)
+
+        dp_a = dpnp.array(np_a, dtype=arr_dt)
+        dp_ai = dpnp.array(np_ai, dtype=idx_dt)
+
+        expected = numpy.take_along_axis(np_a, np_ai, axis=1)
+        result = dpnp.take_along_axis(dp_a, dp_ai, axis=1)
+        assert_array_equal(expected, result)
 
 
 @pytest.mark.usefixtures("allow_fall_back_on_numpy")
@@ -459,42 +643,6 @@ def test_put_invalid_axis(axis):
         dpnp.put(a, ind, vals, axis=axis)
 
 
-@pytest.mark.usefixtures("allow_fall_back_on_numpy")
-def test_put_along_axis_val_int():
-    a = numpy.arange(16).reshape(4, 4)
-    ai = dpnp.array(a)
-    ind_r = numpy.array([[3, 0, 2, 1]])
-    ind_r_i = dpnp.array(ind_r)
-    for axis in range(2):
-        numpy.put_along_axis(a, ind_r, 777, axis)
-        dpnp.put_along_axis(ai, ind_r_i, 777, axis)
-        assert_array_equal(a, ai)
-
-
-@pytest.mark.usefixtures("allow_fall_back_on_numpy")
-def test_put_along_axis1():
-    a = numpy.arange(64).reshape(4, 4, 4)
-    ai = dpnp.array(a)
-    ind_r = numpy.array([[[3, 0, 2, 1]]])
-    ind_r_i = dpnp.array(ind_r)
-    for axis in range(3):
-        numpy.put_along_axis(a, ind_r, 777, axis)
-        dpnp.put_along_axis(ai, ind_r_i, 777, axis)
-        assert_array_equal(a, ai)
-
-
-@pytest.mark.usefixtures("allow_fall_back_on_numpy")
-def test_put_along_axis2():
-    a = numpy.arange(64).reshape(4, 4, 4)
-    ai = dpnp.array(a)
-    ind_r = numpy.array([[[3, 0, 2, 1]]])
-    ind_r_i = dpnp.array(ind_r)
-    for axis in range(3):
-        numpy.put_along_axis(a, ind_r, [100, 200, 300, 400], axis)
-        dpnp.put_along_axis(ai, ind_r_i, [100, 200, 300, 400], axis)
-        assert_array_equal(a, ai)
-
-
 @pytest.mark.parametrize("vals", [[100, 200]], ids=["[100, 200]"])
 @pytest.mark.parametrize(
     "mask",
@@ -686,28 +834,6 @@ def test_take_over_index(indices, array_type, mode):
     expected = dpnp.array([-2, 2], dtype=a.dtype)
     result = dpnp.take(a, ind, mode=mode)
     assert_array_equal(expected, result)
-
-
-def test_take_along_axis():
-    a = numpy.arange(16).reshape(4, 4)
-    ai = dpnp.array(a)
-    ind_r = numpy.array([[3, 0, 2, 1]])
-    ind_r_i = dpnp.array(ind_r)
-    for axis in range(2):
-        expected = numpy.take_along_axis(a, ind_r, axis)
-        result = dpnp.take_along_axis(ai, ind_r_i, axis)
-        assert_array_equal(expected, result)
-
-
-def test_take_along_axis1():
-    a = numpy.arange(64).reshape(4, 4, 4)
-    ai = dpnp.array(a)
-    ind_r = numpy.array([[[3, 0, 2, 1]]])
-    ind_r_i = dpnp.array(ind_r)
-    for axis in range(3):
-        expected = numpy.take_along_axis(a, ind_r, axis)
-        result = dpnp.take_along_axis(ai, ind_r_i, axis)
-        assert_array_equal(expected, result)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -1299,20 +1299,21 @@ def test_asarray(device_x, device_y):
     assert_sycl_queue_equal(y.sycl_queue, x.to_device(device_y).sycl_queue)
 
 
+@pytest.mark.parametrize("func", ["take", "take_along_axis"])
 @pytest.mark.parametrize(
     "device",
     valid_devices,
     ids=[device.filter_string for device in valid_devices],
 )
-def test_take(device):
+def test_take(func, device):
     numpy_data = numpy.arange(5)
     dpnp_data = dpnp.array(numpy_data, device=device)
 
-    ind = [0, 2, 4]
-    dpnp_ind = dpnp.array(ind, device=device)
+    dpnp_ind = dpnp.array([0, 2, 4], device=device)
+    np_ind = dpnp_ind.asnumpy()
 
-    result = dpnp.take(dpnp_data, dpnp_ind)
-    expected = numpy.take(numpy_data, ind)
+    result = getattr(dpnp, func)(dpnp_data, dpnp_ind, axis=None)
+    expected = getattr(numpy, func)(numpy_data, np_ind, axis=None)
     assert_allclose(expected, result)
 
     expected_queue = dpnp_data.get_array().sycl_queue

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -472,14 +472,15 @@ def test_broadcast_to(usm_type):
     assert x.usm_type == y.usm_type
 
 
+@pytest.mark.parametrize("func", ["take", "take_along_axis"])
 @pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
 @pytest.mark.parametrize(
     "usm_type_ind", list_of_usm_types, ids=list_of_usm_types
 )
-def test_take(usm_type_x, usm_type_ind):
+def test_take(func, usm_type_x, usm_type_ind):
     x = dp.arange(5, usm_type=usm_type_x)
     ind = dp.array([0, 2, 4], usm_type=usm_type_ind)
-    z = dp.take(x, ind)
+    z = getattr(dp, func)(x, ind, axis=None)
 
     assert x.usm_type == usm_type_x
     assert ind.usm_type == usm_type_ind

--- a/tests/third_party/cupy/indexing_tests/test_indexing.py
+++ b/tests/third_party/cupy/indexing_tests/test_indexing.py
@@ -7,7 +7,6 @@ import dpnp as cupy
 from tests.third_party.cupy import testing
 
 
-@testing.gpu
 class TestIndexing(unittest.TestCase):
     @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
@@ -51,14 +50,12 @@ class TestIndexing(unittest.TestCase):
         b = xp.array([0], dtype=dtype)
         return a.take(b)
 
-    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_take_along_axis(self, xp):
         a = testing.shaped_random((2, 4, 3), xp, dtype="float32")
         b = testing.shaped_random((2, 6, 3), xp, dtype="int64", scale=4)
         return xp.take_along_axis(a, b, axis=-2)
 
-    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_take_along_axis_none_axis(self, xp):
         a = testing.shaped_random((2, 4, 3), xp, dtype="float32")


### PR DESCRIPTION
The PR proposes to implement `dpnp.put_along_axis` and `dpnp.take_along_axis` functions through building a fancy index.
The indexing functionality will be used to either replace the values in an input array based on the index or to extract the values following the fancy index.
The PR continues the work started with updating `dpnp.put` and `dpnp.take` functions to leverage on dpctl.tensor implementation for indexing routine.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
