### PR TITLE
Implement `dpnp.searchsorted`

### DIFF
--- a/dpnp/backend/include/dpnp_iface_fptr.hpp
+++ b/dpnp/backend/include/dpnp_iface_fptr.hpp
@@ -339,13 +339,11 @@ enum class DPNPFuncName : size_t
     DPNP_FN_RNG_ZIPF_EXT, /**< Used in numpy.random.zipf() impl, requires extra
                              parameters */
     DPNP_FN_SEARCHSORTED, /**< Used in numpy.searchsorted() impl  */
-    DPNP_FN_SEARCHSORTED_EXT, /**< Used in numpy.searchsorted() impl, requires
-                                 extra parameters */
-    DPNP_FN_SIGN,             /**< Used in numpy.sign() impl  */
-    DPNP_FN_SIN,              /**< Used in numpy.sin() impl  */
-    DPNP_FN_SINH,             /**< Used in numpy.sinh() impl  */
-    DPNP_FN_SORT,             /**< Used in numpy.sort() impl  */
-    DPNP_FN_SQRT,             /**< Used in numpy.sqrt() impl  */
+    DPNP_FN_SIGN,         /**< Used in numpy.sign() impl  */
+    DPNP_FN_SIN,          /**< Used in numpy.sin() impl  */
+    DPNP_FN_SINH,         /**< Used in numpy.sinh() impl  */
+    DPNP_FN_SORT,         /**< Used in numpy.sort() impl  */
+    DPNP_FN_SQRT,         /**< Used in numpy.sqrt() impl  */
     DPNP_FN_SQRT_EXT, /**< Used in numpy.sqrt() impl, requires extra parameters
                        */
     DPNP_FN_SQUARE,   /**< Used in numpy.square() impl  */

--- a/dpnp/backend/kernels/dpnp_krnl_sorting.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_sorting.cpp
@@ -403,17 +403,6 @@ void (*dpnp_searchsorted_default_c)(void *,
                                     const size_t) =
     dpnp_searchsorted_c<_DataType, _IndexingType>;
 
-template <typename _DataType, typename _IndexingType>
-DPCTLSyclEventRef (*dpnp_searchsorted_ext_c)(DPCTLSyclQueueRef,
-                                             void *,
-                                             const void *,
-                                             const void *,
-                                             bool,
-                                             const size_t,
-                                             const size_t,
-                                             const DPCTLEventVectorRef) =
-    dpnp_searchsorted_c<_DataType, _IndexingType>;
-
 template <typename _DataType>
 class dpnp_sort_c_kernel;
 
@@ -506,15 +495,6 @@ void func_map_init_sorting(func_map_t &fmap)
         eft_FLT, (void *)dpnp_searchsorted_default_c<float, int64_t>};
     fmap[DPNPFuncName::DPNP_FN_SEARCHSORTED][eft_DBL][eft_DBL] = {
         eft_DBL, (void *)dpnp_searchsorted_default_c<double, int64_t>};
-
-    fmap[DPNPFuncName::DPNP_FN_SEARCHSORTED_EXT][eft_INT][eft_INT] = {
-        eft_INT, (void *)dpnp_searchsorted_ext_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_SEARCHSORTED_EXT][eft_LNG][eft_LNG] = {
-        eft_LNG, (void *)dpnp_searchsorted_ext_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_SEARCHSORTED_EXT][eft_FLT][eft_FLT] = {
-        eft_FLT, (void *)dpnp_searchsorted_ext_c<float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_SEARCHSORTED_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void *)dpnp_searchsorted_ext_c<double, int64_t>};
 
     fmap[DPNPFuncName::DPNP_FN_SORT][eft_INT][eft_INT] = {
         eft_INT, (void *)dpnp_sort_default_c<int32_t>};

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -159,8 +159,6 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_RNG_WEIBULL_EXT
         DPNP_FN_RNG_ZIPF
         DPNP_FN_RNG_ZIPF_EXT
-        DPNP_FN_SEARCHSORTED
-        DPNP_FN_SEARCHSORTED_EXT
         DPNP_FN_TRACE
         DPNP_FN_TRACE_EXT
         DPNP_FN_TRANSPOSE

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -1121,7 +1121,17 @@ class dpnp_array:
 
         return dpnp.around(self, decimals, out)
 
-    # 'searchsorted',
+    def searchsorted(self, v, side="left", sorter=None):
+        """
+        Find indices where elements of `v` should be inserted in `a`
+        to maintain order.
+
+        Refer to :obj:`dpnp.searchsorted` for full documentation
+
+        """
+
+        return dpnp.searchsorted(self, v, side=side, sorter=sorter)
+
     # 'setfield',
     # 'setflags',
 

--- a/dpnp/dpnp_iface_searching.py
+++ b/dpnp/dpnp_iface_searching.py
@@ -232,9 +232,57 @@ def searchsorted(a, v, side="left", sorter=None):
 
     For full documentation refer to :obj:`numpy.searchsorted`.
 
+    Parameters
+    ----------
+    a : {dpnp.ndarray, usm_ndarray}
+        Input 1-D array. If `sorter` is ``None``, then it must be sorted in
+        ascending order, otherwise `sorter` must be an array of indices that
+        sort it.
+    v : {dpnp.ndarray, usm_ndarray, scalar}
+        Values to insert into `a`.
+    side : {'left', 'right'}, optional
+        If ``'left'``, the index of the first suitable location found is given.
+        If ``'right'``, return the last such index. If there is no suitable
+        index, return either 0 or N (where N is the length of `a`).
+    sorter : {dpnp.ndarray, usm_ndarray}, optional
+        Optional 1-D array of integer indices that sort array a into ascending
+        order. They are typically the result of argsort.
+
+    Returns
+    -------
+    indices : dpnp.ndarray
+        Array of insertion points with the same shape as `v`,
+        or 0-D array if `v` is a scalar.
+
+    See Also
+    --------
+    :obj:`dpnp.sort` : Return a sorted copy of an array.
+    :obj:`dpnp.histogram` : Produce histogram from 1-D data.
+
+    Examples
+    --------
+    >>> import dpnp as np
+    >>> a = np.array([11,12,13,14,15])
+    >>> np.searchsorted(a, 13)
+    array(2)
+    >>> np.searchsorted(a, 13, side='right')
+    array(3)
+    >>> v = np.array([-10, 20, 12, 13])
+    >>> np.searchsorted(a, v)
+    array([0, 5, 1, 2])
+
     """
 
-    return call_origin(numpy.where, a, v, side, sorter)
+    usm_a = dpnp.get_usm_ndarray(a)
+    if dpnp.isscalar(v):
+        usm_v = dpt.asarray(v, sycl_queue=a.sycl_queue, usm_type=a.usm_type)
+    else:
+        usm_v = dpnp.get_usm_ndarray(v)
+
+    usm_sorter = None if sorter is None else dpnp.get_usm_ndarray(sorter)
+    return dpnp_array._create_from_usm_ndarray(
+        dpt.searchsorted(usm_a, usm_v, side=side, sorter=usm_sorter)
+    )
 
 
 def where(condition, x=None, y=None, /):

--- a/dpnp/dpnp_iface_searching.py
+++ b/dpnp/dpnp_iface_searching.py
@@ -244,9 +244,13 @@ def searchsorted(a, v, side="left", sorter=None):
         If ``'left'``, the index of the first suitable location found is given.
         If ``'right'``, return the last such index. If there is no suitable
         index, return either 0 or N (where N is the length of `a`).
+        Default is ``'left'``.
     sorter : {dpnp.ndarray, usm_ndarray}, optional
         Optional 1-D array of integer indices that sort array a into ascending
         order. They are typically the result of argsort.
+        Out of bound index values of `sorter` array are treated using `"wrap"`
+        mode documented in :py:func:`dpnp.take`.
+        Default is ``None``.
 
     Returns
     -------

--- a/dpnp/dpnp_iface_sorting.py
+++ b/dpnp/dpnp_iface_sorting.py
@@ -47,14 +47,13 @@ import dpnp
 # pylint: disable=no-name-in-module
 from .dpnp_algo import (
     dpnp_partition,
-    dpnp_searchsorted,
 )
 from .dpnp_array import dpnp_array
 from .dpnp_utils import (
     call_origin,
 )
 
-__all__ = ["argsort", "partition", "searchsorted", "sort"]
+__all__ = ["argsort", "partition", "sort"]
 
 
 def argsort(a, axis=-1, kind=None, order=None):
@@ -187,41 +186,6 @@ def partition(x1, kth, axis=-1, kind="introselect", order=None):
             return dpnp_partition(x1_desc, kth, axis, kind, order).get_pyobj()
 
     return call_origin(numpy.partition, x1, kth, axis, kind, order)
-
-
-def searchsorted(x1, x2, side="left", sorter=None):
-    """
-    Find indices where elements should be inserted to maintain order.
-
-    For full documentation refer to :obj:`numpy.searchsorted`.
-
-    Limitations
-    -----------
-    Input arrays is supported as :obj:`dpnp.ndarray`.
-    Input array is supported only sorted.
-    Input side is supported only values ``left``, ``right``.
-    Parameter `sorter` is supported only with default values.
-
-    """
-
-    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
-    x2_desc = dpnp.get_dpnp_descriptor(x2, copy_when_nondefault_queue=False)
-    # pylint: disable=condition-evals-to-constant
-    if 0 and x1_desc and x2_desc:
-        if x1_desc.ndim != 1:
-            pass
-        elif x1_desc.dtype != x2_desc.dtype:
-            pass
-        elif side not in ["left", "right"]:
-            pass
-        elif sorter is not None:
-            pass
-        elif x1_desc.size < 2:
-            pass
-        else:
-            return dpnp_searchsorted(x1_desc, x2_desc, side=side).get_pyobj()
-
-    return call_origin(numpy.searchsorted, x1, x2, side=side, sorter=sorter)
 
 
 def sort(a, axis=-1, kind=None, order=None):

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -705,28 +705,6 @@ tests/third_party/cupy/random_tests/test_sample.py::TestRandomIntegers2::test_bo
 tests/third_party/cupy/random_tests/test_sample.py::TestRandomIntegers2::test_goodness_of_fit
 tests/third_party/cupy/random_tests/test_sample.py::TestRandomIntegers2::test_goodness_of_fit_2
 
-tests/third_party/cupy/sorting_tests/test_search.py::TestArgMinMaxDtype::test_argminmax_dtype[_param_0_{func='argmin', is_module=True, shape=(3, 4)}]
-tests/third_party/cupy/sorting_tests/test_search.py::TestArgMinMaxDtype::test_argminmax_dtype[_param_1_{func='argmin', is_module=True, shape=()}]
-tests/third_party/cupy/sorting_tests/test_search.py::TestArgMinMaxDtype::test_argminmax_dtype[_param_2_{func='argmin', is_module=False, shape=(3, 4)}]
-tests/third_party/cupy/sorting_tests/test_search.py::TestArgMinMaxDtype::test_argminmax_dtype[_param_3_{func='argmin', is_module=False, shape=()}]
-tests/third_party/cupy/sorting_tests/test_search.py::TestArgMinMaxDtype::test_argminmax_dtype[_param_4_{func='argmax', is_module=True, shape=(3, 4)}]
-tests/third_party/cupy/sorting_tests/test_search.py::TestArgMinMaxDtype::test_argminmax_dtype[_param_5_{func='argmax', is_module=True, shape=()}]
-tests/third_party/cupy/sorting_tests/test_search.py::TestArgMinMaxDtype::test_argminmax_dtype[_param_6_{func='argmax', is_module=False, shape=(3, 4)}]
-tests/third_party/cupy/sorting_tests/test_search.py::TestArgMinMaxDtype::test_argminmax_dtype[_param_7_{func='argmax', is_module=False, shape=()}]
-
-tests/third_party/cupy/sorting_tests/test_search.py::TestArgwhere::test_argwhere[0]
-tests/third_party/cupy/sorting_tests/test_search.py::TestArgwhere::test_argwhere[1]
-tests/third_party/cupy/sorting_tests/test_search.py::TestArgwhere::test_argwhere[2]
-
-tests/third_party/cupy/sorting_tests/test_search.py::TestFlatNonzero::test_flatnonzero[0]
-tests/third_party/cupy/sorting_tests/test_search.py::TestFlatNonzero::test_flatnonzero[1]
-tests/third_party/cupy/sorting_tests/test_search.py::TestFlatNonzero::test_flatnonzero[2]
-tests/third_party/cupy/sorting_tests/test_search.py::TestFlatNonzero::test_flatnonzero[3]
-tests/third_party/cupy/sorting_tests/test_search.py::TestFlatNonzero::test_flatnonzero[4]
-
-tests/third_party/cupy/sorting_tests/test_search.py::TestNonzeroZeroDimension_param_0_{array=array(0)}::test_nonzero
-tests/third_party/cupy/sorting_tests/test_search.py::TestNonzeroZeroDimension_param_1_{array=array(1)}::test_nonzero
-
 tests/third_party/cupy/sorting_tests/test_sort.py::TestArgpartition_param_0_{external=False}::test_argpartition_axis
 tests/third_party/cupy/sorting_tests/test_sort.py::TestArgpartition_param_0_{external=False}::test_argpartition_invalid_axis1
 tests/third_party/cupy/sorting_tests/test_sort.py::TestArgpartition_param_0_{external=False}::test_argpartition_invalid_axis2

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -767,28 +767,6 @@ tests/third_party/cupy/random_tests/test_sample.py::TestRandomIntegers2::test_bo
 tests/third_party/cupy/random_tests/test_sample.py::TestRandomIntegers2::test_goodness_of_fit
 tests/third_party/cupy/random_tests/test_sample.py::TestRandomIntegers2::test_goodness_of_fit_2
 
-tests/third_party/cupy/sorting_tests/test_search.py::TestArgMinMaxDtype::test_argminmax_dtype[_param_0_{func='argmin', is_module=True, shape=(3, 4)}]
-tests/third_party/cupy/sorting_tests/test_search.py::TestArgMinMaxDtype::test_argminmax_dtype[_param_1_{func='argmin', is_module=True, shape=()}]
-tests/third_party/cupy/sorting_tests/test_search.py::TestArgMinMaxDtype::test_argminmax_dtype[_param_2_{func='argmin', is_module=False, shape=(3, 4)}]
-tests/third_party/cupy/sorting_tests/test_search.py::TestArgMinMaxDtype::test_argminmax_dtype[_param_3_{func='argmin', is_module=False, shape=()}]
-tests/third_party/cupy/sorting_tests/test_search.py::TestArgMinMaxDtype::test_argminmax_dtype[_param_4_{func='argmax', is_module=True, shape=(3, 4)}]
-tests/third_party/cupy/sorting_tests/test_search.py::TestArgMinMaxDtype::test_argminmax_dtype[_param_5_{func='argmax', is_module=True, shape=()}]
-tests/third_party/cupy/sorting_tests/test_search.py::TestArgMinMaxDtype::test_argminmax_dtype[_param_6_{func='argmax', is_module=False, shape=(3, 4)}]
-tests/third_party/cupy/sorting_tests/test_search.py::TestArgMinMaxDtype::test_argminmax_dtype[_param_7_{func='argmax', is_module=False, shape=()}]
-
-tests/third_party/cupy/sorting_tests/test_search.py::TestArgwhere::test_argwhere[0]
-tests/third_party/cupy/sorting_tests/test_search.py::TestArgwhere::test_argwhere[1]
-tests/third_party/cupy/sorting_tests/test_search.py::TestArgwhere::test_argwhere[2]
-
-tests/third_party/cupy/sorting_tests/test_search.py::TestFlatNonzero::test_flatnonzero[0]
-tests/third_party/cupy/sorting_tests/test_search.py::TestFlatNonzero::test_flatnonzero[1]
-tests/third_party/cupy/sorting_tests/test_search.py::TestFlatNonzero::test_flatnonzero[2]
-tests/third_party/cupy/sorting_tests/test_search.py::TestFlatNonzero::test_flatnonzero[3]
-tests/third_party/cupy/sorting_tests/test_search.py::TestFlatNonzero::test_flatnonzero[4]
-
-tests/third_party/cupy/sorting_tests/test_search.py::TestNonzeroZeroDimension_param_0_{array=array(0)}::test_nonzero
-tests/third_party/cupy/sorting_tests/test_search.py::TestNonzeroZeroDimension_param_1_{array=array(1)}::test_nonzero
-
 tests/third_party/cupy/sorting_tests/test_sort.py::TestArgpartition_param_0_{external=False}::test_argpartition_axis
 tests/third_party/cupy/sorting_tests/test_sort.py::TestArgpartition_param_0_{external=False}::test_argpartition_invalid_axis1
 tests/third_party/cupy/sorting_tests/test_sort.py::TestArgpartition_param_0_{external=False}::test_argpartition_invalid_axis2

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -1,10 +1,281 @@
 import numpy
 import pytest
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_equal, assert_raises
 
 import dpnp
 
-from .helper import assert_dtype_allclose, get_all_dtypes, get_complex_dtypes
+from .helper import (
+    assert_dtype_allclose,
+    get_all_dtypes,
+    get_complex_dtypes,
+    get_float_dtypes,
+)
+
+
+class TestArgsort:
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
+    def test_argsort_dtype(self, dtype):
+        a = numpy.random.uniform(-5, 5, 10)
+        np_array = numpy.array(a, dtype=dtype)
+        dp_array = dpnp.array(np_array)
+
+        result = dpnp.argsort(dp_array, kind="stable")
+        expected = numpy.argsort(np_array, kind="stable")
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_complex_dtypes())
+    def test_argsort_complex(self, dtype):
+        a = numpy.random.uniform(-5, 5, 10)
+        b = numpy.random.uniform(-5, 5, 10)
+        np_array = numpy.array(a + b * 1j, dtype=dtype)
+        dp_array = dpnp.array(np_array)
+
+        result = dpnp.argsort(dp_array)
+        expected = numpy.argsort(np_array)
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("axis", [None, -2, -1, 0, 1, 2])
+    def test_argsort_axis(self, axis):
+        a = numpy.random.uniform(-10, 10, 36)
+        np_array = numpy.array(a).reshape(3, 4, 3)
+        dp_array = dpnp.array(np_array)
+
+        result = dpnp.argsort(dp_array, axis=axis)
+        expected = numpy.argsort(np_array, axis=axis)
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_all_dtypes())
+    @pytest.mark.parametrize("axis", [None, -2, -1, 0, 1])
+    def test_argsort_ndarray(self, dtype, axis):
+        a = numpy.random.uniform(-10, 10, 12)
+        np_array = numpy.array(a, dtype=dtype).reshape(6, 2)
+        dp_array = dpnp.array(np_array)
+
+        result = dp_array.argsort(axis=axis)
+        expected = np_array.argsort(axis=axis)
+        assert_dtype_allclose(result, expected)
+
+    def test_argsort_stable(self):
+        np_array = numpy.repeat(numpy.arange(10), 10)
+        dp_array = dpnp.array(np_array)
+
+        result = dpnp.argsort(dp_array, kind="stable")
+        expected = numpy.argsort(np_array, kind="stable")
+        assert_dtype_allclose(result, expected)
+
+    def test_argsort_zero_dim(self):
+        np_array = numpy.array(2.5)
+        dp_array = dpnp.array(np_array)
+
+        # with default axis=-1
+        with pytest.raises(numpy.AxisError):
+            dpnp.argsort(dp_array)
+
+        # with axis = None
+        result = dpnp.argsort(dp_array, axis=None)
+        expected = numpy.argsort(np_array, axis=None)
+        assert_dtype_allclose(result, expected)
+
+    def test_sort_notimplemented(self):
+        dp_array = dpnp.arange(10)
+
+        with pytest.raises(NotImplementedError):
+            dpnp.argsort(dp_array, kind="quicksort")
+
+        with pytest.raises(NotImplementedError):
+            dpnp.argsort(dp_array, order=["age"])
+
+
+class TestSearchSorted:
+    @pytest.mark.parametrize("side", ["left", "right"])
+    @pytest.mark.parametrize("dtype", get_float_dtypes(no_float16=False))
+    def test_nans_float(self, side, dtype):
+        a = numpy.array([0, 1, numpy.nan], dtype=dtype)
+        dp_a = dpnp.array(a)
+
+        result = dp_a.searchsorted(dp_a, side=side)
+        expected = a.searchsorted(a, side=side)
+        assert_equal(result, expected)
+
+        result = dpnp.searchsorted(dp_a, dp_a[-1], side=side)
+        expected = numpy.searchsorted(a, a[-1], side=side)
+        assert_equal(result, expected)
+
+    @pytest.mark.parametrize("side", ["left", "right"])
+    @pytest.mark.parametrize("dtype", get_complex_dtypes())
+    def test_nans_complex(self, side, dtype):
+        a = numpy.zeros(9, dtype=dtype)
+        a.real += [0, 0, 1, 1, 0, 1, numpy.nan, numpy.nan, numpy.nan]
+        a.imag += [0, 1, 0, 1, numpy.nan, numpy.nan, 0, 1, numpy.nan]
+        dp_a = dpnp.array(a)
+
+        result = dp_a.searchsorted(dp_a, side=side)
+        expected = a.searchsorted(a, side=side)
+        assert_equal(result, expected)
+
+    @pytest.mark.parametrize("n", range(3))
+    @pytest.mark.parametrize("side", ["left", "right"])
+    def test_n_elements(self, n, side):
+        a = numpy.ones(n)
+        dp_a = dpnp.array(a)
+
+        v = numpy.array([0, 1, 2])
+        dp_v = dpnp.array(v)
+
+        result = dp_a.searchsorted(dp_v, side=side)
+        expected = a.searchsorted(v, side=side)
+        assert_equal(result, expected)
+
+    @pytest.mark.parametrize("side", ["left", "right"])
+    def test_smart_resetting(self, side):
+        a = numpy.arange(5)
+        dp_a = dpnp.array(a)
+
+        v = numpy.array([6, 5, 4])
+        dp_v = dpnp.array(v)
+
+        result = dp_a.searchsorted(dp_v, side=side)
+        expected = a.searchsorted(v, side=side)
+        assert_equal(result, expected)
+
+    @pytest.mark.parametrize("side", ["left", "right"])
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_float16=False))
+    def test_type_specific(self, side, dtype):
+        if dtype == numpy.bool_:
+            a = numpy.arange(2, dtype=dtype)
+        else:
+            a = numpy.arange(0, 5, dtype=dtype)
+        dp_a = dpnp.array(a)
+
+        result = dp_a.searchsorted(dp_a, side=side)
+        expected = a.searchsorted(a, side=side)
+        assert_equal(result, expected)
+
+        e = numpy.ndarray(shape=0, buffer=b"", dtype=dtype)
+        dp_e = dpnp.array(e)
+
+        result = dp_e.searchsorted(dp_a, side=side)
+        expected = e.searchsorted(a, side=side)
+        assert_array_equal(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_float_dtypes())
+    def test_sorter(self, dtype):
+        a = numpy.random.rand(300).astype(dtype)
+        s = a.argsort()
+        k = numpy.linspace(0, 1, 20, dtype=dtype)
+
+        dp_a = dpnp.array(a)
+        dp_s = dpnp.array(s)
+        dp_k = dpnp.array(k)
+
+        result = dp_a.searchsorted(dp_k, sorter=dp_s)
+        expected = a.searchsorted(k, sorter=s)
+        assert_equal(result, expected)
+
+    @pytest.mark.parametrize("side", ["left", "right"])
+    def test_sorter_with_side(self, side):
+        a = numpy.array([0, 1, 2, 3, 5] * 20)
+        s = a.argsort()
+        k = [0, 1, 2, 3, 5]
+
+        dp_a = dpnp.array(a)
+        dp_s = dpnp.array(s)
+        dp_k = dpnp.array(k)
+
+        result = dp_a.searchsorted(dp_k, side=side, sorter=dp_s)
+        expected = a.searchsorted(k, side=side, sorter=s)
+        assert_equal(result, expected)
+
+    @pytest.mark.parametrize("side", ["left", "right"])
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_float16=False))
+    def test_sorter_type_specific(self, side, dtype):
+        if dtype == numpy.bool_:
+            a = numpy.array([1, 0], dtype=dtype)
+            # a sorter array to be of a type that is different
+            # from np.intp in all platforms
+            s = numpy.array([1, 0], dtype=numpy.int16)
+        else:
+            a = numpy.arange(0, 5, dtype=dtype)
+            # a sorter array to be of a type that is different
+            # from np.intp in all platforms
+            s = numpy.array([4, 2, 3, 0, 1], dtype=numpy.int16)
+
+        dp_a = dpnp.array(a)
+        dp_s = dpnp.array(s)
+
+        result = dp_a.searchsorted(dp_a, side, dp_s)
+        expected = a.searchsorted(a, side, s)
+        assert_equal(result, expected)
+
+    @pytest.mark.parametrize("side", ["left", "right"])
+    def test_sorter_non_contiguous(self, side):
+        a = numpy.array([3, 4, 1, 2, 0])
+        srt = numpy.empty((10,), dtype=numpy.intp)
+        srt[1::2] = -1
+        srt[::2] = [4, 2, 3, 0, 1]
+        s = srt[::2]
+
+        dp_a = dpnp.array(a)
+        dp_s = dpnp.array(s)
+
+        result = dp_a.searchsorted(dp_a, side=side, sorter=dp_s)
+        expected = a.searchsorted(a, side=side, sorter=s)
+        assert_equal(result, expected)
+
+    def test_invalid_sorter(self):
+        for xp in [dpnp, numpy]:
+            a = xp.array([5, 2, 1, 3, 4])
+
+            assert_raises(
+                TypeError,
+                ValueError,
+                xp.searchsorted,
+                a,
+                0,
+                sorter=xp.array([1.1]),
+            )
+            assert_raises(
+                ValueError, xp.searchsorted, a, 0, sorter=xp.array([1, 2, 3, 4])
+            )
+            assert_raises(
+                ValueError,
+                xp.searchsorted,
+                a,
+                0,
+                sorter=xp.array([1, 2, 3, 4, 5, 6]),
+            )
+
+            # # bounds check
+            assert_raises(
+                ValueError,
+                xp.searchsorted,
+                a,
+                4,
+                sorter=xp.array([0, 1, 2, 3, 5]),
+            )
+            assert_raises(
+                ValueError,
+                xp.searchsorted,
+                a,
+                0,
+                sorter=xp.array([-1, 0, 1, 2, 3]),
+            )
+            assert_raises(
+                ValueError,
+                xp.searchsorted,
+                a,
+                0,
+                sorter=xp.array([4, 0, -1, 2, 3]),
+            )
+
+    def test_v_scalar(self):
+        v = 0
+        a = numpy.array([-8, -5, -1, 3, 6, 10])
+        dp_a = dpnp.array(a)
+
+        result = dpnp.searchsorted(dp_a, v)
+        expected = numpy.searchsorted(a, v)
+        assert_equal(result, expected)
 
 
 class TestSort:
@@ -87,80 +358,6 @@ class TestSort:
             dpnp.sort(dp_array, order=["age"])
 
 
-class TestArgsort:
-    @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
-    def test_argsort_dtype(self, dtype):
-        a = numpy.random.uniform(-5, 5, 10)
-        np_array = numpy.array(a, dtype=dtype)
-        dp_array = dpnp.array(np_array)
-
-        result = dpnp.argsort(dp_array, kind="stable")
-        expected = numpy.argsort(np_array, kind="stable")
-        assert_dtype_allclose(result, expected)
-
-    @pytest.mark.parametrize("dtype", get_complex_dtypes())
-    def test_argsort_complex(self, dtype):
-        a = numpy.random.uniform(-5, 5, 10)
-        b = numpy.random.uniform(-5, 5, 10)
-        np_array = numpy.array(a + b * 1j, dtype=dtype)
-        dp_array = dpnp.array(np_array)
-
-        result = dpnp.argsort(dp_array)
-        expected = numpy.argsort(np_array)
-        assert_dtype_allclose(result, expected)
-
-    @pytest.mark.parametrize("axis", [None, -2, -1, 0, 1, 2])
-    def test_argsort_axis(self, axis):
-        a = numpy.random.uniform(-10, 10, 36)
-        np_array = numpy.array(a).reshape(3, 4, 3)
-        dp_array = dpnp.array(np_array)
-
-        result = dpnp.argsort(dp_array, axis=axis)
-        expected = numpy.argsort(np_array, axis=axis)
-        assert_dtype_allclose(result, expected)
-
-    @pytest.mark.parametrize("dtype", get_all_dtypes())
-    @pytest.mark.parametrize("axis", [None, -2, -1, 0, 1])
-    def test_argsort_ndarray(self, dtype, axis):
-        a = numpy.random.uniform(-10, 10, 12)
-        np_array = numpy.array(a, dtype=dtype).reshape(6, 2)
-        dp_array = dpnp.array(np_array)
-
-        result = dp_array.argsort(axis=axis)
-        expected = np_array.argsort(axis=axis)
-        assert_dtype_allclose(result, expected)
-
-    def test_argsort_stable(self):
-        np_array = numpy.repeat(numpy.arange(10), 10)
-        dp_array = dpnp.array(np_array)
-
-        result = dpnp.argsort(dp_array, kind="stable")
-        expected = numpy.argsort(np_array, kind="stable")
-        assert_dtype_allclose(result, expected)
-
-    def test_argsort_zero_dim(self):
-        np_array = numpy.array(2.5)
-        dp_array = dpnp.array(np_array)
-
-        # with default axis=-1
-        with pytest.raises(numpy.AxisError):
-            dpnp.argsort(dp_array)
-
-        # with axis = None
-        result = dpnp.argsort(dp_array, axis=None)
-        expected = numpy.argsort(np_array, axis=None)
-        assert_dtype_allclose(result, expected)
-
-    def test_sort_notimplemented(self):
-        dp_array = dpnp.arange(10)
-
-        with pytest.raises(NotImplementedError):
-            dpnp.argsort(dp_array, kind="quicksort")
-
-        with pytest.raises(NotImplementedError):
-            dpnp.argsort(dp_array, order=["age"])
-
-
 @pytest.mark.parametrize("kth", [0, 1], ids=["0", "1"])
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
 @pytest.mark.parametrize(
@@ -191,61 +388,3 @@ def test_partition(array, dtype, kth):
 
     assert (p[..., 0:kth] <= p[..., kth : kth + 1]).all()
     assert (p[..., kth : kth + 1] <= p[..., kth + 1 :]).all()
-
-
-@pytest.mark.usefixtures("allow_fall_back_on_numpy")
-@pytest.mark.parametrize("side", ["left", "right"], ids=['"left"', '"right"'])
-@pytest.mark.parametrize(
-    "v_",
-    [
-        [[3, 4], [2, 1]],
-        [[1, 0], [3, 0]],
-        [[3, 2, 1, 6]],
-        [[4, 2], [3, 3], [4, 1]],
-        [[1, -3, 3], [0, 5, 2], [0, 1, 1], [0, 0, 1]],
-        [
-            [[[8, 2], [3, 0]], [[5, 2], [0, 1]]],
-            [[[1, 3], [3, 1]], [[5, 2], [0, 1]]],
-        ],
-    ],
-    ids=[
-        "[[3, 4], [2, 1]]",
-        "[[1, 0], [3, 0]]",
-        "[[3, 2, 1, 6]]",
-        "[[4, 2], [3, 3], [4, 1]]",
-        "[[1, -3, 3], [0, 5, 2], [0, 1, 1], [0, 0, 1]]",
-        "[[[[8, 2], [3, 0]], [[5, 2], [0, 1]]], [[[1, 3], [3, 1]], [[5, 2], [0, 1]]]]",
-    ],
-)
-@pytest.mark.parametrize(
-    "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
-)
-@pytest.mark.parametrize(
-    "array",
-    [
-        [1, 2, 3, 4],
-        [-5, -1, 0, 3, 17, 100],
-        [1, 0, 3, 0],
-        [3, 2, 1, 6],
-        [4, 2, 3, 3, 4, 1],
-        [1, -3, 3, 0, 5, 2, 0, 1, 1, 0, 0, 1],
-        [8, 2, 3, 0, 5, 2, 0, 1, 1, 3, 3, 1, 5, 2, 0, 1],
-    ],
-    ids=[
-        "[1, 2, 3, 4]",
-        "[-5, -1, 0, 3, 17, 100]",
-        "[1, 0, 3, 0]",
-        "[3, 2, 1, 6]",
-        "[4, 2, 3, 3, 4, 1]",
-        "[1, -3, 3, 0, 5, 2, 0, 1, 1, 0, 0, 1]",
-        "[8, 2, 3, 0, 5, 2, 0, 1, 1, 3, 3, 1, 5, 2, 0, 1]",
-    ],
-)
-def test_searchsorted(array, dtype, v_, side):
-    a = numpy.array(array, dtype)
-    ia = dpnp.array(array, dtype)
-    v = numpy.array(v_, dtype)
-    iv = dpnp.array(v_, dtype)
-    expected = numpy.searchsorted(a, v, side=side)
-    result = dpnp.searchsorted(ia, iv, side=side)
-    assert_array_equal(expected, result)

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -245,29 +245,6 @@ class TestSearchSorted:
                 sorter=xp.array([1, 2, 3, 4, 5, 6]),
             )
 
-            # # bounds check
-            assert_raises(
-                ValueError,
-                xp.searchsorted,
-                a,
-                4,
-                sorter=xp.array([0, 1, 2, 3, 5]),
-            )
-            assert_raises(
-                ValueError,
-                xp.searchsorted,
-                a,
-                0,
-                sorter=xp.array([-1, 0, 1, 2, 3]),
-            )
-            assert_raises(
-                ValueError,
-                xp.searchsorted,
-                a,
-                0,
-                sorter=xp.array([4, 0, -1, 2, 3]),
-            )
-
     def test_v_scalar(self):
         v = 0
         a = numpy.array([-8, -5, -1, 3, 6, 10])

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -47,7 +47,12 @@ class TestArgsort:
     @pytest.mark.parametrize("dtype", get_all_dtypes())
     @pytest.mark.parametrize("axis", [None, -2, -1, 0, 1])
     def test_argsort_ndarray(self, dtype, axis):
-        a = numpy.random.uniform(-10, 10, 12)
+        if dtype and issubclass(dtype, numpy.integer):
+            a = numpy.random.choice(
+                numpy.arange(-10, 10), replace=False, size=12
+            )
+        else:
+            a = numpy.random.uniform(-10, 10, 12)
         np_array = numpy.array(a, dtype=dtype).reshape(6, 2)
         dp_array = dpnp.array(np_array)
 

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -631,6 +631,7 @@ def test_reduce_hypot(device):
             [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
             [5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0],
         ),
+        pytest.param("searchsorted", [11, 12, 13, 14, 15], [-10, 20, 12, 13]),
         pytest.param(
             "subtract",
             [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
@@ -666,6 +667,28 @@ def test_2in_1out(func, data1, data2, device):
 
     assert_sycl_queue_equal(result.sycl_queue, x1.sycl_queue)
     assert_sycl_queue_equal(result.sycl_queue, x2.sycl_queue)
+
+
+@pytest.mark.parametrize(
+    "func, data, scalar",
+    [
+        pytest.param("searchsorted", [11, 12, 13, 14, 15], 13),
+    ],
+)
+@pytest.mark.parametrize(
+    "device",
+    valid_devices,
+    ids=[device.filter_string for device in valid_devices],
+)
+def test_2in_with_scalar_1out(func, data, scalar, device):
+    x1_orig = numpy.array(data)
+    expected = getattr(numpy, func)(x1_orig, scalar)
+
+    x1 = dpnp.array(data, device=device)
+    result = getattr(dpnp, func)(x1, scalar)
+
+    assert_allclose(result, expected)
+    assert_sycl_queue_equal(result.sycl_queue, x1.sycl_queue)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -575,6 +575,7 @@ def test_1in_1out(func, data, usm_type):
         pytest.param("logaddexp", [[-1, 2, 5, 9]], [[4, -3, 2, -8]]),
         pytest.param("maximum", [[0.0, 1.0, 2.0]], [[3.0, 4.0, 5.0]]),
         pytest.param("minimum", [[0.0, 1.0, 2.0]], [[3.0, 4.0, 5.0]]),
+        pytest.param("searchsorted", [11, 12, 13, 14, 15], [-10, 20, 12, 13]),
         pytest.param(
             "tensordot",
             [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]],
@@ -597,6 +598,19 @@ def test_2in_1out(func, data1, data2, usm_type_x, usm_type_y):
     assert x.usm_type == usm_type_x
     assert y.usm_type == usm_type_y
     assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
+
+
+@pytest.mark.parametrize(
+    "func, data, scalar",
+    [
+        pytest.param("searchsorted", [11, 12, 13, 14, 15], 13),
+    ],
+)
+@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+def test_2in_with_scalar_1out(func, data, scalar, usm_type):
+    x = dp.array(data, usm_type=usm_type)
+    z = getattr(dp, func)(x, scalar)
+    assert z.usm_type == usm_type
 
 
 @pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)

--- a/tests/third_party/cupy/sorting_tests/test_search.py
+++ b/tests/third_party/cupy/sorting_tests/test_search.py
@@ -1,12 +1,9 @@
-import unittest
-
 import numpy
 import pytest
 
 import dpnp as cupy
+from tests.helper import has_support_aspect64
 from tests.third_party.cupy import testing
-
-# from cupy.core import _accelerator
 
 
 class TestSearch:
@@ -84,6 +81,14 @@ class TestSearch:
         a = testing.shaped_random((0, 1), xp, dtype)
         return a.argmax(axis=1)
 
+    @testing.slow
+    def test_argmax_int32_overflow(self):
+        try:
+            a = testing.shaped_arange((2**32 + 1,), cupy, numpy.float64)
+        except MemoryError as e:
+            pytest.skip("Not enough memory: " + str(e))
+        assert a.argmax().item() == 2**32
+
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_argmin_all(self, xp, dtype):
@@ -158,62 +163,116 @@ class TestSearch:
         a = testing.shaped_random((0, 1), xp, dtype)
         return a.argmin(axis=1)
 
+    @testing.slow
+    def test_argmin_int32_overflow(self):
+        try:
+            a = testing.shaped_arange((2**32 + 1,), cupy, numpy.float64)
+        except MemoryError as e:
+            pytest.skip("Not enough memory: " + str(e))
+        cupy.negative(a, out=a)
+        assert a.argmin().item() == 2**32
+
 
 # This class compares CUB results against NumPy's
 # TODO(leofang): test axis after support is added
-# @testing.parameterize(*testing.product({
-# 'shape': [(10,), (10, 20), (10, 20, 30), (10, 20, 30, 40)],
-# 'order': ('C', 'F'),
-# }))
-# @unittest.skipUnless(cupy.cuda.cub.available, 'The CUB routine is not enabled')
-# class TestCubReduction(unittest.TestCase):
+@testing.parameterize(
+    *testing.product(
+        {
+            "shape": [(10,), (10, 20), (10, 20, 30), (10, 20, 30, 40)],
+            "order_and_axis": (("C", -1), ("C", None), ("F", 0), ("F", None)),
+            "backend": ("device", "block"),
+        }
+    )
+)
+@pytest.mark.skip("The CUB routine is not enabled")
+class TestCubReduction:
+    @pytest.fixture(autouse=True)
+    def setUp(self):
+        self.order, self.axis = self.order_and_axis
+        old_routine_accelerators = _acc.get_routine_accelerators()
+        old_reduction_accelerators = _acc.get_reduction_accelerators()
+        if self.backend == "device":
+            if self.axis is not None:
+                pytest.skip("does not support")
+            _acc.set_routine_accelerators(["cub"])
+            _acc.set_reduction_accelerators([])
+        elif self.backend == "block":
+            _acc.set_routine_accelerators([])
+            _acc.set_reduction_accelerators(["cub"])
+        yield
+        _acc.set_routine_accelerators(old_routine_accelerators)
+        _acc.set_reduction_accelerators(old_reduction_accelerators)
 
-# def setUp(self):
-# self.old_accelerators = _accelerator.get_routine_accelerators()
-# _accelerator.set_routine_accelerators(['cub'])
+    @testing.for_dtypes("bhilBHILefdFD")
+    @testing.numpy_cupy_allclose(rtol=1e-5, contiguous_check=False)
+    def test_cub_argmin(self, xp, dtype):
+        a = testing.shaped_random(self.shape, xp, dtype)
+        if self.order == "C":
+            a = xp.ascontiguousarray(a)
+        else:
+            a = xp.asfortranarray(a)
 
-# def tearDown(self):
-# _accelerator.set_routine_accelerators(self.old_accelerators)
+        if xp is numpy:
+            return a.argmin(axis=self.axis)
 
-# @testing.for_dtypes('bhilBHILefdFD')
-# @testing.numpy_cupy_allclose(rtol=1E-5)
-# def test_cub_argmin(self, xp, dtype):
-# a = testing.shaped_random(self.shape, xp, dtype)
-# if self.order == 'C':
-# a = xp.ascontiguousarray(a)
-# else:
-# a = xp.asfortranarray(a)
+        # xp is cupy, first ensure we really use CUB
+        ret = cupy.empty(())  # Cython checks return type, need to fool it
+        if self.backend == "device":
+            func_name = "cupy._core._routines_statistics.cub."
+            func_name += "device_reduce"
+            with testing.AssertFunctionIsCalled(func_name, return_value=ret):
+                a.argmin(axis=self.axis)
+        elif self.backend == "block":
+            # this is the only function we can mock; the rest is cdef'd
+            func_name = "cupy._core._cub_reduction."
+            func_name += "_SimpleCubReductionKernel_get_cached_function"
+            # func = _cub_reduction._SimpleCubReductionKernel_get_cached_function
+            if self.axis is not None and len(self.shape) > 1:
+                times_called = 1  # one pass
+            else:
+                times_called = 2  # two passes
+            with testing.AssertFunctionIsCalled(
+                func_name, wraps=func, times_called=times_called
+            ):
+                a.argmin(axis=self.axis)
+        # ...then perform the actual computation
+        return a.argmin(axis=self.axis)
 
-# if xp is numpy:
-# return a.argmin()
+    @testing.for_dtypes("bhilBHILefdFD")
+    @testing.numpy_cupy_allclose(rtol=1e-5, contiguous_check=False)
+    def test_cub_argmax(self, xp, dtype):
+        # _skip_cuda90(dtype)
+        a = testing.shaped_random(self.shape, xp, dtype)
+        if self.order == "C":
+            a = xp.ascontiguousarray(a)
+        else:
+            a = xp.asfortranarray(a)
 
-# # xp is cupy, first ensure we really use CUB
-# ret = cupy.empty(())  # Cython checks return type, need to fool it
-# func = 'cupy.core._routines_statistics.cub.device_reduce'
-# with testing.AssertFunctionIsCalled(func, return_value=ret):
-# a.argmin()
-# # ...then perform the actual computation
-# return a.argmin()
+        if xp is numpy:
+            return a.argmax(axis=self.axis)
 
-# @testing.for_dtypes('bhilBHILefdFD')
-# @testing.numpy_cupy_allclose(rtol=1E-5)
-# def test_cub_argmax(self, xp, dtype):
-# a = testing.shaped_random(self.shape, xp, dtype)
-# if self.order == 'C':
-# a = xp.ascontiguousarray(a)
-# else:
-# a = xp.asfortranarray(a)
-
-# if xp is numpy:
-# return a.argmax()
-
-# # xp is cupy, first ensure we really use CUB
-# ret = cupy.empty(())  # Cython checks return type, need to fool it
-# func = 'cupy.core._routines_statistics.cub.device_reduce'
-# with testing.AssertFunctionIsCalled(func, return_value=ret):
-# a.argmax()
-# # ...then perform the actual computation
-# return a.argmax()
+        # xp is cupy, first ensure we really use CUB
+        ret = cupy.empty(())  # Cython checks return type, need to fool it
+        if self.backend == "device":
+            func_name = "cupy._core._routines_statistics.cub."
+            func_name += "device_reduce"
+            with testing.AssertFunctionIsCalled(func_name, return_value=ret):
+                a.argmax(axis=self.axis)
+        elif self.backend == "block":
+            # this is the only function we can mock; the rest is cdef'd
+            func_name = "cupy._core._cub_reduction."
+            func_name += "_SimpleCubReductionKernel_get_cached_function"
+            # func = _cub_reduction._SimpleCubReductionKernel_get_cached_function
+            if self.axis is not None and len(self.shape) > 1:
+                times_called = 1  # one pass
+            else:
+                times_called = 2  # two passes
+            with testing.AssertFunctionIsCalled(
+                func_name, wraps=func, times_called=times_called
+            ):
+                a.argmax(axis=self.axis)
+        # ...then perform the actual computation
+        return a.argmax(axis=self.axis)
 
 
 @testing.parameterize(
@@ -225,6 +284,7 @@ class TestSearch:
         }
     )
 )
+@pytest.mark.skip("dtype is not supported")
 class TestArgMinMaxDtype:
     @testing.for_dtypes(
         dtypes=[numpy.int8, numpy.int16, numpy.int32, numpy.int64],
@@ -249,9 +309,9 @@ class TestArgMinMaxDtype:
     {"cond_shape": (2, 3, 4), "x_shape": (2, 3, 4), "y_shape": (3, 4)},
     {"cond_shape": (3, 4), "x_shape": (2, 3, 4), "y_shape": (4,)},
 )
-class TestWhereTwoArrays(unittest.TestCase):
+class TestWhereTwoArrays:
     @testing.for_all_dtypes_combination(names=["cond_type", "x_type", "y_type"])
-    @testing.numpy_cupy_allclose(type_check=False)
+    @testing.numpy_cupy_allclose(type_check=has_support_aspect64())
     def test_where_two_arrays(self, xp, cond_type, x_type, y_type):
         m = testing.shaped_random(self.cond_shape, xp, xp.bool_)
         # Almost all values of a matrix `shaped_random` makes are not zero.
@@ -268,7 +328,7 @@ class TestWhereTwoArrays(unittest.TestCase):
     {"cond_shape": (2, 3, 4)},
     {"cond_shape": (3, 4)},
 )
-class TestWhereCond(unittest.TestCase):
+class TestWhereCond:
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_where_cond(self, xp, dtype):
@@ -277,7 +337,7 @@ class TestWhereCond(unittest.TestCase):
         return xp.where(cond)
 
 
-class TestWhereError(unittest.TestCase):
+class TestWhereError:
     def test_one_argument(self):
         for xp in (numpy, cupy):
             cond = testing.shaped_random((3, 4), xp, dtype=xp.bool_)
@@ -287,6 +347,8 @@ class TestWhereError(unittest.TestCase):
 
 
 @testing.parameterize(
+    {"array": numpy.random.randint(0, 2, (20,))},
+    {"array": numpy.random.randn(3, 2, 4)},
     {"array": numpy.empty((0,))},
     {"array": numpy.empty((0, 2))},
     {"array": numpy.empty((0, 2, 0))},
@@ -304,17 +366,20 @@ class TestNonzero:
     {"array": numpy.array(0)},
     {"array": numpy.array(1)},
 )
+@pytest.mark.skip("Only positive rank is supported")
 @testing.with_requires("numpy>=1.17.0")
-class TestNonzeroZeroDimension(unittest.TestCase):
+class TestNonzeroZeroDimension:
     @testing.for_all_dtypes()
-    def test_nonzero(self, dtype):
-        for xp in (numpy, cupy):
-            array = xp.array(self.array, dtype=dtype)
-            with pytest.raises(DeprecationWarning):
-                xp.nonzero(array)
+    @testing.numpy_cupy_array_equal()
+    def test_nonzero(self, xp, dtype):
+        array = xp.array(self.array, dtype=dtype)
+        with testing.assert_warns(DeprecationWarning):
+            return xp.nonzero(array)
 
 
 @testing.parameterize(
+    {"array": numpy.random.randint(0, 2, (20,))},
+    {"array": numpy.random.randn(3, 2, 4)},
     {"array": numpy.array(0)},
     {"array": numpy.array(1)},
     {"array": numpy.empty((0,))},
@@ -322,6 +387,7 @@ class TestNonzeroZeroDimension(unittest.TestCase):
     {"array": numpy.empty((0, 2, 0))},
     _ids=False,  # Do not generate ids from randomly generated params
 )
+@pytest.mark.skip("flatnonzero isn't implemented yet")
 class TestFlatNonzero:
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
@@ -331,11 +397,14 @@ class TestFlatNonzero:
 
 
 @testing.parameterize(
+    {"array": numpy.random.randint(0, 2, (20,))},
+    {"array": numpy.random.randn(3, 2, 4)},
     {"array": numpy.empty((0,))},
     {"array": numpy.empty((0, 2))},
     {"array": numpy.empty((0, 2, 0))},
     _ids=False,  # Do not generate ids from randomly generated params
 )
+@pytest.mark.skip("argwhere isn't implemented yet")
 class TestArgwhere:
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
@@ -344,19 +413,18 @@ class TestArgwhere:
         return xp.argwhere(array)
 
 
-# DPNP_BUG
-# dpnp/backend.pyx:86: in dpnp.backend.dpnp_array
-# raise TypeError(f"Intel NumPy array(): Unsupported non-sequence obj={type(obj)}")
-# E   TypeError: Intel NumPy array(): Unsupported non-sequence obj=<class 'int'>
-# @testing.parameterize(
-# {'array': cupy.array(1)},
-# )
-
-# class TestArgwhereZeroDimension(unittest.TestCase):
-
-# def test_argwhere(self):
-# with testing.assert_warns(DeprecationWarning):
-# return cupy.nonzero(self.array)
+@testing.parameterize(
+    {"value": 0},
+    {"value": 3},
+)
+@pytest.mark.skip("argwhere isn't implemented yet")
+@testing.with_requires("numpy>=1.18")
+class TestArgwhereZeroDimension:
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_argwhere(self, xp, dtype):
+        array = xp.array(self.value, dtype=dtype)
+        return xp.argwhere(array)
 
 
 class TestNanArgMin:
@@ -560,8 +628,7 @@ class TestNanArgMax:
         }
     )
 )
-@pytest.mark.usefixtures("allow_fall_back_on_numpy")
-class TestSearchSorted(unittest.TestCase):
+class TestSearchSorted:
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_array_equal()
     def test_searchsorted(self, xp, dtype):
@@ -570,10 +637,17 @@ class TestSearchSorted(unittest.TestCase):
         y = xp.searchsorted(bins, x, side=self.side)
         return (y,)
 
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_array_equal()
+    def test_ndarray_searchsorted(self, xp, dtype):
+        x = testing.shaped_arange(self.shape, xp, dtype)
+        bins = xp.array(self.bins)
+        y = bins.searchsorted(x, side=self.side)
+        return (y,)
+
 
 @testing.parameterize({"side": "left"}, {"side": "right"})
-@pytest.mark.usefixtures("allow_fall_back_on_numpy")
-class TestSearchSortedNanInf(unittest.TestCase):
+class TestSearchSortedNanInf:
     @testing.numpy_cupy_array_equal()
     def test_searchsorted_nanbins(self, xp):
         x = testing.shaped_arange((10,), xp, xp.float64)
@@ -589,33 +663,37 @@ class TestSearchSortedNanInf(unittest.TestCase):
         y = xp.searchsorted(bins, x, side=self.side)
         return (y,)
 
-    # DPNP_BUG
-    # Segmentation fault on access to negative index # x[-1] = float('nan') #######
-    # @testing.numpy_cupy_array_equal()
-    # def test_searchsorted_nan_last(self, xp):
-    # x = testing.shaped_arange((10,), xp, xp.float64)
-    # x[-1] = float('nan')
-    # bins = xp.array([0, 1, 2, 4, float('nan')])
-    # y = xp.searchsorted(bins, x, side=self.side)
-    # return y,
+    @testing.numpy_cupy_array_equal()
+    def test_searchsorted_nan_last(self, xp):
+        x = testing.shaped_arange((10,), xp, xp.float64)
+        x[-1] = float("nan")
+        bins = xp.array([0, 1, 2, 4, float("nan")])
+        y = xp.searchsorted(bins, x, side=self.side)
+        return (y,)
 
-    # @testing.numpy_cupy_array_equal()
-    # def test_searchsorted_nan_last_repeat(self, xp):
-    # x = testing.shaped_arange((10,), xp, xp.float64)
-    # x[-1] = float('nan')
-    # bins = xp.array([0, 1, 2, float('nan'), float('nan')])
-    # y = xp.searchsorted(bins, x, side=self.side)
-    # return y,
+    @testing.numpy_cupy_array_equal()
+    def test_searchsorted_nan_last_repeat(self, xp):
+        x = testing.shaped_arange((10,), xp, xp.float64)
+        x[-1] = float("nan")
+        bins = xp.array([0, 1, 2, float("nan"), float("nan")])
+        y = xp.searchsorted(bins, x, side=self.side)
+        return (y,)
 
-    # @testing.numpy_cupy_array_equal()
-    # def test_searchsorted_all_nans(self, xp):
-    # x = testing.shaped_arange((10,), xp, xp.float64)
-    # x[-1] = float('nan')
-    # bins = xp.array([float('nan'), float('nan'), float('nan'),
-    # float('nan'), float('nan')])
-    # y = xp.searchsorted(bins, x, side=self.side)
-    # return y,
-    ###############################################################################
+    @testing.numpy_cupy_array_equal()
+    def test_searchsorted_all_nans(self, xp):
+        x = testing.shaped_arange((10,), xp, xp.float64)
+        x[-1] = float("nan")
+        bins = xp.array(
+            [
+                float("nan"),
+                float("nan"),
+                float("nan"),
+                float("nan"),
+                float("nan"),
+            ]
+        )
+        y = xp.searchsorted(bins, x, side=self.side)
+        return (y,)
 
     @testing.numpy_cupy_array_equal()
     def test_searchsorted_inf(self, xp):
@@ -634,8 +712,7 @@ class TestSearchSortedNanInf(unittest.TestCase):
         return (y,)
 
 
-@pytest.mark.usefixtures("allow_fall_back_on_numpy")
-class TestSearchSortedInvalid(unittest.TestCase):
+class TestSearchSortedInvalid:
     # Cant test unordered bins due to numpy undefined
     # behavior for searchsorted
 
@@ -646,9 +723,15 @@ class TestSearchSortedInvalid(unittest.TestCase):
             with pytest.raises(ValueError):
                 xp.searchsorted(bins, x)
 
+    def test_ndarray_searchsorted_ndbins(self):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((10,), xp, xp.float64)
+            bins = xp.array([[10, 4], [2, 1], [7, 8]])
+            with pytest.raises(ValueError):
+                bins.searchsorted(x)
 
-@pytest.mark.usefixtures("allow_fall_back_on_numpy")
-class TestSearchSortedWithSorter(unittest.TestCase):
+
+class TestSearchSortedWithSorter:
     @testing.numpy_cupy_array_equal()
     def test_sorter(self, xp):
         x = testing.shaped_arange((12,), xp, xp.float64)
@@ -667,8 +750,102 @@ class TestSearchSortedWithSorter(unittest.TestCase):
 
     def test_nonint_sorter(self):
         for xp in (numpy, cupy):
-            x = testing.shaped_arange((12,), xp, xp.float32)
+            dt = cupy.default_float_type()
+            x = testing.shaped_arange((12,), xp, dt)
             bins = xp.array([10, 4, 2, 1, 8])
-            sorter = xp.array([], dtype=xp.float32)
-            with pytest.raises(TypeError):
+            sorter = xp.array([], dtype=dt)
+            with pytest.raises((TypeError, ValueError)):
                 xp.searchsorted(bins, x, sorter=sorter)
+
+
+@testing.parameterize({"side": "left"}, {"side": "right"})
+class TestNdarraySearchSortedNanInf:
+    @testing.numpy_cupy_array_equal()
+    def test_searchsorted_nanbins(self, xp):
+        x = testing.shaped_arange((10,), xp, xp.float64)
+        bins = xp.array([0, 1, 2, 4, 10, float("nan")])
+        y = bins.searchsorted(x, side=self.side)
+        return (y,)
+
+    @testing.numpy_cupy_array_equal()
+    def test_searchsorted_nan(self, xp):
+        x = testing.shaped_arange((10,), xp, xp.float64)
+        x[5] = float("nan")
+        bins = xp.array([0, 1, 2, 4, 10])
+        y = bins.searchsorted(x, side=self.side)
+        return (y,)
+
+    @testing.numpy_cupy_array_equal()
+    def test_searchsorted_nan_last(self, xp):
+        x = testing.shaped_arange((10,), xp, xp.float64)
+        x[-1] = float("nan")
+        bins = xp.array([0, 1, 2, 4, float("nan")])
+        y = bins.searchsorted(x, side=self.side)
+        return (y,)
+
+    @testing.numpy_cupy_array_equal()
+    def test_searchsorted_nan_last_repeat(self, xp):
+        x = testing.shaped_arange((10,), xp, xp.float64)
+        x[-1] = float("nan")
+        bins = xp.array([0, 1, 2, float("nan"), float("nan")])
+        y = bins.searchsorted(x, side=self.side)
+        return (y,)
+
+    @testing.numpy_cupy_array_equal()
+    def test_searchsorted_all_nans(self, xp):
+        x = testing.shaped_arange((10,), xp, xp.float64)
+        x[-1] = float("nan")
+        bins = xp.array(
+            [
+                float("nan"),
+                float("nan"),
+                float("nan"),
+                float("nan"),
+                float("nan"),
+            ]
+        )
+        y = bins.searchsorted(x, side=self.side)
+        return (y,)
+
+    @testing.numpy_cupy_array_equal()
+    def test_searchsorted_inf(self, xp):
+        x = testing.shaped_arange((10,), xp, xp.float64)
+        x[5] = float("inf")
+        bins = xp.array([0, 1, 2, 4, 10])
+        y = bins.searchsorted(x, side=self.side)
+        return (y,)
+
+    @testing.numpy_cupy_array_equal()
+    def test_searchsorted_minf(self, xp):
+        x = testing.shaped_arange((10,), xp, xp.float64)
+        x[5] = float("-inf")
+        bins = xp.array([0, 1, 2, 4, 10])
+        y = bins.searchsorted(x, side=self.side)
+        return (y,)
+
+
+class TestNdarraySearchSortedWithSorter:
+    @testing.numpy_cupy_array_equal()
+    def test_sorter(self, xp):
+        x = testing.shaped_arange((12,), xp, xp.float64)
+        bins = xp.array([10, 4, 2, 1, 8])
+        sorter = xp.array([3, 2, 1, 4, 0])
+        y = bins.searchsorted(x, sorter=sorter)
+        return (y,)
+
+    def test_invalid_sorter(self):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((12,), xp, xp.float64)
+            bins = xp.array([10, 4, 2, 1, 8])
+            sorter = xp.array([0])
+            with pytest.raises(ValueError):
+                bins.searchsorted(x, sorter=sorter)
+
+    def test_nonint_sorter(self):
+        for xp in (numpy, cupy):
+            dt = cupy.default_float_type()
+            x = testing.shaped_arange((12,), xp, dt)
+            bins = xp.array([10, 4, 2, 1, 8])
+            sorter = xp.array([], dtype=dt)
+            with pytest.raises((TypeError, ValueError)):
+                bins.searchsorted(x, sorter=sorter)

--- a/tests/third_party/cupy/sorting_tests/test_search.py
+++ b/tests/third_party/cupy/sorting_tests/test_search.py
@@ -82,11 +82,9 @@ class TestSearch:
         return a.argmax(axis=1)
 
     @testing.slow
+    @pytest.mark.skip("slow mark is not implemented")
     def test_argmax_int32_overflow(self):
-        try:
-            a = testing.shaped_arange((2**32 + 1,), cupy, numpy.float64)
-        except MemoryError as e:
-            pytest.skip("Not enough memory: " + str(e))
+        a = testing.shaped_arange((2**32 + 1,), cupy, numpy.float64)
         assert a.argmax().item() == 2**32
 
     @testing.for_all_dtypes(no_complex=True)
@@ -164,11 +162,9 @@ class TestSearch:
         return a.argmin(axis=1)
 
     @testing.slow
+    @pytest.mark.skip("slow mark is not implemented")
     def test_argmin_int32_overflow(self):
-        try:
-            a = testing.shaped_arange((2**32 + 1,), cupy, numpy.float64)
-        except MemoryError as e:
-            pytest.skip("Not enough memory: " + str(e))
+        a = testing.shaped_arange((2**32 + 1,), cupy, numpy.float64)
         cupy.negative(a, out=a)
         assert a.argmin().item() == 2**32
 


### PR DESCRIPTION
The PR is about to implement `dpnp.searchsorted` through leveraging on `dpctl` implementation.
In addition, the PR adds missing `dpnp.ndarray.searchsorted` method and increases tests coverage.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
