### PR TITLE
update_argsort_test

### DIFF
--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -94,8 +94,8 @@ class TestArgsort:
         np_array = numpy.array(a, dtype=dtype)
         dp_array = dpnp.array(np_array)
 
-        result = dpnp.argsort(dp_array)
-        expected = numpy.argsort(np_array)
+        result = dpnp.argsort(dp_array, kind="stable")
+        expected = numpy.argsort(np_array, kind="stable")
         assert_dtype_allclose(result, expected)
 
     @pytest.mark.parametrize("dtype", get_complex_dtypes())

--- a/tests/third_party/cupy/sorting_tests/test_sort.py
+++ b/tests/third_party/cupy/sorting_tests/test_sort.py
@@ -296,12 +296,12 @@ class TestLexsort(unittest.TestCase):
     )
 )
 class TestArgsort(unittest.TestCase):
-    def argsort(self, a, axis=-1):
+    def argsort(self, a, axis=-1, kind=None):
         if self.external:
             xp = cupy.get_array_module(a)
-            return xp.argsort(a, axis=axis)
+            return xp.argsort(a, axis=axis, kind=kind)
         else:
-            return a.argsort(axis=axis)
+            return a.argsort(axis=axis, kind=kind)
 
     # Test base cases
 
@@ -317,7 +317,7 @@ class TestArgsort(unittest.TestCase):
     @testing.numpy_cupy_array_equal()
     def test_argsort_one_dim(self, xp, dtype):
         a = testing.shaped_random((10,), xp, dtype)
-        return self.argsort(a)
+        return self.argsort(a, axis=-1, kind="stable")
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()


### PR DESCRIPTION
In this PR, a few test related to `dpnp.argsort` are updated.

`dpnp.argsort` output is always "stable" (which means the returned indices must maintain the relative order of input values which compare as equal) but for `NumPy` its not necessary "stable".
In the updated tests, random floating numbers are generated, and when their data type is changed to integer type to align with requested data type of the test, we may encounter with repetitive numbers in the input array for which "stable" condition plays a role.
"stable" flag is added to the tests to make sure `NumPy` also always returns the stable result.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
