### PR TITLE
return a view for `dpnp.ndarray.real` and `dpnp.ndarray.imag`

### DIFF
--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -831,7 +831,9 @@ class dpnp_array:
         array([0.        , 0.70710677])
 
         """
-        return dpnp.imag(self)
+        return dpnp_array._create_from_usm_ndarray(
+            dpnp.get_usm_ndarray(self).imag
+        )
 
     @imag.setter
     def imag(self, value):
@@ -1042,7 +1044,9 @@ class dpnp_array:
         array([1.        , 0.70710677])
 
         """
-        return dpnp.real(self)
+        return dpnp_array._create_from_usm_ndarray(
+            dpnp.get_usm_ndarray(self).real
+        )
 
     @real.setter
     def real(self, value):

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -1044,9 +1044,12 @@ class dpnp_array:
         array([1.        , 0.70710677])
 
         """
-        return dpnp_array._create_from_usm_ndarray(
-            dpnp.get_usm_ndarray(self).real
-        )
+        if dpnp.issubsctype(self.dtype, dpnp.complexfloating):
+            return dpnp_array._create_from_usm_ndarray(
+                dpnp.get_usm_ndarray(self).real
+            )
+        else:
+            return self
 
     @real.setter
     def real(self, value):

--- a/tests/test_dparray.py
+++ b/tests/test_dparray.py
@@ -86,6 +86,23 @@ def test_flags_strides(dtype, order, strides):
     assert numpy_array.flags.f_contiguous == dpnp_array.flags.f_contiguous
 
 
+def test_flags_writable():
+    a = dpnp.arange(10, dtype="f4")
+    a.flags["W"] = False
+
+    a.shape = (5, 2)
+    assert not a.flags.writable
+    assert not a.T.flags.writable
+    assert not a.real.flags.writable
+    assert not a[0:3].flags.writable
+
+    a = dpnp.arange(10, dtype="c8")
+    a.flags["W"] = False
+
+    assert not a.real.flags.writable
+    assert not a.imag.flags.writable
+
+
 def test_print_dpnp_int():
     result = repr(dpnp.array([1, 0, 2, -3, -1, 2, 21, -9], dtype="i4"))
     expected = "array([ 1,  0,  2, -3, -1,  2, 21, -9], dtype=int32)"

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -945,13 +945,13 @@ class TestConj:
 
         assert_dtype_allclose(ia.conj(), a.conj())
 
-    @pytest.mark.parametrize("dtype", get_all_dtypes())
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
     def test_conj_out(self, dtype):
         a = numpy.array(numpy.random.uniform(-5, 5, 20), dtype=dtype)
         ia = dpnp.array(a)
 
         expected = numpy.conj(a)
-        dp_out = dpnp.empty(ia.shape, dtype=expected.dtype)
+        dp_out = dpnp.empty(ia.shape, dtype=dtype)
         result = dpnp.conj(ia, out=dp_out)
         assert dp_out is result
         assert_dtype_allclose(result, expected)

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -906,70 +906,141 @@ def test_signbit(data, dtype):
     assert_dtype_allclose(result, expected)
 
 
-@pytest.mark.parametrize(
-    "func",
-    ["real", "imag", "conj"],
-    ids=["real", "imag", "conj"],
-)
-@pytest.mark.parametrize(
-    "data",
-    [complex(-1, -4), complex(-1, 2), complex(3, -7), complex(4, 12)],
-    ids=[
-        "complex(-1, -4)",
-        "complex(-1, 2)",
-        "complex(3, -7)",
-        "complex(4, 12)",
-    ],
-)
-@pytest.mark.parametrize("dtype", get_complex_dtypes())
-def test_complex_funcs(func, data, dtype):
-    np_a = numpy.array(data, dtype=dtype)
-    dpnp_a = dpnp.array(data, dtype=dtype)
+class TestConj:
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
+    def test_conj(self, dtype):
+        a = numpy.array(numpy.random.uniform(-5, 5, 20), dtype=dtype)
+        ia = dpnp.array(a)
 
-    result = getattr(dpnp, func)(dpnp_a)
-    expected = getattr(numpy, func)(np_a)
-    assert_dtype_allclose(result, expected)
+        result = dpnp.conj(ia)
+        expected = numpy.conj(a)
+        assert_dtype_allclose(result, expected)
 
-    # out keyword
-    if func == "conj":
-        dp_out = dpnp.empty(expected.shape, dtype=expected.dtype)
-        result = getattr(dpnp, func)(dpnp_a, out=dp_out)
+    @pytest.mark.parametrize("dtype", get_complex_dtypes())
+    def test_conj_complex(self, dtype):
+        x1 = numpy.random.uniform(-5, 5, 20)
+        x2 = numpy.random.uniform(-5, 5, 20)
+        a = numpy.array(x1 + 1j * x2, dtype=dtype)
+        ia = dpnp.array(a)
+
+        result = dpnp.conj(ia)
+        expected = numpy.conj(a)
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
+    def test_conj_ndarray(self, dtype):
+        a = numpy.array(numpy.random.uniform(-5, 5, 20), dtype=dtype)
+        ia = dpnp.array(a)
+
+        result = ia.conj()
+        assert result is ia
+        assert_dtype_allclose(result, a.conj())
+
+    @pytest.mark.parametrize("dtype", get_complex_dtypes())
+    def test_conj_complex_ndarray(self, dtype):
+        x1 = numpy.random.uniform(-5, 5, 20)
+        x2 = numpy.random.uniform(-5, 5, 20)
+        a = numpy.array(x1 + 1j * x2, dtype=dtype)
+        ia = dpnp.array(a)
+
+        assert_dtype_allclose(ia.conj(), a.conj())
+
+    @pytest.mark.parametrize("dtype", get_all_dtypes())
+    def test_conj_out(self, dtype):
+        a = numpy.array(numpy.random.uniform(-5, 5, 20), dtype=dtype)
+        ia = dpnp.array(a)
+
+        expected = numpy.conj(a)
+        dp_out = dpnp.empty(ia.shape, dtype=expected.dtype)
+        result = dpnp.conj(ia, out=dp_out)
         assert dp_out is result
         assert_dtype_allclose(result, expected)
 
 
-@pytest.mark.parametrize("dtype", get_complex_dtypes())
-def test_projection_infinity(dtype):
-    X = [
-        complex(1, 2),
-        complex(dpnp.inf, -1),
-        complex(0, -dpnp.inf),
-        complex(-dpnp.inf, dpnp.nan),
-    ]
-    Y = [
-        complex(1, 2),
-        complex(dpnp.inf, -0.0),
-        complex(dpnp.inf, -0.0),
-        complex(dpnp.inf, 0.0),
-    ]
+class TestRealImag:
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
+    def test_real_imag(self, dtype):
+        a = numpy.array(numpy.random.uniform(-5, 5, 20), dtype=dtype)
+        ia = dpnp.array(a)
 
-    a = dpnp.array(X, dtype=dtype)
-    result = dpnp.proj(a)
-    expected = dpnp.array(Y, dtype=dtype)
-    assert_dtype_allclose(result, expected)
+        result = dpnp.real(ia)
+        assert result is ia
+        expected = numpy.real(a)
+        assert expected is a
+        assert_dtype_allclose(result, expected)
 
-    # out keyword
-    dp_out = dpnp.empty(expected.shape, dtype=expected.dtype)
-    result = dpnp.proj(a, out=dp_out)
-    assert dp_out is result
-    assert_dtype_allclose(result, expected)
+        result = dpnp.imag(ia)
+        expected = numpy.imag(a)
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_complex_dtypes())
+    def test_real_imag_complex(self, dtype):
+        x1 = numpy.random.uniform(-5, 5, 20)
+        x2 = numpy.random.uniform(-5, 5, 20)
+        a = numpy.array(x1 + 1j * x2, dtype=dtype)
+        ia = dpnp.array(a)
+
+        result = dpnp.real(ia)
+        expected = numpy.real(a)
+        assert_dtype_allclose(result, expected)
+
+        result = dpnp.imag(ia)
+        expected = numpy.imag(a)
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
+    def test_real_imag_ndarray(self, dtype):
+        a = numpy.array(numpy.random.uniform(-5, 5, 20), dtype=dtype)
+        ia = dpnp.array(a)
+
+        result = ia.real
+        assert result is ia
+        assert_dtype_allclose(result, a.real)
+        assert_dtype_allclose(ia.imag, a.imag)
+
+    @pytest.mark.parametrize("dtype", get_complex_dtypes())
+    def test_real_imag_complex_ndarray(self, dtype):
+        x1 = numpy.random.uniform(-5, 5, 20)
+        x2 = numpy.random.uniform(-5, 5, 20)
+        a = numpy.array(x1 + 1j * x2, dtype=dtype)
+        ia = dpnp.array(a)
+
+        assert_dtype_allclose(ia.real, a.real)
+        assert_dtype_allclose(ia.imag, a.imag)
 
 
-@pytest.mark.parametrize("dtype", get_all_dtypes())
-def test_projection(dtype):
-    result = dpnp.proj(dpnp.array(1, dtype=dtype))
-    expected = dpnp.array(complex(1, 0))
-    assert_allclose(result, expected)
+class TestProjection:
+    @pytest.mark.parametrize("dtype", get_complex_dtypes())
+    def test_projection_infinity(self, dtype):
+        X = [
+            complex(1, 2),
+            complex(dpnp.inf, -1),
+            complex(0, -dpnp.inf),
+            complex(-dpnp.inf, dpnp.nan),
+        ]
+        Y = [
+            complex(1, 2),
+            complex(dpnp.inf, -0.0),
+            complex(dpnp.inf, -0.0),
+            complex(dpnp.inf, 0.0),
+        ]
+
+        a = dpnp.array(X, dtype=dtype)
+        result = dpnp.proj(a)
+        expected = dpnp.array(Y, dtype=dtype)
+        assert_dtype_allclose(result, expected)
+
+        # out keyword
+        dp_out = dpnp.empty(expected.shape, dtype=expected.dtype)
+        result = dpnp.proj(a, out=dp_out)
+        assert dp_out is result
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_all_dtypes())
+    def test_projection(self, dtype):
+        result = dpnp.proj(dpnp.array(1, dtype=dtype))
+        expected = dpnp.array(complex(1, 0))
+        assert_allclose(result, expected)
 
 
 @pytest.mark.parametrize("val_type", get_all_dtypes(no_none=True))


### PR DESCRIPTION
In this PR, `dpnp.ndarray.real` and `dpnp.ndarray.imag` are modified to return a view of the input array using their `dpctl` counterpart. Note that `dpnp.real` and `dpnp.imag` return a copy consistent with `dpctl` behavior.
Also, new tests are added to check the correctness of writable flag in different scenarios, due to new changes in [dpctl #1527](https://github.com/IntelPython/dpctl/pull/1527).

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
