### PR TITLE
Clipping with both min and max values as None

### DIFF
--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -491,6 +491,8 @@ def clip(a, a_min, a_max, *, out=None, order="K", **kwargs):
 
     if kwargs:
         raise NotImplementedError(f"kwargs={kwargs} is currently not supported")
+    elif a_min is None and a_max is None:
+        raise ValueError("One of max or min must be given")
 
     if order is None:
         order = "K"


### PR DESCRIPTION
Dpctl implemented `clip` function according to Python array API specification. And dpnp fully relies on `dpctl.tensor.clip` implementation.
While NumPy requires that only one of `min` or `max` be allowed to be `None` at the same time.

The PR proposes to align `dpnp.clip` with both `min` and `max` as `None` with NumPy implementation.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
