### PR TITLE
Stay away from 2024.0.1 compiler package

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Install dpnp dependencies
         run: |
-          conda install numpy"<1.24" dpctl">=0.15.1dev2" mkl-devel-dpcpp onedpl-devel tbb-devel dpcpp_linux-64 \
+          conda install numpy"<1.24" dpctl">=0.15.1dev2" mkl-devel-dpcpp onedpl-devel tbb-devel dpcpp_linux-64"<2024.0.1" \
               cmake cython pytest ninja scikit-build sysroot_linux-64">=2.28" ${{ env.CHANNELS }}
 
       - name: Install cuPy dependencies

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,4 +1,5 @@
 {% set required_compiler_and_mkl_version = "2024.0" %}
+{% set max_compiler_version = "2024.0.1" %}
 {% set required_dpctl_version = "0.15.1dev2" %}
 
 package:
@@ -24,7 +25,7 @@ requirements:
       - scikit-build
     build:
       - {{ compiler('cxx') }}
-      - {{ compiler('dpcpp') }} >={{ required_compiler_and_mkl_version }}  # [not osx]
+      - {{ compiler('dpcpp') }} >={{ required_compiler_and_mkl_version }},<{{ max_compiler_version }} # [not osx]
       - sysroot_linux-64 >=2.28 # [linux]
     run:
       - python


### PR DESCRIPTION
The compiler package `dpcpp_linux-64=2024.0.1` has known issues breaking CMake integration with DPC++.
This PR pins build-time version to `2024.0.0` until the underlying issue gets resolved.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
