### PR TITLE
Adding dependabot file to update GH action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -193,6 +193,8 @@ jobs:
     permissions:
       # Needed to remove docs for closed pull request from the repo
       contents: write
+      # Needed to modify a comment in the pull request's issue
+      pull-requests: write
 
     runs-on: ubuntu-20.04
 


### PR DESCRIPTION
The PR adds `.github/dependabot.yml` to run weekly jobs to update version of GitHub Actions.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
