### PR TITLE
Fix dpnp.asfortranarray and dpnp.ascontiguousarray functions for not array input

### DIFF
--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -612,7 +612,7 @@ def ascontiguousarray(
         )
 
     # at least 1-d array has to be returned
-    if a.ndim == 0:
+    if dpnp.isscalar(a) or dpnp.is_supported_array_type(a) and a.ndim == 0:
         a = [a]
 
     return asarray(
@@ -723,7 +723,7 @@ def asfortranarray(
         )
 
     # at least 1-d array has to be returned
-    if a.ndim == 0:
+    if dpnp.isscalar(a) or hasattr(a, "ndim") and a.ndim == 0:
         a = [a]
 
     return asarray(

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -612,7 +612,7 @@ def ascontiguousarray(
         )
 
     # at least 1-d array has to be returned
-    if dpnp.isscalar(a) or dpnp.is_supported_array_type(a) and a.ndim == 0:
+    if dpnp.isscalar(a) or hasattr(a, "ndim") and a.ndim == 0:
         a = [a]
 
     return asarray(

--- a/tests/test_arraycreation.py
+++ b/tests/test_arraycreation.py
@@ -878,3 +878,35 @@ def test_logspace_axis(axis):
         [2, 3], [20, 15], num=2, base=[[1, 3], [5, 7]], axis=axis
     )
     assert_dtype_allclose(func(dpnp), func(numpy))
+
+
+@pytest.mark.parametrize(
+    "data", [(), 1, (2, 3), [4], numpy.array(5), numpy.array([6, 7])]
+)
+def test_ascontiguousarray(data):
+    func = lambda xp: xp.ascontiguousarray(data)
+    assert_dtype_allclose(func(dpnp), func(numpy))
+
+
+@pytest.mark.parametrize("data", [(), 1, (2, 3), [4]])
+def test_ascontiguousarray1(data):
+    func = lambda xp, x: xp.ascontiguousarray(x)
+    a = dpnp.array(data)
+    a_np = numpy.array(data)
+    assert_dtype_allclose(func(dpnp, a), func(numpy, a_np))
+
+
+@pytest.mark.parametrize(
+    "data", [(), 1, (2, 3), [4], numpy.array(5), numpy.array([6, 7])]
+)
+def test_asfortranarray(data):
+    func = lambda xp: xp.asfortranarray(data)
+    assert_dtype_allclose(func(dpnp), func(numpy))
+
+
+@pytest.mark.parametrize("data", [(), 1, (2, 3), [4]])
+def test_asfortranarray1(data):
+    func = lambda xp, x: xp.asfortranarray(x)
+    a = dpnp.array(data)
+    a_np = numpy.array(data)
+    assert_dtype_allclose(func(dpnp, a), func(numpy, a_np))

--- a/tests/test_arraycreation.py
+++ b/tests/test_arraycreation.py
@@ -884,29 +884,33 @@ def test_logspace_axis(axis):
     "data", [(), 1, (2, 3), [4], numpy.array(5), numpy.array([6, 7])]
 )
 def test_ascontiguousarray(data):
-    func = lambda xp: xp.ascontiguousarray(data)
-    assert_dtype_allclose(func(dpnp), func(numpy))
+    result = dpnp.ascontiguousarray(data)
+    expected = numpy.ascontiguousarray(data)
+    assert_dtype_allclose(result, expected)
+    assert result.shape == expected.shape
 
 
 @pytest.mark.parametrize("data", [(), 1, (2, 3), [4]])
 def test_ascontiguousarray1(data):
-    func = lambda xp, x: xp.ascontiguousarray(x)
-    a = dpnp.array(data)
-    a_np = numpy.array(data)
-    assert_dtype_allclose(func(dpnp, a), func(numpy, a_np))
+    result = dpnp.ascontiguousarray(dpnp.array(data))
+    expected = numpy.ascontiguousarray(numpy.array(data))
+    assert_dtype_allclose(result, expected)
+    assert result.shape == expected.shape
 
 
 @pytest.mark.parametrize(
     "data", [(), 1, (2, 3), [4], numpy.array(5), numpy.array([6, 7])]
 )
 def test_asfortranarray(data):
-    func = lambda xp: xp.asfortranarray(data)
-    assert_dtype_allclose(func(dpnp), func(numpy))
+    result = dpnp.asfortranarray(data)
+    expected = numpy.asfortranarray(data)
+    assert_dtype_allclose(result, expected)
+    assert result.shape == expected.shape
 
 
 @pytest.mark.parametrize("data", [(), 1, (2, 3), [4]])
 def test_asfortranarray1(data):
-    func = lambda xp, x: xp.asfortranarray(x)
-    a = dpnp.array(data)
-    a_np = numpy.array(data)
-    assert_dtype_allclose(func(dpnp, a), func(numpy, a_np))
+    result = dpnp.asfortranarray(dpnp.array(data))
+    expected = numpy.asfortranarray(numpy.array(data))
+    assert_dtype_allclose(result, expected)
+    assert result.shape == expected.shape


### PR DESCRIPTION
Fix dpnp.asfortranarray and dpnp.ascontiguousarray functions for not array input. Add tests

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
