### PR TITLE
update `out` keyword for elementwise functions

### DIFF
--- a/doc/reference/math.rst
+++ b/doc/reference/math.rst
@@ -205,6 +205,7 @@ Miscellaneous
    dpnp.sqrt
    dpnp.cbrt
    dpnp.square
+   dpnp.rsqrt
    dpnp.abs
    dpnp.absolute
    dpnp.fabs

--- a/doc/reference/ufunc.rst
+++ b/doc/reference/ufunc.rst
@@ -44,8 +44,10 @@ Math operations
    dpnp.log1p
    dpnp.proj
    dpnp.sqrt
+   dpnp.cbrt
    dpnp.square
    dpnp.reciprocal
+   dpnp.rsqrt
    dpnp.gcd
    dpnp.lcm
 

--- a/dpnp/dpnp_algo/dpnp_elementwise_common.py
+++ b/dpnp/dpnp_algo/dpnp_elementwise_common.py
@@ -273,7 +273,10 @@ def dpnp_abs(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = abs_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _acos_docstring = """
@@ -314,7 +317,10 @@ def dpnp_acos(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = acos_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _acosh_docstring = """
@@ -355,7 +361,10 @@ def dpnp_acosh(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = acosh_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _add_docstring = """
@@ -401,7 +410,10 @@ def dpnp_add(x1, x2, out=None, order="K"):
     res_usm = add_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _asin_docstring = """
@@ -442,7 +454,10 @@ def dpnp_asin(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = asin_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _asinh_docstring = """
@@ -483,7 +498,10 @@ def dpnp_asinh(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = asinh_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _atan_docstring = """
@@ -524,7 +542,10 @@ def dpnp_atan(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = atan_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _atan2_docstring = """
@@ -574,7 +595,10 @@ def dpnp_atan2(x1, x2, out=None, order="K"):
     res_usm = atan2_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _atanh_docstring = """
@@ -615,7 +639,10 @@ def dpnp_atanh(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = atanh_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _bitwise_and_docstring = """
@@ -659,7 +686,10 @@ def dpnp_bitwise_and(x1, x2, out=None, order="K"):
     res_usm = bitwise_and_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _bitwise_or_docstring = """
@@ -703,7 +733,10 @@ def dpnp_bitwise_or(x1, x2, out=None, order="K"):
     res_usm = bitwise_or_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _bitwise_xor_docstring = """
@@ -747,7 +780,10 @@ def dpnp_bitwise_xor(x1, x2, out=None, order="K"):
     res_usm = bitwise_xor_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _cbrt_docstring = """
@@ -787,7 +823,10 @@ def dpnp_cbrt(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = cbrt_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _ceil_docstring = """
@@ -827,7 +866,10 @@ def dpnp_ceil(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = ceil_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _conj_docstring = """
@@ -866,7 +908,10 @@ def dpnp_conj(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = conj_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _copysign_docstring = """
@@ -907,7 +952,10 @@ def dpnp_copysign(x1, x2, out=None, order="K"):
     res_usm = copysign_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _cos_docstring = """
@@ -947,7 +995,10 @@ def dpnp_cos(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = cos_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _cosh_docstring = """
@@ -987,7 +1038,10 @@ def dpnp_cosh(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = cosh_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _divide_docstring = """
@@ -1033,7 +1087,10 @@ def dpnp_divide(x1, x2, out=None, order="K"):
     res_usm = divide_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _equal_docstring = """
@@ -1073,7 +1130,10 @@ def dpnp_equal(x1, x2, out=None, order="K"):
     res_usm = equal_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _exp_docstring = """
@@ -1114,7 +1174,10 @@ def dpnp_exp(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = exp_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _exp2_docstring = """
@@ -1155,7 +1218,10 @@ def dpnp_exp2(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = exp2_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _expm1_docstring = """
@@ -1198,7 +1264,10 @@ def dpnp_expm1(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = expm1_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _floor_docstring = """
@@ -1238,7 +1307,10 @@ def dpnp_floor(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = floor_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _floor_divide_docstring = """
@@ -1282,7 +1354,10 @@ def dpnp_floor_divide(x1, x2, out=None, order="K"):
     res_usm = floor_divide_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _greater_docstring = """
@@ -1322,7 +1397,10 @@ def dpnp_greater(x1, x2, out=None, order="K"):
     res_usm = greater_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _greater_equal_docstring = """
@@ -1364,7 +1442,10 @@ def dpnp_greater_equal(x1, x2, out=None, order="K"):
     res_usm = greater_equal_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _hypot_docstring = """
@@ -1410,7 +1491,10 @@ def dpnp_hypot(x1, x2, out=None, order="K"):
     res_usm = hypot_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _imag_docstring = """
@@ -1447,7 +1531,10 @@ def dpnp_imag(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = imag_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _invert_docstring = """
@@ -1482,7 +1569,10 @@ def dpnp_invert(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = invert_func(x_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _isfinite_docstring = """
@@ -1517,7 +1607,10 @@ def dpnp_isfinite(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = isfinite_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _isinf_docstring = """
@@ -1551,7 +1644,10 @@ def dpnp_isinf(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = isinf_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _isnan_docstring = """
@@ -1585,7 +1681,10 @@ def dpnp_isnan(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = isnan_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _left_shift_docstring = """
@@ -1629,7 +1728,10 @@ def dpnp_left_shift(x1, x2, out=None, order="K"):
     res_usm = left_shift_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _less_docstring = """
@@ -1669,7 +1771,10 @@ def dpnp_less(x1, x2, out=None, order="K"):
     res_usm = less_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _less_equal_docstring = """
@@ -1711,7 +1816,10 @@ def dpnp_less_equal(x1, x2, out=None, order="K"):
     res_usm = less_equal_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _log_docstring = """
@@ -1752,7 +1860,10 @@ def dpnp_log(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = log_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _log10_docstring = """
@@ -1793,7 +1904,10 @@ def dpnp_log10(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = log10_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _log1p_docstring = """
@@ -1833,7 +1947,10 @@ def dpnp_log1p(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = log1p_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _log2_docstring = """
@@ -1874,7 +1991,10 @@ def dpnp_log2(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = log2_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _logaddexp_docstring = """
@@ -1922,7 +2042,10 @@ def dpnp_logaddexp(x1, x2, out=None, order="K"):
     res_usm = logaddexp_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _logical_and_docstring = """
@@ -1963,7 +2086,10 @@ def dpnp_logical_and(x1, x2, out=None, order="K"):
     res_usm = logical_and_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _logical_not_docstring = """
@@ -1998,7 +2124,10 @@ def dpnp_logical_not(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = logical_not_func(x_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _logical_or_docstring = """
@@ -2039,7 +2168,10 @@ def dpnp_logical_or(x1, x2, out=None, order="K"):
     res_usm = logical_or_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _logical_xor_docstring = """
@@ -2080,7 +2212,10 @@ def dpnp_logical_xor(x1, x2, out=None, order="K"):
     res_usm = logical_xor_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _maximum_docstring = """
@@ -2120,7 +2255,10 @@ def dpnp_maximum(x1, x2, out=None, order="K"):
     res_usm = maximum_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _minimum_docstring = """
@@ -2160,7 +2298,10 @@ def dpnp_minimum(x1, x2, out=None, order="K"):
     res_usm = minimum_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _multiply_docstring = """
@@ -2210,7 +2351,10 @@ def dpnp_multiply(x1, x2, out=None, order="K"):
     res_usm = multiply_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _negative_docstring = """
@@ -2250,7 +2394,10 @@ def dpnp_negative(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = negative_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _not_equal_docstring = """
@@ -2292,7 +2439,10 @@ def dpnp_not_equal(x1, x2, out=None, order="K"):
     res_usm = not_equal_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _positive_docstring = """
@@ -2331,7 +2481,10 @@ def dpnp_positive(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = positive_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _power_docstring = """
@@ -2378,7 +2531,10 @@ def dpnp_power(x1, x2, out=None, order="K"):
     res_usm = power_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _proj_docstring = """
@@ -2412,7 +2568,10 @@ def dpnp_proj(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = proj_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _real_docstring = """
@@ -2449,7 +2608,10 @@ def dpnp_real(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = real_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _remainder_docstring = """
@@ -2490,7 +2652,10 @@ def dpnp_remainder(x1, x2, out=None, order="K"):
     res_usm = remainder_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _right_shift_docstring = """
@@ -2533,7 +2698,10 @@ def dpnp_right_shift(x1, x2, out=None, order="K"):
     res_usm = right_shift_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _round_docstring = """
@@ -2573,7 +2741,10 @@ def dpnp_round(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = round_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _rsqrt_docstring = """
@@ -2608,7 +2779,10 @@ def dpnp_rsqrt(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = rsqrt_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _sign_docstring = """
@@ -2650,7 +2824,10 @@ def dpnp_sign(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = sign_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _signbit_docstring = """
@@ -2685,7 +2862,10 @@ def dpnp_signbit(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = signbit_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _sin_docstring = """
@@ -2725,7 +2905,10 @@ def dpnp_sin(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = sin_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _sinh_docstring = """
@@ -2765,7 +2948,10 @@ def dpnp_sinh(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = sinh_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _sqrt_docstring = """
@@ -2804,7 +2990,10 @@ def dpnp_sqrt(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = sqrt_func(x_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _square_docstring = """
@@ -2843,7 +3032,10 @@ def dpnp_square(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = square_func(x_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _subtract_docstring = """
@@ -2904,7 +3096,10 @@ def dpnp_subtract(x1, x2, out=None, order="K"):
     res_usm = subtract_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order
     )
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _tan_docstring = """
@@ -2944,7 +3139,10 @@ def dpnp_tan(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = tan_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _tanh_docstring = """
@@ -2984,7 +3182,10 @@ def dpnp_tanh(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = tanh_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out
 
 
 _trunc_docstring = """
@@ -3026,4 +3227,7 @@ def dpnp_trunc(x, out=None, order="K"):
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = trunc_func(x1_usm, out=out_usm, order=order)
-    return dpnp_array._create_from_usm_ndarray(res_usm)
+    if out is None:
+        return dpnp_array._create_from_usm_ndarray(res_usm)
+    else:
+        return out

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -574,7 +574,7 @@ def copysign(
     Parameters `where`, `dtype` and `subok` are supported with their default values.
     Keyword argument `kwargs` is currently unsupported.
     Otherwise the function will be executed sequentially on CPU.
-    Input array data types are limited by supported real data types.
+    Input array data types are limited by supported real-valued data types.
 
     See Also
     --------

--- a/dpnp/dpnp_iface_trigonometric.py
+++ b/dpnp/dpnp_iface_trigonometric.py
@@ -437,7 +437,7 @@ def arctan2(
     Parameters `where`, `dtype` and `subok` are supported with their default values.
     Keyword arguments `kwargs` are currently unsupported.
     Otherwise the function will be executed sequentially on CPU.
-    Input array data types are limited by supported DPNP :ref:`Data types`.
+    Input array data types are limited by real-valued data types.
 
     See Also
     --------


### PR DESCRIPTION
In this PR, a bug related to `out` keyword in elementwise functions is fixed.
In the old implementation, the output of the function and the output corresponding to `out` keyword were two different copies of the same data while one should be a view of the other one. This PR corrects this issue.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
