### PR TITLE
Get rid of `call_origin` in `dpnp.nonzero`

### DIFF
--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -21,7 +21,7 @@ jobs:
 
     env:
       python-ver: '3.10'
-      CHANNELS: '-c dppy/label/dev -c intel -c conda-forge --override-channels'
+      CHANNELS: '-c dppy/label/coverage -c intel -c conda-forge --override-channels'
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -21,7 +21,7 @@ jobs:
 
     env:
       python-ver: '3.10'
-      CHANNELS: '-c dppy/label/coverage -c intel -c conda-forge --override-channels'
+      CHANNELS: '-c dppy/label/dev -c intel -c conda-forge --override-channels'
 
     steps:
       - name: Cancel Previous Runs

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -173,6 +173,7 @@ class dpnp_array:
         Used if :func:`copy.copy` is called on an array. Returns a copy of the array.
 
         Equivalent to ``a.copy(order="K")``.
+
         """
         return self.copy(order="K")
 
@@ -911,6 +912,7 @@ class dpnp_array:
         Return the maximum along an axis.
 
         Refer to :obj:`dpnp.max` for full documentation.
+
         """
 
         return dpnp.max(self, axis, out, keepdims, initial, where)
@@ -922,6 +924,7 @@ class dpnp_array:
         Returns the average of the array elements.
 
         Refer to :obj:`dpnp.mean` for full documentation.
+
         """
 
         return dpnp.mean(self, axis, dtype, out, keepdims, where=where)
@@ -938,6 +941,7 @@ class dpnp_array:
         Return the minimum along a given axis.
 
         Refer to :obj:`dpnp.min` for full documentation.
+
         """
 
         return dpnp.min(self, axis, out, keepdims, initial, where)
@@ -957,7 +961,12 @@ class dpnp_array:
     # 'newbyteorder',
 
     def nonzero(self):
-        """Return the indices of the elements that are non-zero."""
+        """
+        Return the indices of the elements that are non-zero.
+
+        Refer to :obj:`dpnp.nonzero` for full documentation.
+
+        """
 
         return dpnp.nonzero(self)
 
@@ -1015,6 +1024,7 @@ class dpnp_array:
         Puts values of an array into another array along a given axis.
 
         For full documentation refer to :obj:`numpy.put`.
+
         """
 
         return dpnp.put(self, indices, vals, axis=axis, mode=mode)
@@ -1226,6 +1236,7 @@ class dpnp_array:
         Returns the standard deviation of the array elements, along given axis.
 
         Refer to :obj:`dpnp.std` for full documentation.
+
         """
 
         return dpnp.std(self, axis, dtype, out, ddof, keepdims, where=where)
@@ -1261,6 +1272,7 @@ class dpnp_array:
         Returns the sum along a given axis.
 
         For full documentation refer to :obj:`dpnp.sum`.
+
         """
 
         return dpnp.sum(
@@ -1278,6 +1290,7 @@ class dpnp_array:
         Interchange two axes of an array.
 
         For full documentation refer to :obj:`numpy.swapaxes`.
+
         """
 
         return dpnp.swapaxes(self, axis1=axis1, axis2=axis2)
@@ -1371,6 +1384,7 @@ class dpnp_array:
         Returns the variance of the array elements, along given axis.
 
         Refer to :obj:`dpnp.var` for full documentation.
+
         """
         return dpnp.var(self, axis, dtype, out, ddof, keepdims, where=where)
 

--- a/dpnp/dpnp_iface_indexing.py
+++ b/dpnp/dpnp_iface_indexing.py
@@ -525,7 +525,7 @@ def nonzero(a):
     Notes
     -----
     While the nonzero values can be obtained with ``a[nonzero(a)]``, it is
-    recommended to use ``x[x.astype(bool)]`` or ``x[x != 0]`` instead, which
+    recommended to use ``a[a.astype(bool)]`` or ``a[a != 0]`` instead, which
     will correctly handle 0-d arrays.
 
     Examples

--- a/dpnp/dpnp_iface_searching.py
+++ b/dpnp/dpnp_iface_searching.py
@@ -299,7 +299,7 @@ def where(condition, x=None, y=None, /):
     Parameters
     ----------
     condition : {dpnp.ndarray, usm_ndarray}
-        Where True, yield `x`, otherwise yield `y`.
+        When ``True``, yield `x`, otherwise yield `y`.
     x, y : {dpnp.ndarray, usm_ndarray, scalar}, optional
         Values from which to choose. `x`, `y` and `condition` need to be
         broadcastable to some shape.
@@ -307,8 +307,8 @@ def where(condition, x=None, y=None, /):
     Returns
     -------
     y : dpnp.ndarray
-        An array with elements from `x` where `condition` is True, and elements
-        from `y` elsewhere.
+        An array with elements from `x` when `condition` is ``True``, and
+        elements from `y` elsewhere.
 
     See Also
     --------

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -85,6 +85,69 @@ class TestIndexing:
         assert_array_equal(arr, 10.0)
 
 
+class TestNonzero:
+    @pytest.mark.parametrize("list_val", [[], [0], [1]])
+    def test_trivial(self, list_val):
+        np_res = numpy.nonzero(numpy.array(list_val))
+        dpnp_res = dpnp.nonzero(dpnp.array(list_val))
+        assert_array_equal(np_res, dpnp_res)
+
+    @pytest.mark.parametrize("val", [0, 1])
+    def test_0d(self, val):
+        assert_raises(ValueError, dpnp.nonzero, dpnp.array(val))
+        assert_raises(ValueError, dpnp.nonzero, dpnp.array(val))
+
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
+    def test_1d(self, dtype):
+        a = numpy.array([1, 0, 2, -1, 0, 0, 8], dtype=dtype)
+        ia = dpnp.array(a)
+
+        np_res = numpy.nonzero(a)
+        dpnp_res = dpnp.nonzero(ia)
+        assert_array_equal(np_res, dpnp_res)
+
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
+    def test_2d(self, dtype):
+        a = numpy.array([[0, 1, 0], [2, 0, 3]], dtype=dtype)
+        ia = dpnp.array(a)
+
+        np_res = numpy.nonzero(a)
+        dpnp_res = dpnp.nonzero(ia)
+        assert_array_equal(np_res, dpnp_res)
+
+        a = numpy.eye(3, dtype=dtype)
+        ia = dpnp.eye(3, dtype=dtype)
+
+        np_res = numpy.nonzero(a)
+        dpnp_res = dpnp.nonzero(ia)
+        assert_array_equal(np_res, dpnp_res)
+
+    def test_sparse(self):
+        for i in range(20):
+            a = numpy.zeros(200, dtype=bool)
+            a[i::20] = True
+            ia = dpnp.array(a)
+
+            np_res = numpy.nonzero(a)
+            dpnp_res = dpnp.nonzero(ia)
+            assert_array_equal(np_res, dpnp_res)
+
+            a = numpy.zeros(400, dtype=bool)
+            a[10 + i : 20 + i] = True
+            a[20 + i * 2] = True
+            ia = dpnp.array(a)
+
+            np_res = numpy.nonzero(a)
+            dpnp_res = dpnp.nonzero(ia)
+            assert_array_equal(np_res, dpnp_res)
+
+    @pytest.mark.parametrize("dtype", get_all_dtypes())
+    def test_array_method(self, dtype):
+        a = numpy.array([[1, 0, 0], [4, 0, 6]], dtype=dtype)
+        ia = dpnp.array(a)
+        assert_array_equal(a.nonzero(), ia.nonzero())
+
+
 class TestPutAlongAxis:
     @pytest.mark.parametrize(
         "arr_dt", get_all_dtypes(no_bool=True, no_none=True)
@@ -369,40 +432,6 @@ def test_indices(dimension, dtype, sparse):
     result = dpnp.indices(dimension, dtype=dtype, sparse=sparse)
     for Xnp, X in zip(expected, result):
         assert_array_equal(Xnp, X)
-
-
-@pytest.mark.parametrize(
-    "array",
-    [
-        [],
-        [[0, 0], [0, 0]],
-        [[1, 0], [1, 0]],
-        [[1, 2], [3, 4]],
-        [[0, 1, 2], [3, 0, 5], [6, 7, 0]],
-        [[0, 1, 0, 3, 0], [5, 0, 7, 0, 9]],
-        [[[1, 2], [0, 4]], [[0, 2], [0, 1]], [[0, 0], [3, 1]]],
-        [
-            [[[1, 2, 3], [3, 4, 5]], [[1, 2, 3], [2, 1, 0]]],
-            [[[1, 3, 5], [3, 1, 0]], [[0, 1, 2], [1, 3, 4]]],
-        ],
-    ],
-    ids=[
-        "[]",
-        "[[0, 0], [0, 0]]",
-        "[[1, 0], [1, 0]]",
-        "[[1, 2], [3, 4]]",
-        "[[0, 1, 2], [3, 0, 5], [6, 7, 0]]",
-        "[[0, 1, 0, 3, 0], [5, 0, 7, 0, 9]]",
-        "[[[1, 2], [0, 4]], [[0, 2], [0, 1]], [[0, 0], [3, 1]]]",
-        "[[[[1, 2, 3], [3, 4, 5]], [[1, 2, 3], [2, 1, 0]]], [[[1, 3, 5], [3, 1, 0]], [[0, 1, 2], [1, 3, 4]]]]",
-    ],
-)
-def test_nonzero(array):
-    a = numpy.array(array)
-    ia = dpnp.array(array)
-    expected = numpy.nonzero(a)
-    result = dpnp.nonzero(ia)
-    assert_array_equal(expected, result)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -1763,6 +1763,18 @@ def test_indices(device, sparse):
     valid_devices,
     ids=[device.filter_string for device in valid_devices],
 )
+def test_nonzero(device):
+    a = dpnp.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], device=device)
+    x = dpnp.nonzero(a)
+    for x_el in x:
+        assert_sycl_queue_equal(x_el.sycl_queue, a.sycl_queue)
+
+
+@pytest.mark.parametrize(
+    "device",
+    valid_devices,
+    ids=[device.filter_string for device in valid_devices],
+)
 @pytest.mark.parametrize("func", ["mgrid", "ogrid"])
 def test_grid(device, func):
     sycl_queue = dpctl.SyclQueue(device)

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -753,6 +753,14 @@ def test_indices_sparse(usm_type, sparse):
 
 
 @pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+def test_nonzero(usm_type):
+    a = dp.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], usm_type=usm_type)
+    x = dp.nonzero(a)
+    for x_el in x:
+        assert x_el.usm_type == usm_type
+
+
+@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
 def test_clip(usm_type):
     x = dp.arange(10, usm_type=usm_type)
     y = dp.clip(x, 2, 7)


### PR DESCRIPTION
That PR propose to remove `call_origin` call from implementation of `dpnp.nonzero` function.
Also the PR adds more tests (including missing ones for compute follows data support) and increases coverage rate.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
