### PR TITLE
Align arguments of `dpnp.true_divide` with `dpnp.divide`

### DIFF
--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -254,6 +254,10 @@ def add(
     Otherwise the function will be executed sequentially on CPU.
     Input array data types are limited by supported DPNP :ref:`Data types`.
 
+    Notes
+    -----
+    Equivalent to `x1` + `x2` in terms of array broadcasting.
+
     Examples
     --------
     >>> import dpnp as np
@@ -783,6 +787,13 @@ def divide(
     Keyword argument `kwargs` is currently unsupported.
     Otherwise the function will be executed sequentially on CPU.
     Input array data types are limited by supported DPNP :ref:`Data types`.
+
+    Notes
+    -----
+    Equivalent to `x1` / `x2` in terms of array-broadcasting.
+
+    The ``true_divide(x1, x2)`` function is an alias for
+    ``divide(x1, x2)``.
 
     Examples
     --------
@@ -1716,6 +1727,10 @@ def multiply(
     Keyword argument `kwargs` is currently unsupported.
     Otherwise the function will be executed sequentially on CPU.
     Input array data types are limited by supported DPNP :ref:`Data types`.
+
+    Notes
+    -----
+    Equivalent to `x1` * `x2` in terms of array broadcasting.
 
     Examples
     --------
@@ -2685,6 +2700,10 @@ def subtract(
     Otherwise the function will be executed sequentially on CPU.
     Input array data types are limited by supported DPNP :ref:`Data types`.
 
+    Notes
+    -----
+    Equivalent to `x1` - `x2` in terms of array broadcasting.
+
     Examples
     --------
     >>> import dpnp as np
@@ -2908,23 +2927,7 @@ def trapz(y1, x1=None, dx=1.0, axis=-1):
     return call_origin(numpy.trapz, y1, x1, dx, axis)
 
 
-def true_divide(*args, **kwargs):
-    """
-    Provide a true division of the inputs, element-wise.
-
-    For full documentation refer to :obj:`numpy.true_divide`.
-
-    See Also
-    --------
-    :obj:`dpnp.divide` : Standard division.
-
-    Notes
-    -----
-    This function works the same as :obj:`dpnp.divide`.
-
-    """
-
-    return dpnp.divide(*args, **kwargs)
+true_divide = divide
 
 
 def trunc(


### PR DESCRIPTION
In NumPy `true_divide` is alias on `divide` function.
The PR proposes to implement exactly the same behavior. It will allow to have exactly the same arguments for `true_divide` as `divide` has.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
