### PR TITLE
Retrying build coverage step on failure

### DIFF
--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -56,6 +56,7 @@ jobs:
         id: build_coverage
         uses: nick-fields/retry@v2.9.0
         with:
+          timeout_minutes: 60
           max_attempts: 5
           retry_on: error
           command: |

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -53,8 +53,19 @@ jobs:
           conda list
 
       - name: Build dpnp with coverage
+        id: build_coverage
+        uses: nick-fields/retry@v2.9.0
+        with:
+          max_attempts: 5
+          retry_on: error
+          command: |
+            python scripts/gen_coverage.py --pytest-opts="--ignore tests/test_random.py"
+          on_retry_command: |
+            git clean -fxd
+
+      - name: Total number of coverage attempts
         run: |
-          python scripts/gen_coverage.py --pytest-opts="--ignore tests/test_random.py"
+          echo "Total number of coverage attempts made: ${{ steps.build_coverage.outputs.total_attempts }}"
 
       - name: Install coverall dependencies
         run: |

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -56,13 +56,15 @@ jobs:
         id: build_coverage
         uses: nick-fields/retry@v2.9.0
         with:
+          shell: bash
           timeout_minutes: 60
           max_attempts: 5
           retry_on: error
           command: |
-            python scripts/gen_coverage.py --pytest-opts="--ignore tests/test_random.py"
-          on_retry_command: |
+            . $CONDA/etc/profile.d/conda.sh
+            conda activate coverage
             git clean -fxd
+            python scripts/gen_coverage.py --pytest-opts="--ignore tests/test_random.py"
 
       - name: Total number of coverage attempts
         run: |


### PR DESCRIPTION
The step with building coverage is failing quite often due to known issue with OCL RT.
The PR propose to automatically rerun the step multiple times until the issue is resolved and a fix is available.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
