### PR TITLE
Temporary mute all SYCL tests for OpenCL GPU device due to known issue

### DIFF
--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -37,6 +37,9 @@ for device in available_devices:
         pass
     elif device.device_type.name not in list_of_device_type_str:
         pass
+    elif device.backend.name in "opencl" and device.is_gpu:
+        # due to reproted crash on Windows: CMPLRLLVM-55640
+        pass
     else:
         valid_devices.append(device)
 
@@ -474,9 +477,6 @@ def test_meshgrid(device_x, device_y):
     ids=[device.filter_string for device in valid_devices],
 )
 def test_1in_1out(func, data, device):
-    if func in ("std", "var") and "opencl:gpu" in device.filter_string:
-        pytest.skip("due to reproted crash on Windows: CMPLRLLVM-55640")
-
     x = dpnp.array(data, device=device)
     result = getattr(dpnp, func)(x)
 


### PR DESCRIPTION
The PR proposes to temporary skip SYCL relating tests with OpneCL GPU device due to known issue which may lead to crash on Windows.
Previously #1672 already muted few tests for OpneCL GPU device, but the same problem is facing with other SYCL relating tests occasionally.
Thus the idea is to exclude OpneCL GPU device from the verification scope temporary to unblock the internal CI verification flow.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
