### PR TITLE
Temporary mute tests due to known issue with OpenCL GPU

### DIFF
--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -417,6 +417,9 @@ def test_meshgrid(device_x, device_y):
     ids=[device.filter_string for device in valid_devices],
 )
 def test_1in_1out(func, data, device):
+    if func in ("std", "var") and "opencl:gpu" in device.filter_string:
+        pytest.skip("due to reproted crash on Windows: CMPLRLLVM-55640")
+
     x = dpnp.array(data, device=device)
     result = getattr(dpnp, func)(x)
 


### PR DESCRIPTION
The PR proposes to temporary skip tests relating to run of `var` and `std` function with OpneCL GPU device due to known issue which may lead to crash on Windows.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
