### PR TITLE
Implement `dpnp.nancumsum()` through `dpnp.cumsum` call

### DIFF
--- a/doc/reference/math.rst
+++ b/doc/reference/math.rst
@@ -66,17 +66,17 @@ Sums, products, differences
 
    dpnp.prod
    dpnp.sum
+   dpnp.nanprod
+   dpnp.nansum
    dpnp.cumprod
    dpnp.cumsum
    dpnp.nancumprod
    dpnp.nancumsum
-   dpnp.nansum
-   dpnp.nanprod
-   dpnp.cross
    dpnp.diff
    dpnp.ediff1d
    dpnp.gradient
    dpnp.trapz
+   dpnp.cross
 
 
 Exponents and logarithms

--- a/dpnp/backend/include/dpnp_iface_fptr.hpp
+++ b/dpnp/backend/include/dpnp_iface_fptr.hpp
@@ -108,8 +108,6 @@ enum class DPNPFuncName : size_t
     DPNP_FN_CUMPROD_EXT,   /**< Used in numpy.cumprod() impl, requires extra
                               parameters */
     DPNP_FN_CUMSUM,        /**< Used in numpy.cumsum() impl  */
-    DPNP_FN_CUMSUM_EXT,    /**< Used in numpy.cumsum() impl, requires extra
-                              parameters */
     DPNP_FN_DEGREES,       /**< Used in numpy.degrees() impl  */
     DPNP_FN_DEGREES_EXT,   /**< Used in numpy.degrees() impl, requires extra
                               parameters */

--- a/dpnp/backend/kernels/dpnp_krnl_mathematical.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_mathematical.cpp
@@ -425,14 +425,6 @@ template <typename _DataType_input, typename _DataType_output>
 void (*dpnp_cumsum_default_c)(void *, void *, size_t) =
     dpnp_cumsum_c<_DataType_input, _DataType_output>;
 
-template <typename _DataType_input, typename _DataType_output>
-DPCTLSyclEventRef (*dpnp_cumsum_ext_c)(DPCTLSyclQueueRef,
-                                       void *,
-                                       void *,
-                                       size_t,
-                                       const DPCTLEventVectorRef) =
-    dpnp_cumsum_c<_DataType_input, _DataType_output>;
-
 template <typename _KernelNameSpecialization1,
           typename _KernelNameSpecialization2>
 class dpnp_ediff1d_c_kernel;
@@ -1178,15 +1170,6 @@ void func_map_init_mathematical(func_map_t &fmap)
         eft_FLT, (void *)dpnp_cumsum_default_c<float, float>};
     fmap[DPNPFuncName::DPNP_FN_CUMSUM][eft_DBL][eft_DBL] = {
         eft_DBL, (void *)dpnp_cumsum_default_c<double, double>};
-
-    fmap[DPNPFuncName::DPNP_FN_CUMSUM_EXT][eft_INT][eft_INT] = {
-        eft_LNG, (void *)dpnp_cumsum_ext_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_CUMSUM_EXT][eft_LNG][eft_LNG] = {
-        eft_LNG, (void *)dpnp_cumsum_ext_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_CUMSUM_EXT][eft_FLT][eft_FLT] = {
-        eft_FLT, (void *)dpnp_cumsum_ext_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_CUMSUM_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void *)dpnp_cumsum_ext_c<double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_EDIFF1D][eft_INT][eft_INT] = {
         eft_LNG, (void *)dpnp_ediff1d_default_c<int32_t, int64_t>};

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -38,7 +38,6 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_COPY_EXT
         DPNP_FN_CORRELATE_EXT
         DPNP_FN_CUMPROD_EXT
-        DPNP_FN_CUMSUM_EXT
         DPNP_FN_DEGREES_EXT
         DPNP_FN_DIAG_INDICES_EXT
         DPNP_FN_DIAGONAL_EXT

--- a/dpnp/dpnp_algo/dpnp_algo_mathematical.pxi
+++ b/dpnp/dpnp_algo/dpnp_algo_mathematical.pxi
@@ -45,7 +45,6 @@ __all__ += [
     "dpnp_fmin",
     "dpnp_modf",
     "dpnp_nancumprod",
-    "dpnp_nancumsum",
     "dpnp_trapz",
 ]
 
@@ -68,18 +67,6 @@ cpdef utils.dpnp_descriptor dpnp_cumprod(utils.dpnp_descriptor x1):
     # (4,)
 
     return call_fptr_1in_1out(DPNP_FN_CUMPROD_EXT, x1, (x1.size,))
-
-
-cpdef utils.dpnp_descriptor dpnp_cumsum(utils.dpnp_descriptor x1):
-    # instead of x1.shape, (x1.size, ) is passed to the function
-    # due to the following:
-    # >>> import numpy
-    # >>> a = numpy.array([[1, 2], [2, 3]])
-    # >>> res = numpy.cumsum(a)
-    # >>> res.shape
-    # (4,)
-
-    return call_fptr_1in_1out(DPNP_FN_CUMSUM_EXT, x1, (x1.size,))
 
 
 cpdef utils.dpnp_descriptor dpnp_ediff1d(utils.dpnp_descriptor x1):
@@ -251,19 +238,6 @@ cpdef utils.dpnp_descriptor dpnp_nancumprod(utils.dpnp_descriptor x1):
 
     x1_desc = dpnp.get_dpnp_descriptor(cur_x1, copy_when_nondefault_queue=False)
     return dpnp_cumprod(x1_desc)
-
-
-cpdef utils.dpnp_descriptor dpnp_nancumsum(utils.dpnp_descriptor x1):
-    cur_x1 = x1.get_pyobj().copy()
-
-    cur_x1_flatiter = cur_x1.flat
-
-    for i in range(cur_x1.size):
-        if dpnp.isnan(cur_x1_flatiter[i]):
-            cur_x1_flatiter[i] = 0
-
-    x1_desc = dpnp.get_dpnp_descriptor(cur_x1, copy_when_nondefault_queue=False)
-    return dpnp_cumsum(x1_desc)
 
 
 cpdef utils.dpnp_descriptor dpnp_trapz(utils.dpnp_descriptor y1, utils.dpnp_descriptor x1, double dx):

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -961,13 +961,10 @@ class TestNorm:
     def test_norm_1D(self, dtype, ord, axis, keepdims):
         a = numpy.array(numpy.random.uniform(-5, 5, 10), dtype=dtype)
         ia = inp.array(a)
+
         result = inp.linalg.norm(ia, ord=ord, axis=axis, keepdims=keepdims)
         expected = numpy.linalg.norm(a, ord=ord, axis=axis, keepdims=keepdims)
-        # use only type kinds check when dpnp handles complex64 arrays
-        # since `dpnp.sum()` and `numpy.sum()` return different dtypes
-        assert_dtype_allclose(
-            result, expected, check_only_type_kind=(dtype == inp.float32)
-        )
+        assert_dtype_allclose(result, expected)
 
     @pytest.mark.usefixtures("suppress_divide_numpy_warnings")
     @pytest.mark.parametrize("dtype", get_complex_dtypes())
@@ -983,11 +980,10 @@ class TestNorm:
         x2 = numpy.random.uniform(-5, 5, 10)
         a = numpy.array(x1 + 1j * x2, dtype=dtype)
         ia = inp.array(a)
+
         result = inp.linalg.norm(ia, ord=ord, axis=axis, keepdims=keepdims)
         expected = numpy.linalg.norm(a, ord=ord, axis=axis, keepdims=keepdims)
-        assert_dtype_allclose(
-            result, expected, check_only_type_kind=(dtype == inp.complex64)
-        )
+        assert_dtype_allclose(result, expected)
 
     @pytest.mark.usefixtures("suppress_divide_numpy_warnings")
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
@@ -1027,9 +1023,7 @@ class TestNorm:
             expected = numpy.linalg.norm(
                 a, ord=ord, axis=axis, keepdims=keepdims
             )
-            assert_dtype_allclose(
-                result, expected, check_only_type_kind=(dtype == inp.float32)
-            )
+            assert_dtype_allclose(result, expected)
 
     @pytest.mark.usefixtures("suppress_divide_numpy_warnings")
     @pytest.mark.parametrize("dtype", get_complex_dtypes())
@@ -1069,9 +1063,7 @@ class TestNorm:
             expected = numpy.linalg.norm(
                 a, ord=ord, axis=axis, keepdims=keepdims
             )
-            assert_dtype_allclose(
-                result, expected, check_only_type_kind=(dtype == inp.complex64)
-            )
+            assert_dtype_allclose(result, expected)
 
     @pytest.mark.usefixtures("suppress_divide_numpy_warnings")
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
@@ -1117,9 +1109,7 @@ class TestNorm:
             expected = numpy.linalg.norm(
                 a, ord=ord, axis=axis, keepdims=keepdims
             )
-            assert_dtype_allclose(
-                result, expected, check_only_type_kind=(dtype == inp.float32)
-            )
+            assert_dtype_allclose(result, expected)
 
     @pytest.mark.usefixtures("suppress_divide_numpy_warnings")
     @pytest.mark.parametrize("dtype", get_complex_dtypes())
@@ -1165,9 +1155,7 @@ class TestNorm:
             expected = numpy.linalg.norm(
                 a, ord=ord, axis=axis, keepdims=keepdims
             )
-            assert_dtype_allclose(
-                result, expected, check_only_type_kind=(dtype == inp.complex64)
-            )
+            assert_dtype_allclose(result, expected)
 
     @pytest.mark.usefixtures("suppress_divide_numpy_warnings")
     @pytest.mark.parametrize("dtype", get_all_dtypes())
@@ -1213,11 +1201,7 @@ class TestNorm:
             expected = numpy.linalg.norm(
                 a, ord=ord, axis=axis, keepdims=keepdims
             )
-            assert_dtype_allclose(
-                result,
-                expected,
-                check_only_type_kind=(dtype in [inp.float32, inp.complex64]),
-            )
+            assert_dtype_allclose(result, expected)
 
     @pytest.mark.parametrize("stride", [3, -1, -5], ids=["3", "-1", "-5"])
     def test_norm_strided_1D(self, stride):

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -720,42 +720,6 @@ def test_power_scalar(shape, dtype):
     assert_allclose(result, expected, rtol=1e-6)
 
 
-@pytest.mark.usefixtures("allow_fall_back_on_numpy")
-@pytest.mark.parametrize(
-    "array",
-    [
-        [1, 2, 3, 4, 5],
-        [1, 2, numpy.nan, 4, 5],
-        [[1, 2, numpy.nan], [3, -4, -5]],
-    ],
-)
-def test_nancumprod(array):
-    np_a = numpy.array(array)
-    dpnp_a = dpnp.array(np_a)
-
-    result = dpnp.nancumprod(dpnp_a)
-    expected = numpy.nancumprod(np_a)
-    assert_array_equal(expected, result)
-
-
-@pytest.mark.usefixtures("allow_fall_back_on_numpy")
-@pytest.mark.parametrize(
-    "array",
-    [
-        [1, 2, 3, 4, 5],
-        [1, 2, numpy.nan, 4, 5],
-        [[1, 2, numpy.nan], [3, -4, -5]],
-    ],
-)
-def test_nancumsum(array):
-    np_a = numpy.array(array)
-    dpnp_a = dpnp.array(np_a)
-
-    result = dpnp.nancumsum(dpnp_a)
-    expected = numpy.nancumsum(np_a)
-    assert_array_equal(expected, result)
-
-
 @pytest.mark.parametrize(
     "data",
     [[[1.0, -1.0], [0.1, -0.1]], [-2, -1, 0, 1, 2]],
@@ -2518,71 +2482,6 @@ def test_sum(shape, dtype_in, dtype_out, transpose, keepdims, order):
         numpy_res = a_np.sum(axis=axis, dtype=dtype_out, keepdims=keepdims)
         dpnp_res = a.sum(axis=axis, dtype=dtype_out, keepdims=keepdims)
         assert_array_equal(numpy_res, dpnp_res.asnumpy())
-
-
-class TestNanSum:
-    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
-    @pytest.mark.parametrize("axis", [None, 0, 1, (0, 1)])
-    @pytest.mark.parametrize("keepdims", [True, False])
-    def test_nansum(self, dtype, axis, keepdims):
-        dp_array = dpnp.array([[dpnp.nan, 1, 2], [3, dpnp.nan, 0]], dtype=dtype)
-        np_array = dpnp.asnumpy(dp_array)
-
-        expected = numpy.nansum(np_array, axis=axis, keepdims=keepdims)
-        result = dpnp.nansum(dp_array, axis=axis, keepdims=keepdims)
-        assert_allclose(result, expected)
-
-    @pytest.mark.parametrize("dtype", get_complex_dtypes())
-    def test_nansum_complex(self, dtype):
-        x1 = numpy.random.rand(10)
-        x2 = numpy.random.rand(10)
-        a = numpy.array(x1 + 1j * x2, dtype=dtype)
-        a[::3] = numpy.nan
-        ia = dpnp.array(a)
-
-        expected = numpy.nansum(a)
-        result = dpnp.nansum(ia)
-
-        # use only type kinds check when dpnp handles complex64 arrays
-        # since `dpnp.sum()` and `numpy.sum()` return different dtypes
-        assert_dtype_allclose(
-            result, expected, check_only_type_kind=(dtype == dpnp.complex64)
-        )
-
-    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
-    @pytest.mark.parametrize("axis", [0, 1])
-    def test_nansum_out(self, dtype, axis):
-        dp_array = dpnp.array([[dpnp.nan, 1, 2], [3, dpnp.nan, 0]], dtype=dtype)
-        np_array = dpnp.asnumpy(dp_array)
-
-        expected = numpy.nansum(np_array, axis=axis)
-        out = dpnp.empty_like(dpnp.asarray(expected))
-        result = dpnp.nansum(dp_array, axis=axis, out=out)
-        assert out is result
-        assert_dtype_allclose(result, expected)
-
-    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
-    def test_nansum_dtype(self, dtype):
-        dp_array = dpnp.array([[dpnp.nan, 1, 2], [3, dpnp.nan, 0]])
-        np_array = dpnp.asnumpy(dp_array)
-
-        expected = numpy.nansum(np_array, dtype=dtype)
-        result = dpnp.nansum(dp_array, dtype=dtype)
-        assert_dtype_allclose(result, expected)
-
-    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
-    def test_nansum_strided(self, dtype):
-        dp_array = dpnp.arange(20, dtype=dtype)
-        dp_array[::3] = dpnp.nan
-        np_array = dpnp.asnumpy(dp_array)
-
-        result = dpnp.nansum(dp_array[::-1])
-        expected = numpy.nansum(np_array[::-1])
-        assert_allclose(result, expected)
-
-        result = dpnp.nansum(dp_array[::2])
-        expected = numpy.nansum(np_array[::2])
-        assert_allclose(result, expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_nanfunctions.py
+++ b/tests/test_nanfunctions.py
@@ -1,0 +1,193 @@
+import numpy
+import pytest
+from numpy.testing import (
+    assert_allclose,
+    assert_almost_equal,
+    assert_array_equal,
+    assert_equal,
+)
+
+import dpnp
+from dpnp.dpnp_array import dpnp_array
+from tests.third_party.cupy import testing
+
+from .helper import (
+    assert_dtype_allclose,
+    get_complex_dtypes,
+    get_float_complex_dtypes,
+    get_float_dtypes,
+)
+
+
+@testing.parameterize(
+    *testing.product(
+        {
+            "func": ("nancumsum", "nancumprod"),
+        }
+    )
+)
+class TestNanCumSumProd:
+    @pytest.fixture(autouse=True)
+    def setUp(self):
+        if self.func == "nancumprod":
+            pytest.skip("nancumprod() is not implemented yet")
+        pass
+
+    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
+    @pytest.mark.parametrize(
+        "array",
+        [numpy.array(numpy.nan), numpy.full((3, 3), numpy.nan)],
+        ids=["0d", "2d"],
+    )
+    def test_allnans(self, dtype, array):
+        a = numpy.array(array, dtype=dtype)
+        ia = dpnp.array(a, dtype=dtype)
+
+        result = getattr(dpnp, self.func)(ia)
+        expected = getattr(numpy, self.func)(a)
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("axis", [None, 0, 1])
+    def test_empty(self, axis):
+        a = numpy.zeros((0, 3))
+        ia = dpnp.array(a)
+
+        result = getattr(dpnp, self.func)(ia, axis=axis)
+        expected = getattr(numpy, self.func)(a, axis=axis)
+        assert_equal(result, expected)
+
+    @pytest.mark.parametrize("axis", [None, 0, 1])
+    def test_keepdims(self, axis):
+        a = numpy.eye(3)
+        ia = dpnp.array(a)
+
+        result = getattr(dpnp, self.func)(ia, axis=axis, out=None)
+        expected = getattr(numpy, self.func)(a, axis=axis, out=None)
+        assert_equal(result, expected)
+        assert result.ndim == expected.ndim
+
+    @pytest.mark.parametrize("axis", [None] + list(range(4)))
+    def test_keepdims_random(self, axis):
+        a = numpy.ones((3, 5, 7, 11))
+        # Randomly set some elements to NaN:
+        rs = numpy.random.RandomState(0)
+        a[rs.rand(*a.shape) < 0.5] = numpy.nan
+        ia = dpnp.array(a)
+
+        result = getattr(dpnp, self.func)(ia, axis=axis)
+        expected = getattr(numpy, self.func)(a, axis=axis)
+        assert_equal(result, expected)
+
+    @pytest.mark.parametrize("axis", [-2, -1, 0, 1, None])
+    @pytest.mark.parametrize("dtype", get_float_dtypes())
+    def test_ndat_ones(self, axis, dtype):
+        a = numpy.array(
+            [
+                [0.6244, 1.0, 0.2692, 0.0116, 1.0, 0.1170],
+                [0.5351, -0.9403, 1.0, 0.2100, 0.4759, 0.2833],
+                [1.0, 1.0, 1.0, 0.1042, 1.0, -0.5954],
+                [0.1610, 1.0, 1.0, 0.1859, 0.3146, 1.0],
+            ]
+        )
+        a = a.astype(dtype=dtype)
+        ia = dpnp.array(a)
+
+        result = getattr(dpnp, self.func)(ia, axis=axis)
+        expected = getattr(numpy, self.func)(a, axis=axis)
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("axis", [-2, -1, 0, 1, None])
+    @pytest.mark.parametrize("dtype", get_float_dtypes())
+    def test_ndat_zeros(self, axis, dtype):
+        a = numpy.array(
+            [
+                [0.6244, 0.0, 0.2692, 0.0116, 0.0, 0.1170],
+                [0.5351, -0.9403, 0.0, 0.2100, 0.4759, 0.2833],
+                [0.0, 0.0, 0.0, 0.1042, 0.0, -0.5954],
+                [0.1610, 0.0, 0.0, 0.1859, 0.3146, 0.0],
+            ]
+        )
+        a = a.astype(dtype=dtype)
+        ia = dpnp.array(a)
+
+        result = getattr(dpnp, self.func)(ia, axis=axis)
+        expected = getattr(numpy, self.func)(a, axis=axis)
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("axis", [-2, -1, 0, 1])
+    def test_out(self, axis):
+        a = numpy.eye(3)
+        out = numpy.eye(3)
+
+        ia = dpnp.array(a)
+        iout = dpnp.array(out)
+
+        result = getattr(dpnp, self.func)(ia, axis=axis, out=iout)
+        expected = getattr(numpy, self.func)(a, axis=axis, out=out)
+        assert_almost_equal(result, expected)
+        assert result is iout
+
+
+class TestNanSum:
+    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
+    @pytest.mark.parametrize("axis", [None, 0, 1, (0, 1)])
+    @pytest.mark.parametrize("keepdims", [True, False])
+    def test_nansum(self, dtype, axis, keepdims):
+        dp_array = dpnp.array([[dpnp.nan, 1, 2], [3, dpnp.nan, 0]], dtype=dtype)
+        np_array = dpnp.asnumpy(dp_array)
+
+        expected = numpy.nansum(np_array, axis=axis, keepdims=keepdims)
+        result = dpnp.nansum(dp_array, axis=axis, keepdims=keepdims)
+        assert_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_complex_dtypes())
+    def test_nansum_complex(self, dtype):
+        x1 = numpy.random.rand(10)
+        x2 = numpy.random.rand(10)
+        a = numpy.array(x1 + 1j * x2, dtype=dtype)
+        a[::3] = numpy.nan
+        ia = dpnp.array(a)
+
+        expected = numpy.nansum(a)
+        result = dpnp.nansum(ia)
+
+        # use only type kinds check when dpnp handles complex64 arrays
+        # since `dpnp.sum()` and `numpy.sum()` return different dtypes
+        assert_dtype_allclose(
+            result, expected, check_only_type_kind=(dtype == dpnp.complex64)
+        )
+
+    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
+    @pytest.mark.parametrize("axis", [0, 1])
+    def test_nansum_out(self, dtype, axis):
+        dp_array = dpnp.array([[dpnp.nan, 1, 2], [3, dpnp.nan, 0]], dtype=dtype)
+        np_array = dpnp.asnumpy(dp_array)
+
+        expected = numpy.nansum(np_array, axis=axis)
+        out = dpnp.empty_like(dpnp.asarray(expected))
+        result = dpnp.nansum(dp_array, axis=axis, out=out)
+        assert out is result
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
+    def test_nansum_dtype(self, dtype):
+        dp_array = dpnp.array([[dpnp.nan, 1, 2], [3, dpnp.nan, 0]])
+        np_array = dpnp.asnumpy(dp_array)
+
+        expected = numpy.nansum(np_array, dtype=dtype)
+        result = dpnp.nansum(dp_array, dtype=dtype)
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
+    def test_nansum_strided(self, dtype):
+        dp_array = dpnp.arange(20, dtype=dtype)
+        dp_array[::3] = dpnp.nan
+        np_array = dpnp.asnumpy(dp_array)
+
+        result = dpnp.nansum(dp_array[::-1])
+        expected = numpy.nansum(np_array[::-1])
+        assert_allclose(result, expected)
+
+        result = dpnp.nansum(dp_array[::2])
+        expected = numpy.nansum(np_array[::2])
+        assert_allclose(result, expected)

--- a/tests/test_nanfunctions.py
+++ b/tests/test_nanfunctions.py
@@ -3,12 +3,10 @@ import pytest
 from numpy.testing import (
     assert_allclose,
     assert_almost_equal,
-    assert_array_equal,
     assert_equal,
 )
 
 import dpnp
-from dpnp.dpnp_array import dpnp_array
 from tests.third_party.cupy import testing
 
 from .helper import (
@@ -150,12 +148,7 @@ class TestNanSum:
 
         expected = numpy.nansum(a)
         result = dpnp.nansum(ia)
-
-        # use only type kinds check when dpnp handles complex64 arrays
-        # since `dpnp.sum()` and `numpy.sum()` return different dtypes
-        assert_dtype_allclose(
-            result, expected, check_only_type_kind=(dtype == dpnp.complex64)
-        )
+        assert_dtype_allclose(result, expected)
 
     @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
     @pytest.mark.parametrize("axis", [0, 1])

--- a/tests/test_sum.py
+++ b/tests/test_sum.py
@@ -9,13 +9,9 @@ from tests.helper import (
     assert_dtype_allclose,
     get_all_dtypes,
     get_float_dtypes,
-    has_support_aspect64,
 )
 
 
-# Note: dpnp.sum() always upcast integers to (u)int64 and float32 to
-# float64 for dtype=None. `numpy.sum()` does that too for integers, but not for
-# float32, so we need to special-case it for these tests
 @pytest.mark.parametrize("dtype", get_float_dtypes())
 def test_sum_float(dtype):
     a = numpy.array(
@@ -28,16 +24,10 @@ def test_sum_float(dtype):
     )
     ia = dpnp.array(a)
 
-    # Flag for type check in special cases
-    # Use only type kinds checks when dpnp handles float32 arrays
-    # as `dpnp.sum()` and `numpy.sum()` return different dtypes
-    check_type_kind = dtype == dpnp.float32
     for axis in range(len(a)):
         result = dpnp.sum(ia, axis=axis)
         expected = numpy.sum(a, axis=axis)
-        assert_dtype_allclose(
-            result, expected, check_only_type_kind=check_type_kind
-        )
+        assert_dtype_allclose(result, expected)
 
 
 def test_sum_int():

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -1105,7 +1105,7 @@ def test_fft_rfft(type, shape, device):
     np_res = numpy.fft.rfft(np_data)
     dpnp_res = dpnp.fft.rfft(dpnp_data)
 
-    assert_dtype_allclose(dpnp_res, np_res, check_only_type_kind=False)
+    assert_dtype_allclose(dpnp_res, np_res, check_only_type_kind=True)
 
     expected_queue = dpnp_data.get_array().sycl_queue
     result_queue = dpnp_res.get_array().sycl_queue

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -1105,7 +1105,7 @@ def test_fft_rfft(type, shape, device):
     np_res = numpy.fft.rfft(np_data)
     dpnp_res = dpnp.fft.rfft(dpnp_data)
 
-    assert_dtype_allclose(dpnp_res, np_res, check_only_type_kind=True)
+    assert_dtype_allclose(dpnp_res, np_res, check_only_type_kind=False)
 
     expected_queue = dpnp_data.get_array().sycl_queue
     result_queue = dpnp_res.get_array().sycl_queue
@@ -1479,7 +1479,7 @@ def test_norm(device, ord, axis):
     else:
         result = dpnp.linalg.norm(ia, ord=ord, axis=axis)
         expected = numpy.linalg.norm(a, ord=ord, axis=axis)
-        assert_dtype_allclose(result, expected, check_only_type_kind=True)
+        assert_dtype_allclose(result, expected)
 
         expected_queue = ia.get_array().sycl_queue
         result_queue = result.get_array().sycl_queue

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -541,6 +541,7 @@ def test_norm(usm_type, ord, axis):
         pytest.param("min", [1.0, 2.0, 4.0, 7.0]),
         pytest.param("nanargmax", [1.0, 2.0, 4.0, dp.nan]),
         pytest.param("nanargmin", [1.0, 2.0, 4.0, dp.nan]),
+        pytest.param("nancumsum", [3.0, dp.nan]),
         pytest.param("nanmax", [1.0, 2.0, 4.0, dp.nan]),
         pytest.param("nanmean", [1.0, 2.0, 4.0, dp.nan]),
         pytest.param("nanmin", [1.0, 2.0, 4.0, dp.nan]),

--- a/tests/third_party/cupy/math_tests/test_sumprod.py
+++ b/tests/third_party/cupy/math_tests/test_sumprod.py
@@ -606,9 +606,14 @@ class TestCumprod:
         }
     )
 )
-@pytest.mark.skip("nancumsum() and nancumprod() are not implemented yet")
 class TestNanCumSumProd:
     zero_density = 0.25
+
+    @pytest.fixture(autouse=True)
+    def setUp(self):
+        if self.func == "nancumprod":
+            pytest.skip("nancumprod() is not implemented yet")
+        pass
 
     def _make_array(self, dtype):
         dtype = numpy.dtype(dtype)


### PR DESCRIPTION
The PR proposes to implement `dpnp.nancumsum()` through existing call of `dpnp.cumsum` function.
The tests relating to NaN-like functions are decoupled to a new test scope `tests/test_nanfunctions.py`

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
