### PR TITLE
Add dpnp.linalg.pinv() implementation 

### DIFF
--- a/dpnp/linalg/dpnp_iface_linalg.py
+++ b/dpnp/linalg/dpnp_iface_linalg.py
@@ -51,6 +51,7 @@ from .dpnp_utils_linalg import (
     dpnp_det,
     dpnp_eigh,
     dpnp_inv,
+    dpnp_pinv,
     dpnp_slogdet,
     dpnp_solve,
     dpnp_svd,
@@ -68,6 +69,7 @@ __all__ = [
     "matrix_rank",
     "multi_dot",
     "norm",
+    "pinv",
     "qr",
     "solve",
     "svd",
@@ -471,6 +473,55 @@ def multi_dot(arrays, out=None):
         result = dpnp.dot(result, arrays[id])
 
     return result
+
+
+def pinv(a, rcond=1e-15, hermitian=False):
+    """
+    Compute the (Moore-Penrose) pseudo-inverse of a matrix.
+
+    Calculate the generalized inverse of a matrix using its
+    singular-value decomposition (SVD) and including all large singular values.
+
+    For full documentation refer to :obj:`numpy.linalg.inv`.
+
+    Parameters
+    ----------
+    a : (..., M, N) {dpnp.ndarray, usm_ndarray}
+        Matrix or stack of matrices to be pseudo-inverted.
+    rcond : float or dpnp.ndarray of float, optional
+        Cutoff for small singular values.
+        Singular values less than or equal to ``rcond * largest_singular_value``
+        are set to zero.
+        Default: ``1e-15``.
+    hermitian : bool, optional
+        If ``True``, a is assumed to be Hermitian (symmetric if real-valued),
+        enabling a more efficient method for finding singular values.
+        Default: ``False``.
+
+    Returns
+    -------
+    out : (..., N, M) dpnp.ndarray
+        The pseudo-inverse of a.
+
+    Examples
+    --------
+    The following example checks that ``a * a+ * a == a`` and
+    ``a+ * a * a+ == a+``:
+
+    >>> import dpnp as np
+    >>> a = np.random.randn(9, 6)
+    >>> B = np.linalg.pinv(a)
+    >>> np.allclose(a, np.dot(a, np.dot(B, a)))
+    array([ True])
+    >>> np.allclose(B, np.dot(B, np.dot(a, B)))
+    array([ True])
+
+    """
+
+    dpnp.check_supported_arrays_type(a)
+    check_stacked_2d(a)
+
+    return dpnp_pinv(a, rcond=rcond, hermitian=hermitian)
 
 
 def norm(x1, ord=None, axis=None, keepdims=False):

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -1632,3 +1632,45 @@ def test_slogdet(shape, is_empty, device):
 
     assert_sycl_queue_equal(sign_queue, dpnp_x.sycl_queue)
     assert_sycl_queue_equal(logdet_queue, dpnp_x.sycl_queue)
+
+
+@pytest.mark.parametrize(
+    "shape, hermitian",
+    [
+        ((4, 4), False),
+        ((2, 0), False),
+        ((4, 4), True),
+        ((2, 2, 3), False),
+        ((0, 2, 3), False),
+        ((1, 0, 3), False),
+    ],
+    ids=[
+        "(4, 4)",
+        "(2, 0)",
+        "(2, 2), hermitian)",
+        "(2, 2, 3)",
+        "(0, 2, 3)",
+        "(1, 0, 3)",
+    ],
+)
+@pytest.mark.parametrize(
+    "device",
+    valid_devices,
+    ids=[device.filter_string for device in valid_devices],
+)
+def test_pinv(shape, hermitian, device):
+    if hermitian:
+        a_np = numpy.random.randn(*shape) + 1j * numpy.random.randn(*shape)
+        a_np = numpy.conj(a_np.T) @ a_np
+    else:
+        a_np = numpy.random.randn(*shape)
+
+    a_dp = dpnp.array(a_np, device=device)
+
+    B_result = dpnp.linalg.pinv(a_dp, hermitian=hermitian)
+    B_expected = numpy.linalg.pinv(a_np, hermitian=hermitian)
+    assert_allclose(B_expected, B_result, rtol=1e-3, atol=1e-4)
+
+    B_queue = B_result.sycl_queue
+
+    assert_sycl_queue_equal(B_queue, a_dp.sycl_queue)

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -800,6 +800,39 @@ def test_svd(usm_type, shape, full_matrices_param, compute_uv_param):
 
 @pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
 @pytest.mark.parametrize(
+    "shape, hermitian",
+    [
+        ((4, 4), False),
+        ((2, 0), False),
+        ((4, 4), True),
+        ((2, 2, 3), False),
+        ((0, 2, 3), False),
+        ((1, 0, 3), False),
+    ],
+    ids=[
+        "(4, 4)",
+        "(2, 0)",
+        "(2, 2), hermitian)",
+        "(2, 2, 3)",
+        "(0, 2, 3)",
+        "(1, 0, 3)",
+    ],
+)
+def test_pinv(shape, hermitian, usm_type):
+    if hermitian:
+        a = dp.random.randn(*shape) + 1j * dp.random.randn(*shape)
+        a = dp.conj(a.T) @ a
+    else:
+        a = dp.random.randn(*shape)
+
+    a = dp.array(a, usm_type=usm_type)
+    B = dp.lialg.pinv(a, hermitian=hermitian)
+
+    assert a.usm_type == B.usm_type
+
+
+@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize(
     "shape",
     [
         (4, 4),
@@ -821,7 +854,7 @@ def test_svd(usm_type, shape, full_matrices_param, compute_uv_param):
     ["r", "raw", "complete", "reduced"],
     ids=["r", "raw", "complete", "reduced"],
 )
-def test_qr(shape, mode, usm_type):
+def test_pinv(shape, mode, usm_type):
     count_elems = numpy.prod(shape)
     a = dp.arange(count_elems, usm_type=usm_type).reshape(shape)
 


### PR DESCRIPTION
This PR adds a new `dpnp.linalg.pinv()` function to calculate the (Moore-Penrose) pseudo-inverse of input arrray using `dpnp.linalg.svd()` and `dpnp.matmul()`
The changes are related to support of all types and support of function arguments as `hermitian`


- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
