### PR TITLE
Pin conda-build to latest version (24.1.2)

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -13,6 +13,7 @@ env:
   MODULE_NAME: dpnp
   CHANNELS: '-c dppy/label/dev -c intel -c conda-forge --override-channels'
   CONDA_BUILD_VERSION: '24.1.2'
+  CONDA_INDEX_VERSION: '0.4.0'
   # TODO: to add test_arraymanipulation.py back to the scope once crash on Windows is gone
   TEST_SCOPE: >-
       test_arraycreation.py
@@ -172,12 +173,12 @@ jobs:
           miniconda-version: 'latest'
           activate-environment: 'test'
 
-      # Needed to be able to run conda index
-      - name: Install conda-build
-        run: conda install conda-build=${{ env.CONDA_BUILD_VERSION}}
+      - name: Install conda-index
+        run: conda install conda-index=${{ env.CONDA_INDEX_VERSION}}
 
       - name: Create conda channel
-        run: conda index ${{ env.channel-path }}
+        run: |
+          python -m conda_index ${{ env.channel-path }}
 
       - name: Test conda channel
         run: |
@@ -288,12 +289,13 @@ jobs:
           (echo CONDA_LIB_PATH=%CONDA_PREFIX%\Library\lib\) >> %GITHUB_ENV%
           (echo CONDA_LIB_BIN_PATH=%CONDA_PREFIX%\Library\bin\) >> %GITHUB_ENV%
 
-      # Needed to be able to run conda index
-      - name: Install conda-build
-        run: conda install conda-build=${{ env.CONDA_BUILD_VERSION}}
+      - name: Install conda-index
+        run: conda install conda-index=${{ env.CONDA_INDEX_VERSION}}
 
       - name: Create conda channel
-        run: conda index ${{ env.channel-path }}
+        run: |
+          @echo on
+          python -m conda_index ${{ env.channel-path }}
 
       - name: Test conda channel
         run: |

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -12,6 +12,7 @@ env:
   PACKAGE_NAME: dpnp
   MODULE_NAME: dpnp
   CHANNELS: '-c dppy/label/dev -c intel -c conda-forge --override-channels'
+  CONDA_BUILD_VERSION: '24.1.2'
   # TODO: to add test_arraymanipulation.py back to the scope once crash on Windows is gone
   TEST_SCOPE: >-
       test_arraycreation.py
@@ -102,7 +103,7 @@ jobs:
           (echo CONDA_BLD=%CONDA_PREFIX%\conda-bld\win-64\) >> %GITHUB_ENV%
 
       - name: Install conda-build
-        run: conda install conda-build=3.28.4
+        run: conda install conda-build=${{ env.CONDA_BUILD_VERSION}}
 
       - name: Cache conda packages
         uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
@@ -173,7 +174,7 @@ jobs:
 
       # Needed to be able to run conda index
       - name: Install conda-build
-        run: conda install conda-build=3.28.4
+        run: conda install conda-build=${{ env.CONDA_BUILD_VERSION}}
 
       - name: Create conda channel
         run: conda index ${{ env.channel-path }}
@@ -289,7 +290,7 @@ jobs:
 
       # Needed to be able to run conda index
       - name: Install conda-build
-        run: conda install conda-build=3.28.4
+        run: conda install conda-build=${{ env.CONDA_BUILD_VERSION}}
 
       - name: Create conda channel
         run: conda index ${{ env.channel-path }}


### PR DESCRIPTION
This PR removes pinning on previous version of `conda-build` introduced in #1678 and moves forward to the latest available version of `conda-build=24.1.2`, since it includes the fix now for `nonzero exitcode on success`.
Additionally PR enables `conda-index` package instead of deprecated one from `conda-build` package.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
