### PR TITLE
Boolean subtract to raise TypeError exception

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Install dpnp dependencies
         run: |
-          conda install numpy"<1.24" dpctl">=0.16.0*" mkl-devel-dpcpp onedpl-devel tbb-devel dpcpp_linux-64"<2024.0.1" \
+          conda install numpy"<1.24" dpctl">=0.17.0dev0" mkl-devel-dpcpp onedpl-devel tbb-devel dpcpp_linux-64"<2024.0.1" \
               cmake cython pytest ninja scikit-build sysroot_linux-64">=2.28" ${{ env.CHANNELS }}
 
       - name: Install cuPy dependencies

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -50,7 +50,7 @@ jobs:
         run: |
           # use DPC++ compiler 2023.2 to work around an issue with crash
           conda install cython llvm cmake">=3.21" scikit-build ninja pytest pytest-cov coverage[toml] \
-              dpctl">=0.16.0*" dpcpp_linux-64"=2023.2" sysroot_linux-64">=2.28" mkl-devel-dpcpp tbb-devel"=2021.10" \
+              dpctl">=0.17.0dev0" dpcpp_linux-64"=2023.2" sysroot_linux-64">=2.28" mkl-devel-dpcpp tbb-devel"=2021.10" \
               onedpl-devel ${{ env.CHANNELS }}
 
       - name: Conda info

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set required_compiler_and_mkl_version = "2024.0" %}
 {% set excluded_compiler_version1 = "2024.0.1" %}
 {% set excluded_compiler_version2 = "2024.0.2" %}
-{% set required_dpctl_version = "0.16.0*" %}
+{% set required_dpctl_version = "0.16.0" %}
 
 package:
     name: dpnp

--- a/dpnp/dpnp_algo/dpnp_elementwise_common.py
+++ b/dpnp/dpnp_algo/dpnp_elementwise_common.py
@@ -2284,16 +2284,16 @@ negative_func = _make_unary_func("negative", dpt.negative, _negative_docstring)
 def dpnp_negative(x, out=None, order="K"):
     """Invokes negative() from dpctl.tensor implementation for negative() function."""
 
-    # TODO: discuss with dpctl if the check is needed to be moved there
+    # dpctl.tensor only works with usm_ndarray
+    x1_usm = dpnp.get_usm_ndarray(x)
+    out_usm = None if out is None else dpnp.get_usm_ndarray(out)
+
+    # TODO: discuss with dpctl if the check is needed to be moved out of there
     if not dpnp.isscalar(x) and x.dtype == dpnp.bool:
         raise TypeError(
             "DPNP boolean negative, the `-` operator, is not supported, "
             "use the `~` operator or the logical_not function instead."
         )
-
-    # dpctl.tensor only works with usm_ndarray
-    x1_usm = dpnp.get_usm_ndarray(x)
-    out_usm = None if out is None else dpnp.get_usm_ndarray(out)
 
     res_usm = negative_func(x1_usm, out=out_usm, order=order)
     return _get_result(res_usm, out=out)
@@ -2966,23 +2966,30 @@ def dpnp_subtract(x1, x2, out=None, order="K"):
     Invokes sub() function from pybind11 extension of OneMKL VM if possible.
 
     Otherwise fully relies on dpctl.tensor implementation for subtract() function.
-    """
 
-    # TODO: discuss with dpctl if the check is needed to be moved there
-    if (
-        not dpnp.isscalar(x1)
-        and not dpnp.isscalar(x2)
-        and x1.dtype == x2.dtype == dpnp.bool
-    ):
-        raise TypeError(
-            "DPNP boolean subtract, the `-` operator, is not supported, "
-            "use the bitwise_xor, the `^` operator, or the logical_xor function instead."
-        )
+    """
 
     # dpctl.tensor only works with usm_ndarray or scalar
     x1_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x1)
     x2_usm_or_scalar = dpnp.get_usm_ndarray_or_scalar(x2)
     out_usm = None if out is None else dpnp.get_usm_ndarray(out)
+
+    # TODO: discuss with dpctl if the check is needed to be moved out of there
+    boolean_subtract = False
+    if dpnp.isscalar(x1):
+        if isinstance(x1, bool) and x2.dtype == dpnp.bool:
+            boolean_subtract = True
+    elif dpnp.isscalar(x2):
+        if isinstance(x2, bool) and x1.dtype == dpnp.bool:
+            boolean_subtract = True
+    elif x1.dtype == x2.dtype == dpnp.bool:
+        boolean_subtract = True
+    
+    if boolean_subtract:
+        raise TypeError(
+            "DPNP boolean subtract, the `-` operator, is not supported, "
+            "use the bitwise_xor, the `^` operator, or the logical_xor function instead."
+        )
 
     res_usm = subtract_func(
         x1_usm_or_scalar, x2_usm_or_scalar, out=out_usm, order=order

--- a/dpnp/dpnp_algo/dpnp_elementwise_common.py
+++ b/dpnp/dpnp_algo/dpnp_elementwise_common.py
@@ -2984,7 +2984,7 @@ def dpnp_subtract(x1, x2, out=None, order="K"):
             boolean_subtract = True
     elif x1.dtype == x2.dtype == dpnp.bool:
         boolean_subtract = True
-    
+
     if boolean_subtract:
         raise TypeError(
             "DPNP boolean subtract, the `-` operator, is not supported, "


### PR DESCRIPTION
The PR is intended to adopt to the latest changes in dpctl#1554 where boolean subtract raises `ValueError` exception. While numpy raises `TypeError` exception for the same use cases.
This PR implements a temporary workaround to unblock the CI verification loop.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
