### PR TITLE
Allow for newer version of DPC++ compiler

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Install dpnp dependencies
         run: |
-          conda install numpy"<1.24" dpctl">=0.15.1dev2" mkl-devel-dpcpp onedpl-devel tbb-devel dpcpp_linux-64"<2024.0.1" \
+          conda install numpy"<1.24" dpctl">=0.15.1dev3" mkl-devel-dpcpp onedpl-devel tbb-devel dpcpp_linux-64"<2024.0.1" \
               cmake cython pytest ninja scikit-build sysroot_linux-64">=2.28" ${{ env.CHANNELS }}
 
       - name: Install cuPy dependencies

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -44,7 +44,7 @@ jobs:
         run: |
           # use DPC++ compiler 2023.2 to work around an issue with crash
           conda install cython llvm cmake">=3.21" scikit-build ninja pytest pytest-cov coverage[toml] \
-              dpctl">=0.15.1dev2" dpcpp_linux-64"=2023.2" sysroot_linux-64">=2.28" mkl-devel-dpcpp tbb-devel"=2021.10" \
+              dpctl">=0.15.1dev3" dpcpp_linux-64"=2023.2" sysroot_linux-64">=2.28" mkl-devel-dpcpp tbb-devel"=2021.10" \
               onedpl-devel ${{ env.CHANNELS }}
 
       - name: Conda info

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,7 @@
 {% set required_compiler_and_mkl_version = "2024.0" %}
-{% set max_compiler_version = "2024.0.1" %}
-{% set required_dpctl_version = "0.15.1dev2" %}
+{% set excluded_compiler_version1 = "2024.0.1" %}
+{% set excluded_compiler_version2 = "2024.0.2" %}
+{% set required_dpctl_version = "0.15.1dev3" %}
 
 package:
     name: dpnp
@@ -25,7 +26,7 @@ requirements:
       - scikit-build
     build:
       - {{ compiler('cxx') }}
-      - {{ compiler('dpcpp') }} >={{ required_compiler_and_mkl_version }},<{{ max_compiler_version }} # [not osx]
+      - {{ compiler('dpcpp') }} >={{ required_compiler_and_mkl_version }},!={{ excluded_compiler_version1 }},!={{ excluded_compiler_version2 }} # [not osx]
       - sysroot_linux-64 >=2.28 # [linux]
     run:
       - python


### PR DESCRIPTION
The PR modifies `meta.yaml` to disallow 2024.0.1 and 2024.0.2 but allow for newer DPC++ compiler versions.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
