### PR TITLE
Add support of missing arguments in `dpnp.amax` and `dpnp.amin`

### DIFF
--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -1477,11 +1477,11 @@ def maximum(
     --------
     :obj:`dpnp.minimum` : Element-wise minimum of two arrays, propagates NaNs.
     :obj:`dpnp.fmax` : Element-wise maximum of two arrays, ignores NaNs.
-    :obj:`dpnp.amax` : The maximum value of an array along a given axis, propagates NaNs.
+    :obj:`dpnp.max` : The maximum value of an array along a given axis, propagates NaNs.
     :obj:`dpnp.nanmax` : The maximum value of an array along a given axis, ignores NaNs.
-    :obj:`dpnp.fmax` : Element-wise maximum of two arrays, ignores NaNs.
-    :obj:`dpnp.amax` : The maximum value of an array along a given axis, propagates NaNs.
-    :obj:`dpnp.nanmax` : The maximum value of an array along a given axis, ignores NaNs.
+    :obj:`dpnp.fmin` : Element-wise minimum of two arrays, ignores NaNs.
+    :obj:`dpnp.min` : The minimum value of an array along a given axis, propagates NaNs.
+    :obj:`dpnp.nanmin` : The minimum value of an array along a given axis, ignores NaNs.
 
     Examples
     --------
@@ -1556,11 +1556,11 @@ def minimum(
     --------
     :obj:`dpnp.maximum` : Element-wise maximum of two arrays, propagates NaNs.
     :obj:`dpnp.fmin` : Element-wise minimum of two arrays, ignores NaNs.
-    :obj:`dpnp.amin` : The minimum value of an array along a given axis, propagates NaNs.
+    :obj:`dpnp.min` : The minimum value of an array along a given axis, propagates NaNs.
     :obj:`dpnp.nanmin` : The minimum value of an array along a given axis, ignores NaNs.
-    :obj:`dpnp.fmin` : Element-wise minimum of two arrays, ignores NaNs.
-    :obj:`dpnp.amin` : The minimum value of an array along a given axis, propagates NaNs.
-    :obj:`dpnp.nanmin` : The minimum value of an array along a given axis, ignores NaNs.
+    :obj:`dpnp.fmax` : Element-wise maximum of two arrays, ignores NaNs.
+    :obj:`dpnp.max` : The maximum value of an array along a given axis, propagates NaNs.
+    :obj:`dpnp.nanmax` : The maximum value of an array along a given axis, ignores NaNs.
 
     Examples
     --------

--- a/dpnp/dpnp_iface_searching.py
+++ b/dpnp/dpnp_iface_searching.py
@@ -82,7 +82,7 @@ def argmax(a, axis=None, out=None, *, keepdims=False):
     --------
     :obj:`dpnp.ndarray.argmax` : Equivalent function.
     :obj:`dpnp.argmin` : Returns the indices of the minimum values along an axis.
-    :obj:`dpnp.amax` : The maximum value along a given axis.
+    :obj:`dpnp.max` : The maximum value along a given axis.
     :obj:`dpnp.unravel_index` : Convert a flat index into an index tuple.
     :obj:`dpnp.take_along_axis` : Apply ``np.expand_dims(index_array, axis)``
                                   from argmax to an array as if by calling max.
@@ -162,7 +162,7 @@ def argmin(a, axis=None, out=None, *, keepdims=False):
     --------
     :obj:`dpnp.ndarray.argmin` : Equivalent function.
     :obj:`dpnp.argmax` : Returns the indices of the maximum values along an axis.
-    :obj:`dpnp.amin` : The minimum value along a given axis.
+    :obj:`dpnp.min` : The minimum value along a given axis.
     :obj:`dpnp.unravel_index` : Convert a flat index into an index tuple.
     :obj:`dpnp.take_along_axis` : Apply ``np.expand_dims(index_array, axis)``
                                   from argmin to an array as if by calling min.

--- a/dpnp/dpnp_iface_statistics.py
+++ b/dpnp/dpnp_iface_statistics.py
@@ -70,7 +70,7 @@ def amax(a, axis=None, out=None, keepdims=False, initial=None, where=True):
     """
     Return the maximum of an array or maximum along an axis.
 
-    `amax` is an alias of `~dpnp.max`.
+    `amax` is an alias of :obj:`dpnp.max`.
 
     See Also
     --------
@@ -88,7 +88,7 @@ def amin(a, axis=None, out=None, keepdims=False, initial=None, where=True):
     """
     Return the minimum of an array or minimum along an axis.
 
-    `amin` is an alias of `~dpnp.min`.
+    `amin` is an alias of :obj:`dpnp.min`.
 
     See Also
     --------

--- a/dpnp/dpnp_iface_statistics.py
+++ b/dpnp/dpnp_iface_statistics.py
@@ -66,63 +66,40 @@ __all__ = [
 ]
 
 
-def amax(input, axis=None, out=None):
+def amax(a, axis=None, out=None, keepdims=False, initial=None, where=True):
     """
     Return the maximum of an array or maximum along an axis.
 
-    For full documentation refer to :obj:`numpy.amax`.
+    `amax` is an alias of `~dpnp.max`.
 
     See Also
     --------
-    :obj:`dpnp.amin` : The minimum value of an array along a given axis,
-                       propagating any NaNs.
-    :obj:`dpnp.nanmax` : The maximum value of an array along a given axis,
-                         ignoring any NaNs.
-    :obj:`dpnp.maximum` : Element-wise maximum of two arrays,
-                          propagating any NaNs.
-    :obj:`dpnp.fmax` : Element-wise maximum of two arrays, ignoring any NaNs.
-    :obj:`dpnp.argmax` : Return the indices of the maximum values.
-    :obj:`dpnp.nanmin` : Return minimum of an array or minimum along an axis,
-                         ignoring any NaNs.
-    :obj:`dpnp.minimum` : Element-wise minimum of array elements.
-    :obj:`dpnp.fmin` : Element-wise minimum of array elements.
-
-    Notes
-    -----
-    This function works exactly the same as :obj:`dpnp.max`.
+    :obj:`dpnp.max` : alias of this function
+    :obj:`dpnp.ndarray.max` : equivalent method
 
     """
-    return max(input, axis=axis, out=out)
+
+    return max(
+        a, axis=axis, out=out, keepdims=keepdims, initial=initial, where=where
+    )
 
 
-def amin(input, axis=None, out=None):
+def amin(a, axis=None, out=None, keepdims=False, initial=None, where=True):
     """
     Return the minimum of an array or minimum along an axis.
 
-    For full documentation refer to :obj:`numpy.amin`.
+    `amin` is an alias of `~dpnp.min`.
 
     See Also
     --------
-    :obj:`dpnp.amax` : The maximum value of an array along a given axis,
-                       propagating any NaNs.
-    :obj:`dpnp.nanmin` : Return minimum of an array or minimum along an axis,
-                         ignoring any NaNs.
-    :obj:`dpnp.minimum` : Element-wise minimum of array elements.
-    :obj:`dpnp.fmin` : Element-wise minimum of array elements.
-    :obj:`dpnp.argmin` : Return the indices of the minimum values.
-    :obj:`dpnp.nanmax` : The maximum value of an array along a given axis,
-                         ignoring any NaNs.
-    :obj:`dpnp.maximum` : Element-wise maximum of two arrays,
-                          propagating any NaNs.
-    :obj:`dpnp.fmax` : Element-wise maximum of two arrays, ignoring any NaNs.
-
-    Notes
-    -----
-    This function works exactly the same as :obj:`dpnp.min`.
+    :obj:`dpnp.min` : alias of this function
+    :obj:`dpnp.ndarray.min` : equivalent method
 
     """
 
-    return min(input, axis=axis, out=out)
+    return min(
+        a, axis=axis, out=out, keepdims=keepdims, initial=initial, where=where
+    )
 
 
 def average(x1, axis=None, weights=None, returned=False):

--- a/tests/test_amin_amax.py
+++ b/tests/test_amin_amax.py
@@ -7,8 +7,10 @@ import dpnp
 from .helper import get_all_dtypes
 
 
+@pytest.mark.parametrize("func", ["amax", "amin"])
+@pytest.mark.parametrize("keepdims", [True, False])
 @pytest.mark.parametrize("dtype", get_all_dtypes())
-def test_amax(dtype):
+def test_amax_amin(func, keepdims, dtype):
     a = numpy.array(
         [
             [[-2.0, 3.0], [9.1, 0.2]],
@@ -20,26 +22,8 @@ def test_amax(dtype):
     ia = dpnp.array(a)
 
     for axis in range(len(a)):
-        result = dpnp.amax(ia, axis=axis)
-        expected = numpy.amax(a, axis=axis)
-        assert_allclose(expected, result)
-
-
-@pytest.mark.parametrize("dtype", get_all_dtypes())
-def test_amin(dtype):
-    a = numpy.array(
-        [
-            [[-2.0, 3.0], [9.1, 0.2]],
-            [[-2.0, 5.0], [-2, -1.2]],
-            [[1.0, -2.0], [5.0, -1.1]],
-        ],
-        dtype=dtype,
-    )
-    ia = dpnp.array(a)
-
-    for axis in range(len(a)):
-        result = dpnp.amin(ia, axis=axis)
-        expected = numpy.amin(a, axis=axis)
+        result = getattr(dpnp, func)(ia, axis=axis, keepdims=keepdims)
+        expected = getattr(numpy, func)(a, axis=axis, keepdims=keepdims)
         assert_allclose(expected, result)
 
 


### PR DESCRIPTION
The PR aligns supported arguments of `dpnp.amax` and `dpnp.amin` with numpy implementation.
The functions are only aliased on already updated `dpnp.max` and `dpnp.min` methods.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
