### PR TITLE
Remove find_common_type which is never used in DPNP and deprecated since NumPy 1.25.0

### DIFF
--- a/doc/reference/dtype.rst
+++ b/doc/reference/dtype.rst
@@ -44,7 +44,6 @@ Data type testing
    dpnp.issubdtype
    dpnp.issubsctype
    dpnp.issubclass_
-   dpnp.find_common_type
 
 Miscellaneous
 -------------

--- a/dpnp/dpnp_utils/dpnp_algo_utils.pxd
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pxd
@@ -90,12 +90,6 @@ Returns a tuple of:
 2. dtype
 """
 
-cpdef find_common_type(object x1_obj, object x2_obj)
-"""
-Find common type of 2 input objects
-"""
-
-
 cpdef long _get_linear_index(key, tuple shape, int ndim)
 """
 Compute linear index of an element in memory from array indices

--- a/dpnp/dpnp_utils/dpnp_algo_utils.pyx
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pyx
@@ -432,26 +432,6 @@ cdef tuple get_shape_dtype(object input_obj):
     return (return_shape, dpnp.dtype(type(input_obj)))
 
 
-cpdef find_common_type(object x1_obj, object x2_obj):
-    _, x1_dtype = get_shape_dtype(x1_obj)
-    _, x2_dtype = get_shape_dtype(x2_obj)
-
-    cdef list array_types = []
-    cdef list scalar_types = []
-
-    if dpnp.isscalar(x1_obj):
-        scalar_types.append(x1_dtype)
-    else:
-        array_types.append(x1_dtype)
-
-    if dpnp.isscalar(x2_obj):
-        scalar_types.append(x2_dtype)
-    else:
-        array_types.append(x2_dtype)
-
-    return numpy.find_common_type(array_types, scalar_types)
-
-
 cdef shape_type_c get_common_shape(shape_type_c input1_shape, shape_type_c input2_shape) except *:
     cdef shape_type_c input1_shape_orig = input1_shape
     cdef shape_type_c input2_shape_orig = input2_shape


### PR DESCRIPTION
The PR removes unused function `find_common_type` from Cython backend layout.
The function also was present in NumPy and deprecated since `1.25.0`, so also it removes documentation reference on it.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
