### PR TITLE
Implemented dpnp.frombuffer, dpnp.fromfile and dpnp.fromstring

### DIFF
--- a/tests/test_arraycreation.py
+++ b/tests/test_arraycreation.py
@@ -52,6 +52,7 @@ def test_exception_order(func, args):
         pytest.param("asfortranarray", [2]),
         pytest.param("empty", [(2,)]),
         pytest.param("eye", [2]),
+        pytest.param("frombuffer", [b"\x01\x02\x03\x04"]),
         pytest.param("full", [(2,), 4]),
         pytest.param("identity", [2]),
         pytest.param("ones", [(2,)]),
@@ -208,21 +209,14 @@ def test_eye(N, M, k, dtype, order):
     assert_array_equal(func(numpy), func(dpnp))
 
 
-@pytest.mark.usefixtures("allow_fall_back_on_numpy")
-@pytest.mark.parametrize(
-    "dtype",
-    get_all_dtypes(
-        no_float16=False, no_none=False if has_support_aspect64() else True
-    ),
-)
+@pytest.mark.parametrize("dtype", get_all_dtypes(no_float16=False))
 def test_frombuffer(dtype):
     buffer = b"12345678ABCDEF00"
     func = lambda xp: xp.frombuffer(buffer, dtype=dtype)
-    assert_allclose(func(dpnp), func(numpy))
+    assert_dtype_allclose(func(dpnp), func(numpy))
 
 
-@pytest.mark.usefixtures("allow_fall_back_on_numpy")
-@pytest.mark.parametrize("dtype", get_all_dtypes())
+@pytest.mark.parametrize("dtype", get_all_dtypes(no_float16=False))
 def test_fromfile(dtype):
     with tempfile.TemporaryFile() as fh:
         fh.write(b"\x00\x01\x02\x03\x04\x05\x06\x07\x08")
@@ -236,7 +230,7 @@ def test_fromfile(dtype):
         fh.seek(0)
         dpnp_res = func(dpnp)
 
-        assert_almost_equal(dpnp_res, np_res)
+    assert_dtype_allclose(dpnp_res, np_res)
 
 
 @pytest.mark.usefixtures("allow_fall_back_on_numpy")
@@ -260,7 +254,6 @@ def test_fromiter(dtype):
     assert_array_equal(func(dpnp), func(numpy))
 
 
-@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_float16=False))
 def test_fromstring(dtype):
     string = "1 2 3 4"

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -1,3 +1,5 @@
+import tempfile
+
 import dpctl
 import dpctl.tensor as dpt
 import numpy
@@ -83,6 +85,10 @@ def vvsort(val, vec, size, xp):
     "func, arg, kwargs",
     [
         pytest.param("arange", [-25.7], {"stop": 10**8, "step": 15}),
+        pytest.param(
+            "frombuffer", [b"\x01\x02\x03\x04"], {"dtype": dpnp.int32}
+        ),
+        pytest.param("fromstring", ["1, 2"], {"dtype": int, "sep": " "}),
         pytest.param("full", [(2, 2)], {"fill_value": 5}),
         pytest.param("eye", [4, 2], {}),
         pytest.param("geomspace", [1, 4, 8], {}),
@@ -104,7 +110,9 @@ def test_array_creation(func, arg, kwargs, device):
     dpnp_kwargs["device"] = device
     dpnp_array = getattr(dpnp, func)(*arg, **dpnp_kwargs)
 
-    numpy_array = getattr(numpy, func)(*arg, dtype=dpnp_array.dtype, **kwargs)
+    numpy_kwargs = dict(kwargs)
+    numpy_kwargs["dtype"] = dpnp_array.dtype
+    numpy_array = getattr(numpy, func)(*arg, **numpy_kwargs)
 
     assert_dtype_allclose(dpnp_array, numpy_array)
     assert dpnp_array.sycl_device == device
@@ -309,6 +317,26 @@ def test_array_creation_cross_device_2d_array(
     assert_allclose(y_orig, y)
 
     assert_sycl_queue_equal(y.sycl_queue, x.to_device(device_y).sycl_queue)
+
+
+@pytest.mark.parametrize(
+    "device",
+    valid_devices,
+    ids=[device.filter_string for device in valid_devices],
+)
+def test_array_creation_from_file(device):
+    with tempfile.TemporaryFile() as fh:
+        fh.write(b"\x00\x01\x02\x03\x04\x05\x06\x07\x08")
+        fh.flush()
+
+        fh.seek(0)
+        numpy_array = numpy.fromfile(fh)
+
+        fh.seek(0)
+        dpnp_array = dpnp.fromfile(fh, device=device)
+
+    assert_dtype_allclose(dpnp_array, numpy_array)
+    assert dpnp_array.sycl_device == device
 
 
 @pytest.mark.parametrize(

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -1,10 +1,10 @@
+import tempfile
 from math import prod
 
 import dpctl.tensor as dpt
 import dpctl.utils as du
 import numpy
 import pytest
-from numpy.testing import assert_allclose
 
 import dpnp as dp
 
@@ -193,6 +193,8 @@ def test_array_creation_from_2d_array(func, args, usm_type_x, usm_type_y):
     "func, arg, kwargs",
     [
         pytest.param("arange", [-25.7], {"stop": 10**8, "step": 15}),
+        pytest.param("frombuffer", [b"\x01\x02\x03\x04"], {"dtype": dp.int32}),
+        pytest.param("fromstring", ["1, 2"], {"dtype": int, "sep": " "}),
         pytest.param("full", [(2, 2)], {"fill_value": 5}),
         pytest.param("eye", [4, 2], {}),
         pytest.param("geomspace", [1, 4, 8], {}),
@@ -209,12 +211,30 @@ def test_array_creation_from_scratch(func, arg, kwargs, usm_type):
     dpnp_kwargs = dict(kwargs)
     dpnp_kwargs["usm_type"] = usm_type
     dpnp_array = getattr(dp, func)(*arg, **dpnp_kwargs)
-    numpy_array = getattr(numpy, func)(*arg, dtype=dpnp_array.dtype, **kwargs)
 
-    tol = 1e-06
-    assert_allclose(dpnp_array, numpy_array, rtol=tol, atol=tol)
-    assert dpnp_array.shape == numpy_array.shape
+    numpy_kwargs = dict(kwargs)
+    numpy_kwargs["dtype"] = dpnp_array.dtype
+    numpy_array = getattr(numpy, func)(*arg, **numpy_kwargs)
+
     assert_dtype_allclose(dpnp_array, numpy_array)
+    assert dpnp_array.shape == numpy_array.shape
+    assert dpnp_array.usm_type == usm_type
+
+
+@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+def test_array_creation_from_file(usm_type):
+    with tempfile.TemporaryFile() as fh:
+        fh.write(b"\x00\x01\x02\x03\x04\x05\x06\x07\x08")
+        fh.flush()
+
+        fh.seek(0)
+        numpy_array = numpy.fromfile(fh)
+
+        fh.seek(0)
+        dpnp_array = dp.fromfile(fh, usm_type=usm_type)
+
+    assert_dtype_allclose(dpnp_array, numpy_array)
+    assert dpnp_array.shape == numpy_array.shape
     assert dpnp_array.usm_type == usm_type
 
 

--- a/tests/third_party/cupy/creation_tests/test_from_data.py
+++ b/tests/third_party/cupy/creation_tests/test_from_data.py
@@ -543,7 +543,6 @@ class TestFromData(unittest.TestCase):
         a = xp.ones((), dtype=dtype_a)
         return xp.asfortranarray(a, dtype=dtype_b)
 
-    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_fromfile(self, xp):
         with tempfile.TemporaryFile() as fh:
@@ -566,12 +565,10 @@ class TestFromData(unittest.TestCase):
         iterable = (x * x for x in range(5))
         return xp.fromiter(iterable, float)
 
-    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_fromstring(self, xp):
         return xp.fromstring("1 2", dtype=int, sep=" ")
 
-    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.numpy_cupy_array_equal()
     def test_frombuffer(self, xp):
         return xp.frombuffer(b"\x01\x02", dtype=numpy.uint8)


### PR DESCRIPTION
This PR adds compute follows data keywords to `dpnp.frombuffer`, `dpnp.fromfile` and `dpnp.fromstring` functions.
The implementation relies on appropriate NumPy functions where the result is coerced to a DPNP array through `dpnp.asarray` call with device aware keywords passed.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
