### PR TITLE
update `dpctl` function signature

### DIFF
--- a/dpnp/dpnp_container.py
+++ b/dpnp/dpnp_container.py
@@ -301,13 +301,13 @@ def ones(
 
 def tril(x1, /, *, k=0):
     """Creates `dpnp_array` as lower triangular part of an input array."""
-    array_obj = dpt.tril(dpnp.get_usm_ndarray(x1), k)
+    array_obj = dpt.tril(dpnp.get_usm_ndarray(x1), k=k)
     return dpnp_array(array_obj.shape, buffer=array_obj, order="K")
 
 
 def triu(x1, /, *, k=0):
     """Creates `dpnp_array` as upper triangular part of an input array."""
-    array_obj = dpt.triu(dpnp.get_usm_ndarray(x1), k)
+    array_obj = dpt.triu(dpnp.get_usm_ndarray(x1), k=k)
     return dpnp_array(array_obj.shape, buffer=array_obj, order="K")
 
 

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -531,7 +531,7 @@ def can_cast(from_, to, casting="safe"):
         if dpnp.is_supported_array_type(from_)
         else dpnp.dtype(from_)
     )
-    return dpt.can_cast(dtype_from, to, casting)
+    return dpt.can_cast(dtype_from, to, casting=casting)
 
 
 def column_stack(tup):

--- a/dpnp/random/dpnp_random_state.py
+++ b/dpnp/random/dpnp_random_state.py
@@ -257,7 +257,7 @@ class RandomState:
                         f"scale={scale}, but must be non-negative."
                     )
 
-                dpu.validate_usm_type(usm_type=usm_type, allow_none=False)
+                dpu.validate_usm_type(usm_type, allow_none=False)
                 return self._random_state.normal(
                     loc=loc,
                     scale=scale,


### PR DESCRIPTION
Due to changes in [dpctl-1626](https://github.com/IntelPython/dpctl/pull/1626), the function signatures of a few functions are modified and positional arguments are converted to keyword-only arguments.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
