### PR TITLE
Remove use of -flink-huge-device-code link option

### DIFF
--- a/dpnp/backend/CMakeLists.txt
+++ b/dpnp/backend/CMakeLists.txt
@@ -80,10 +80,6 @@ endif()
 # endif()
 
 target_link_options(${_trgt} PUBLIC -fsycl-device-code-split=per_kernel)
-if(UNIX)
-    # this option is support on Linux only
-    target_link_options(${_trgt} PUBLIC -flink-huge-device-code)
-endif()
 
 if(DPNP_GENERATE_COVERAGE)
     target_link_options(${_trgt} PRIVATE -fprofile-instr-generate -fcoverage-mapping)

--- a/dpnp/backend/extensions/blas/CMakeLists.txt
+++ b/dpnp/backend/extensions/blas/CMakeLists.txt
@@ -66,10 +66,6 @@ else()
 endif()
 
 target_link_options(${python_module_name} PUBLIC -fsycl-device-code-split=per_kernel)
-if (UNIX)
-    # this option is support on Linux only
-    target_link_options(${python_module_name} PUBLIC -flink-huge-device-code)
-endif()
 
 if (DPNP_GENERATE_COVERAGE)
     target_link_options(${python_module_name} PRIVATE -fprofile-instr-generate -fcoverage-mapping)

--- a/dpnp/backend/extensions/lapack/CMakeLists.txt
+++ b/dpnp/backend/extensions/lapack/CMakeLists.txt
@@ -77,10 +77,6 @@ else()
 endif()
 
 target_link_options(${python_module_name} PUBLIC -fsycl-device-code-split=per_kernel)
-if (UNIX)
-    # this option is support on Linux only
-    target_link_options(${python_module_name} PUBLIC -flink-huge-device-code)
-endif()
 
 if (DPNP_GENERATE_COVERAGE)
     target_link_options(${python_module_name} PRIVATE -fprofile-instr-generate -fcoverage-mapping)

--- a/dpnp/backend/extensions/sycl_ext/CMakeLists.txt
+++ b/dpnp/backend/extensions/sycl_ext/CMakeLists.txt
@@ -61,10 +61,6 @@ else()
 endif()
 
 target_link_options(${python_module_name} PUBLIC -fsycl-device-code-split=per_kernel)
-if (UNIX)
-    # this option is support on Linux only
-    target_link_options(${python_module_name} PUBLIC -flink-huge-device-code)
-endif()
 
 if (DPNP_GENERATE_COVERAGE)
     target_link_options(${python_module_name} PRIVATE -fprofile-instr-generate -fcoverage-mapping)

--- a/dpnp/backend/extensions/vm/CMakeLists.txt
+++ b/dpnp/backend/extensions/vm/CMakeLists.txt
@@ -61,10 +61,6 @@ else()
 endif()
 
 target_link_options(${python_module_name} PUBLIC -fsycl-device-code-split=per_kernel)
-if (UNIX)
-    # this option is support on Linux only
-    target_link_options(${python_module_name} PUBLIC -flink-huge-device-code)
-endif()
 
 if (DPNP_GENERATE_COVERAGE)
     target_link_options(${python_module_name} PRIVATE -fprofile-instr-generate -fcoverage-mapping)


### PR DESCRIPTION
The PR proposes to remove use of `-flink-huge-device-code` link option, because it is no longer necessary and suspectedly makes linking of device code somewhat longer.
The option was previously introduced in scope of #1270.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
