### PR TITLE
Remove step with installing `opencl_rt`

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -334,9 +334,6 @@ jobs:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-
 
-      - name: Install opencl_rt
-        run: conda install opencl_rt -c intel --override-channels
-
       - name: Install dpnp
         run: |
           @echo on


### PR DESCRIPTION
The PR proposes to get rid of installation of `opencl_rt` package before running tests for Windows.

The step was previously added as a workaround and isn't required anymore, since fully covered by dependent conda packages.
Removing the step will slightly speed up `Conda package` action.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
