### PR TITLE
Merge `0.14.0` from master to gold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.14.0] - MM/DD/2024
+## [0.14.0] - 02/19/2024
 
 This release will require DPC++ `2024.1.0`, which no longer supports Intel Gen9 integrated GPUs found in Intel CPUs of 10th generation and older.
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set required_compiler_and_mkl_version = "2024.1" %}
-{% set required_dpctl_version = "0.16.0*" %}
+{% set required_dpctl_version = "0.16.0" %}
 
 package:
     name: dpnp


### PR DESCRIPTION
Merge the latest content from master branch to gold/2021 as part of `0.14.0` release tag.
The PR includes changes from:
- #1720 