### PR TITLE
Redesign `dpnp.diff` thorough existing calls

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -38,14 +38,7 @@ env:
       third_party/cupy/manipulation_tests/test_join.py
       third_party/cupy/manipulation_tests/test_rearrange.py
       third_party/cupy/manipulation_tests/test_transpose.py
-      third_party/cupy/math_tests/test_arithmetic.py
-      third_party/cupy/math_tests/test_explog.py
-      third_party/cupy/math_tests/test_floating.py
-      third_party/cupy/math_tests/test_hyperbolic.py
-      third_party/cupy/math_tests/test_matmul.py
-      third_party/cupy/math_tests/test_misc.py
-      third_party/cupy/math_tests/test_rounding.py
-      third_party/cupy/math_tests/test_trigonometric.py
+      third_party/cupy/math_tests
       third_party/cupy/sorting_tests/test_sort.py
       third_party/cupy/sorting_tests/test_count.py
       third_party/cupy/statistics_tests/test_meanvar.py

--- a/dpnp/dpnp_algo/dpnp_algo_mathematical.pxi
+++ b/dpnp/dpnp_algo/dpnp_algo_mathematical.pxi
@@ -39,7 +39,6 @@ __all__ += [
     "dpnp_cross",
     "dpnp_cumprod",
     "dpnp_cumsum",
-    "dpnp_diff",
     "dpnp_ediff1d",
     "dpnp_fabs",
     "dpnp_fmod",
@@ -93,35 +92,6 @@ cpdef utils.dpnp_descriptor dpnp_cumsum(utils.dpnp_descriptor x1):
     # (4,)
 
     return call_fptr_1in_1out(DPNP_FN_CUMSUM_EXT, x1, (x1.size,))
-
-
-cpdef utils.dpnp_descriptor dpnp_diff(utils.dpnp_descriptor x1, int n):
-    cdef utils.dpnp_descriptor res
-
-    x1_obj = x1.get_array()
-
-    if x1.size - n < 1:
-        res_obj = dpnp_container.empty(0,
-                                       dtype=x1.dtype,
-                                       device=x1_obj.sycl_device,
-                                       usm_type=x1_obj.usm_type,
-                                       sycl_queue=x1_obj.sycl_queue)
-        res = utils.dpnp_descriptor(res_obj)
-        return res
-
-    res_obj = dpnp_container.empty(x1.size - 1,
-                                   dtype=x1.dtype,
-                                   device=x1_obj.sycl_device,
-                                   usm_type=x1_obj.usm_type,
-                                   sycl_queue=x1_obj.sycl_queue)
-    res = utils.dpnp_descriptor(res_obj)
-    for i in range(res.size):
-        res.get_pyobj()[i] = x1.get_pyobj()[i + 1] - x1.get_pyobj()[i]
-
-    if n == 1:
-        return res
-
-    return dpnp_diff(res, n - 1)
 
 
 cpdef utils.dpnp_descriptor dpnp_ediff1d(utils.dpnp_descriptor x1):

--- a/dpnp/dpnp_iface_indexing.py
+++ b/dpnp/dpnp_iface_indexing.py
@@ -550,17 +550,24 @@ def put_along_axis(a, indices, values, axis):
 
     For full documentation refer to :obj:`numpy.put_along_axis`.
 
-    Limitations
-    -----------
-    Parameters `a` and `indices` are supported either as :class:`dpnp.ndarray`
-    or :class:`dpctl.tensor.usm_ndarray`.
-    Parameter `values` is supported either as scalar, :class:`dpnp.ndarray`
-    or :class:`dpctl.tensor.usm_ndarray`.
-    Otherwise ``TypeError`` exception will be raised.
+    Parameters
+    ----------
+    a : {dpnp.ndarray, usm_ndarray}, (Ni..., M, Nk...)
+        Destination array.
+    indices : {dpnp.ndarray, usm_ndarray}, (Ni..., J, Nk...)
+        Indices to change along each 1d slice of `a`. This must match the
+        dimension of input array, but dimensions in ``Ni`` and ``Nj``
+        may be 1 to broadcast against `a`.
+    values : {scalar, array_like}, (Ni..., J, Nk...)
+        Values to insert at those indices. Its shape and dimension are
+        broadcast to match that of `indices`.
+    axis : int
+        The axis to take 1d slices along. If axis is ``None``, the destination
+        array is treated as if a flattened 1d view had been created of it.
 
     See Also
     --------
-    :obj:`dpnp.put`  : Put values along an axis, using the same indices for every 1d slice.
+    :obj:`dpnp.put` : Put values along an axis, using the same indices for every 1d slice.
     :obj:`dpnp.take_along_axis` : Take values from the input array by matching 1d index and data slices.
 
     Examples
@@ -736,16 +743,23 @@ def take_along_axis(a, indices, axis):
 
     For full documentation refer to :obj:`numpy.take_along_axis`.
 
+    Parameters
+    ----------
+    a : {dpnp.ndarray, usm_ndarray}, (Ni..., M, Nk...)
+        Source array
+    indices : {dpnp.ndarray, usm_ndarray}, (Ni..., J, Nk...)
+        Indices to take along each 1d slice of `a`. This must match the
+        dimension of the input array, but dimensions ``Ni`` and ``Nj``
+        only need to broadcast against `a`.
+    axis : int
+        The axis to take 1d slices along. If axis is ``None``, the input
+        array is treated as if it had first been flattened to 1d,
+        for consistency with `sort` and `argsort`.
+
     Returns
     -------
     out : dpnp.ndarray
         The indexed result.
-
-    Limitations
-    -----------
-    Parameters `a` and `indices` are supported either as :class:`dpnp.ndarray`
-    or :class:`dpctl.tensor.usm_ndarray`.
-    Otherwise ``TypeError`` exception will be raised.
 
     See Also
     --------

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -43,7 +43,10 @@ it contains:
 import dpctl.tensor as dpt
 import dpctl.utils as du
 import numpy
-from numpy.core.numeric import normalize_axis_tuple
+from numpy.core.numeric import (
+    normalize_axis_index,
+    normalize_axis_tuple,
+)
 
 import dpnp
 from dpnp.dpnp_array import dpnp_array
@@ -127,6 +130,31 @@ __all__ = [
     "true_divide",
     "trunc",
 ]
+
+
+def _append_to_diff_array(a, axis, combined, values):
+    """
+    Append `values` to `combined` list based on data of array `a`.
+
+    Scalar value (including case with 0d array) is expanded to an array
+    with length=1 in the direction of axis and the shape of the input array `a`
+    in along all other axes.
+    Note, if `values` is a scalar. then it is converted to 0d array allocating
+    on the same SYCL queue as the input array `a` and with the same USM type.
+
+    """
+
+    dpnp.check_supported_arrays_type(values, scalar_type=True)
+    if dpnp.isscalar(values):
+        values = dpnp.asarray(
+            values, sycl_queue=a.sycl_queue, usm_type=a.usm_type
+        )
+
+    if values.ndim == 0:
+        shape = list(a.shape)
+        shape[axis] = 1
+        values = dpnp.broadcast_to(values, tuple(shape))
+    combined.append(values)
 
 
 def absolute(
@@ -609,6 +637,10 @@ def cumsum(x1, **kwargs):
     Otherwise the function will be executed sequentially on CPU.
     Input array data types are limited by supported DPNP :ref:`Data types`.
 
+    See Also
+    --------
+    :obj:`dpnp.diff` : Calculate the n-th discrete difference along the given axis.
+
     Examples
     --------
     >>> import dpnp as np
@@ -630,39 +662,95 @@ def cumsum(x1, **kwargs):
     return call_origin(numpy.cumsum, x1, **kwargs)
 
 
-def diff(x1, n=1, axis=-1, prepend=numpy._NoValue, append=numpy._NoValue):
+def diff(a, n=1, axis=-1, prepend=None, append=None):
     """
     Calculate the n-th discrete difference along the given axis.
 
     For full documentation refer to :obj:`numpy.diff`.
 
-    Limitations
-    -----------
-    Input array is supported as :obj:`dpnp.ndarray`.
-    Parameters `axis`, `prepend` and `append` are supported only with default values.
-    Otherwise the function will be executed sequentially on CPU.
+    Parameters
+    ----------
+    a : {dpnp.ndarray, usm_ndarray}
+        Input array
+    n : int, optional
+        The number of times values are differenced. If zero, the input
+        is returned as-is.
+    axis : int, optional
+        The axis along which the difference is taken, default is the
+        last axis.
+    prepend, append : {scalar, dpnp.ndarray, usm_ndarray}, optional
+        Values to prepend or append to `a` along axis prior to
+        performing the difference. Scalar values are expanded to
+        arrays with length 1 in the direction of axis and the shape
+        of the input array in along all other axes. Otherwise the
+        dimension and shape must match `a` except along axis.
+
+    Returns
+    -------
+    out : dpnp.ndarray
+        The n-th differences. The shape of the output is the same as `a`
+        except along `axis` where the dimension is smaller by `n`. The
+        type of the output is the same as the type of the difference
+        between any two elements of `a`. This is the same as the type of
+        `a` in most cases.
+
+    See Also
+    --------
+    :obj:`dpnp.gradient` : Return the gradient of an N-dimensional array.
+    :obj:`dpnp.ediff1d` : Compute the differences between consecutive elements of an array.
+    :obj:`dpnp.cumsum` : Return the cumulative sum of the elements along a given axis.
+
+    Examples
+    --------
+    >>> import dpnp as np
+    >>> x = np.array([1, 2, 4, 7, 0])
+    >>> np.diff(x)
+    array([ 1,  2,  3, -7])
+    >>> np.diff(x, n=2)
+    array([  1,   1, -10])
+
+    >>> x = np.array([[1, 3, 6, 10], [0, 5, 6, 8]])
+    >>> np.diff(x)
+    array([[2, 3, 4],
+           [5, 1, 2]])
+    >>> np.diff(x, axis=0)
+    array([[-1,  2,  0, -2]])
+
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
-    if x1_desc:
-        if not isinstance(n, int):
-            pass
-        elif n < 1:
-            pass
-        elif x1_desc.ndim != 1:
-            pass
-        elif axis != -1:
-            pass
-        elif prepend is not numpy._NoValue:
-            pass
-        elif append is not numpy._NoValue:
-            pass
-        else:
-            return dpnp_diff(x1_desc, n).get_pyobj()
+    dpnp.check_supported_arrays_type(a)
+    if n == 0:
+        return a
+    if n < 0:
+        raise ValueError(f"order must be non-negative but got {n}")
 
-    return call_origin(
-        numpy.diff, x1, n=n, axis=axis, prepend=prepend, append=append
-    )
+    nd = a.ndim
+    if nd == 0:
+        raise ValueError("diff requires input that is at least one dimensional")
+    axis = normalize_axis_index(axis, nd)
+
+    combined = []
+    if prepend is not None:
+        _append_to_diff_array(a, axis, combined, prepend)
+
+    combined.append(a)
+    if append is not None:
+        _append_to_diff_array(a, axis, combined, append)
+
+    if len(combined) > 1:
+        a = dpnp.concatenate(combined, axis=axis)
+
+    slice1 = [slice(None)] * nd
+    slice2 = [slice(None)] * nd
+    slice1[axis] = slice(1, None)
+    slice2[axis] = slice(None, -1)
+    slice1 = tuple(slice1)
+    slice2 = tuple(slice2)
+
+    op = dpnp.not_equal if a.dtype == numpy.bool_ else dpnp.subtract
+    for _ in range(n):
+        a = op(a[slice1], a[slice2])
+    return a
 
 
 def divide(
@@ -1275,6 +1363,10 @@ def gradient(x1, *varargs, **kwargs):
     Keyword argument `kwargs` is currently unsupported.
     Otherwise the function will be executed sequentially on CPU.
     Input array data types are limited by supported DPNP :ref:`Data types`.
+
+    See Also
+    --------
+    :obj:`dpnp.diff` : Calculate the n-th discrete difference along the given axis.
 
     Examples
     --------

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -558,9 +558,7 @@ tests/third_party/cupy/math_tests/test_rounding.py::TestRounding::test_fix
 tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_out
 tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_out_wrong_shape
 tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_ndarray_cumprod_2dim_with_axis
-tests/third_party/cupy/math_tests/test_sumprod.py::TestDiff::test_diff_1dim
-tests/third_party/cupy/math_tests/test_sumprod.py::TestDiff::test_diff_1dim_with_n
-tests/third_party/cupy/math_tests/test_sumprod.py::TestDiff::test_diff_2dim_without_axis
+
 tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_cumprod_arraylike
 tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_cumprod_huge_array
 tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_cumprod_numpy_array
@@ -571,10 +569,7 @@ tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum_param_1_{axis=1}::
 tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum_param_1_{axis=1}::test_cumsum_numpy_array
 tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum_param_2_{axis=2}::test_cumsum_arraylike
 tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum_param_2_{axis=2}::test_cumsum_numpy_array
-tests/third_party/cupy/math_tests/test_sumprod.py::TestDiff::test_diff_2dim_with_append
-tests/third_party/cupy/math_tests/test_sumprod.py::TestDiff::test_diff_2dim_with_axis
-tests/third_party/cupy/math_tests/test_sumprod.py::TestDiff::test_diff_2dim_with_n_and_axis
-tests/third_party/cupy/math_tests/test_sumprod.py::TestDiff::test_diff_2dim_with_prepend
+
 tests/third_party/cupy/math_tests/test_sumprod.py::TestNansumNanprodAxes_param_0_{axis=(1, 3), shape=(2, 3, 4, 5)}::test_nansum_axes
 tests/third_party/cupy/math_tests/test_sumprod.py::TestNansumNanprodAxes_param_1_{axis=(1, 3), shape=(20, 30, 40, 50)}::test_nansum_axes
 tests/third_party/cupy/math_tests/test_sumprod.py::TestNansumNanprodAxes_param_2_{axis=(0, 2, 3), shape=(2, 3, 4, 5)}::test_nansum_axes

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -655,9 +655,7 @@ tests/third_party/cupy/math_tests/test_rounding.py::TestRounding::test_fix
 tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_out
 tests/third_party/cupy/math_tests/test_sumprod.py::TestSumprod::test_sum_out_wrong_shape
 tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_ndarray_cumprod_2dim_with_axis
-tests/third_party/cupy/math_tests/test_sumprod.py::TestDiff::test_diff_1dim
-tests/third_party/cupy/math_tests/test_sumprod.py::TestDiff::test_diff_1dim_with_n
-tests/third_party/cupy/math_tests/test_sumprod.py::TestDiff::test_diff_2dim_without_axis
+
 tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_cumprod_arraylike
 tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_cumprod_huge_array
 tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_cumprod_numpy_array
@@ -676,10 +674,7 @@ tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum_param_1_{axis=1}::
 tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum_param_1_{axis=1}::test_cumsum_numpy_array
 tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum_param_2_{axis=2}::test_cumsum_arraylike
 tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum_param_2_{axis=2}::test_cumsum_numpy_array
-tests/third_party/cupy/math_tests/test_sumprod.py::TestDiff::test_diff_2dim_with_append
-tests/third_party/cupy/math_tests/test_sumprod.py::TestDiff::test_diff_2dim_with_axis
-tests/third_party/cupy/math_tests/test_sumprod.py::TestDiff::test_diff_2dim_with_n_and_axis
-tests/third_party/cupy/math_tests/test_sumprod.py::TestDiff::test_diff_2dim_with_prepend
+
 tests/third_party/cupy/math_tests/test_sumprod.py::TestNansumNanprodAxes_param_0_{axis=(1, 3), shape=(2, 3, 4, 5)}::test_nansum_axes
 tests/third_party/cupy/math_tests/test_sumprod.py::TestNansumNanprodAxes_param_1_{axis=(1, 3), shape=(20, 30, 40, 50)}::test_nansum_axes
 tests/third_party/cupy/math_tests/test_sumprod.py::TestNansumNanprodAxes_param_2_{axis=(0, 2, 3), shape=(2, 3, 4, 5)}::test_nansum_axes

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -54,7 +54,6 @@ class TestConvolve:
             dpnp.convolve(d, k, mode=None)
 
 
-@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize(
     "array",
     [
@@ -67,19 +66,16 @@ class TestConvolve:
             [[[1, 3], [3, 1]], [[0, 1], [1, 3]]],
         ],
     ],
-    ids=[
-        "[[0, 0], [0, 0]]",
-        "[[1, 2], [1, 2]]",
-        "[[1, 2], [3, 4]]",
-        "[[[1, 2], [3, 4]], [[1, 2], [2, 1]], [[1, 3], [3, 1]]]",
-        "[[[[1, 2], [3, 4]], [[1, 2], [2, 1]]], [[[1, 3], [3, 1]], [[0, 1], [1, 3]]]]",
-    ],
 )
-def test_diff(array):
-    np_a = numpy.array(array)
-    dpnp_a = dpnp.array(array)
-    expected = numpy.diff(np_a)
-    result = dpnp.diff(dpnp_a)
+@pytest.mark.parametrize("n", list(range(0, 3)))
+@pytest.mark.parametrize("axis", list(range(-1, 2)))
+@pytest.mark.parametrize("dt", get_all_dtypes())
+def test_diff(array, n, axis, dt):
+    np_a = numpy.array(array, dtype=dt)
+    dpnp_a = dpnp.array(array, dtype=dt)
+
+    expected = numpy.diff(np_a, n=n, axis=axis)
+    result = dpnp.diff(dpnp_a, n=n, axis=axis)
     assert_allclose(expected, result)
 
 

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -1299,6 +1299,32 @@ def test_asarray(device_x, device_y):
     assert_sycl_queue_equal(y.sycl_queue, x.to_device(device_y).sycl_queue)
 
 
+@pytest.mark.parametrize(
+    "device",
+    valid_devices,
+    ids=[device.filter_string for device in valid_devices],
+)
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"prepend": 7}),
+        pytest.param({"append": -2}),
+        pytest.param({"prepend": -4, "append": 5}),
+    ],
+)
+def test_diff_scalar_append(device, kwargs):
+    numpy_data = numpy.arange(7)
+    dpnp_data = dpnp.array(numpy_data, device=device)
+
+    expected = numpy.diff(numpy_data, **kwargs)
+    result = dpnp.diff(dpnp_data, **kwargs)
+    assert_allclose(expected, result)
+
+    expected_queue = dpnp_data.get_array().sycl_queue
+    result_queue = result.get_array().sycl_queue
+    assert_sycl_queue_equal(result_queue, expected_queue)
+
+
 @pytest.mark.parametrize("func", ["take", "take_along_axis"])
 @pytest.mark.parametrize(
     "device",
@@ -1318,5 +1344,4 @@ def test_take(func, device):
 
     expected_queue = dpnp_data.get_array().sycl_queue
     result_queue = result.get_array().sycl_queue
-
     assert_sycl_queue_equal(result_queue, expected_queue)

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -382,6 +382,7 @@ def test_meshgrid(usm_type_x, usm_type_y):
         ),
         pytest.param("cosh", [-5.0, -3.5, 0.0, 3.5, 5.0]),
         pytest.param("count_nonzero", [0, 1, 7, 0]),
+        pytest.param("diff", [1.0, 2.0, 4.0, 7.0, 0.0]),
         pytest.param("exp", [1.0, 2.0, 4.0, 7.0]),
         pytest.param("exp2", [0.0, 1.0, 2.0]),
         pytest.param("expm1", [1.0e-10, 1.0, 2.0, 4.0, 7.0]),

--- a/tests/third_party/cupy/math_tests/test_sumprod.py
+++ b/tests/third_party/cupy/math_tests/test_sumprod.py
@@ -569,8 +569,7 @@ class TestCumprod(unittest.TestCase):
             return cupy.cumprod(a_numpy)
 
 
-@testing.gpu
-class TestDiff(unittest.TestCase):
+class TestDiff:
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_diff_1dim(self, xp, dtype):
@@ -617,7 +616,6 @@ class TestDiff(unittest.TestCase):
         b = testing.shaped_arange((1, 5), xp, dtype)
         return xp.diff(a, axis=0, append=b, n=2)
 
-    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.with_requires("numpy>=1.16")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(type_check=has_support_aspect64())
@@ -625,7 +623,6 @@ class TestDiff(unittest.TestCase):
         a = testing.shaped_arange((4, 5), xp, dtype)
         return xp.diff(a, prepend=1, append=0)
 
-    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.with_requires("numpy>=1.16")
     def test_diff_invalid_axis(self):
         for xp in (numpy, cupy):


### PR DESCRIPTION
The PR proposes to implement `dpnp.diff` function through existing dpnp python API. While the previous implementation of `dpnp.diff` was done through cython and has limited support of input arguments.

The PR assumes to get rid of all the limitations and to align with numpy implementation of `diff` function.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
