### PR TITLE
Fix ExecutionPlacementError for dpnp.take_along_axis

### DIFF
--- a/dpnp/dpnp_iface_indexing.py
+++ b/dpnp/dpnp_iface_indexing.py
@@ -111,7 +111,12 @@ def _build_along_axis_index(a, indices, axis):
         else:
             ind_shape = shape_ones[:dim] + (-1,) + shape_ones[dim + 1 :]
             fancy_index.append(
-                dpnp.arange(n, dtype=indices.dtype).reshape(ind_shape)
+                dpnp.arange(
+                    n,
+                    dtype=indices.dtype,
+                    usm_type=indices.usm_type,
+                    sycl_queue=indices.sycl_queue,
+                ).reshape(ind_shape)
             )
 
     return tuple(fancy_index)

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -1541,25 +1541,28 @@ def test_take(device):
     assert_sycl_queue_equal(result_queue, expected_queue)
 
 
-@pytest.mark.parametrize("axis", [None, 1], ids=["axis_None", "axis_1"])
+@pytest.mark.parametrize(
+    "data, ind, axis",
+    [
+        (numpy.arange(6), numpy.array([0, 2, 4]), None),
+        (
+            numpy.arange(6).reshape((2, 3)),
+            numpy.array([0, 1]).reshape((2, 1)),
+            1,
+        ),
+    ],
+)
 @pytest.mark.parametrize(
     "device",
     valid_devices,
     ids=[device.filter_string for device in valid_devices],
 )
-def test_take_along_axis(axis, device):
-    if axis is None:
-        np_data = numpy.arange(6)
-        np_ind = numpy.array([0, 2, 4])
-    else:  # create 2d array
-        np_data = numpy.arange(6).reshape((2, 3))
-        np_ind = numpy.array([0, 1]).reshape((2, 1))
-
-    dp_data = dpnp.array(np_data, device=device)
-    dp_ind = dpnp.array(np_ind, device=device)
+def test_take_along_axis(data, ind, axis, device):
+    dp_data = dpnp.array(data, device=device)
+    dp_ind = dpnp.array(ind, device=device)
 
     result = dpnp.take_along_axis(dp_data, dp_ind, axis=axis)
-    expected = numpy.take_along_axis(np_data, np_ind, axis=axis)
+    expected = numpy.take_along_axis(data, ind, axis=axis)
     assert_allclose(expected, result)
 
     expected_queue = dp_data.get_array().sycl_queue

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -570,6 +570,26 @@ def test_take(func, usm_type_x, usm_type_ind):
     assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_ind])
 
 
+@pytest.mark.parametrize("axis", [None, 1], ids=["axis_None", "axis_1"])
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize(
+    "usm_type_ind", list_of_usm_types, ids=list_of_usm_types
+)
+def test_take_along_axis(axis, usm_type_x, usm_type_ind):
+    if axis is None:
+        x = dp.arange(6, usm_type=usm_type_x)
+        ind = dp.array([0, 2, 4], usm_type=usm_type_ind)
+    else:  # create 2d array
+        x = dp.arange(6, usm_type=usm_type_x).reshape((2, 3))
+        ind = dp.array([0, 1], usm_type=usm_type_ind).reshape((2, 1))
+
+    z = dp.take_along_axis(x, ind, axis=axis)
+
+    assert x.usm_type == usm_type_x
+    assert ind.usm_type == usm_type_ind
+    assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_ind])
+
+
 @pytest.mark.parametrize(
     "data, is_empty",
     [

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -570,18 +570,24 @@ def test_take(func, usm_type_x, usm_type_ind):
     assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_ind])
 
 
-@pytest.mark.parametrize("axis", [None, 1], ids=["axis_None", "axis_1"])
+@pytest.mark.parametrize(
+    "data, ind, axis",
+    [
+        (numpy.arange(6), numpy.array([0, 2, 4]), None),
+        (
+            numpy.arange(6).reshape((2, 3)),
+            numpy.array([0, 1]).reshape((2, 1)),
+            1,
+        ),
+    ],
+)
 @pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
 @pytest.mark.parametrize(
     "usm_type_ind", list_of_usm_types, ids=list_of_usm_types
 )
-def test_take_along_axis(axis, usm_type_x, usm_type_ind):
-    if axis is None:
-        x = dp.arange(6, usm_type=usm_type_x)
-        ind = dp.array([0, 2, 4], usm_type=usm_type_ind)
-    else:  # create 2d array
-        x = dp.arange(6, usm_type=usm_type_x).reshape((2, 3))
-        ind = dp.array([0, 1], usm_type=usm_type_ind).reshape((2, 1))
+def test_take_along_axis(data, ind, axis, usm_type_x, usm_type_ind):
+    x = dp.array(data, usm_type=usm_type_x)
+    ind = dp.array(ind, usm_type=usm_type_ind)
 
     z = dp.take_along_axis(x, ind, axis=axis)
 


### PR DESCRIPTION
This PR solves the issue of raising `ExecutionPlacementError` when using `dpnp.take_along_axis()` with 2D arrays and `axis not None`
Filling `fancy_index` in `_build_along_axis_index` did not follow compute follows data and allocated dpnp index arrays on the device and queues by default. 
Also this case was not covered in the tests so I extended them. 


- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
