### PR TITLE
Replace use of queue mgr

### DIFF
--- a/doc/dpctl.rst
+++ b/doc/dpctl.rst
@@ -26,7 +26,7 @@ easily combined with the device management interface provided by dpctl package.
       # locate argument where function attains global maximum
       max_arg = x[dpnp.argmax(f)]
       max_val = dpnp.max(f)
-      
+
 
 For more information please refer to `Data Parallel Control Library`_
 documentation.

--- a/doc/dpctl.rst
+++ b/doc/dpctl.rst
@@ -10,20 +10,23 @@ Interplay with the Data Parallel Control Library
 An example below demonstrates how the Data Parallel Extension for NumPy* can be
 easily combined with the device management interface provided by dpctl package.
 
-Literally, the SYCL* queue manager interface from the dpctl package allows
-to set an input queue as the currently usable queue inside the context
-manager's scope. This way an array creation function from the dpnp package
-which is defined inside the context will allocate the data using that queue.
-
 .. code-block:: python
   :linenos:
 
-  import dpctl
-  import dpnp as np
+      import dpctl
+      import dpnp
 
-  with dpctl.device_context("opencl:gpu"):
-      x = np.array([1, 2, 3])
-      s = np.sum(x)
+      d = dpctl.select_cpu_device()
+      x = dpnp.array([1, 2, 3], device=d)
+      s = dpnp.sum(x)
+
+      y = dpnp.linspace(0, dpnp.pi, num=10**6, device="gpu")
+      f = 1 + y * dpnp.sin(y)
+
+      # locate argument where function attains global maximum
+      max_arg = x[dpnp.argmax(f)]
+      max_val = dpnp.max(f)
+      
 
 For more information please refer to `Data Parallel Control Library`_
 documentation.

--- a/dpnp/backend/examples/example10.cpp
+++ b/dpnp/backend/examples/example10.cpp
@@ -50,8 +50,6 @@ void test_dpnp_random_normal(const size_t size,
     double dev_time_used = 0.0;
     double sum_dev_time_used = 0.0;
 
-    dpnp_queue_initialize_c(QueueOptions::GPU_SELECTOR);
-
     double *result = (double *)dpnp_memory_alloc_c(size * sizeof(double));
 
     dpnp_rng_srand_c(seed); // TODO: will move

--- a/dpnp/backend/examples/example3.cpp
+++ b/dpnp/backend/examples/example3.cpp
@@ -44,7 +44,6 @@ int main(int, char **)
 {
     const size_t size = 256;
 
-    dpnp_queue_initialize_c();
     std::cout << "SYCL queue is CPU: " << dpnp_queue_is_cpu_c() << std::endl;
 
     int *array1 = (int *)dpnp_memory_alloc_c(size * sizeof(int));

--- a/dpnp/backend/examples/example5.cpp
+++ b/dpnp/backend/examples/example5.cpp
@@ -52,8 +52,6 @@ int main(int, char **)
 {
     const size_t size = 256;
 
-    dpnp_queue_initialize_c(QueueOptions::CPU_SELECTOR);
-
     double *result = (double *)dpnp_memory_alloc_c(size * sizeof(double));
 
     size_t seed = 10;

--- a/dpnp/backend/examples/example7.cpp
+++ b/dpnp/backend/examples/example7.cpp
@@ -45,8 +45,6 @@ int main(int, char **)
     const size_t size = 2;
     size_t len = size * size;
 
-    dpnp_queue_initialize_c(QueueOptions::CPU_SELECTOR);
-
     float *array = (float *)dpnp_memory_alloc_c(len * sizeof(float));
     float *result1 = (float *)dpnp_memory_alloc_c(size * sizeof(float));
     float *result2 = (float *)dpnp_memory_alloc_c(len * sizeof(float));

--- a/dpnp/backend/examples/example8.cpp
+++ b/dpnp/backend/examples/example8.cpp
@@ -42,8 +42,6 @@ int main(int, char **)
 {
     const size_t size = 16;
 
-    dpnp_queue_initialize_c(QueueOptions::GPU_SELECTOR);
-
     double *array = (double *)dpnp_memory_alloc_c(size * sizeof(double));
     long *result = (long *)dpnp_memory_alloc_c(size * sizeof(long));
 

--- a/dpnp/backend/examples/example9.cpp
+++ b/dpnp/backend/examples/example9.cpp
@@ -46,8 +46,6 @@ int main(int, char **)
     long result = 0;
     long result_verification = 0;
 
-    dpnp_queue_initialize_c(QueueOptions::CPU_SELECTOR);
-
     long *array =
         reinterpret_cast<long *>(dpnp_memory_alloc_c(size * sizeof(long)));
 

--- a/dpnp/backend/examples/example_bs.cpp
+++ b/dpnp/backend/examples/example_bs.cpp
@@ -229,7 +229,6 @@ int main(int, char **)
     const double RISK_FREE = 0.1;
     const double VOLATILITY = 0.2;
 
-    dpnp_queue_initialize_c(QueueOptions::GPU_SELECTOR);
     std::cout << "SYCL queue is CPU: " << dpnp_queue_is_cpu_c() << std::endl;
 
     double *price = (double *)dpnp_memory_alloc_c(SIZE * sizeof(double));

--- a/dpnp/backend/include/dpnp_iface.hpp
+++ b/dpnp/backend/include/dpnp_iface.hpp
@@ -68,32 +68,6 @@ typedef ssize_t shape_elem_type;
  * @}
  */
 
-/**
- * @ingroup BACKEND_API
- * @brief SYCL queue initialization selector.
- *
- * The structure defines the parameters that are used for the library
- * initialization by @ref dpnp_queue_initialize_c "dpnp_queue_initialize".
- */
-enum class QueueOptions : uint32_t
-{
-    CPU_SELECTOR, /**< CPU side execution mode */
-    GPU_SELECTOR, /**< Intel GPU side execution mode */
-    AUTO_SELECTOR /**< Automatic selection based on environment variable with
-                     @ref CPU_SELECTOR default */
-};
-
-/**
- * @ingroup BACKEND_API
- * @brief SYCL queue initialization.
- *
- * Global SYCL queue initialization.
- *
- * @param [in]  selector       Select type @ref QueueOptions of the SYCL queue.
- * Default @ref AUTO_SELECTOR
- */
-INP_DLLEXPORT void dpnp_queue_initialize_c(
-    QueueOptions selector = QueueOptions::AUTO_SELECTOR);
 
 /**
  * @ingroup BACKEND_API
@@ -112,8 +86,7 @@ INP_DLLEXPORT size_t dpnp_queue_is_cpu_c();
  * @param [in]  size_in_bytes  Number of bytes for requested memory allocation.
  * @param [in]  q_ref          Reference to SYCL queue.
  *
- * @return  A pointer to newly created memory on @ref dpnp_queue_initialize_c
- * "initialized SYCL device".
+ * @return  A pointer to newly created memory on SYCL device.
  */
 INP_DLLEXPORT char *dpnp_memory_alloc_c(DPCTLSyclQueueRef q_ref,
                                         size_t size_in_bytes);

--- a/dpnp/backend/include/dpnp_iface.hpp
+++ b/dpnp/backend/include/dpnp_iface.hpp
@@ -68,7 +68,6 @@ typedef ssize_t shape_elem_type;
  * @}
  */
 
-
 /**
  * @ingroup BACKEND_API
  * @brief SYCL queue device status.

--- a/dpnp/backend/kernels/dpnp_krnl_random.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_random.cpp
@@ -70,7 +70,7 @@ static VSLStreamStatePtr get_rng_stream()
 
 void dpnp_rng_srand_c(size_t seed)
 {
-    auto &be = backend_sycl_singleton::get();
+    auto &be = backend_sycl::get();
     be.set_rng_engines_seed(seed);
     set_rng_stream(seed);
 }

--- a/dpnp/backend/kernels/dpnp_krnl_random.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_random.cpp
@@ -70,7 +70,8 @@ static VSLStreamStatePtr get_rng_stream()
 
 void dpnp_rng_srand_c(size_t seed)
 {
-    backend_sycl::backend_sycl_rng_engine_init(seed);
+    auto &be = backend_sycl_singleton::get();
+    be.set_rng_engines_seed(seed);
     set_rng_stream(seed);
 }
 

--- a/dpnp/backend/src/queue_sycl.cpp
+++ b/dpnp/backend/src/queue_sycl.cpp
@@ -80,7 +80,6 @@
 }
 #endif
 
-
 #if defined(DPNPC_TOUCH_KERNEL_TO_LINK)
 /**
  * Function push the SYCL kernels to be linked (final stage of the compilation)

--- a/dpnp/backend/src/queue_sycl.cpp
+++ b/dpnp/backend/src/queue_sycl.cpp
@@ -111,13 +111,8 @@ static long dpnp_kernels_link()
 }
 #endif
 
-void dpnp_queue_initialize_c(QueueOptions)
-{
-    [[maybe_unused]] auto &be = backend_sycl_singleton::get();
-}
-
 size_t dpnp_queue_is_cpu_c()
 {
-    const auto &be = backend_sycl_singleton::get();
+    const auto &be = backend_sycl::get();
     return be.backend_sycl_is_cpu();
 }

--- a/dpnp/backend/src/queue_sycl.hpp
+++ b/dpnp/backend/src/queue_sycl.hpp
@@ -88,7 +88,7 @@ public:
     {
         queue = nullptr;
         rng_engine = nullptr;
-	rng_mcg59_engine = nullptr;
+        rng_mcg59_engine = nullptr;
     }
 
     virtual ~backend_sycl()

--- a/dpnp/backend/src/queue_sycl.hpp
+++ b/dpnp/backend/src/queue_sycl.hpp
@@ -47,43 +47,58 @@
 
 namespace mkl_rng = oneapi::mkl::rng;
 
-#define DPNP_QUEUE            backend_sycl_singleton::get_queue()
-#define DPNP_RNG_ENGINE       backend_sycl_singleton::get_rng_engine()
-#define DPNP_RNG_MCG59_ENGINE backend_sycl_singleton::get_rng_mcg59_engine()
+#define DPNP_QUEUE            backend_sycl::get_queue()
+#define DPNP_RNG_ENGINE       backend_sycl::get_rng_engine()
+#define DPNP_RNG_MCG59_ENGINE backend_sycl::get_rng_mcg59_engine()
 
-class backend_sycl_singleton {
+/**
+ * This is container for the SYCL queue, random number generation engine and
+ * related functions like queue and engine initialization and maintenance. The
+ * queue could not be initialized as a global object. Global object
+ * initialization order is undefined. This class postpone initialization of the
+ * SYCL queue and mt19937 random number generation engine.
+ */
+class backend_sycl 
+{
 public:
-    ~backend_sycl_singleton() {}
+    ~backend_sycl() {}
 
-    static backend_sycl_singleton& get() {
-        static backend_sycl_singleton backend = lookup();
+    static backend_sycl& get()
+    {
+        static backend_sycl backend{};
         return backend;
     }
 
-    static sycl::queue& get_queue() {
-        auto &be = backend_sycl_singleton::get();
+    static sycl::queue& get_queue()
+    {
+        auto &be = backend_sycl::get();
         return *(be.queue_ptr);
     } 
 
-    static mkl_rng::mt19937& get_rng_engine() {
-        auto &be = backend_sycl_singleton::get();
+    static mkl_rng::mt19937& get_rng_engine()
+    {
+        auto &be = backend_sycl::get();
         return *(be.rng_mt19937_engine_ptr);
     } 
 
-    static mkl_rng::mcg59& get_rng_mcg59_engine() {
-        auto &be = backend_sycl_singleton::get();
+    static mkl_rng::mcg59& get_rng_mcg59_engine()
+    {
+        auto &be = backend_sycl::get();
         return *(be.rng_mcg59_engine_ptr);
     }
 
     template <typename SeedT>
-    void set_rng_engines_seed(const SeedT &seed) {
-        auto rng_eng_mt19937 = std::make_shared<mkl_rng::mt19937>(*queue_ptr, seed);
+    void set_rng_engines_seed(const SeedT &seed) 
+    {
+        auto rng_eng_mt19937 = 
+            std::make_shared<mkl_rng::mt19937>(*queue_ptr, seed);
         if (!rng_eng_mt19937) {
             throw std::runtime_error(
                 "Could not create MT19937 engine with given seed"
             );
         }
-        auto rng_eng_mcg59 = std::make_shared<mkl_rng::mcg59>(*queue_ptr, seed);
+        auto rng_eng_mcg59 = 
+            std::make_shared<mkl_rng::mcg59>(*queue_ptr, seed);
         if (!rng_eng_mcg59) {
             throw std::runtime_error(
                 "Could not create MCG59 engine with given seed"
@@ -94,18 +109,15 @@ public:
         rng_mcg59_engine_ptr.swap(rng_eng_mcg59);
     }
 
-    bool backend_sycl_is_cpu() const {
-        if (queue_ptr) {
-            const sycl::queue &q = *queue_ptr;
-
-            return q.get_device().is_cpu();
-        }
-        return false;     
+    bool backend_sycl_is_cpu() const 
+    {
+        const sycl::queue &q = *queue_ptr;
+        return q.get_device().is_cpu();
     }
 
 private:
-    backend_sycl_singleton() : 
-        queue_ptr{}, rng_mt19937_engine_ptr{}, rng_mcg59_engine_ptr{} 
+    backend_sycl() 
+        : queue_ptr{}, rng_mt19937_engine_ptr{}, rng_mcg59_engine_ptr{} 
     {
         const sycl::property_list &prop = (is_verbose_mode()) ? 
               sycl::property_list{sycl::property::queue::enable_profiling()}
@@ -134,120 +146,13 @@ private:
         }
     }
 
-    static backend_sycl_singleton& lookup() {
-        static backend_sycl_singleton backend{};
-        return backend;
-    }
+    backend_sycl(backend_sycl const &) = default;
+    backend_sycl &operator=(backend_sycl const &) = default;
+    backend_sycl &operator=(backend_sycl &&) = default;
 
     std::shared_ptr<sycl::queue> queue_ptr;
     std::shared_ptr<mkl_rng::mt19937> rng_mt19937_engine_ptr;
     std::shared_ptr<mkl_rng::mcg59> rng_mcg59_engine_ptr;
 };
-
-/**
- * This is container for the SYCL queue, random number generation engine and
- * related functions like queue and engine initialization and maintenance. The
- * queue could not be initialized as a global object. Global object
- * initialization order is undefined. This class postpone initialization of the
- * SYCL queue and mt19937 random number generation engine.
- */
-#if 0
-class backend_sycl
-{
-    /**< contains SYCL queue pointer initialized in
-        @ref backend_sycl_queue_init */
-    static sycl::queue *queue;
-    /**< RNG MT19937 engine ptr. initialized in @ref
-                        backend_sycl_rng_engine_init */
-    static mkl_rng::mt19937 *rng_engine;
-    /**< RNG MCG59 engine ptr. initialized in @ref
-        backend_sycl_rng_engine_init */
-    static mkl_rng::mcg59 *rng_mcg59_engine;
-
-    static void destroy()
-    {
-        backend_sycl::destroy_rng_engine();
-        delete queue;
-    }
-
-    static void destroy_rng_engine()
-    {
-        delete rng_engine;
-        delete rng_mcg59_engine;
-
-        rng_engine = nullptr;
-        rng_mcg59_engine = nullptr;
-    }
-
-public:
-    backend_sycl()
-    {
-        queue = nullptr;
-        rng_engine = nullptr;
-        rng_mcg59_engine = nullptr;
-    }
-
-    virtual ~backend_sycl()
-    {
-        backend_sycl::destroy();
-    }
-
-    /**
-     * Explicitly disallow copying
-     */
-    backend_sycl(const backend_sycl &) = delete;
-    backend_sycl &operator=(const backend_sycl &) = delete;
-
-    /**
-     * Initialize @ref queue
-     */
-    static void backend_sycl_queue_init(
-        QueueOptions selector = QueueOptions::AUTO_SELECTOR);
-
-    /**
-     * Return True if current @ref queue is related to cpu device
-     */
-    static bool backend_sycl_is_cpu();
-
-    /**
-     * Initialize @ref rng_engine and @ref rng_mcg59_engine
-     */
-    static void backend_sycl_rng_engine_init(size_t seed = 1);
-
-    /**
-     * Return the @ref queue to the user
-     */
-    static sycl::queue &get_queue()
-    {
-        if (!queue) {
-            backend_sycl_queue_init();
-        }
-
-        return *queue;
-    }
-
-    /**
-     * Return the @ref rng_engine to the user
-     */
-    static mkl_rng::mt19937 &get_rng_engine()
-    {
-        if (!rng_engine) {
-            backend_sycl_rng_engine_init();
-        }
-        return *rng_engine;
-    }
-
-    /**
-     * Return the @ref rng_mcg59_engine to the user
-     */
-    static mkl_rng::mcg59 &get_rng_mcg59_engine()
-    {
-        if (!rng_engine) {
-            backend_sycl_rng_engine_init();
-        }
-        return *rng_mcg59_engine;
-    }
-};
-#endif
 
 #endif // QUEUE_SYCL_H

--- a/dpnp/backend/tests/test_broadcast_iterator.cpp
+++ b/dpnp/backend/tests/test_broadcast_iterator.cpp
@@ -30,8 +30,6 @@
 #include "dpnp_iterator.hpp"
 #include "dpnp_test_utils.hpp"
 
-// TODO need to fix build procedure and remove this workaround. Issue #551
-#define DPNP_LOCAL_QUEUE 1
 #include "queue_sycl.hpp"
 
 struct IteratorParameters

--- a/dpnp/backend/tests/test_utils_iterator.cpp
+++ b/dpnp/backend/tests/test_utils_iterator.cpp
@@ -30,8 +30,6 @@
 #include "dpnp_iterator.hpp"
 #include "dpnp_test_utils.hpp"
 
-// TODO need to fix build procedure and remove this workaround. Issue #551
-#define DPNP_LOCAL_QUEUE 1
 #include "queue_sycl.hpp"
 
 using namespace std;

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -194,17 +194,10 @@ cdef extern from "dpnp_iface_fptr.hpp":
     DPNPFuncData get_dpnp_function_ptr(DPNPFuncName name, DPNPFuncType first_type, DPNPFuncType second_type) except +
 
 
-cdef extern from "dpnp_iface.hpp" namespace "QueueOptions":  # need this namespace for Enum import
-    cdef enum QueueOptions "QueueOptions":
-        CPU_SELECTOR
-        GPU_SELECTOR
-        AUTO_SELECTOR
-
 cdef extern from "constants.hpp":
     void dpnp_python_constants_initialize_c(void * py_none, void * py_nan)
 
 cdef extern from "dpnp_iface.hpp":
-    void dpnp_queue_initialize_c(QueueOptions selector)
 
     char * dpnp_memory_alloc_c(size_t size_in_bytes) except +
     void dpnp_memory_free_c(void * ptr)

--- a/dpnp/dpnp_algo/dpnp_algo.pyx
+++ b/dpnp/dpnp_algo/dpnp_algo.pyx
@@ -83,12 +83,7 @@ cpdef dpnp_queue_initialize():
     It takes visible time and needs to be done in the module loading procedure.
     """
     cdef time_t seed_from_time
-    cdef QueueOptions queue_type = CPU_SELECTOR
 
-    if (config.__DPNP_QUEUE_GPU__):
-        queue_type = GPU_SELECTOR
-
-    dpnp_queue_initialize_c(queue_type)
     dpnp_python_constants_initialize_c(< void*> None,
                                         < void * > dpnp.nan)
 

--- a/examples/example10.py
+++ b/examples/example10.py
@@ -87,12 +87,7 @@ def example():
 
 
 if __name__ == "__main__":
-    try:
-        import dpctl
+    import dpctl
 
-        with dpctl.device_context("opencl:gpu") as gpu_queue:
-            gpu_queue.get_sycl_device().print_device_info()
-            example()
-
-    except ImportError:
-        example()
+    dpctl.select_default_device().print_device_info()
+    example()

--- a/tests/third_party/intel/zero-copy-test1.py
+++ b/tests/third_party/intel/zero-copy-test1.py
@@ -62,12 +62,7 @@ def test_dppy_array_pass():
     hb = np.arange(0, global_size, dtype="i4")
     da = DuckUSMArray(hb.shape, dtype=hb.dtype, host_buffer=hb)
 
-    if dpctl.has_gpu_queues(dpctl.backend_type.level_zero):
-        print("\nScheduling on OpenCL GPU\n")
-        with dpctl.device_context("opencl:gpu") as gpu_queue:
-            dppy_f[global_size, dppy.DEFAULT_LOCAL_SIZE](da)
-    else:
-        print("\nSkip scheduling on OpenCL GPU\n")
+    dppy_f[global_size, dppy.DEFAULT_LOCAL_SIZE](da)
 
     assert da[0] == 10
 


### PR DESCRIPTION
`DPCTLQueueMgr_*` is being removed, see https://github.com/IntelPython/dpctl/pull/1576.

This PR removes use of `DPCTLQueueMgr_*` in `queue_sycl.cpp` and `queue_sycl.hpp`. 

It effectively reverts to using `DPNP_LOCAL_QUEUE=1`.

Examples, documentation were also updated to avoid uses of `device_selector` as it is being removed.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
