### PR TITLE
update compiler flag

### DIFF
--- a/dpnp/backend/CMakeLists.txt
+++ b/dpnp/backend/CMakeLists.txt
@@ -82,7 +82,7 @@ endif()
 target_link_options(${_trgt} PUBLIC -fsycl-device-code-split=per_kernel)
 if(UNIX)
     # this option is support on Linux only
-    target_link_options(${_trgt} PUBLIC -fsycl-link-huge-device-code)
+    target_link_options(${_trgt} PUBLIC -flink-huge-device-code)
 endif()
 
 if(DPNP_GENERATE_COVERAGE)

--- a/dpnp/backend/extensions/blas/CMakeLists.txt
+++ b/dpnp/backend/extensions/blas/CMakeLists.txt
@@ -65,7 +65,7 @@ endif()
 target_link_options(${python_module_name} PUBLIC -fsycl-device-code-split=per_kernel)
 if (UNIX)
     # this option is support on Linux only
-    target_link_options(${python_module_name} PUBLIC -fsycl-link-huge-device-code)
+    target_link_options(${python_module_name} PUBLIC -flink-huge-device-code)
 endif()
 
 if (DPNP_GENERATE_COVERAGE)

--- a/dpnp/backend/extensions/lapack/CMakeLists.txt
+++ b/dpnp/backend/extensions/lapack/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 target_link_options(${python_module_name} PUBLIC -fsycl-device-code-split=per_kernel)
 if (UNIX)
     # this option is support on Linux only
-    target_link_options(${python_module_name} PUBLIC -fsycl-link-huge-device-code)
+    target_link_options(${python_module_name} PUBLIC -flink-huge-device-code)
 endif()
 
 if (DPNP_GENERATE_COVERAGE)

--- a/dpnp/backend/extensions/sycl_ext/CMakeLists.txt
+++ b/dpnp/backend/extensions/sycl_ext/CMakeLists.txt
@@ -63,7 +63,7 @@ endif()
 target_link_options(${python_module_name} PUBLIC -fsycl-device-code-split=per_kernel)
 if (UNIX)
     # this option is support on Linux only
-    target_link_options(${python_module_name} PUBLIC -fsycl-link-huge-device-code)
+    target_link_options(${python_module_name} PUBLIC -flink-huge-device-code)
 endif()
 
 if (DPNP_GENERATE_COVERAGE)

--- a/dpnp/backend/extensions/vm/CMakeLists.txt
+++ b/dpnp/backend/extensions/vm/CMakeLists.txt
@@ -63,7 +63,7 @@ endif()
 target_link_options(${python_module_name} PUBLIC -fsycl-device-code-split=per_kernel)
 if (UNIX)
     # this option is support on Linux only
-    target_link_options(${python_module_name} PUBLIC -fsycl-link-huge-device-code)
+    target_link_options(${python_module_name} PUBLIC -flink-huge-device-code)
 endif()
 
 if (DPNP_GENERATE_COVERAGE)


### PR DESCRIPTION
In this PR, deprecated option `-fsycl-link-huge-device-code` is replaced by `-flink-huge-device-code` following [llvm/sycl release notes for Oct'23](https://github.com/intel/llvm/blob/sycl/sycl/ReleaseNotes.md) to get rid of warnings generated during build process.
The new option is identical in functionality but allowed with `-fopenmp-targets`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
