### PR TITLE
Remove a temporary workaround in GitHub actions

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Install dpnp dependencies
         run: |
-          conda install numpy"<1.24" dpctl mkl-devel-dpcpp onedpl-devel tbb-devel dpcpp_linux-64 \
+          conda install numpy"<1.24" dpctl">=0.17.0dev0" mkl-devel-dpcpp onedpl-devel tbb-devel dpcpp_linux-64 \
               cmake cython pytest ninja scikit-build ${{ env.CHANNELS }}
 
       - name: Install cuPy dependencies

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -107,8 +107,8 @@ jobs:
 
       - name: Install dpnp dependencies
         run: |
-          conda install numpy"<1.24" dpctl">=0.17.0dev0" mkl-devel-dpcpp onedpl-devel tbb-devel dpcpp_linux-64"<2024.0.1" \
-              cmake cython pytest ninja scikit-build sysroot_linux-64">=2.28" ${{ env.CHANNELS }}
+          conda install numpy"<1.24" dpctl mkl-devel-dpcpp onedpl-devel tbb-devel dpcpp_linux-64 \
+              cmake cython pytest ninja scikit-build ${{ env.CHANNELS }}
 
       - name: Install cuPy dependencies
         run: conda install cupy cudatoolkit=10.0

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Install dpnp dependencies
         run: |
           conda install cython llvm cmake">=3.21" scikit-build ninja pytest pytest-cov coverage[toml] \
-              dpctl dpcpp_linux-64 mkl-devel-dpcpp tbb-devel onedpl-devel ${{ env.CHANNELS }}
+              dpctl">=0.17.0dev0" dpctl dpcpp_linux-64 mkl-devel-dpcpp tbb-devel onedpl-devel ${{ env.CHANNELS }}
 
       - name: Conda info
         run: |

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -48,10 +48,8 @@ jobs:
 
       - name: Install dpnp dependencies
         run: |
-          # use DPC++ compiler 2023.2 to work around an issue with crash
           conda install cython llvm cmake">=3.21" scikit-build ninja pytest pytest-cov coverage[toml] \
-              dpctl">=0.17.0dev0" dpcpp_linux-64"=2023.2" sysroot_linux-64">=2.28" mkl-devel-dpcpp tbb-devel"=2021.10" \
-              onedpl-devel ${{ env.CHANNELS }}
+              dpctl dpcpp_linux-64 mkl-devel-dpcpp tbb-devel onedpl-devel ${{ env.CHANNELS }}
 
       - name: Conda info
         run: |


### PR DESCRIPTION
Since `2024.1` is published on `intel` channel, which contains the required fixes, there is no need to keep the workarounds with pinning of DPC++ compiler to older versions (see #1628 and #1643 for more details).

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
