### PR TITLE
update `dpnp.vdot` implementation

### DIFF
--- a/dpnp/backend/extensions/blas/CMakeLists.txt
+++ b/dpnp/backend/extensions/blas/CMakeLists.txt
@@ -28,6 +28,7 @@ set(python_module_name _blas_impl)
 set(_module_src
     ${CMAKE_CURRENT_SOURCE_DIR}/blas_py.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dot.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dotc.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dotu.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gemm.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gemm_batch.cpp

--- a/dpnp/backend/extensions/blas/blas_py.cpp
+++ b/dpnp/backend/extensions/blas/blas_py.cpp
@@ -40,6 +40,7 @@ namespace py = pybind11;
 void init_dispatch_tables(void)
 {
     blas_ext::init_dot_dispatch_table();
+    blas_ext::init_dotc_dispatch_table();
     blas_ext::init_dotu_dispatch_table();
     blas_ext::init_gemm_batch_dispatch_table();
     blas_ext::init_gemm_dispatch_table();
@@ -53,6 +54,15 @@ PYBIND11_MODULE(_blas_impl, m)
         m.def("_dot", &blas_ext::dot,
               "Call `dot` from OneMKL LAPACK library to return "
               "the dot product of two real-valued vectors.",
+              py::arg("sycl_queue"), py::arg("vectorA"), py::arg("vectorB"),
+              py::arg("result"), py::arg("depends") = py::list());
+    }
+
+    {
+        m.def("_dotc", &blas_ext::dotc,
+              "Call `dotc` from OneMKL LAPACK library to return "
+              "the dot product of two complex vectors, "
+              "conjugating the first vector.",
               py::arg("sycl_queue"), py::arg("vectorA"), py::arg("vectorB"),
               py::arg("result"), py::arg("depends") = py::list());
     }

--- a/dpnp/backend/extensions/blas/dot.hpp
+++ b/dpnp/backend/extensions/blas/dot.hpp
@@ -46,6 +46,13 @@ extern std::pair<sycl::event, sycl::event>
         const std::vector<sycl::event> &depends);
 
 extern std::pair<sycl::event, sycl::event>
+    dotc(sycl::queue &exec_q,
+         dpctl::tensor::usm_ndarray vectorA,
+         dpctl::tensor::usm_ndarray vectorB,
+         dpctl::tensor::usm_ndarray result,
+         const std::vector<sycl::event> &depends);
+
+extern std::pair<sycl::event, sycl::event>
     dotu(sycl::queue &exec_q,
          dpctl::tensor::usm_ndarray vectorA,
          dpctl::tensor::usm_ndarray vectorB,
@@ -53,6 +60,7 @@ extern std::pair<sycl::event, sycl::event>
          const std::vector<sycl::event> &depends);
 
 extern void init_dot_dispatch_table(void);
+extern void init_dotc_dispatch_table(void);
 extern void init_dotu_dispatch_table(void);
 } // namespace blas
 } // namespace ext

--- a/dpnp/backend/extensions/blas/dotc.cpp
+++ b/dpnp/backend/extensions/blas/dotc.cpp
@@ -1,0 +1,241 @@
+//*****************************************************************************
+// Copyright (c) 2024, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//*****************************************************************************
+
+#include <pybind11/pybind11.h>
+
+// dpctl tensor headers
+#include "utils/memory_overlap.hpp"
+#include "utils/type_utils.hpp"
+
+#include "dot.hpp"
+#include "types_matrix.hpp"
+
+#include "dpnp_utils.hpp"
+
+namespace dpnp
+{
+namespace backend
+{
+namespace ext
+{
+namespace blas
+{
+namespace mkl_blas = oneapi::mkl::blas;
+namespace py = pybind11;
+namespace type_utils = dpctl::tensor::type_utils;
+
+typedef sycl::event (*dotc_impl_fn_ptr_t)(sycl::queue &,
+                                          const std::int64_t,
+                                          char *,
+                                          const std::int64_t,
+                                          char *,
+                                          const std::int64_t,
+                                          char *,
+                                          const std::vector<sycl::event> &);
+
+static dotc_impl_fn_ptr_t dotc_dispatch_table[dpctl_td_ns::num_types]
+                                             [dpctl_td_ns::num_types];
+
+template <typename Tab, typename Tc>
+static sycl::event dotc_impl(sycl::queue &exec_q,
+                             const std::int64_t n,
+                             char *vectorA,
+                             const std::int64_t stride_a,
+                             char *vectorB,
+                             const std::int64_t stride_b,
+                             char *result,
+                             const std::vector<sycl::event> &depends)
+{
+    type_utils::validate_type_for_device<Tab>(exec_q);
+    type_utils::validate_type_for_device<Tc>(exec_q);
+
+    Tab *a = reinterpret_cast<Tab *>(vectorA);
+    Tab *b = reinterpret_cast<Tab *>(vectorB);
+    Tc *res = reinterpret_cast<Tc *>(result);
+
+    std::stringstream error_msg;
+    bool is_exception_caught = false;
+
+    sycl::event dotc_event;
+    try {
+        dotc_event = mkl_blas::row_major::dotc(exec_q,
+                                               n, // size of the input vectors
+                                               a, // Pointer to vector a.
+                                               stride_a, // Stride of vector a.
+                                               b,        // Pointer to vector b.
+                                               stride_b, // Stride of vector b.
+                                               res,      // Pointer to result.
+                                               depends);
+    } catch (oneapi::mkl::exception const &e) {
+        error_msg
+            << "Unexpected MKL exception caught during dotc() call:\nreason: "
+            << e.what();
+        is_exception_caught = true;
+    } catch (sycl::exception const &e) {
+        error_msg << "Unexpected SYCL exception caught during dotc() call:\n"
+                  << e.what();
+        is_exception_caught = true;
+    }
+
+    if (is_exception_caught) // an unexpected error occurs
+    {
+        throw std::runtime_error(error_msg.str());
+    }
+
+    return dotc_event;
+}
+
+std::pair<sycl::event, sycl::event>
+    dotc(sycl::queue &exec_q,
+         dpctl::tensor::usm_ndarray vectorA,
+         dpctl::tensor::usm_ndarray vectorB,
+         dpctl::tensor::usm_ndarray result,
+         const std::vector<sycl::event> &depends)
+{
+    const int vectorA_nd = vectorA.get_ndim();
+    const int vectorB_nd = vectorB.get_ndim();
+    const int result_nd = result.get_ndim();
+
+    if ((vectorA_nd != 1)) {
+        throw py::value_error(
+            "The first input array has ndim=" + std::to_string(vectorA_nd) +
+            ", but a 1-dimensional array is expected.");
+    }
+
+    if ((vectorB_nd != 1)) {
+        throw py::value_error(
+            "The second input array has ndim=" + std::to_string(vectorB_nd) +
+            ", but a 1-dimensional array is expected.");
+    }
+
+    if ((result_nd != 0)) {
+        throw py::value_error(
+            "The output array has ndim=" + std::to_string(result_nd) +
+            ", but a 0-dimensional array is expected.");
+    }
+
+    auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
+    if (overlap(vectorA, result)) {
+        throw py::value_error(
+            "The first input array and output array are overlapping "
+            "segments of memory");
+    }
+    if (overlap(vectorB, result)) {
+        throw py::value_error(
+            "The second input array and output array are overlapping "
+            "segments of memory");
+    }
+
+    // check compatibility of execution queue and allocation queue
+    if (!dpctl::utils::queues_are_compatible(
+            exec_q,
+            {vectorA.get_queue(), vectorB.get_queue(), result.get_queue()}))
+    {
+        throw py::value_error(
+            "USM allocations are not compatible with the execution queue.");
+    }
+
+    py::ssize_t a_size = vectorA.get_size();
+    py::ssize_t b_size = vectorB.get_size();
+    if (a_size != b_size) {
+        throw py::value_error("The size of the first input array must be "
+                              "equal to the size of the second input array.");
+    }
+
+    std::vector<py::ssize_t> a_stride = vectorA.get_strides_vector();
+    std::vector<py::ssize_t> b_stride = vectorB.get_strides_vector();
+
+    const std::int64_t n = a_size;
+    const std::int64_t str_a = a_stride[0];
+    const std::int64_t str_b = b_stride[0];
+
+    int vectorA_typenum = vectorA.get_typenum();
+    int vectorB_typenum = vectorB.get_typenum();
+    int result_typenum = result.get_typenum();
+
+    if (vectorA_typenum != vectorB_typenum) {
+        throw py::value_error(
+            "Input arrays must be of must be of the same type.");
+    }
+
+    auto array_types = dpctl_td_ns::usm_ndarray_types();
+    int vectorAB_type_id = array_types.typenum_to_lookup_id(vectorA_typenum);
+    int result_type_id = array_types.typenum_to_lookup_id(result_typenum);
+
+    dotc_impl_fn_ptr_t dotc_fn =
+        dotc_dispatch_table[vectorAB_type_id][result_type_id];
+    if (dotc_fn == nullptr) {
+        throw py::value_error(
+            "Types of input vectors and result array are mismatched.");
+    }
+
+    char *a_typeless_ptr = vectorA.get_data();
+    char *b_typeless_ptr = vectorB.get_data();
+    char *r_typeless_ptr = result.get_data();
+
+    const int a_elemsize = vectorA.get_elemsize();
+    const int b_elemsize = vectorB.get_elemsize();
+    if (str_a < 0) {
+        a_typeless_ptr -= (n - 1) * std::abs(str_a) * a_elemsize;
+    }
+    if (str_b < 0) {
+        b_typeless_ptr -= (n - 1) * std::abs(str_b) * b_elemsize;
+    }
+
+    sycl::event dotc_ev =
+        dotc_fn(exec_q, n, a_typeless_ptr, str_a, b_typeless_ptr, str_b,
+                r_typeless_ptr, depends);
+
+    sycl::event args_ev = dpctl::utils::keep_args_alive(
+        exec_q, {vectorA, vectorB, result}, {dotc_ev});
+
+    return std::make_pair(args_ev, dotc_ev);
+}
+
+template <typename fnT, typename Tab, typename Tc>
+struct DotcContigFactory
+{
+    fnT get()
+    {
+        if constexpr (types::DotcTypePairSupportFactory<Tab, Tc>::is_defined) {
+            return dotc_impl<Tab, Tc>;
+        }
+        else {
+            return nullptr;
+        }
+    }
+};
+
+void init_dotc_dispatch_table(void)
+{
+    dpctl_td_ns::DispatchTableBuilder<dotc_impl_fn_ptr_t, DotcContigFactory,
+                                      dpctl_td_ns::num_types>
+        contig;
+    contig.populate_dispatch_table(dotc_dispatch_table);
+}
+} // namespace blas
+} // namespace ext
+} // namespace backend
+} // namespace dpnp

--- a/dpnp/backend/extensions/blas/types_matrix.hpp
+++ b/dpnp/backend/extensions/blas/types_matrix.hpp
@@ -64,6 +64,30 @@ struct DotTypePairSupportFactory
 
 /**
  * @brief A factory to define pairs of supported types for which
+ * MKL BLAS library provides support in oneapi::mkl::blas::dotc<Tab, Tc>
+ * function.
+ *
+ * @tparam Tab Type of arrays containing input vectors A and B.
+ * @tparam Tc Type of array containing output.
+ */
+template <typename Tab, typename Tc>
+struct DotcTypePairSupportFactory
+{
+    static constexpr bool is_defined = std::disjunction<
+        dpctl_td_ns::TypePairDefinedEntry<Tab,
+                                          std::complex<float>,
+                                          Tc,
+                                          std::complex<float>>,
+        dpctl_td_ns::TypePairDefinedEntry<Tab,
+                                          std::complex<double>,
+                                          Tc,
+                                          std::complex<double>>,
+        // fall-through
+        dpctl_td_ns::NotDefinedEntry>::is_defined;
+};
+
+/**
+ * @brief A factory to define pairs of supported types for which
  * MKL BLAS library provides support in oneapi::mkl::blas::dotu<Tab, Tc>
  * function.
  *

--- a/dpnp/dpnp_iface.py
+++ b/dpnp/dpnp_iface.py
@@ -205,7 +205,7 @@ def astype(x1, dtype, order="K", casting="unsafe", copy=True):
     return dpnp_array._create_from_usm_ndarray(array_obj)
 
 
-def check_supported_arrays_type(*arrays, scalar_type=False):
+def check_supported_arrays_type(*arrays, scalar_type=False, all_scalars=False):
     """
     Return ``True`` if each array has either type of scalar,
     :class:`dpnp.ndarray` or :class:`dpctl.tensor.usm_ndarray`.
@@ -216,7 +216,9 @@ def check_supported_arrays_type(*arrays, scalar_type=False):
     arrays : {dpnp_array, usm_ndarray}
         Input arrays to check for supported types.
     scalar_type : {bool}, optional
-        A scalar type is also considered as supported if flag is True.
+        A scalar type is also considered as supported if flag is ``True``.
+    all_scalars : {bool}, optional
+        All the input arrays can be scalar if flag is ``True``.
 
     Returns
     -------
@@ -231,12 +233,21 @@ def check_supported_arrays_type(*arrays, scalar_type=False):
 
     """
 
+    any_is_array = False
     for a in arrays:
-        if scalar_type and dpnp.isscalar(a) or is_supported_array_type(a):
+        if is_supported_array_type(a):
+            any_is_array = True
+            continue
+        elif scalar_type and dpnp.isscalar(a):
             continue
 
         raise TypeError(
             "An array must be any of supported type, but got {}".format(type(a))
+        )
+
+    if len(arrays) > 1 and not (all_scalars or any_is_array):
+        raise TypeError(
+            "At least one input must be of supported array type, but got all scalars."
         )
     return True
 

--- a/dpnp/dpnp_iface_linearalgebra.py
+++ b/dpnp/dpnp_iface_linearalgebra.py
@@ -121,8 +121,7 @@ def dot(a, b, out=None):
 
     """
 
-    dpnp.check_supported_arrays_type(a, scalar_type=True)
-    dpnp.check_supported_arrays_type(b, scalar_type=True)
+    dpnp.check_supported_arrays_type(a, b, scalar_type=True)
 
     if out is not None:
         dpnp.check_supported_arrays_type(out)
@@ -333,8 +332,7 @@ def matmul(
 
     """
 
-    dpnp.check_supported_arrays_type(x1)
-    dpnp.check_supported_arrays_type(x2)
+    dpnp.check_supported_arrays_type(x1, x2)
     if subok is False:
         raise NotImplementedError(
             "subok keyword argument is only supported by its default value."
@@ -468,6 +466,7 @@ def vdot(a, b):
     See Also
     --------
     :obj:`dpnp.dot` : Returns the dot product.
+    :obj:`dpnp.matmul` : Returns the matrix product.
 
     Examples
     --------
@@ -492,17 +491,17 @@ def vdot(a, b):
 
     """
 
-    dpnp.check_supported_arrays_type(a, scalar_type=True)
-    dpnp.check_supported_arrays_type(b, scalar_type=True)
+    dpnp.check_supported_arrays_type(a, b, scalar_type=True)
 
     if dpnp.isscalar(a) or dpnp.isscalar(b):
         if dpnp.isscalar(b) and a.size != 1:
             raise ValueError("The first array should be of size one.")
         if dpnp.isscalar(a) and b.size != 1:
             raise ValueError("The second array should be of size one.")
+        a_conj = numpy.conj(a) if dpnp.isscalar(a) else dpnp.conj(a)
         # TODO: investigate usage of axpy (axpy_batch) or scal
         # functions from BLAS here instead of dpnp.multiply
-        return dpnp.multiply(numpy.conj(a), b)
+        return dpnp.multiply(a_conj, b)
     elif a.ndim == 1 and b.ndim == 1:
         return dpnp_dot(a, b, out=None, conjugate=True)
     else:

--- a/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
+++ b/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
@@ -231,21 +231,16 @@ def dpnp_dot(a, b, /, out=None, *, conjugate=False):
         b = _copy_array(b, dep_events_list, host_tasks_list, dtype=dot_dtype)
         if dpnp.issubdtype(res_dtype, dpnp.complexfloating):
             if conjugate:
-                ht_ev, _ = bi._dotc(
-                    exec_q,
-                    dpnp.get_usm_ndarray(a),
-                    dpnp.get_usm_ndarray(b),
-                    dpnp.get_usm_ndarray(result),
-                    dep_events_list,
-                )
+                dot_func = "_dotc"
             else:
-                ht_ev, _ = bi._dotu(
-                    exec_q,
-                    dpnp.get_usm_ndarray(a),
-                    dpnp.get_usm_ndarray(b),
-                    dpnp.get_usm_ndarray(result),
-                    dep_events_list,
-                )
+                dot_func = "_dotu"
+            ht_ev, _ = getattr(bi, dot_func)(
+                exec_q,
+                dpnp.get_usm_ndarray(a),
+                dpnp.get_usm_ndarray(b),
+                dpnp.get_usm_ndarray(result),
+                dep_events_list,
+            )
         else:
             ht_ev, _ = bi._dot(
                 exec_q,

--- a/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
+++ b/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
@@ -33,7 +33,7 @@ import dpnp.backend.extensions.blas._blas_impl as bi
 from dpnp.dpnp_array import dpnp_array
 from dpnp.dpnp_utils import get_usm_allocations
 
-__all__ = ["dpnp_dot", "dpnp_matmul", "dpnp_vdot"]
+__all__ = ["dpnp_dot", "dpnp_matmul"]
 
 
 def _copy_array(x, dep_events, host_events, contig_copy=False, dtype=None):
@@ -185,7 +185,7 @@ def _op_res_dtype(*arrays, dtype, casting, sycl_queue):
     return op_dtype, res_dtype
 
 
-def dpnp_dot(a, b, /, out=None):
+def dpnp_dot(a, b, /, out=None, *, conjugate=False):
     """
     Return the dot product of two arrays.
 
@@ -194,7 +194,9 @@ def dpnp_dot(a, b, /, out=None):
     `dpctl.tensor.vecdot` form the Data Parallel Control library is used,
     2) For real-valued floating point data types, `dot` routines from
     BLAS library of OneMKL are used, and 3) For complex data types,
-    `dotu` routines from BLAS library of OneMKL are used.
+    `dotu` or `dotc` routines from BLAS library of OneMKL are used.
+    If `conjugate` is ``False``, `dotu` is used. Otherwise, `dotc` is used,
+    for which the first array is conjugated before calculating the dot product.
 
     """
 
@@ -228,13 +230,22 @@ def dpnp_dot(a, b, /, out=None):
         a = _copy_array(a, dep_events_list, host_tasks_list, dtype=dot_dtype)
         b = _copy_array(b, dep_events_list, host_tasks_list, dtype=dot_dtype)
         if dpnp.issubdtype(res_dtype, dpnp.complexfloating):
-            ht_ev, _ = bi._dotu(
-                exec_q,
-                dpnp.get_usm_ndarray(a),
-                dpnp.get_usm_ndarray(b),
-                dpnp.get_usm_ndarray(result),
-                dep_events_list,
-            )
+            if conjugate:
+                ht_ev, _ = bi._dotc(
+                    exec_q,
+                    dpnp.get_usm_ndarray(a),
+                    dpnp.get_usm_ndarray(b),
+                    dpnp.get_usm_ndarray(result),
+                    dep_events_list,
+                )
+            else:
+                ht_ev, _ = bi._dotu(
+                    exec_q,
+                    dpnp.get_usm_ndarray(a),
+                    dpnp.get_usm_ndarray(b),
+                    dpnp.get_usm_ndarray(result),
+                    dep_events_list,
+                )
         else:
             ht_ev, _ = bi._dot(
                 exec_q,
@@ -253,7 +264,7 @@ def dpnp_dot(a, b, /, out=None):
     if dot_dtype != res_dtype:
         result = result.astype(res_dtype, copy=False)
 
-    # NumPy does not allow casting even if it is safe
+    # numpy.dot does not allow casting even if it is safe
     return dpnp.get_result_array(result, out, casting="no")
 
 
@@ -447,74 +458,3 @@ def dpnp_matmul(
             return result
     else:
         return dpnp.get_result_array(result, out, casting=casting)
-
-
-def dpnp_vdot(a, b):
-    """
-    Return the dot product of two arrays.
-
-    The routine that is used to perform the main calculation
-    depends on input arrays data type: 1) For integer and boolean data types,
-    `dpctl.tensor.vecdot` form the Data Parallel Control library is used,
-    2) For real-valued floating point data types, `dot` routines from
-    BLAS library of OneMKL are used, and 3) For complex data types,
-    `dotc` routines from BLAS library of OneMKL are used.
-
-    """
-
-    if a.size != b.size:
-        raise ValueError(
-            "Input arrays have a mismatch in their size. "
-            f"(size {a.size} is different from {b.size})"
-        )
-
-    res_usm_type, exec_q = get_usm_allocations([a, b])
-
-    # Determine the appropriate data types
-    # casting is irrelevant here since dtype is `None`
-    dot_dtype, res_dtype = _op_res_dtype(
-        a, b, dtype=None, casting="no", sycl_queue=exec_q
-    )
-
-    # create result array
-    result = dpnp.empty(
-        (),
-        dtype=dot_dtype,
-        usm_type=res_usm_type,
-        sycl_queue=exec_q,
-    )
-
-    # input arrays should have the proper data type
-    dep_events_list = []
-    host_tasks_list = []
-    if dpnp.issubdtype(res_dtype, dpnp.inexact):
-        # copying is needed if dtypes of input arrays are different
-        a = _copy_array(a, dep_events_list, host_tasks_list, dtype=dot_dtype)
-        b = _copy_array(b, dep_events_list, host_tasks_list, dtype=dot_dtype)
-        if dpnp.issubdtype(res_dtype, dpnp.complexfloating):
-            ht_ev, _ = bi._dotc(
-                exec_q,
-                dpnp.get_usm_ndarray(a),
-                dpnp.get_usm_ndarray(b),
-                dpnp.get_usm_ndarray(result),
-                dep_events_list,
-            )
-        else:
-            ht_ev, _ = bi._dot(
-                exec_q,
-                dpnp.get_usm_ndarray(a),
-                dpnp.get_usm_ndarray(b),
-                dpnp.get_usm_ndarray(result),
-                dep_events_list,
-            )
-        host_tasks_list.append(ht_ev)
-        dpctl.SyclEvent.wait_for(host_tasks_list)
-    else:
-        dpt_a = dpnp.get_usm_ndarray(a)
-        dpt_b = dpnp.get_usm_ndarray(b)
-        result = dpnp_array._create_from_usm_ndarray(dpt.vecdot(dpt_a, dpt_b))
-
-    if dot_dtype != res_dtype:
-        result = result.astype(res_dtype, copy=False)
-
-    return result

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -335,13 +335,10 @@ tests/third_party/cupy/linalg_tests/test_einsum.py::TestListArgEinSumError::test
 tests/third_party/cupy/linalg_tests/test_product.py::TestMatrixPower::test_matrix_power_invlarge
 tests/third_party/cupy/linalg_tests/test_product.py::TestMatrixPower::test_matrix_power_large
 tests/third_party/cupy/linalg_tests/test_product.py::TestMatrixPower::test_matrix_power_of_two
-tests/third_party/cupy/linalg_tests/test_product.py::TestProduct::test_multidim_vdot
 tests/third_party/cupy/linalg_tests/test_product.py::TestProduct::test_tensordot_zero_dim
-tests/third_party/cupy/linalg_tests/test_product.py::TestProduct::test_transposed_multidim_vdot
 tests/third_party/cupy/linalg_tests/test_product.py::TestProduct::test_transposed_tensordot
 tests/third_party/cupy/linalg_tests/test_product.py::TestProduct::test_transposed_tensordot_with_int_axes
 tests/third_party/cupy/linalg_tests/test_product.py::TestProduct::test_transposed_tensordot_with_list_axes
-tests/third_party/cupy/linalg_tests/test_product.py::TestProduct::test_reversed_vdot
 
 tests/third_party/cupy/logic_tests/test_comparison.py::TestArrayEqual::test_array_equal_broadcast_not_allowed
 tests/third_party/cupy/logic_tests/test_comparison.py::TestArrayEqual::test_array_equal_diff_dtypes_is_equal

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -437,13 +437,10 @@ tests/third_party/cupy/linalg_tests/test_einsum.py::TestListArgEinSumError::test
 tests/third_party/cupy/linalg_tests/test_product.py::TestMatrixPower::test_matrix_power_invlarge
 tests/third_party/cupy/linalg_tests/test_product.py::TestMatrixPower::test_matrix_power_large
 tests/third_party/cupy/linalg_tests/test_product.py::TestMatrixPower::test_matrix_power_of_two
-tests/third_party/cupy/linalg_tests/test_product.py::TestProduct::test_multidim_vdot
 tests/third_party/cupy/linalg_tests/test_product.py::TestProduct::test_transposed_tensordot
 tests/third_party/cupy/linalg_tests/test_product.py::TestProduct::test_transposed_tensordot_with_int_axes
 tests/third_party/cupy/linalg_tests/test_product.py::TestProduct::test_transposed_tensordot_with_list_axes
 tests/third_party/cupy/linalg_tests/test_product.py::TestProduct::test_tensordot_zero_dim
-tests/third_party/cupy/linalg_tests/test_product.py::TestProduct::test_transposed_multidim_vdot
-tests/third_party/cupy/linalg_tests/test_product.py::TestProduct::test_reversed_vdot
 
 tests/third_party/cupy/logic_tests/test_comparison.py::TestArrayEqual::test_array_equal_broadcast_not_allowed
 tests/third_party/cupy/logic_tests/test_comparison.py::TestArrayEqual::test_array_equal_diff_dtypes_is_equal

--- a/tests/test_dot.py
+++ b/tests/test_dot.py
@@ -376,7 +376,7 @@ def test_multi_dot(type):
 class TestVdot:
     @pytest.mark.parametrize("dtype", get_all_dtypes())
     def test_vdot_scalar(self, dtype):
-        a = numpy.array(3.5, dtype=dtype)
+        a = numpy.array([3.5], dtype=dtype)
         ia = dpnp.array(a)
         b = 2 + 3j
 

--- a/tests/test_dot.py
+++ b/tests/test_dot.py
@@ -384,6 +384,10 @@ class TestVdot:
         expected = numpy.vdot(a, b)
         assert_allclose(result, expected)
 
+        result = dpnp.vdot(b, ia)
+        expected = numpy.vdot(b, a)
+        assert_allclose(result, expected)
+
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
     @pytest.mark.parametrize(
         "array_info",
@@ -505,3 +509,7 @@ class TestVdot:
         # The first array should be of size one
         with pytest.raises(ValueError):
             dpnp.vdot(a, b)
+
+        # The second array should be of size one
+        with pytest.raises(ValueError):
+            dpnp.vdot(b, a)

--- a/tests/test_dot.py
+++ b/tests/test_dot.py
@@ -8,7 +8,7 @@ import dpnp
 from .helper import assert_dtype_allclose, get_all_dtypes, get_complex_dtypes
 
 
-class Testdot:
+class TestDot:
     @pytest.mark.parametrize("dtype", get_all_dtypes())
     def test_dot_ones(self, dtype):
         n = 10**5
@@ -371,3 +371,137 @@ def test_multi_dot(type):
     result = dpnp.linalg.multi_dot([a, b, c, d])
     expected = numpy.linalg.multi_dot([a1, b1, c1, d1])
     assert_array_equal(expected, result)
+
+
+class TestVdot:
+    @pytest.mark.parametrize("dtype", get_all_dtypes())
+    def test_vdot_scalar(self, dtype):
+        a = numpy.array(3.5, dtype=dtype)
+        ia = dpnp.array(a)
+        b = 2 + 3j
+
+        result = dpnp.vdot(ia, b)
+        expected = numpy.vdot(a, b)
+        assert_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
+    @pytest.mark.parametrize(
+        "array_info",
+        [
+            (1, 1, (), ()),
+            (10, 10, (10,), (10,)),
+            (12, 12, (4, 3), (3, 4)),
+            (12, 12, (4, 3), (12,)),
+            (60, 60, (5, 4, 3), (60,)),
+            (8, 8, (8,), (4, 2)),
+            (60, 60, (5, 3, 4), (3, 4, 5)),
+        ],
+        ids=[
+            "0d_0d",
+            "1d_1d",
+            "2d_2d",
+            "2d_1d",
+            "3d_1d",
+            "1d_2d",
+            "3d_3d",
+        ],
+    )
+    def test_vdot(self, dtype, array_info):
+        size1, size2, shape1, shape2 = array_info
+        a = numpy.array(
+            numpy.random.uniform(-5, 5, size1), dtype=dtype
+        ).reshape(shape1)
+        b = numpy.array(
+            numpy.random.uniform(-5, 5, size2), dtype=dtype
+        ).reshape(shape2)
+        ia = dpnp.array(a)
+        ib = dpnp.array(b)
+
+        result = dpnp.vdot(ia, ib)
+        expected = numpy.vdot(a, b)
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_complex_dtypes())
+    @pytest.mark.parametrize(
+        "array_info",
+        [
+            (1, 1, (), ()),
+            (10, 10, (10,), (10,)),
+            (12, 12, (4, 3), (3, 4)),
+            (12, 12, (4, 3), (12,)),
+            (60, 60, (5, 4, 3), (60,)),
+            (8, 8, (8,), (4, 2)),
+            (60, 60, (5, 3, 4), (3, 4, 5)),
+        ],
+        ids=[
+            "0d_0d",
+            "1d_1d",
+            "2d_2d",
+            "2d_1d",
+            "3d_1d",
+            "1d_2d",
+            "3d_3d",
+        ],
+    )
+    def test_vdot_complex(self, dtype, array_info):
+        size1, size2, shape1, shape2 = array_info
+        x11 = numpy.random.uniform(-5, 5, size1)
+        x12 = numpy.random.uniform(-5, 5, size1)
+        x21 = numpy.random.uniform(-5, 5, size2)
+        x22 = numpy.random.uniform(-5, 5, size2)
+        a = numpy.array(x11 + 1j * x12, dtype=dtype).reshape(shape1)
+        b = numpy.array(x21 + 1j * x22, dtype=dtype).reshape(shape2)
+        ia = dpnp.array(a)
+        ib = dpnp.array(b)
+
+        result = dpnp.vdot(ia, ib)
+        expected = numpy.vdot(a, b)
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
+    def test_vdot_strided(self, dtype):
+        a = numpy.arange(25, dtype=dtype)
+        b = numpy.arange(25, dtype=dtype)
+        ia = dpnp.array(a)
+        ib = dpnp.array(b)
+
+        result = dpnp.vdot(ia[::3], ib[::3])
+        expected = numpy.vdot(a[::3], b[::3])
+        assert_dtype_allclose(result, expected)
+
+        result = dpnp.vdot(ia, ib[::-1])
+        expected = numpy.vdot(a, b[::-1])
+        assert_dtype_allclose(result, expected)
+
+        result = dpnp.vdot(ia[::-2], ib[::-2])
+        expected = numpy.vdot(a[::-2], b[::-2])
+        assert_dtype_allclose(result, expected)
+
+        result = dpnp.vdot(ia[::-5], ib[::-5])
+        expected = numpy.vdot(a[::-5], b[::-5])
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype1", get_all_dtypes())
+    @pytest.mark.parametrize("dtype2", get_all_dtypes())
+    def test_vdot_input_dtype_matrix(self, dtype1, dtype2):
+        a = numpy.array(numpy.random.uniform(-5, 5, 10), dtype=dtype1)
+        b = numpy.array(numpy.random.uniform(-5, 5, 10), dtype=dtype2)
+        ia = dpnp.array(a)
+        ib = dpnp.array(b)
+
+        result = dpnp.vdot(ia, ib)
+        expected = numpy.vdot(a, b)
+        assert_dtype_allclose(result, expected)
+
+    def test_vdot_error(self):
+        a = dpnp.ones(25)
+        b = dpnp.ones(24)
+        # size of input arrays differ
+        with pytest.raises(ValueError):
+            dpnp.vdot(a, b)
+
+        a = dpnp.ones(25)
+        b = 2
+        # The first array should be of size one
+        with pytest.raises(ValueError):
+            dpnp.vdot(a, b)

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -532,11 +532,11 @@ def test_reduce_hypot(device):
         pytest.param(
             "divide", [0.0, 1.0, 2.0, 3.0, 4.0], [4.0, 4.0, 4.0, 4.0, 4.0]
         ),
-        pytest.param(
-            "dot",
-            [3.0, 4.0, 5.0],
-            [1.0, 2.0, 3.0],
-        ),
+        # dpnp.dot has 3 different implementations based on input arrays dtype
+        # checking all of them
+        pytest.param("dot", [3.0, 4.0, 5.0], [1.0, 2.0, 3.0]),
+        pytest.param("dot", [3, 4, 5], [1, 2, 3]),
+        pytest.param("dot", [3 + 2j, 4 + 1j, 5], [1, 2 + 3j, 3]),
         pytest.param(
             "floor_divide", [1.0, 2.0, 3.0, 4.0], [2.5, 2.5, 2.5, 2.5]
         ),
@@ -579,6 +579,11 @@ def test_reduce_hypot(device):
             [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
             [0.0, 1.0, 2.0, 0.0, 1.0, 2.0, 0.0, 1.0, 2.0],
         ),
+        # dpnp.vdot has 3 different implementations based on input arrays dtype
+        # checking all of them
+        pytest.param("vdot", [3.0, 4.0, 5.0], [1.0, 2.0, 3.0]),
+        pytest.param("vdot", [3, 4, 5], [1, 2, 3]),
+        pytest.param("vdot", [3 + 2j, 4 + 1j, 5], [1, 2 + 3j, 3]),
     ],
 )
 @pytest.mark.parametrize(
@@ -840,11 +845,11 @@ def test_out_1in_1out(func, data, device):
         pytest.param(
             "divide", [0.0, 1.0, 2.0, 3.0, 4.0], [4.0, 4.0, 4.0, 4.0, 4.0]
         ),
-        pytest.param(
-            "dot",
-            [3.0, 4.0, 5.0],
-            [1.0, 2.0, 3.0],
-        ),
+        # dpnp.dot has 3 different implementations based on input arrays dtype
+        # checking all of them
+        pytest.param("dot", [3.0, 4.0, 5.0], [1.0, 2.0, 3.0]),
+        pytest.param("dot", [3, 4, 5], [1, 2, 3]),
+        pytest.param("dot", [3 + 2j, 4 + 1j, 5], [1, 2 + 3j, 3]),
         pytest.param(
             "floor_divide", [1.0, 2.0, 3.0, 4.0], [2.5, 2.5, 2.5, 2.5]
         ),

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -492,11 +492,11 @@ def test_1in_1out(func, data, usm_type):
         ),
         pytest.param("arctan2", [[-1, +1, +1, -1]], [[-1, -1, +1, +1]]),
         pytest.param("copysign", [0.0, 1.0, 2.0], [-1.0, 0.0, 1.0]),
-        pytest.param(
-            "dot",
-            [3.0, 4.0, 5.0],
-            [1.0, 2.0, 3.0],
-        ),
+        # dpnp.dot has 3 different implementations based on input arrays dtype
+        # checking all of them
+        pytest.param("dot", [3.0, 4.0, 5.0], [1.0, 2.0, 3.0]),
+        pytest.param("dot", [3, 4, 5], [1, 2, 3]),
+        pytest.param("dot", [3 + 2j, 4 + 1j, 5], [1, 2 + 3j, 3]),
         pytest.param("fmax", [[0.0, 1.0, 2.0]], [[3.0, 4.0, 5.0]]),
         pytest.param("fmin", [[0.0, 1.0, 2.0]], [[3.0, 4.0, 5.0]]),
         pytest.param(
@@ -505,6 +505,11 @@ def test_1in_1out(func, data, usm_type):
         pytest.param("logaddexp", [[-1, 2, 5, 9]], [[4, -3, 2, -8]]),
         pytest.param("maximum", [[0.0, 1.0, 2.0]], [[3.0, 4.0, 5.0]]),
         pytest.param("minimum", [[0.0, 1.0, 2.0]], [[3.0, 4.0, 5.0]]),
+        # dpnp.vdot has 3 different implementations based on input arrays dtype
+        # checking all of them
+        pytest.param("vdot", [3.0, 4.0, 5.0], [1.0, 2.0, 3.0]),
+        pytest.param("vdot", [3, 4, 5], [1, 2, 3]),
+        pytest.param("vdot", [3 + 2j, 4 + 1j, 5], [1, 2 + 3j, 3]),
     ],
 )
 @pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)


### PR DESCRIPTION
In this PR, `dpnp.vdot` is updated. 1) For integer and boolean data types, `dpctl.tensor.vecdot` form the Data Parallel Control library is used, 2) For real-valued floating point data types, `dot` routines from BLAS library of OneMKL are used, and 3) For complex data types, `dotc` routines from BLAS library of OneMKL are used.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
