### PR TITLE
Pin conda-build to `3.28.4` version in GitHub action

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -96,7 +96,7 @@ jobs:
           (echo CONDA_BLD=%CONDA_PREFIX%\conda-bld\win-64\) >> %GITHUB_ENV%
 
       - name: Install conda-build
-        run: conda install conda-build
+        run: conda install conda-build=3.28.4
 
       - name: Cache conda packages
         uses: actions/cache@v4
@@ -111,12 +111,7 @@ jobs:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-
 
       - name: Build conda package
-        run: |
-          conda config --set verbosity 3 --env
-          conda build --build-only --python ${{ matrix.python }} ${{ env.CHANNELS }} conda-recipe
-          echo "printing some text"
-        env:
-          CONDA_VERBOSITY: 3
+        run: conda build --no-test --python ${{ matrix.python }} ${{ env.CHANNELS }} conda-recipe
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4.3.0

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -72,7 +72,8 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - name: Free Disk Space (Ubuntu)
+      - if: matrix.os == 'ubuntu-20.04'
+        name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           docker-images: false

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -72,6 +72,11 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          docker-images: false
+
       - name: Checkout DPNP repo
         uses: actions/checkout@v4.1.1
         with:

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -72,12 +72,6 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - if: matrix.os == 'ubuntu-20.04'
-        name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          docker-images: false
-
       - name: Checkout DPNP repo
         uses: actions/checkout@v4.1.1
         with:
@@ -117,7 +111,12 @@ jobs:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-
 
       - name: Build conda package
-        run: conda build --no-test --python ${{ matrix.python }} ${{ env.CHANNELS }} conda-recipe
+        run: |
+          conda config --set verbosity 3 --env
+          conda build --build-only --python ${{ matrix.python }} ${{ env.CHANNELS }} conda-recipe
+          echo "printing some text"
+        env:
+          CONDA_VERBOSITY: 3
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4.3.0

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -167,7 +167,7 @@ jobs:
 
       # Needed to be able to run conda index
       - name: Install conda-build
-        run: conda install conda-build
+        run: conda install conda-build=3.28.4
 
       - name: Create conda channel
         run: conda index ${{ env.channel-path }}
@@ -283,7 +283,7 @@ jobs:
 
       # Needed to be able to run conda index
       - name: Install conda-build
-        run: conda install conda-build
+        run: conda install conda-build=3.28.4
 
       - name: Create conda channel
         run: conda index ${{ env.channel-path }}

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -23,11 +23,6 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          docker-images: false
-
       - name: Checkout repo
         uses: actions/checkout@v4.1.1
         with:

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -23,6 +23,11 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          docker-images: false
+
       - name: Checkout repo
         uses: actions/checkout@v4.1.1
         with:


### PR DESCRIPTION
The PR pins `conda-build` to the latest stable version `3.28.4`.

The new version `24.1.0` published on anaconda `main` channel brings unexpected `Process completed with exit code 1` issue at the end of successful run of `conda build` command.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
