### PR TITLE
add support for `axes` as list in `dpnp.ndarray.transpose`

### DIFF
--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -1355,7 +1355,7 @@ class dpnp_array:
             return self
 
         axes_len = len(axes)
-        if axes_len == 1 and isinstance(axes[0], tuple):
+        if axes_len == 1 and isinstance(axes[0], (tuple, list)):
             axes = axes[0]
 
         res = self.__new__(dpnp_array)

--- a/tests/test_manipulation.py
+++ b/tests/test_manipulation.py
@@ -115,7 +115,7 @@ def test_unique(array):
 
 
 class TestTranspose:
-    @pytest.mark.parametrize("axes", [(0, 1), (1, 0)])
+    @pytest.mark.parametrize("axes", [(0, 1), (1, 0), [0, 1]])
     def test_2d_with_axes(self, axes):
         na = numpy.array([[1, 2], [3, 4]])
         da = dpnp.array(na)
@@ -124,11 +124,31 @@ class TestTranspose:
         result = dpnp.transpose(da, axes)
         assert_array_equal(expected, result)
 
-    @pytest.mark.parametrize("axes", [(1, 0, 2), ((1, 0, 2),)])
+        # ndarray
+        expected = na.transpose(axes)
+        result = da.transpose(axes)
+        assert_array_equal(expected, result)
+
+    @pytest.mark.parametrize(
+        "axes",
+        [
+            (1, 0, 2),
+            [1, 0, 2],
+            ((1, 0, 2),),
+            ([1, 0, 2],),
+            [(1, 0, 2)],
+            [[1, 0, 2]],
+        ],
+    )
     def test_3d_with_packed_axes(self, axes):
         na = numpy.ones((1, 2, 3))
         da = dpnp.array(na)
 
+        expected = na.transpose(*axes)
+        result = da.transpose(*axes)
+        assert_array_equal(expected, result)
+
+        # ndarray
         expected = na.transpose(*axes)
         result = da.transpose(*axes)
         assert_array_equal(expected, result)

--- a/tests/third_party/cupy/manipulation_tests/test_transpose.py
+++ b/tests/third_party/cupy/manipulation_tests/test_transpose.py
@@ -64,19 +64,37 @@ class TestTranspose(unittest.TestCase):
             with pytest.raises(numpy.AxisError):
                 xp.moveaxis(a, [0, -4], [1, 2])
 
+    def test_moveaxis_invalid2_3(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(numpy.AxisError):
+                xp.moveaxis(a, -4, 0)
+
     # len(source) != len(destination)
-    def test_moveaxis_invalid3(self):
+    def test_moveaxis_invalid3_1(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3, 4), xp)
             with pytest.raises(ValueError):
                 xp.moveaxis(a, [0, 1, 2], [1, 2])
 
+    def test_moveaxis_invalid3_2(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(ValueError):
+                xp.moveaxis(a, 0, [1, 2])
+
     # len(source) != len(destination)
-    def test_moveaxis_invalid4(self):
+    def test_moveaxis_invalid4_1(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3, 4), xp)
             with pytest.raises(ValueError):
                 xp.moveaxis(a, [0, 1], [1, 2, 0])
+
+    def test_moveaxis_invalid4_2(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(ValueError):
+                xp.moveaxis(a, [0, 1], 1)
 
     # Use the same axis twice
     def test_moveaxis_invalid5_1(self):


### PR DESCRIPTION
In this PR, `dpnp.ndarray.transpose` is updated to support `axes` as list and new tests are added. This PR resolves #1769.
In addition, `tests/third_party/cupy/manipulation_tests/test_transpose.py` is updated to the most recent version.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
