### PR TITLE
Specify permissions in GH Action workflows

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -28,8 +28,12 @@ jobs:
     runs-on: ubuntu-20.04
 
     permissions:
-      # Needed to deploy your static files to GitHub Pages
+      # Needed to cancel any previous runs that are not completed for a given workflow
+      actions: write
+      # Needed to deploy static files to GitHub Pages
       contents: write
+      # Needed to add a comment to a pull request's issue
+      pull-requests: write
 
     env:
       python-ver: '3.9'

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -27,6 +27,10 @@ jobs:
 
     runs-on: ubuntu-20.04
 
+    permissions:
+      # Needed to deploy your static files to GitHub Pages
+      contents: write
+
     env:
       python-ver: '3.9'
       CHANNELS: '-c dppy/label/dev -c intel -c conda-forge --override-channels'

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
 
+permissions: read-all
+
 env:
   GH_BOT_NAME: 'github-actions[bot]'
   GH_BOT_EMAIL: 'github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -60,6 +60,10 @@ jobs:
         python: ['3.9', '3.10', '3.11']
         os: [ubuntu-20.04, windows-latest]
 
+    permissions:
+      # Needed to cancel any previous runs that are not completed for a given workflow
+      actions: write
+
     runs-on: ${{ matrix.os }}
 
     defaults:

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -6,6 +6,8 @@ on:
       - master
   pull_request:
 
+permissions: read-all
+
 env:
   PACKAGE_NAME: dpnp
   MODULE_NAME: dpnp

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [master]
 
+permissions: read-all
+
 jobs:
   generate-coverage:
     name: Generate coverage and push to Coveralls.io

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -11,6 +11,10 @@ jobs:
     name: Generate coverage and push to Coveralls.io
     runs-on: ubuntu-20.04
 
+    permissions:
+      # Needed to cancel any previous runs that are not completed for a given workflow
+      actions: write
+
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches: [master]
 
+permissions: read-all
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR specifies permissions in GitHub Action workflows. Minimal read-all permission is set by default, and specific scope get elevated permission as needed.

This would improve OpenSSF Scorecard value.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
