### PR TITLE
Use pybind11 version `2.12.0`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,9 +57,9 @@ include(GNUInstallDirs)
 # Fetch pybind11
 include(FetchContent)
 FetchContent_Declare(
-  pybind11
-  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.11.1.tar.gz
-  URL_HASH SHA256=d475978da0cdc2d43b73f30910786759d593a9d8ee05b1b6846d1eb16c6d2e0c
+    pybind11
+    URL https://github.com/pybind/pybind11/archive/refs/tags/v2.12.0.tar.gz
+    URL_HASH SHA256=bf8f242abd1abcd375d516a7067490fb71abd79519a282d22b6e4d19282185a7
 )
 FetchContent_MakeAvailable(pybind11)
 


### PR DESCRIPTION
The PR proposes to use `pybind11==2.12.0` to build `dpnp`.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
