### PR TITLE
update `build_locally.py`

### DIFF
--- a/scripts/build_locally.py
+++ b/scripts/build_locally.py
@@ -58,12 +58,21 @@ def run(
         cmake_args += [
             "--cmake-executable=" + cmake_executable,
         ]
-    process = subprocess.Popen(['python', '-m', 'dpctl', '--cmakedir'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    process = subprocess.Popen(
+        ["python", "-m", "dpctl", "--cmakedir"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
     output, error = process.communicate()
     if process.returncode == 0:
-        cmake_dir = output.decode('utf-8').strip()
+        cmake_dir = output.decode("utf-8").strip()
     else:
-        raise RuntimeError("Failed to retrieve dpctl cmake directory: " + error.decode('utf-8').strip())
+        raise RuntimeError(
+            "Failed to retrieve dpctl cmake directory: "
+            + error.decode("utf-8").strip()
+        )
+
     cmake_args += [
         "--build-type=" + build_type,
         "--generator=" + build_system,

--- a/scripts/build_locally.py
+++ b/scripts/build_locally.py
@@ -59,6 +59,9 @@ def run(
             "--cmake-executable=" + cmake_executable,
         ]
 
+    # if dpctl is locally built using `script/build_locally.py`, it is needed
+    # to pass the -DDpctl_ROOT=$(python -m dpctl --cmakedir)
+    # if dpctl is conda installed, it is optional to pass this parameter
     process = subprocess.Popen(
         ["python", "-m", "dpctl", "--cmakedir"],
         stdout=subprocess.PIPE,

--- a/scripts/build_locally.py
+++ b/scripts/build_locally.py
@@ -58,12 +58,19 @@ def run(
         cmake_args += [
             "--cmake-executable=" + cmake_executable,
         ]
+    process = subprocess.Popen(['python', '-m', 'dpctl', '--cmakedir'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output, error = process.communicate()
+    if process.returncode == 0:
+        cmake_dir = output.decode('utf-8').strip()
+    else:
+        raise RuntimeError("Failed to retrieve dpctl cmake directory: " + error.decode('utf-8').strip())
     cmake_args += [
         "--build-type=" + build_type,
         "--generator=" + build_system,
         "--",
         "-DCMAKE_C_COMPILER:PATH=" + c_compiler,
         "-DCMAKE_CXX_COMPILER:PATH=" + cxx_compiler,
+        "-DDpctl_ROOT=" + cmake_dir,
     ]
     if verbose:
         cmake_args += [


### PR DESCRIPTION
Due to the recent changes in #1671 , we also have to modify `script/build_locally.py` to pass `-DDpctl_ROOT=$(python -m dpctl --cmakedir)`. This parameter is needed when `dpctl` is also built locally.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
