### PR TITLE
Remove numpy pinning from conda receipt

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -14,7 +14,7 @@ requirements:
     host:
       - python
       - setuptools
-      - numpy <1.27a0
+      - numpy
       - cython
       - cmake >=3.21
       - ninja


### PR DESCRIPTION
The PR propose to remove pinning of numpy version from conda receipt, because it affects flow of internal CI where the numpy version is specified by conda command.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
