### PR TITLE
Leverage `dpnp.cumsum` through dpctl.tensor implementation

### DIFF
--- a/dpnp/dpnp_algo/dpnp_algo_mathematical.pxi
+++ b/dpnp/dpnp_algo/dpnp_algo_mathematical.pxi
@@ -37,7 +37,6 @@ and the rest of the library
 
 __all__ += [
     "dpnp_cumprod",
-    "dpnp_cumsum",
     "dpnp_ediff1d",
     "dpnp_fabs",
     "dpnp_fmod",

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -533,7 +533,7 @@ class dpnp_array:
         """
         Copy the array with data type casting.
 
-        For full documentation refer to :obj:`numpy.ndarray.astype`.
+        Refer to :obj:`dpnp.astype` for full documentation.
 
         Parameters
         ----------
@@ -593,7 +593,12 @@ class dpnp_array:
     # 'byteswap',
 
     def choose(input, choices, out=None, mode="raise"):
-        """Construct an array from an index array and a set of arrays to choose from."""
+        """
+        Construct an array from an index array and a set of arrays to choose from.
+
+        Refer to :obj:`dpnp.choose` for full documentation.
+
+        """
 
         return dpnp.choose(input, choices, out, mode)
 
@@ -613,7 +618,7 @@ class dpnp_array:
         """
         Complex-conjugate all elements.
 
-        For full documentation refer to :obj:`numpy.ndarray.conj`.
+        Refer to :obj:`dpnp.conjugate` for full documentation.
 
         """
 
@@ -626,7 +631,7 @@ class dpnp_array:
         """
         Return the complex conjugate, element-wise.
 
-        For full documentation refer to :obj:`numpy.ndarray.conjugate`.
+        Refer to :obj:`dpnp.conjugate` for full documentation.
 
         """
 
@@ -683,9 +688,7 @@ class dpnp_array:
         """
         Return the cumulative sum of the elements along the given axis.
 
-        See Also
-        --------
-        :obj:`dpnp.cumsum`
+        Refer to :obj:`dpnp.cumsum` for full documentation.
 
         """
 
@@ -697,9 +700,7 @@ class dpnp_array:
         """
         Return specified diagonals.
 
-        See Also
-        --------
-        :obj:`dpnp.diagonal`
+        Refer to :obj:`dpnp.diagonal` for full documentation.
 
         """
 
@@ -709,7 +710,7 @@ class dpnp_array:
         """
         Dot product of two arrays.
 
-        For full documentation refer to :obj:`dpnp.dot`.
+        Refer to :obj:`dpnp.dot` for full documentation.
 
         Examples
         --------
@@ -1013,7 +1014,7 @@ class dpnp_array:
         """
         Returns the prod along a given axis.
 
-        For full documentation refer to :obj:`dpnp.prod`.
+        Refer to :obj:`dpnp.prod` for full documentation.
 
         """
 
@@ -1023,7 +1024,7 @@ class dpnp_array:
         """
         Puts values of an array into another array along a given axis.
 
-        For full documentation refer to :obj:`numpy.put`.
+        Refer to :obj:`dpnp.put` for full documentation.
 
         """
 
@@ -1033,7 +1034,7 @@ class dpnp_array:
         """
         Return a contiguous flattened array.
 
-        For full documentation refer to :obj:`dpnp.ravel`.
+        Refer to :obj:`dpnp.ravel` for full documentation.
 
         """
 
@@ -1083,7 +1084,7 @@ class dpnp_array:
         """
         Repeat elements of an array.
 
-        For full documentation refer to :obj:`dpnp.repeat`.
+        Refer to :obj:`dpnp.repeat` for full documentation.
 
         """
 
@@ -1093,7 +1094,7 @@ class dpnp_array:
         """
         Returns an array containing the same data with a new shape.
 
-        For full documentation refer to :obj:`numpy.ndarray.reshape`.
+        Refer to :obj:`dpnp.reshape` for full documentation.
 
         Returns
         -------
@@ -1124,8 +1125,7 @@ class dpnp_array:
         """
         Return array with each element rounded to the given number of decimals.
 
-        .. seealso::
-           :obj:`dpnp.around` for full documentation.
+        Refer to :obj:`dpnp.round` for full documentation.
 
         """
 
@@ -1271,7 +1271,7 @@ class dpnp_array:
         """
         Returns the sum along a given axis.
 
-        For full documentation refer to :obj:`dpnp.sum`.
+        Refer to :obj:`dpnp.sum` for full documentation.
 
         """
 
@@ -1289,7 +1289,7 @@ class dpnp_array:
         """
         Interchange two axes of an array.
 
-        For full documentation refer to :obj:`numpy.swapaxes`.
+        Refer to :obj:`dpnp.swapaxes` for full documentation.
 
         """
 
@@ -1299,7 +1299,7 @@ class dpnp_array:
         """
         Take elements from an array along an axis.
 
-        For full documentation refer to :obj:`numpy.take`.
+        Refer to :obj:`dpnp.take` for full documentation.
 
         """
 

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -882,10 +882,10 @@ def cumsum(a, axis=None, dtype=None, out=None):
     Returns
     -------
     out : dpnp.ndarray
-        A new array holding the result is returned unless `out` is specified,
-        in which case a reference to `out` is returned. The result has the same
-        size as `a`, and the same shape as `a` if `axis` is not ``None`` or `a`
-        is a 1-d array.
+        A new array holding the result is returned unless `out` is specified as
+        :class:`dpnp.ndarray`, in which case a reference to `out` is returned.
+        The result has the same size as `a`, and the same shape as `a` if `axis`
+        is not ``None`` or `a` is a 1-d array.
 
     See Also
     --------
@@ -947,17 +947,8 @@ def cumsum(a, axis=None, dtype=None, out=None):
         usm_out = dpnp.get_usm_ndarray(out)
 
     res_usm = dpt.cumulative_sum(usm_a, axis=axis, dtype=dtype, out=usm_out)
-    if out is None:
-        return dpnp_array._create_from_usm_ndarray(res_usm)
-
-    if input_out is not out:
-        # need to copy back from temporary memory to input `out`
-        dpnp.copyto(input_out, out, casting="unsafe")
-
-    if not isinstance(input_out, dpnp_array):
-        return dpnp_array._create_from_usm_ndarray(input_out)
-    else:
-        return input_out
+    res = dpnp_array._create_from_usm_ndarray(res_usm)
+    return dpnp.get_result_array(res, input_out, casting="unsafe")
 
 
 def diff(a, n=1, axis=-1, prepend=None, append=None):

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -37,7 +37,10 @@ def assert_dtype_allclose(
     """
 
     list_64bit_types = [numpy.float64, numpy.complex128]
-    is_inexact = lambda x: dpnp.issubdtype(x.dtype, dpnp.inexact)
+    is_inexact = lambda x: hasattr(x, "dtype") and dpnp.issubdtype(
+        x.dtype, dpnp.inexact
+    )
+
     if is_inexact(dpnp_arr) or is_inexact(numpy_arr):
         tol_dpnp = (
             dpnp.finfo(dpnp_arr).resolution
@@ -73,7 +76,7 @@ def assert_dtype_allclose(
                     assert dpnp_arr_dtype.kind == numpy_arr_dtype.kind
     else:
         assert_array_equal(dpnp_arr.asnumpy(), numpy_arr)
-        if check_type:
+        if check_type and hasattr(numpy_arr, "dtype"):
             if check_only_type_kind:
                 assert dpnp_arr.dtype.kind == numpy_arr.dtype.kind
             else:

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -479,21 +479,6 @@ tests/third_party/cupy/math_tests/test_misc.py::TestConvolve::test_convolve_diff
 
 tests/third_party/cupy/math_tests/test_rounding.py::TestRounding::test_fix
 
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_ndarray_cumprod_2dim_with_axis
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_cumprod_arraylike
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_cumprod_huge_array
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_cumprod_numpy_array
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_cumprod_out_noncontiguous
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_cumprod_1dim
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_cumprod_2dim_without_axis
-
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum::test_cumsum_arraylike[_param_0_{axis=0}]
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum::test_cumsum_arraylike[_param_1_{axis=1}]
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum::test_cumsum_arraylike[_param_2_{axis=2}]
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum::test_cumsum_numpy_array[_param_0_{axis=0}]
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum::test_cumsum_numpy_array[_param_1_{axis=1}]
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum::test_cumsum_numpy_array[_param_2_{axis=2}]
-
 tests/third_party/cupy/math_tests/test_trigonometric.py::TestUnwrap::test_unwrap_1dim
 tests/third_party/cupy/math_tests/test_trigonometric.py::TestUnwrap::test_unwrap_1dim_with_discont
 tests/third_party/cupy/math_tests/test_trigonometric.py::TestUnwrap::test_unwrap_1dim_with_period

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -586,28 +586,6 @@ tests/third_party/cupy/math_tests/test_misc.py::TestConvolve::test_convolve_diff
 
 tests/third_party/cupy/math_tests/test_rounding.py::TestRounding::test_fix
 
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_ndarray_cumprod_2dim_with_axis
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_cumprod_arraylike
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_cumprod_huge_array
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_cumprod_numpy_array
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_cumprod_out_noncontiguous
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_cumprod_1dim
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumprod::test_cumprod_2dim_without_axis
-
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum::test_cumsum[_param_0_{axis=0}]
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum::test_cumsum[_param_1_{axis=1}]
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum::test_cumsum[_param_2_{axis=2}]
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum::test_cumsum_2dim[_param_0_{axis=0}]
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum::test_cumsum_2dim[_param_1_{axis=1}]
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum::test_cumsum_2dim[_param_2_{axis=2}]
-
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum::test_cumsum_arraylike[_param_0_{axis=0}]
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum::test_cumsum_arraylike[_param_1_{axis=1}]
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum::test_cumsum_arraylike[_param_2_{axis=2}]
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum::test_cumsum_numpy_array[_param_0_{axis=0}]
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum::test_cumsum_numpy_array[_param_1_{axis=1}]
-tests/third_party/cupy/math_tests/test_sumprod.py::TestCumsum::test_cumsum_numpy_array[_param_2_{axis=2}]
-
 tests/third_party/cupy/math_tests/test_trigonometric.py::TestUnwrap::test_unwrap_1dim
 tests/third_party/cupy/math_tests/test_trigonometric.py::TestUnwrap::test_unwrap_1dim_with_discont
 tests/third_party/cupy/math_tests/test_trigonometric.py::TestUnwrap::test_unwrap_1dim_with_period

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -161,6 +161,69 @@ class TestClip:
             dpnp.clip(a, 1, 5, **kwargs)
 
 
+class TestCumSum:
+    @pytest.mark.parametrize(
+        "arr, axis",
+        [
+            pytest.param([1, 2, 10, 11, 6, 5, 4], 0),
+            pytest.param([[1, 2, 3, 4], [5, 6, 7, 9], [10, 3, 4, 5]], 0),
+            pytest.param([[1, 2, 3, 4], [5, 6, 7, 9], [10, 3, 4, 5]], 1),
+            pytest.param([[0, 1, 2], [3, 4, 5]], 0),
+            pytest.param([[0, 1, 2], [3, 4, 5]], -1),
+        ],
+    )
+    @pytest.mark.parametrize("dtype", get_all_dtypes())
+    def test_axis(self, arr, axis, dtype):
+        a = numpy.array(arr, dtype=dtype)
+        ia = dpnp.array(a)
+
+        result = dpnp.cumsum(ia, axis=axis)
+        expected = numpy.cumsum(a, axis=axis)
+        assert_array_equal(expected, result)
+
+    @pytest.mark.parametrize("dtype", get_all_dtypes())
+    def test_ndarray_method(self, dtype):
+        a = numpy.arange(10).astype(dtype=dtype)
+        ia = dpnp.array(a)
+
+        result = ia.cumsum()
+        expected = a.cumsum()
+        assert_array_equal(expected, result)
+
+    @pytest.mark.parametrize("sh", [(10,), (2, 5)])
+    def test_usm_ndarray(self, sh):
+        a = numpy.arange(10).reshape(sh)
+        ia = dpt.asarray(a)
+
+        result = dpnp.cumsum(ia)
+        expected = numpy.cumsum(a)
+        assert_array_equal(expected, result)
+
+        out = numpy.empty((10,))
+        iout = dpt.asarray(out)
+
+        result = dpnp.cumsum(ia, out=iout)
+        expected = numpy.cumsum(a, out=out)
+        assert_array_equal(expected, result)
+        assert result is not iout
+
+    @pytest.mark.usefixtures("suppress_complex_warning")
+    @pytest.mark.parametrize("arr_dt", get_all_dtypes(no_none=True))
+    @pytest.mark.parametrize("out_dt", get_all_dtypes(no_none=True))
+    @pytest.mark.parametrize("dtype", get_all_dtypes())
+    def test_out_dtype(self, arr_dt, out_dt, dtype):
+        a = numpy.arange(10, 20).astype(dtype=arr_dt)
+        out = numpy.zeros_like(a, dtype=out_dt)
+
+        ia = dpnp.array(a)
+        iout = dpnp.array(out)
+
+        result = ia.cumsum(out=iout, dtype=dtype)
+        expected = a.cumsum(out=out, dtype=dtype)
+        assert_array_equal(expected, result)
+        assert result is iout
+
+
 class TestDiff:
     @pytest.mark.parametrize("n", list(range(0, 3)))
     @pytest.mark.parametrize("dt", get_integer_dtypes())

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -191,21 +191,29 @@ class TestCumSum:
         assert_array_equal(expected, result)
 
     @pytest.mark.parametrize("sh", [(10,), (2, 5)])
-    def test_usm_ndarray(self, sh):
+    @pytest.mark.parametrize(
+        "xp_in, xp_out, check",
+        [
+            pytest.param(dpt, dpt, False),
+            pytest.param(dpt, dpnp, True),
+            pytest.param(dpnp, dpt, False),
+        ],
+    )
+    def test_usm_ndarray(self, sh, xp_in, xp_out, check):
         a = numpy.arange(10).reshape(sh)
-        ia = dpt.asarray(a)
+        ia = xp_in.asarray(a)
 
         result = dpnp.cumsum(ia)
         expected = numpy.cumsum(a)
         assert_array_equal(expected, result)
 
         out = numpy.empty((10,))
-        iout = dpt.asarray(out)
+        iout = xp_out.asarray(out)
 
         result = dpnp.cumsum(ia, out=iout)
         expected = numpy.cumsum(a, out=out)
         assert_array_equal(expected, result)
-        assert result is not iout
+        assert (result is iout) is check
 
     @pytest.mark.usefixtures("suppress_complex_warning")
     @pytest.mark.parametrize("arr_dt", get_all_dtypes(no_none=True))

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -487,9 +487,7 @@ def test_1in_1out(func, data, device):
 
     x_orig = dpnp.asnumpy(x)
     expected = getattr(numpy, func)(x_orig)
-
-    tol = numpy.finfo(x.dtype).resolution
-    assert_allclose(result, expected, rtol=tol)
+    assert_dtype_allclose(result, expected)
 
     expected_queue = x.get_array().sycl_queue
     result_queue = result.get_array().sycl_queue

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -418,7 +418,7 @@ def test_meshgrid(device_x, device_y):
         pytest.param("cosh", [-5.0, -3.5, 0.0, 3.5, 5.0]),
         pytest.param("count_nonzero", [3, 0, 2, -1.2]),
         pytest.param("cumprod", [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
-        pytest.param("cumsum", [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+        pytest.param("cumsum", [[1, 2, 3], [4, 5, 6]]),
         pytest.param("diff", [1.0, 2.0, 4.0, 7.0, 0.0]),
         pytest.param("ediff1d", [1.0, 2.0, 4.0, 7.0, 0.0]),
         pytest.param("exp", [1.0, 2.0, 4.0, 7.0]),

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -522,6 +522,7 @@ def test_norm(usm_type, ord, axis):
         ),
         pytest.param("cosh", [-5.0, -3.5, 0.0, 3.5, 5.0]),
         pytest.param("count_nonzero", [0, 1, 7, 0]),
+        pytest.param("cumsum", [[1, 2, 3], [4, 5, 6]]),
         pytest.param("diff", [1.0, 2.0, 4.0, 7.0, 0.0]),
         pytest.param("exp", [1.0, 2.0, 4.0, 7.0]),
         pytest.param("exp2", [0.0, 1.0, 2.0]),

--- a/tests/third_party/cupy/math_tests/test_sumprod.py
+++ b/tests/third_party/cupy/math_tests/test_sumprod.py
@@ -13,20 +13,6 @@ from tests.helper import (
 from tests.third_party.cupy import testing
 
 
-# Note: numpy.sum() always upcasts integers to (u)int64 and float32 to
-# float64 for dtype=None. dpnp.sum() does that too for integers, but not for
-# float32, so we need to special-case it for these tests
-def _get_dtype_kwargs(xp, dtype):
-    if xp is numpy:
-        dtype = numpy.dtype(dtype)
-        # numpy.sum() doesn't upcast float16, but dpnp.sum() does that
-        # to default floating type, so needs to cover this use case also
-        if dtype == numpy.float16:
-            dt = numpy.float64 if has_support_aspect64() else numpy.float32
-            return {"dtype": dt}
-    return {}
-
-
 class TestSumprod:
     @pytest.fixture(autouse=True)
     def tearDown(self):
@@ -106,7 +92,7 @@ class TestSumprod:
         # Note that the above test example overflows in float16. We use a
         # smaller array instead.
         a = testing.shaped_arange((2, 30, 4), xp, dtype="e")
-        return a.sum(**_get_dtype_kwargs(xp, "e"), axis=1)
+        return a.sum(axis=1)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)

--- a/tests/third_party/cupy/math_tests/test_sumprod.py
+++ b/tests/third_party/cupy/math_tests/test_sumprod.py
@@ -507,9 +507,12 @@ class TestCumprod:
         self._cumprod(xp, a, out=out)
         return out
 
+    # TODO: remove skip once proper cumprod is implemented
+    @pytest.mark.skipif(
+        is_win_platform(), reason="numpy has another default integral dtype"
+    )
     @testing.for_all_dtypes()
-    # TODO: remove type_check once proper cumprod is implemented
-    @testing.numpy_cupy_allclose(rtol=1e-6, type_check=(not is_win_platform()))
+    @testing.numpy_cupy_allclose(rtol=1e-6)
     def test_cumprod_2dim_without_axis(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
         return self._cumprod(xp, a)

--- a/tests/third_party/cupy/math_tests/test_sumprod.py
+++ b/tests/third_party/cupy/math_tests/test_sumprod.py
@@ -5,7 +5,7 @@ import numpy
 import pytest
 
 import dpnp as cupy
-from tests.helper import has_support_aspect64
+from tests.helper import has_support_aspect64, is_win_platform
 from tests.third_party.cupy import testing
 
 
@@ -479,7 +479,8 @@ class TestCumprod:
         return res
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    # TODO: remove type_check once proper cumprod is implemented
+    @testing.numpy_cupy_allclose(type_check=(not is_win_platform()))
     def test_cumprod_1dim(self, xp, dtype):
         a = testing.shaped_arange((5,), xp, dtype)
         return self._cumprod(xp, a)
@@ -503,7 +504,8 @@ class TestCumprod:
         return out
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(rtol=1e-6)
+    # TODO: remove type_check once proper cumprod is implemented
+    @testing.numpy_cupy_allclose(rtol=1e-6, type_check=(not is_win_platform()))
     def test_cumprod_2dim_without_axis(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
         return self._cumprod(xp, a)

--- a/tests/third_party/cupy/math_tests/test_sumprod.py
+++ b/tests/third_party/cupy/math_tests/test_sumprod.py
@@ -1,3 +1,6 @@
+import math
+import warnings
+
 import numpy
 import pytest
 
@@ -7,6 +10,7 @@ from tests.third_party.cupy import testing
 
 
 class TestSumprod:
+    @pytest.fixture(autouse=True)
     def tearDown(self):
         # Free huge memory for slow test
         # cupy.get_default_memory_pool().free_all_blocks()
@@ -58,7 +62,8 @@ class TestSumprod:
     @testing.slow
     @testing.numpy_cupy_allclose()
     def test_sum_axis_huge(self, xp):
-        a = testing.shaped_random((204, 102, 102), xp, "i4")
+        a = testing.shaped_random((2048, 1, 1024), xp, "b")
+        a = xp.broadcast_to(a, (2048, 1024, 1024))
         return a.sum(axis=2)
 
     @testing.for_all_dtypes()
@@ -74,6 +79,16 @@ class TestSumprod:
     def test_sum_axis2(self, xp, dtype):
         a = testing.shaped_arange((20, 30, 40), xp, dtype)
         return a.sum(axis=1)
+
+    @pytest.mark.skip("TODO: check with dpctl")
+    def test_sum_axis2_float16(self):
+        # Note that the above test example overflows in float16. We use a
+        # smaller array instead.
+        a = testing.shaped_arange((2, 30, 4), dtype="e")
+        sa = a.sum(axis=1)
+        b = testing.shaped_arange((2, 30, 4), numpy, dtype="f")
+        sb = b.sum(axis=1)
+        testing.assert_allclose(sa, sb.astype("e"))
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
@@ -120,12 +135,16 @@ class TestSumprod:
     @testing.for_all_dtypes_combination(names=["src_dtype", "dst_dtype"])
     @testing.numpy_cupy_allclose()
     def test_sum_dtype(self, xp, src_dtype, dst_dtype):
+        if not xp.can_cast(src_dtype, dst_dtype):
+            pytest.skip()
         a = testing.shaped_arange((2, 3, 4), xp, src_dtype)
         return a.sum(dtype=dst_dtype)
 
     @testing.for_all_dtypes_combination(names=["src_dtype", "dst_dtype"])
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(rtol={numpy.float16: 1e-2, "default": 1e-7})
     def test_sum_keepdims_and_dtype(self, xp, src_dtype, dst_dtype):
+        if not xp.can_cast(src_dtype, dst_dtype):
+            pytest.skip()
         a = testing.shaped_arange((2, 3, 4), xp, src_dtype)
         return a.sum(axis=2, dtype=dst_dtype, keepdims=True)
 
@@ -176,8 +195,18 @@ class TestSumprod:
     @testing.for_all_dtypes_combination(names=["src_dtype", "dst_dtype"])
     @testing.numpy_cupy_allclose()
     def test_prod_dtype(self, xp, src_dtype, dst_dtype):
+        if not xp.can_cast(src_dtype, dst_dtype):
+            pytest.skip()
         a = testing.shaped_arange((2, 3), xp, src_dtype)
         return a.prod(dtype=dst_dtype)
+
+    @pytest.mark.skip("product() is deprecated")
+    @testing.numpy_cupy_allclose()
+    def test_product_alias(self, xp):
+        a = testing.shaped_arange((2, 3), xp, xp.float32)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            return xp.product(a)
 
 
 @testing.parameterize(
@@ -252,6 +281,19 @@ class TestNansumNanprodLong:
     )
 )
 class TestNansumNanprodExtra:
+    def test_nansum_axis_float16(self):
+        # Note that the above test example overflows in float16. We use a
+        # smaller array instead, just return if array is too large.
+        if numpy.prod(self.shape) > 24:
+            return
+        a = testing.shaped_arange(self.shape, dtype="e")
+        a[:, 1] = cupy.nan
+        sa = cupy.nansum(a, axis=1)
+        b = testing.shaped_arange(self.shape, numpy, dtype="f")
+        b[:, 1] = numpy.nan
+        sb = numpy.nansum(b, axis=1)
+        testing.assert_allclose(sa, sb.astype("e"))
+
     @testing.for_all_dtypes(no_bool=True, no_float16=True)
     @testing.numpy_cupy_allclose()
     def test_nansum_out(self, xp, dtype):
@@ -314,21 +356,25 @@ axes = [0, 1, 2]
 
 
 @testing.parameterize(*testing.product({"axis": axes}))
-@pytest.mark.usefixtures("allow_fall_back_on_numpy")
-# TODO: remove "type_check=False" once leveraged on dpctl call
 class TestCumsum:
+    def _cumsum(self, xp, a, *args, **kwargs):
+        b = a.copy()
+        res = xp.cumsum(a, *args, **kwargs)
+        testing.assert_array_equal(a, b)  # Check if input array is overwritten
+        return res
+
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(type_check=False)
+    @testing.numpy_cupy_allclose()
     def test_cumsum(self, xp, dtype):
         a = testing.shaped_arange((5,), xp, dtype)
-        return xp.cumsum(a)
+        return self._cumsum(xp, a)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_cumsum_out(self, xp, dtype):
         a = testing.shaped_arange((5,), xp, dtype)
         out = xp.zeros((5,), dtype=dtype)
-        xp.cumsum(a, out=out)
+        self._cumsum(xp, a, out=out)
         return out
 
     @testing.for_all_dtypes()
@@ -336,21 +382,21 @@ class TestCumsum:
     def test_cumsum_out_noncontiguous(self, xp, dtype):
         a = testing.shaped_arange((5,), xp, dtype)
         out = xp.zeros((10,), dtype=dtype)[::2]  # Non contiguous view
-        xp.cumsum(a, out=out)
+        self._cumsum(xp, a, out=out)
         return out
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(type_check=False)
+    @testing.numpy_cupy_allclose()
     def test_cumsum_2dim(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
-        return xp.cumsum(a)
+        return self._cumsum(xp, a)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_cumsum_axis(self, xp, dtype):
         n = len(axes)
         a = testing.shaped_arange(tuple(range(4, 4 + n)), xp, dtype)
-        return xp.cumsum(a, axis=self.axis)
+        return self._cumsum(xp, a, axis=self.axis)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
@@ -359,7 +405,7 @@ class TestCumsum:
         shape = tuple(range(4, 4 + n))
         a = testing.shaped_arange(shape, xp, dtype)
         out = xp.zeros(shape, dtype=dtype)
-        xp.cumsum(a, axis=self.axis, out=out)
+        self._cumsum(xp, a, axis=self.axis, out=out)
         return out
 
     @testing.for_all_dtypes()
@@ -371,7 +417,7 @@ class TestCumsum:
         out = xp.zeros((8,) + shape[1:], dtype=dtype)[
             ::2
         ]  # Non contiguous view
-        xp.cumsum(a, axis=self.axis, out=out)
+        self._cumsum(xp, a, axis=self.axis, out=out)
         return out
 
     @testing.for_all_dtypes()
@@ -386,7 +432,7 @@ class TestCumsum:
     def test_cumsum_axis_empty(self, xp, dtype):
         n = len(axes)
         a = testing.shaped_arange(tuple(range(0, n)), xp, dtype)
-        return xp.cumsum(a, axis=self.axis)
+        return self._cumsum(xp, a, axis=self.axis)
 
     @testing.for_all_dtypes()
     def test_invalid_axis_lower1(self, dtype):
@@ -426,11 +472,17 @@ class TestCumsum:
 
 
 class TestCumprod:
+    def _cumprod(self, xp, a, *args, **kwargs):
+        b = a.copy()
+        res = xp.cumprod(a, *args, **kwargs)
+        testing.assert_array_equal(a, b)  # Check if input array is overwritten
+        return res
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_cumprod_1dim(self, xp, dtype):
         a = testing.shaped_arange((5,), xp, dtype)
-        return xp.cumprod(a)
+        return self._cumprod(xp, a)
 
     @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
@@ -438,36 +490,39 @@ class TestCumprod:
     def test_cumprod_out(self, xp, dtype):
         a = testing.shaped_arange((5,), xp, dtype)
         out = xp.zeros((5,), dtype=dtype)
-        xp.cumprod(a, out=out)
+        self._cumprod(xp, a, out=out)
         return out
 
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_cumprod_out_noncontiguous(self, xp, dtype):
         a = testing.shaped_arange((5,), xp, dtype)
         out = xp.zeros((10,), dtype=dtype)[::2]  # Non contiguous view
-        xp.cumprod(a, out=out)
+        self._cumprod(xp, a, out=out)
         return out
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-6)
     def test_cumprod_2dim_without_axis(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
-        return xp.cumprod(a)
+        return self._cumprod(xp, a)
 
     @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_cumprod_2dim_with_axis(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
-        return xp.cumprod(a, axis=1)
+        return self._cumprod(xp, a, axis=1)
 
+    @pytest.mark.skip("ndarray.cumprod() is not implemented yet")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_ndarray_cumprod_2dim_with_axis(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
         return a.cumprod(axis=1)
 
+    @pytest.mark.skip("buffer overflow")
     @testing.slow
     def test_cumprod_huge_array(self):
         size = 2**32
@@ -476,7 +531,7 @@ class TestCumprod:
         a = cupy.ones(size, "b")
         result = cupy.cumprod(a, dtype="b")
         del a
-        self.assertTrue((result == 1).all())
+        assert (result == 1).all()
         # Free huge memory for slow test
         del result
         cupy.get_default_memory_pool().free_all_blocks()
@@ -512,15 +567,82 @@ class TestCumprod:
         with pytest.raises(numpy.AxisError):
             return cupy.cumprod(a, axis=a.ndim)
 
+    @pytest.mark.skip("no exception is raised by numpy")
     def test_cumprod_arraylike(self):
         with pytest.raises(TypeError):
             return cupy.cumprod((1, 2, 3))
 
+    @pytest.mark.skip("no exception is raised by numpy")
     @testing.for_float_dtypes()
     def test_cumprod_numpy_array(self, dtype):
         a_numpy = numpy.arange(1, 6, dtype=dtype)
         with pytest.raises(TypeError):
             return cupy.cumprod(a_numpy)
+
+    @pytest.mark.skip("cumproduct() is deprecated")
+    @testing.numpy_cupy_allclose()
+    def test_cumproduct_alias(self, xp):
+        a = testing.shaped_arange((2, 3), xp, xp.float32)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            return xp.cumproduct(a)
+
+
+@testing.parameterize(
+    *testing.product(
+        {
+            "shape": [(20,), (7, 6), (3, 4, 5)],
+            "axis": [None, 0, 1, 2],
+            "func": ("nancumsum", "nancumprod"),
+        }
+    )
+)
+@pytest.mark.skip("nancumsum() and nancumprod() are not implemented yet")
+class TestNanCumSumProd:
+    zero_density = 0.25
+
+    def _make_array(self, dtype):
+        dtype = numpy.dtype(dtype)
+        if dtype.char in "efdFD":
+            r_dtype = dtype.char.lower()
+            a = testing.shaped_random(self.shape, numpy, dtype=r_dtype, scale=1)
+            if dtype.char in "FD":
+                ai = a
+                aj = testing.shaped_random(
+                    self.shape, numpy, dtype=r_dtype, scale=1
+                )
+                ai[ai < math.sqrt(self.zero_density)] = 0
+                aj[aj < math.sqrt(self.zero_density)] = 0
+                a = ai + 1j * aj
+            else:
+                a[a < self.zero_density] = 0
+            a = a / a
+        else:
+            a = testing.shaped_random(self.shape, numpy, dtype=dtype)
+        return a
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_nancumsumprod(self, xp, dtype):
+        if self.axis is not None and self.axis >= len(self.shape):
+            pytest.skip()
+        a = xp.array(self._make_array(dtype))
+        out = getattr(xp, self.func)(a, axis=self.axis)
+        return xp.ascontiguousarray(out)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_nancumsumprod_out(self, xp, dtype):
+        dtype = numpy.dtype(dtype)
+        if self.axis is not None and self.axis >= len(self.shape):
+            pytest.skip()
+        if len(self.shape) > 1 and self.axis is None:
+            # Skip the cases where np.nancum{sum|prod} raise AssertionError.
+            pytest.skip()
+        a = xp.array(self._make_array(dtype))
+        out = xp.empty(self.shape, dtype=dtype)
+        getattr(xp, self.func)(a, axis=self.axis, out=out)
+        return xp.ascontiguousarray(out)
 
 
 class TestDiff:
@@ -585,3 +707,278 @@ class TestDiff:
                 xp.diff(a, axis=3)
             with pytest.raises(numpy.AxisError):
                 xp.diff(a, axis=-4)
+
+
+# This class compares CUB results against NumPy's
+@testing.parameterize(
+    *testing.product_dict(
+        testing.product(
+            {
+                "shape": [()],
+                "axis": [None, ()],
+                "spacing": [(), (1.2,)],
+            }
+        )
+        + testing.product(
+            {
+                "shape": [(33,)],
+                "axis": [None, 0, -1, (0,)],
+                "spacing": [(), (1.2,), "sequence of int", "arrays"],
+            }
+        )
+        + testing.product(
+            {
+                "shape": [(10, 20), (10, 20, 30)],
+                "axis": [None, 0, -1, (0, -1), (1, 0)],
+                "spacing": [(), (1.2,), "sequence of int", "arrays", "mixed"],
+            }
+        ),
+        testing.product(
+            {
+                "edge_order": [1, 2],
+            }
+        ),
+    )
+)
+@pytest.mark.skip("gradient() is not implemented yet")
+class TestGradient:
+    def _gradient(self, xp, dtype, shape, spacing, axis, edge_order):
+        x = testing.shaped_random(shape, xp, dtype=dtype)
+        if axis is None:
+            normalized_axes = tuple(range(x.ndim))
+        else:
+            normalized_axes = axis
+            if not isinstance(normalized_axes, tuple):
+                normalized_axes = (normalized_axes,)
+            normalized_axes = tuple(ax % x.ndim for ax in normalized_axes)
+        if spacing == "sequence of int":
+            # one scalar per axis
+            spacing = tuple((ax + 1) / x.ndim for ax in normalized_axes)
+        elif spacing == "arrays":
+            # one array per axis
+            spacing = tuple(
+                xp.arange(x.shape[ax]) * (ax + 0.5) for ax in normalized_axes
+            )
+            # make at one of the arrays have non-constant spacing
+            spacing[-1][5:] *= 2.0
+        elif spacing == "mixed":
+            # mixture of arrays and scalars
+            spacing = [xp.arange(x.shape[normalized_axes[0]])]
+            spacing = spacing + [0.5] * (len(normalized_axes) - 1)
+        return xp.gradient(x, *spacing, axis=axis, edge_order=edge_order)
+
+    @testing.for_dtypes("fFdD")
+    @testing.numpy_cupy_allclose(atol=1e-6, rtol=1e-5)
+    def test_gradient_floating(self, xp, dtype):
+        return self._gradient(
+            xp, dtype, self.shape, self.spacing, self.axis, self.edge_order
+        )
+
+    # unsigned int behavior fixed in 1.18.1
+    # https://github.com/numpy/numpy/issues/15207
+    @testing.with_requires("numpy>=1.18.1")
+    @testing.for_int_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose(atol=1e-6, rtol=1e-5)
+    def test_gradient_int(self, xp, dtype):
+        return self._gradient(
+            xp, dtype, self.shape, self.spacing, self.axis, self.edge_order
+        )
+
+    @testing.numpy_cupy_allclose(atol=2e-2, rtol=1e-3)
+    def test_gradient_float16(self, xp):
+        return self._gradient(
+            xp,
+            numpy.float16,
+            self.shape,
+            self.spacing,
+            self.axis,
+            self.edge_order,
+        )
+
+
+@pytest.mark.skip("gradient() is not implemented yet")
+class TestGradientErrors:
+    def test_gradient_invalid_spacings1(self):
+        # more spacings than axes
+        spacing = (1.0, 2.0, 3.0)
+        for xp in [numpy, cupy]:
+            x = testing.shaped_random((32, 16), xp)
+            with pytest.raises(TypeError):
+                xp.gradient(x, *spacing)
+
+    def test_gradient_invalid_spacings2(self):
+        # wrong length array in spacing
+        shape = (32, 16)
+        spacing = (15, cupy.arange(shape[1] + 1))
+        for xp in [numpy, cupy]:
+            x = testing.shaped_random(shape, xp)
+            with pytest.raises(ValueError):
+                xp.gradient(x, *spacing)
+
+    def test_gradient_invalid_spacings3(self):
+        # spacing array with ndim != 1
+        shape = (32, 16)
+        spacing = (15, cupy.arange(shape[0]).reshape(4, -1))
+        for xp in [numpy, cupy]:
+            x = testing.shaped_random(shape, xp)
+            with pytest.raises(ValueError):
+                xp.gradient(x, *spacing)
+
+    def test_gradient_invalid_edge_order1(self):
+        # unsupported edge order
+        shape = (32, 16)
+        for xp in [numpy, cupy]:
+            x = testing.shaped_random(shape, xp)
+            with pytest.raises(ValueError):
+                xp.gradient(x, edge_order=3)
+
+    def test_gradient_invalid_edge_order2(self):
+        # shape cannot be < edge_order
+        shape = (1, 16)
+        for xp in [numpy, cupy]:
+            x = testing.shaped_random(shape, xp)
+            with pytest.raises(ValueError):
+                xp.gradient(x, axis=0, edge_order=2)
+
+    @testing.with_requires("numpy>=1.16")
+    def test_gradient_invalid_axis(self):
+        # axis out of range
+        shape = (4, 16)
+        for xp in [numpy, cupy]:
+            x = testing.shaped_random(shape, xp)
+            for axis in [-3, 2]:
+                with pytest.raises(numpy.AxisError):
+                    xp.gradient(x, axis=axis)
+
+    def test_gradient_bool_input(self):
+        # axis out of range
+        shape = (4, 16)
+        for xp in [numpy, cupy]:
+            x = testing.shaped_random(shape, xp, dtype=numpy.bool_)
+            with pytest.raises(TypeError):
+                xp.gradient(x)
+
+
+@pytest.mark.skip("ediff1d() is not implemented yet")
+class TestEdiff1d:
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_ediff1d_1dim(self, xp, dtype):
+        a = testing.shaped_arange((5,), xp, dtype)
+        return xp.ediff1d(a)
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_ediff1d_2dim(self, xp, dtype):
+        a = testing.shaped_arange((4, 5), xp, dtype)
+        return xp.ediff1d(a)
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_ediff1d_3dim(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return xp.ediff1d(a)
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_ediff1d_to_begin1(self, xp, dtype):
+        a = testing.shaped_arange((5,), xp, dtype)
+        return xp.ediff1d(a, to_begin=xp.array([0], dtype=dtype))
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_ediff1d_to_begin2(self, xp, dtype):
+        a = testing.shaped_arange((5,), xp, dtype)
+        return xp.ediff1d(a, to_begin=xp.array([4, 4], dtype=dtype))
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_ediff1d_to_begin3(self, xp, dtype):
+        a = testing.shaped_arange((4, 5), xp, dtype)
+        return xp.ediff1d(a, to_begin=xp.array([1, 1], dtype=dtype))
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_ediff1d_to_end1(self, xp, dtype):
+        a = testing.shaped_arange((5,), xp, dtype)
+        return xp.ediff1d(a, to_end=xp.array([0], dtype=dtype))
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_ediff1d_to_end2(self, xp, dtype):
+        a = testing.shaped_arange((4, 1), xp, dtype)
+        return xp.ediff1d(a, to_end=xp.array([1, 2], dtype=dtype))
+
+    @testing.for_dtypes("bhilqefdFD")
+    @testing.numpy_cupy_allclose()
+    def test_ediff1d_ed1(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4, 5), xp, dtype)
+        return xp.ediff1d(
+            a,
+            to_begin=xp.array([-1], dtype=dtype),
+            to_end=xp.array([0], dtype=dtype),
+        )
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_ediff1d_ed2(self, xp, dtype):
+        a = testing.shaped_arange((2, 3), xp, dtype)
+        return xp.ediff1d(
+            a,
+            to_begin=xp.array([0, 4], dtype=dtype),
+            to_end=xp.array([1, 1], dtype=dtype),
+        )
+
+
+@pytest.mark.skip("trapz() is not implemented yet")
+class TestTrapz:
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol={numpy.float16: 1e-1, "default": 1e-7})
+    def test_trapz_1dim(self, xp, dtype):
+        a = testing.shaped_arange((5,), xp, dtype)
+        return xp.trapz(a)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol={numpy.float16: 1e-1, "default": 1e-7})
+    def test_trapz_1dim_with_x(self, xp, dtype):
+        a = testing.shaped_arange((5,), xp, dtype)
+        x = testing.shaped_arange((5,), xp, dtype)
+        return xp.trapz(a, x=x)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol={numpy.float16: 1e-1, "default": 1e-7})
+    def test_trapz_1dim_with_dx(self, xp, dtype):
+        a = testing.shaped_arange((5,), xp, dtype)
+        return xp.trapz(a, dx=0.1)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol={numpy.float16: 1e-1, "default": 1e-7})
+    def test_trapz_2dim_without_axis(self, xp, dtype):
+        a = testing.shaped_arange((4, 5), xp, dtype)
+        return xp.trapz(a)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol={numpy.float16: 1e-1, "default": 1e-7})
+    def test_trapz_2dim_with_axis(self, xp, dtype):
+        a = testing.shaped_arange((4, 5), xp, dtype)
+        return xp.trapz(a, axis=-2)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol={numpy.float16: 1e-1, "default": 1e-7})
+    def test_trapz_2dim_with_x_and_axis(self, xp, dtype):
+        a = testing.shaped_arange((4, 5), xp, dtype)
+        x = testing.shaped_arange((5,), xp, dtype)
+        return xp.trapz(a, x=x, axis=1)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol={numpy.float16: 1e-1, "default": 1e-7})
+    def test_trapz_2dim_with_dx_and_axis(self, xp, dtype):
+        a = testing.shaped_arange((4, 5), xp, dtype)
+        return xp.trapz(a, dx=0.1, axis=1)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol={numpy.float16: 1e-1, "default": 1e-7})
+    def test_trapz_1dim_with_x_and_dx(self, xp, dtype):
+        a = testing.shaped_arange((5,), xp, dtype)
+        x = testing.shaped_arange((5,), xp, dtype)
+        return xp.trapz(a, x=x, dx=0.1)


### PR DESCRIPTION
The PR is about to implement `dpnp.cumsum` through leveraging on dpctl implementation.

Note `dpnp_cumsum` is left in the backend code, because it is used by `dpnp_nancumsum` function also.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
