### PR TITLE
Tune dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "saturday"
+    rebase-strategy: "disabled"


### PR DESCRIPTION
The PR propose to change a day of week when the updates are checking from default Monday to Saturday, because usually there are less load on public CI flow and so the PRs from dependabot will be able to be merged faster.

Another configuration update assumes to disable `rebase-strategy` to prevent automatic rebase by dependabot once any PR is merged. It will be up to assignee to rebase each PR manually, because it speeds up the merge time due to reducing load on public CI.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
