### PR TITLE
update tests affected by changing `TypeError` to `ValueError` in `dpctl`

### DIFF
--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -1160,7 +1160,7 @@ class TestCeil:
         dp_array = dpnp.arange(10, dtype=dpnp_dtype)
         dp_out = dpnp.empty(10, dtype=dtype)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpnp.ceil(dp_array, out=dp_out)
 
     @pytest.mark.parametrize("dtype", get_float_dtypes())
@@ -1200,7 +1200,7 @@ class TestFloor:
         dp_array = dpnp.arange(10, dtype=dpnp_dtype)
         dp_out = dpnp.empty(10, dtype=dtype)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpnp.floor(dp_array, out=dp_out)
 
     @pytest.mark.parametrize("dtype", get_float_dtypes())
@@ -1240,7 +1240,7 @@ class TestTrunc:
         dp_array = dpnp.arange(10, dtype=dpnp_dtype)
         dp_out = dpnp.empty(10, dtype=dtype)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpnp.trunc(dp_array, out=dp_out)
 
     @pytest.mark.parametrize("dtype", get_float_dtypes())
@@ -1291,7 +1291,7 @@ class TestAdd:
         dp_out = dpnp.empty(size, dtype=dpnp.complex64)
         if dtype != dpnp.complex64:
             # dtype of out mismatches types of input arrays
-            with pytest.raises(TypeError):
+            with pytest.raises(ValueError):
                 dpnp.add(dp_array1, dp_array2, out=dp_out)
 
             # allocate new out with expected type
@@ -1388,7 +1388,7 @@ class TestDivide:
         check_dtype = True
         if dtype != dpnp.complex64:
             # dtype of out mismatches types of input arrays
-            with pytest.raises(TypeError):
+            with pytest.raises(ValueError):
                 dpnp.divide(dp_array1, dp_array2, out=dp_out)
 
             # allocate new out with expected type
@@ -1489,7 +1489,7 @@ class TestFloorDivide:
         dp_out = dpnp.empty(size, dtype=dpnp.complex64)
         if dtype != dpnp.complex64:
             # dtype of out mismatches types of input arrays
-            with pytest.raises(TypeError):
+            with pytest.raises(ValueError):
                 dpnp.floor_divide(dp_array1, dp_array2, out=dp_out)
 
             # allocate new out with expected type
@@ -1749,7 +1749,7 @@ class TestHypot:
         dp_out = dpnp.empty(size, dtype=dpnp.float32)
         if dtype != dpnp.float32:
             # dtype of out mismatches types of input arrays
-            with pytest.raises(TypeError):
+            with pytest.raises(ValueError):
                 dpnp.hypot(dp_array1, dp_array2, out=dp_out)
 
             # allocate new out with expected type
@@ -1917,7 +1917,7 @@ class TestMaximum:
         dp_out = dpnp.empty(size, dtype=dpnp.complex64)
         if dtype != dpnp.complex64:
             # dtype of out mismatches types of input arrays
-            with pytest.raises(TypeError):
+            with pytest.raises(ValueError):
                 dpnp.maximum(dp_array1, dp_array2, out=dp_out)
 
             # allocate new out with expected type
@@ -1998,7 +1998,7 @@ class TestMinimum:
         dp_out = dpnp.empty(size, dtype=dpnp.complex64)
         if dtype != dpnp.complex64:
             # dtype of out mismatches types of input arrays
-            with pytest.raises(TypeError):
+            with pytest.raises(ValueError):
                 dpnp.minimum(dp_array1, dp_array2, out=dp_out)
 
             # allocate new out with expected type
@@ -2079,7 +2079,7 @@ class TestMultiply:
         dp_out = dpnp.empty(size, dtype=dpnp.complex64)
         if dtype != dpnp.complex64:
             # dtype of out mismatches types of input arrays
-            with pytest.raises(TypeError):
+            with pytest.raises(ValueError):
                 dpnp.multiply(dp_array1, dp_array2, out=dp_out)
 
             # allocate new out with expected type
@@ -2174,7 +2174,7 @@ class TestPower:
         dp_out = dpnp.empty(size, dtype=dpnp.complex64)
         if dtype != dpnp.complex64:
             # dtype of out mismatches types of input arrays
-            with pytest.raises(TypeError):
+            with pytest.raises(ValueError):
                 dpnp.power(dp_array1, dp_array2, out=dp_out)
 
             # allocate new out with expected type

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -1160,7 +1160,9 @@ class TestCeil:
         dp_array = dpnp.arange(10, dtype=dpnp_dtype)
         dp_out = dpnp.empty(10, dtype=dtype)
 
-        with pytest.raises(ValueError):
+        # TODO: change it to ValueError, when dpctl
+        # is being used in internal CI
+        with pytest.raises((TypeError, ValueError)):
             dpnp.ceil(dp_array, out=dp_out)
 
     @pytest.mark.parametrize("dtype", get_float_dtypes())
@@ -1200,7 +1202,9 @@ class TestFloor:
         dp_array = dpnp.arange(10, dtype=dpnp_dtype)
         dp_out = dpnp.empty(10, dtype=dtype)
 
-        with pytest.raises(ValueError):
+        # TODO: change it to ValueError, when dpctl
+        # is being used in internal CI
+        with pytest.raises((TypeError, ValueError)):
             dpnp.floor(dp_array, out=dp_out)
 
     @pytest.mark.parametrize("dtype", get_float_dtypes())
@@ -1240,7 +1244,9 @@ class TestTrunc:
         dp_array = dpnp.arange(10, dtype=dpnp_dtype)
         dp_out = dpnp.empty(10, dtype=dtype)
 
-        with pytest.raises(ValueError):
+        # TODO: change it to ValueError, when dpctl
+        # is being used in internal CI
+        with pytest.raises((TypeError, ValueError)):
             dpnp.trunc(dp_array, out=dp_out)
 
     @pytest.mark.parametrize("dtype", get_float_dtypes())
@@ -1291,7 +1297,9 @@ class TestAdd:
         dp_out = dpnp.empty(size, dtype=dpnp.complex64)
         if dtype != dpnp.complex64:
             # dtype of out mismatches types of input arrays
-            with pytest.raises(ValueError):
+            # TODO: change it to ValueError, when dpctl
+            # is being used in internal CI
+            with pytest.raises((TypeError, ValueError)):
                 dpnp.add(dp_array1, dp_array2, out=dp_out)
 
             # allocate new out with expected type
@@ -1388,7 +1396,9 @@ class TestDivide:
         check_dtype = True
         if dtype != dpnp.complex64:
             # dtype of out mismatches types of input arrays
-            with pytest.raises(ValueError):
+            # TODO: change it to ValueError, when dpctl
+            # is being used in internal CI
+            with pytest.raises((TypeError, ValueError)):
                 dpnp.divide(dp_array1, dp_array2, out=dp_out)
 
             # allocate new out with expected type
@@ -1489,7 +1499,9 @@ class TestFloorDivide:
         dp_out = dpnp.empty(size, dtype=dpnp.complex64)
         if dtype != dpnp.complex64:
             # dtype of out mismatches types of input arrays
-            with pytest.raises(ValueError):
+            # TODO: change it to ValueError, when dpctl
+            # is being used in internal CI
+            with pytest.raises((TypeError, ValueError)):
                 dpnp.floor_divide(dp_array1, dp_array2, out=dp_out)
 
             # allocate new out with expected type
@@ -1749,7 +1761,9 @@ class TestHypot:
         dp_out = dpnp.empty(size, dtype=dpnp.float32)
         if dtype != dpnp.float32:
             # dtype of out mismatches types of input arrays
-            with pytest.raises(ValueError):
+            # TODO: change it to ValueError, when dpctl
+            # is being used in internal CI
+            with pytest.raises((TypeError, ValueError)):
                 dpnp.hypot(dp_array1, dp_array2, out=dp_out)
 
             # allocate new out with expected type
@@ -1917,7 +1931,9 @@ class TestMaximum:
         dp_out = dpnp.empty(size, dtype=dpnp.complex64)
         if dtype != dpnp.complex64:
             # dtype of out mismatches types of input arrays
-            with pytest.raises(ValueError):
+            # TODO: change it to ValueError, when dpctl
+            # is being used in internal CI
+            with pytest.raises((TypeError, ValueError)):
                 dpnp.maximum(dp_array1, dp_array2, out=dp_out)
 
             # allocate new out with expected type
@@ -1998,7 +2014,9 @@ class TestMinimum:
         dp_out = dpnp.empty(size, dtype=dpnp.complex64)
         if dtype != dpnp.complex64:
             # dtype of out mismatches types of input arrays
-            with pytest.raises(ValueError):
+            # TODO: change it to ValueError, when dpctl
+            # is being used in internal CI
+            with pytest.raises((TypeError, ValueError)):
                 dpnp.minimum(dp_array1, dp_array2, out=dp_out)
 
             # allocate new out with expected type
@@ -2079,7 +2097,9 @@ class TestMultiply:
         dp_out = dpnp.empty(size, dtype=dpnp.complex64)
         if dtype != dpnp.complex64:
             # dtype of out mismatches types of input arrays
-            with pytest.raises(ValueError):
+            # TODO: change it to ValueError, when dpctl
+            # is being used in internal CI
+            with pytest.raises((TypeError, ValueError)):
                 dpnp.multiply(dp_array1, dp_array2, out=dp_out)
 
             # allocate new out with expected type
@@ -2174,7 +2194,9 @@ class TestPower:
         dp_out = dpnp.empty(size, dtype=dpnp.complex64)
         if dtype != dpnp.complex64:
             # dtype of out mismatches types of input arrays
-            with pytest.raises(ValueError):
+            # TODO: change it to ValueError, when dpctl
+            # is being used in internal CI
+            with pytest.raises((TypeError, ValueError)):
                 dpnp.power(dp_array1, dp_array2, out=dp_out)
 
             # allocate new out with expected type

--- a/tests/test_umath.py
+++ b/tests/test_umath.py
@@ -205,7 +205,9 @@ class TestUmath:
         dp_array = dpnp.arange(10, dtype=dpnp_dtype)
         dp_out = dpnp.empty(10, dtype=dtype)
 
-        with pytest.raises(ValueError):
+        # TODO: change it to ValueError, when dpctl
+        # is being used in internal CI
+        with pytest.raises((TypeError, ValueError)):
             getattr(dpnp, func_name)(dp_array, out=dp_out)
 
     @pytest.mark.parametrize(
@@ -250,7 +252,9 @@ class TestCbrt:
         dp_array = dpnp.arange(10, dtype=dpnp_dtype)
         dp_out = dpnp.empty(10, dtype=dtype)
 
-        with pytest.raises(ValueError):
+        # TODO: change it to ValueError, when dpctl
+        # is being used in internal CI
+        with pytest.raises((TypeError, ValueError)):
             dpnp.cbrt(dp_array, out=dp_out)
 
     @pytest.mark.parametrize(
@@ -296,7 +300,9 @@ class TestRsqrt:
         dp_array = dpnp.arange(10, dtype=dpnp_dtype)
         dp_out = dpnp.empty(10, dtype=dtype)
 
-        with pytest.raises(ValueError):
+        # TODO: change it to ValueError, when dpctl
+        # is being used in internal CI
+        with pytest.raises((TypeError, ValueError)):
             dpnp.rsqrt(dp_array, out=dp_out)
 
     @pytest.mark.parametrize(
@@ -337,7 +343,9 @@ class TestSquare:
         dp_array = dpnp.arange(10, dtype=dpnp_dtype)
         dp_out = dpnp.empty(10, dtype=dtype)
 
-        with pytest.raises(ValueError):
+        # TODO: change it to ValueError, when dpctl
+        # is being used in internal CI
+        with pytest.raises((TypeError, ValueError)):
             dpnp.square(dp_array, out=dp_out)
 
     @pytest.mark.parametrize(
@@ -385,7 +393,9 @@ class TestArctan2:
         dp_array = dpnp.arange(10, dtype=dpnp_dtype)
         dp_out = dpnp.empty(10, dtype=dtype)
 
-        with pytest.raises(ValueError):
+        # TODO: change it to ValueError, when dpctl
+        # is being used in internal CI
+        with pytest.raises((TypeError, ValueError)):
             dpnp.arctan2(dp_array, dp_array, out=dp_out)
 
     @pytest.mark.parametrize(
@@ -421,7 +431,9 @@ class TestCopySign:
         dpnp_dtype = get_all_dtypes(no_complex=True, no_none=True)[-1]
         dp_array = dpnp.arange(10, dtype=dpnp_dtype)
         dp_out = dpnp.empty(10, dtype=dtype)
-        with pytest.raises(ValueError):
+        # TODO: change it to ValueError, when dpctl
+        # is being used in internal CI
+        with pytest.raises((TypeError, ValueError)):
             dpnp.copysign(dp_array, dp_array, out=dp_out)
 
     @pytest.mark.parametrize(
@@ -457,7 +469,9 @@ class TestLogaddexp:
         dpnp_dtype = get_all_dtypes(no_complex=True, no_none=True)[-1]
         dp_array = dpnp.arange(10, dtype=dpnp_dtype)
         dp_out = dpnp.empty(10, dtype=dtype)
-        with pytest.raises(ValueError):
+        # TODO: change it to ValueError, when dpctl
+        # is being used in internal CI
+        with pytest.raises((TypeError, ValueError)):
             dpnp.logaddexp(dp_array, dp_array, out=dp_out)
 
     @pytest.mark.parametrize(

--- a/tests/test_umath.py
+++ b/tests/test_umath.py
@@ -205,7 +205,7 @@ class TestUmath:
         dp_array = dpnp.arange(10, dtype=dpnp_dtype)
         dp_out = dpnp.empty(10, dtype=dtype)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             getattr(dpnp, func_name)(dp_array, out=dp_out)
 
     @pytest.mark.parametrize(
@@ -250,7 +250,7 @@ class TestCbrt:
         dp_array = dpnp.arange(10, dtype=dpnp_dtype)
         dp_out = dpnp.empty(10, dtype=dtype)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpnp.cbrt(dp_array, out=dp_out)
 
     @pytest.mark.parametrize(
@@ -296,7 +296,7 @@ class TestRsqrt:
         dp_array = dpnp.arange(10, dtype=dpnp_dtype)
         dp_out = dpnp.empty(10, dtype=dtype)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpnp.rsqrt(dp_array, out=dp_out)
 
     @pytest.mark.parametrize(
@@ -337,7 +337,7 @@ class TestSquare:
         dp_array = dpnp.arange(10, dtype=dpnp_dtype)
         dp_out = dpnp.empty(10, dtype=dtype)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpnp.square(dp_array, out=dp_out)
 
     @pytest.mark.parametrize(
@@ -385,7 +385,7 @@ class TestArctan2:
         dp_array = dpnp.arange(10, dtype=dpnp_dtype)
         dp_out = dpnp.empty(10, dtype=dtype)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpnp.arctan2(dp_array, dp_array, out=dp_out)
 
     @pytest.mark.parametrize(
@@ -421,7 +421,7 @@ class TestCopySign:
         dpnp_dtype = get_all_dtypes(no_complex=True, no_none=True)[-1]
         dp_array = dpnp.arange(10, dtype=dpnp_dtype)
         dp_out = dpnp.empty(10, dtype=dtype)
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpnp.copysign(dp_array, dp_array, out=dp_out)
 
     @pytest.mark.parametrize(
@@ -457,7 +457,7 @@ class TestLogaddexp:
         dpnp_dtype = get_all_dtypes(no_complex=True, no_none=True)[-1]
         dp_array = dpnp.arange(10, dtype=dpnp_dtype)
         dp_out = dpnp.empty(10, dtype=dtype)
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpnp.logaddexp(dp_array, dp_array, out=dp_out)
 
     @pytest.mark.parametrize(

--- a/tests/third_party/cupy/core_tests/test_ndarray_unary_op.py
+++ b/tests/third_party/cupy/core_tests/test_ndarray_unary_op.py
@@ -124,12 +124,14 @@ class TestArrayIntUnaryOp(unittest.TestCase):
     @testing.numpy_cupy_allclose(accept_error=TypeError)
     def check_zerodim_op(self, op, xp, dtype):
         a = xp.array(-2).astype(dtype)
-        if op == operator.invert and numpy.issubdtype(dtype, numpy.inexact):
-            # NumPy returns TypeError
-            # DPNP returns ValueError
-            pytest.skip("NumPy and DPNP returns different types of error.")
-        else:
+        try:
             return op(a)
+        except ValueError:
+            # When op is operator.invert and dtype is inexact,
+            # NumPy raises TypeError while DPNP raises ValueError.
+            # With this logic, when ValueError is raised in DPNP,
+            # it is changed to TypeError to align with Numpy.
+            raise TypeError
 
     def test_invert_zerodim(self):
         self.check_zerodim_op(operator.invert)

--- a/tests/third_party/cupy/core_tests/test_ndarray_unary_op.py
+++ b/tests/third_party/cupy/core_tests/test_ndarray_unary_op.py
@@ -124,7 +124,12 @@ class TestArrayIntUnaryOp(unittest.TestCase):
     @testing.numpy_cupy_allclose(accept_error=TypeError)
     def check_zerodim_op(self, op, xp, dtype):
         a = xp.array(-2).astype(dtype)
-        return op(a)
+        if op == operator.invert and numpy.issubdtype(dtype, numpy.inexact):
+            # NumPy returns TypeError
+            # DPNP returns ValueError
+            pytest.skip("NumPy and DPNP returns different types of error.")
+        else:
+            return op(a)
 
     def test_invert_zerodim(self):
         self.check_zerodim_op(operator.invert)

--- a/tests/third_party/cupy/math_tests/test_rounding.py
+++ b/tests/third_party/cupy/math_tests/test_rounding.py
@@ -8,7 +8,6 @@ from tests.helper import has_support_aspect64
 from tests.third_party.cupy import testing
 
 
-@testing.gpu
 class TestRounding(unittest.TestCase):
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(type_check=False, atol=1e-5)
@@ -26,7 +25,11 @@ class TestRounding(unittest.TestCase):
     def check_unary_complex_unsupported(self, name, dtype):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3), xp, dtype)
-            with pytest.raises(TypeError):
+            if xp == cupy and name in ["ceil", "floor", "trunc"]:
+                Exception = ValueError
+            else:
+                Exception = TypeError
+            with pytest.raises(Exception):
                 getattr(xp, name)(a)
 
     @testing.for_dtypes(["?", "b", "h", "i", "q", "e", "f", "d"])

--- a/tests/third_party/cupy/math_tests/test_rounding.py
+++ b/tests/third_party/cupy/math_tests/test_rounding.py
@@ -25,11 +25,9 @@ class TestRounding(unittest.TestCase):
     def check_unary_complex_unsupported(self, name, dtype):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3), xp, dtype)
-            if xp == cupy and name in ["ceil", "floor", "trunc"]:
-                Exception = ValueError
-            else:
-                Exception = TypeError
-            with pytest.raises(Exception):
+            # NumPy returns TypeError while DPNP returns ValueError
+            # for these functions: "ceil", "floor", "trunc"
+            with pytest.raises((TypeError, ValueError)):
                 getattr(xp, name)(a)
 
     @testing.for_dtypes(["?", "b", "h", "i", "q", "e", "f", "d"])


### PR DESCRIPTION
In this PR, elementwise tests are updated to align with recent changes in `dpctl` [gh-1496](https://github.com/IntelPython/dpctl/pull/1496).

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
