### PR TITLE
Add printing of available devices while triggering tests scope execution

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -49,7 +49,8 @@ test:
       - tests
       - setup.cfg
     commands:
-      - python -c "import dpnp"
+      - python -c "import dpnp; print(dpnp.__version__)"
+      - python -m dpctl -f
       - pytest -s
 
 about:


### PR DESCRIPTION
The PR proposes to execute `python -m dpctl -f` before launching tests scope for printing detailed information about available devices and driver versions.
It might be helpful while troubleshooting issues if any.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
