### PR TITLE
update `dpnp.inner` implementation

### DIFF
--- a/dpnp/dpnp_iface_linearalgebra.py
+++ b/dpnp/dpnp_iface_linearalgebra.py
@@ -45,7 +45,6 @@ import dpnp
 
 # pylint: disable=no-name-in-module
 from .dpnp_algo import (
-    dpnp_inner,
     dpnp_kron,
 )
 from .dpnp_utils import (
@@ -218,43 +217,89 @@ def einsum_path(*args, **kwargs):
     return call_origin(numpy.einsum_path, *args, **kwargs)
 
 
-def inner(x1, x2, **kwargs):
+def inner(a, b):
     """
     Returns the inner product of two arrays.
 
     For full documentation refer to :obj:`numpy.inner`.
 
-    Limitations
-    -----------
-    Parameters `x1` and `x2` are supported as :obj:`dpnp.ndarray`.
-    Keyword argument `kwargs` is currently unsupported.
-    Otherwise the functions will be executed sequentially on CPU.
+    Parameters
+    ----------
+    a : {dpnp.ndarray, usm_ndarray, scalar}
+        First input array. Both inputs `a` and `b` can not be scalars
+        at the same time.
+    b : {dpnp.ndarray, usm_ndarray, scalar}
+        Second input array. Both inputs `a` and `b` can not be scalars
+        at the same time.
+
+    Returns
+    -------
+    out : dpnp.ndarray
+        If `a` and `b` are both scalars or both 1-D arrays then a scalar is
+        returned; otherwise an array is returned.
+        ``out.shape = (*a.shape[:-1], *b.shape[:-1])``
 
     See Also
     --------
-    :obj:`dpnp.einsum` : Evaluates the Einstein summation convention
-                         on the operands.
-    :obj:`dpnp.dot` : Returns the dot product of two arrays.
-    :obj:`dpnp.tensordot` : Compute tensor dot product along specified axes.
-    Input array data types are limited by supported DPNP :ref:`Data types`.
+    :obj:`dpnp.einsum` : Einstein summation convention..
+    :obj:`dpnp.dot` : Generalised matrix product,
+                      using second last dimension of `b`.
+    :obj:`dpnp.tensordot` : Sum products over arbitrary axes.
 
     Examples
     --------
+    # Ordinary inner product for vectors
+
     >>> import dpnp as np
-    >>> a = np.array([1,2,3])
+    >>> a = np.array([1, 2, 3])
     >>> b = np.array([0, 1, 0])
-    >>> result = np.inner(a, b)
-    >>> [x for x in result]
-    [2]
+    >>> np.inner(a, b)
+    array(2)
+
+    # Some multidimensional examples
+
+    >>> a = np.arange(24).reshape((2,3,4))
+    >>> b = np.arange(4)
+    >>> c = np.inner(a, b)
+    >>> c.shape
+    (2, 3)
+    >>> c
+    array([[ 14,  38,  62],
+           [86, 110, 134]])
+
+    >>> a = np.arange(2).reshape((1,1,2))
+    >>> b = np.arange(6).reshape((3,2))
+    >>> c = np.inner(a, b)
+    >>> c.shape
+    (1, 1, 3)
+    >>> c
+    array([[[1, 3, 5]]])
+
+    An example where `b` is a scalar
+
+    >>> np.inner(np.eye(2), 7)
+    array([[7., 0.],
+           [0., 7.]])
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
-    x2_desc = dpnp.get_dpnp_descriptor(x2, copy_when_nondefault_queue=False)
-    if x1_desc and x2_desc and not kwargs:
-        return dpnp_inner(x1_desc, x2_desc).get_pyobj()
+    dpnp.check_supported_arrays_type(a, b, scalar_type=True)
 
-    return call_origin(numpy.inner, x1, x2, **kwargs)
+    if dpnp.isscalar(a) or dpnp.isscalar(b):
+        return dpnp.multiply(a, b)
+
+    if a.ndim == 0 or b.ndim == 0:
+        return dpnp.multiply(a, b)
+
+    if a.shape[-1] != b.shape[-1]:
+        raise ValueError(
+            "shape of input arrays is not similar at the last axis."
+        )
+
+    if a.ndim == 1 and b.ndim == 1:
+        return dpnp_dot(a, b)
+
+    return dpnp.tensordot(a, b, axes=(-1, -1))
 
 
 def kron(x1, x2):
@@ -567,10 +612,19 @@ def tensordot(a, b, axes=2):
 
     dpnp.check_supported_arrays_type(a, b, scalar_type=True)
 
-    if dpnp.isscalar(a):
-        a = dpnp.array(a, sycl_queue=b.sycl_queue, usm_type=b.usm_type)
-    elif dpnp.isscalar(b):
-        b = dpnp.array(b, sycl_queue=a.sycl_queue, usm_type=a.usm_type)
+    if dpnp.isscalar(a) or dpnp.isscalar(b):
+        if axes > 0:
+            raise ValueError("One of the inputs is scalar axes should be zero.")
+        return dpnp.multiply(a, b)
+
+    if a.ndim == 0 or b.ndim == 0:
+        if (isinstance(axes, int) and axes > 0) or (
+            isinstance(axes, tuple) and axes != ((), ())
+        ):
+            raise ValueError(
+                "One of the inputs is zero-dimensional axes should be zero."
+            )
+        return dpnp.multiply(a, b)
 
     try:
         iter(axes)
@@ -590,6 +644,12 @@ def tensordot(a, b, axes=2):
         if len(axes_a) != len(axes_b):
             raise ValueError("Axes length mismatch.")
 
+    # Make the axes non-negative
+    a_ndim = a.ndim
+    b_ndim = b.ndim
+    axes_a = normalize_axis_tuple(axes_a, a_ndim, "axis_a")
+    axes_b = normalize_axis_tuple(axes_b, b_ndim, "axis_b")
+
     a_shape = a.shape
     b_shape = b.shape
     for axis_a, axis_b in zip(axes_a, axes_b):
@@ -597,12 +657,6 @@ def tensordot(a, b, axes=2):
             raise ValueError(
                 "shape of input arrays is not similar at requested axes."
             )
-
-    # Make the axes non-negative
-    a_ndim = a.ndim
-    b_ndim = b.ndim
-    axes_a = normalize_axis_tuple(axes_a, a_ndim, "axis")
-    axes_b = normalize_axis_tuple(axes_b, b_ndim, "axis")
 
     # Move the axes to sum over, to the end of "a"
     notin = tuple(k for k in range(a_ndim) if k not in axes_a)

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -770,6 +770,10 @@ def cross(a, b, axisa=-1, axisb=-1, axisc=-1, axis=None):
             raise TypeError(f"axis should be an integer but got, {type(axis)}.")
         axisa, axisb, axisc = (axis,) * 3
     dpnp.check_supported_arrays_type(a, b)
+    if a.dtype == dpnp.bool and b.dtype == dpnp.bool:
+        raise TypeError(
+            "Input arrays with boolean data type are not supported."
+        )
     # Check axisa and axisb are within bounds
     axisa = normalize_axis_index(axisa, a.ndim, msg_prefix="axisa")
     axisb = normalize_axis_index(axisb, b.ndim, msg_prefix="axisb")

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -111,9 +111,11 @@ class TestCross:
         expected = numpy.cross(a, b, axis=axis)
         assert_dtype_allclose(result, expected)
 
-    @pytest.mark.parametrize("dtype1", get_all_dtypes(no_bool=True))
-    @pytest.mark.parametrize("dtype2", get_all_dtypes(no_bool=True))
+    @pytest.mark.parametrize("dtype1", get_all_dtypes())
+    @pytest.mark.parametrize("dtype2", get_all_dtypes())
     def test_cross_input_dtype_matrix(self, dtype1, dtype2):
+        if dtype1 == dpnp.bool and dtype2 == dpnp.bool:
+            pytest.skip("boolean input arrays is not supported.")
         a = numpy.array(numpy.random.uniform(-5, 5, 3), dtype=dtype1)
         b = numpy.array(numpy.random.uniform(-5, 5, 3), dtype=dtype2)
         ia = dpnp.array(a)
@@ -192,6 +194,11 @@ class TestCross:
         with pytest.raises(TypeError):
             dpnp.cross(a, b, axis=0.0)
 
+        a = dpnp.arange(2, dtype=dpnp.bool)
+        # Input arrays with boolean data type are not supported
+        with pytest.raises(TypeError):
+            dpnp.cross(a, a)
+
 
 class TestDot:
     def setup_method(self):
@@ -230,6 +237,10 @@ class TestDot:
 
         result = dpnp.dot(a, ib)
         expected = numpy.dot(a, b)
+        assert_allclose(result, expected)
+
+        result = dpnp.dot(ib, a)
+        expected = numpy.dot(b, a)
         assert_allclose(result, expected)
 
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
@@ -532,6 +543,123 @@ class TestDot:
                 numpy.dot(a, b, out=np_out)
 
 
+class TestInner:
+    def setup_method(self):
+        numpy.random.seed(42)
+
+    @pytest.mark.parametrize("dtype", get_all_dtypes())
+    def test_inner_scalar(self, dtype):
+        a = 2
+        b = numpy.array(numpy.random.uniform(-5, 5, 10), dtype=dtype)
+        ib = dpnp.array(b)
+
+        result = dpnp.inner(a, ib)
+        expected = numpy.inner(a, b)
+        if dtype in [numpy.int32, numpy.float32, numpy.complex64]:
+            assert_dtype_allclose(result, expected, check_only_type_kind=True)
+        else:
+            assert_dtype_allclose(result, expected)
+
+        result = dpnp.inner(ib, a)
+        expected = numpy.inner(b, a)
+        if dtype in [numpy.int32, numpy.float32, numpy.complex64]:
+            assert_dtype_allclose(result, expected, check_only_type_kind=True)
+        else:
+            assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
+    @pytest.mark.parametrize(
+        "shape1, shape2",
+        [
+            ((5,), (5,)),
+            ((3, 5), (3, 5)),
+            ((2, 4, 3, 5), (2, 4, 3, 5)),
+            ((), (3, 4)),
+            ((5,), ()),
+        ],
+    )
+    def test_inner(self, dtype, shape1, shape2):
+        size1 = numpy.prod(shape1, dtype=int)
+        size2 = numpy.prod(shape2, dtype=int)
+        a = numpy.array(
+            numpy.random.uniform(-5, 5, size1), dtype=dtype
+        ).reshape(shape1)
+        b = numpy.array(
+            numpy.random.uniform(-5, 5, size2), dtype=dtype
+        ).reshape(shape2)
+        ia = dpnp.array(a)
+        ib = dpnp.array(b)
+
+        result = dpnp.inner(ia, ib)
+        expected = numpy.inner(a, b)
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_complex_dtypes())
+    @pytest.mark.parametrize(
+        "shape1, shape2",
+        [
+            ((5,), (5,)),
+            ((3, 5), (3, 5)),
+            ((2, 4, 3, 5), (2, 4, 3, 5)),
+            ((), (3, 4)),
+            ((5,), ()),
+        ],
+    )
+    def test_inner_complex(self, dtype, shape1, shape2):
+        size1 = numpy.prod(shape1, dtype=int)
+        size2 = numpy.prod(shape2, dtype=int)
+        x11 = numpy.random.uniform(-5, 5, size1)
+        x12 = numpy.random.uniform(-5, 5, size1)
+        x21 = numpy.random.uniform(-5, 5, size2)
+        x22 = numpy.random.uniform(-5, 5, size2)
+        a = numpy.array(x11 + 1j * x12, dtype=dtype).reshape(shape1)
+        b = numpy.array(x21 + 1j * x22, dtype=dtype).reshape(shape2)
+        ia = dpnp.array(a)
+        ib = dpnp.array(b)
+
+        result = dpnp.inner(ia, ib)
+        expected = numpy.inner(a, b)
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype1", get_all_dtypes())
+    @pytest.mark.parametrize("dtype2", get_all_dtypes())
+    def test_inner_input_dtype_matrix(self, dtype1, dtype2):
+        a = numpy.array(numpy.random.uniform(-5, 5, 10), dtype=dtype1)
+        b = numpy.array(numpy.random.uniform(-5, 5, 10), dtype=dtype2)
+        ia = dpnp.array(a)
+        ib = dpnp.array(b)
+
+        result = dpnp.inner(ia, ib)
+        expected = numpy.inner(a, b)
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
+    def test_inner_strided(self, dtype):
+        a = numpy.arange(20, dtype=dtype)
+        b = numpy.arange(20, dtype=dtype)
+        ia = dpnp.array(a)
+        ib = dpnp.array(b)
+
+        result = dpnp.inner(ia[::3], ib[::3])
+        expected = numpy.inner(a[::3], b[::3])
+        assert_dtype_allclose(result, expected)
+
+        result = dpnp.inner(ia, ib[::-1])
+        expected = numpy.inner(a, b[::-1])
+        assert_dtype_allclose(result, expected)
+
+        result = dpnp.inner(ia[::-4], ib[::-4])
+        expected = numpy.inner(a[::-4], b[::-4])
+        assert_dtype_allclose(result, expected)
+
+    def test_inner_error(self):
+        a = dpnp.arange(24)
+        b = dpnp.arange(23)
+        # shape of input arrays is not similar at the last axis
+        with pytest.raises(ValueError):
+            dpnp.inner(a, b)
+
+
 @pytest.mark.parametrize("type", get_all_dtypes(no_bool=True, no_complex=True))
 def test_multi_dot(type):
     n = 16
@@ -693,6 +821,14 @@ class TestTensordot:
         # out of range index
         with pytest.raises(IndexError):
             dpnp.tensordot(a, b, axes=([0, 3], [2, 0]))
+
+        # incorrect axes for scalar
+        with pytest.raises(ValueError):
+            dpnp.tensordot(dpnp.arange(4), 5, axes=1)
+
+        # incorrect axes for 0d arrays
+        with pytest.raises(ValueError):
+            dpnp.tensordot(dpnp.arange(4), dpnp.array(5), axes=1)
 
 
 class TestVdot:

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -550,6 +550,7 @@ def test_reduce_hypot(device):
         pytest.param(
             "hypot", [[1.0, 2.0, 3.0, 4.0]], [[-1.0, -2.0, -4.0, -5.0]]
         ),
+        pytest.param("inner", [1.0, 2.0, 3.0], [4.0, 5.0, 6.0]),
         pytest.param("logaddexp", [[-1, 2, 5, 9]], [[4, -3, 2, -8]]),
         pytest.param(
             "matmul", [[1.0, 0.0], [0.0, 1.0]], [[4.0, 1.0], [1.0, 2.0]]

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -503,6 +503,7 @@ def test_1in_1out(func, data, usm_type):
         pytest.param(
             "hypot", [[1.0, 2.0, 3.0, 4.0]], [[-1.0, -2.0, -4.0, -5.0]]
         ),
+        pytest.param("inner", [1.0, 2.0, 3.0], [4.0, 5.0, 6.0]),
         pytest.param("logaddexp", [[-1, 2, 5, 9]], [[4, -3, 2, -8]]),
         pytest.param("maximum", [[0.0, 1.0, 2.0]], [[3.0, 4.0, 5.0]]),
         pytest.param("minimum", [[0.0, 1.0, 2.0]], [[3.0, 4.0, 5.0]]),

--- a/tests/third_party/cupy/linalg_tests/test_product.py
+++ b/tests/third_party/cupy/linalg_tests/test_product.py
@@ -235,7 +235,6 @@ class TestProduct:
         b = testing.shaped_arange((2, 2, 2, 3), xp, dtype).transpose(1, 3, 0, 2)
         return xp.vdot(a, b)
 
-    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_inner(self, xp, dtype):
@@ -243,7 +242,6 @@ class TestProduct:
         b = testing.shaped_reverse_arange((5,), xp, dtype)
         return xp.inner(a, b)
 
-    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_reversed_inner(self, xp, dtype):
@@ -251,7 +249,6 @@ class TestProduct:
         b = testing.shaped_reverse_arange((5,), xp, dtype)[::-1]
         return xp.inner(a, b)
 
-    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_multidim_inner(self, xp, dtype):


### PR DESCRIPTION
In this PR, `dpnp.inner` is updated using existing functions in `dpnp`.

`dpnp.cross` is updated to raise an error when both inputs are boolean.

`dpnp.tensordot` is updated to directly call `dpnp.multiply` when one of the inputs is scalar or 0-dimensional.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
