### PR TITLE
Improve performance of `dpnp.matmul` and `dpnp.dot` with `out` keyword

### DIFF
--- a/dpnp/dpnp_iface.py
+++ b/dpnp/dpnp_iface.py
@@ -484,17 +484,20 @@ def get_result_array(a, out=None, casting="safe"):
     if out is None:
         return a
     else:
-        dpnp.check_supported_arrays_type(out)
-        if out.shape != a.shape:
-            raise ValueError(
-                f"Output array of shape {a.shape} is needed, got {out.shape}."
-            )
-        elif isinstance(out, dpt.usm_ndarray):
-            out = dpnp_array._create_from_usm_ndarray(out)
+        if a is out:
+            return out
+        else:
+            dpnp.check_supported_arrays_type(out)
+            if out.shape != a.shape:
+                raise ValueError(
+                    f"Output array of shape {a.shape} is needed, got {out.shape}."
+                )
+            elif isinstance(out, dpt.usm_ndarray):
+                out = dpnp_array._create_from_usm_ndarray(out)
 
-        dpnp.copyto(out, a, casting=casting)
+            dpnp.copyto(out, a, casting=casting)
 
-        return out
+            return out
 
 
 def get_usm_ndarray(a):

--- a/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
+++ b/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
@@ -48,7 +48,6 @@ def _create_result_array(x1, x2, out, shape, dtype, usm_type, sycl_queue):
     """
 
     if out is not None:
-        dpnp.check_supported_arrays_type(out)
         x1_usm = dpnp.get_usm_ndarray(x1)
         x2_usm = dpnp.get_usm_ndarray(x2)
         out_usm = dpnp.get_usm_ndarray(out)

--- a/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
+++ b/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
@@ -36,7 +36,7 @@ from dpnp.dpnp_utils import get_usm_allocations
 __all__ = ["dpnp_dot", "dpnp_matmul"]
 
 
-def _create_resul_array(x1, x2, out, shape, dtype, usm_type, sycl_queue):
+def _create_result_array(x1, x2, out, shape, dtype, usm_type, sycl_queue):
     """
     Create the result array.
 
@@ -248,7 +248,9 @@ def dpnp_dot(a, b, /, out=None):
         a, b, dtype=None, casting="no", sycl_queue=exec_q
     )
 
-    result = _create_resul_array(a, b, out, (), dot_dtype, res_usm_type, exec_q)
+    result = _create_result_array(
+        a, b, out, (), dot_dtype, res_usm_type, exec_q
+    )
     # input arrays should have the proper data type
     dep_events_list = []
     host_tasks_list = []
@@ -390,7 +392,7 @@ def dpnp_matmul(
         x2_shape = x2.shape
         res_shape = tuple(tmp_shape) + (x1_shape[-2], x2_shape[-1])
 
-    result = _create_resul_array(
+    result = _create_result_array(
         x1, x2, out, res_shape, gemm_dtype, res_usm_type, exec_q
     )
     # calculate result


### PR DESCRIPTION
In this PR, implementation of `dpnp.matmul` and `dpnp.dot` is updated to improve the performance when `out` keyword is present and its feature matches the appropriate shape, dtype, sycl_queue, and usm_type that is needed for performing the calculation in the corresponding OneMKL BLAS routines.

Sample timing including this update
```
>>> import dpnp
>>> a = dpnp.ones((21846, 3), device='cpu')
>>> b = dpnp.ones((21846, 3), device='cpu')
>>> c = dpnp.ones((21846, 21846), device='cpu')

>>> %timeit dpnp.matmul(a, b.T, c)
229 ms ± 22 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Sample timing excluding this update
```
>>> import dpnp
>>> a = dpnp.ones((21846, 3), device='cpu')
>>> b = dpnp.ones((21846, 3), device='cpu')
>>> c = dpnp.ones((21846, 21846), device='cpu')

>>> %timeit dpnp.matmul(a, b.T, c)
798 ms ± 30.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
