### PR TITLE
Unlock skipped linalg tests that use `gesv`

### DIFF
--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -652,8 +652,6 @@ class TestInv:
         expected = numpy.linalg.inv(a)
         assert_dtype_allclose(result, expected)
 
-    # TODO: remove skipif when MKLD-16626 is resolved
-    @pytest.mark.skipif(is_cpu_device(), reason="MKLD-16626")
     @pytest.mark.parametrize(
         "matrix",
         [
@@ -750,12 +748,10 @@ class TestMatrixPower:
         assert_raises(TypeError, inp.linalg.matrix_power, a_dp, [2])
 
         # not invertible
-        # TODO: remove it when mkl>=2024.0 is released (MKLD-16626)
-        if not is_cpu_device():
-            noninv = inp.array([[1, 0], [0, 0]])
-            assert_raises(
-                inp.linalg.LinAlgError, inp.linalg.matrix_power, noninv, -1
-            )
+        noninv = inp.array([[1, 0], [0, 0]])
+        assert_raises(
+            inp.linalg.LinAlgError, inp.linalg.matrix_power, noninv, -1
+        )
 
 
 class TestMatrixRank:
@@ -1456,8 +1452,6 @@ class TestSolve:
         result = inp.linalg.solve(a_dp[::-2, ::-2], b_dp[::-2])
         assert_allclose(expected, result, rtol=1e-05)
 
-    # TODO: remove skipif when MKLD-16626 is resolved
-    @pytest.mark.skipif(is_cpu_device(), reason="MKLD-16626")
     @pytest.mark.parametrize(
         "matrix, vector",
         [

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -433,10 +433,10 @@ class TestDet:
 
         assert_allclose(expected, result, rtol=1e-3, atol=1e-4)
 
-    # TODO: remove skipif when MKLD-16626 is resolved
+    # TODO: remove skipif when MKLD-13852 is resolved
     # _getrf_batch does not raise an error with singular matrices.
     # Skip running on cpu because dpnp uses _getrf_batch only on cpu.
-    @pytest.mark.skipif(is_cpu_device(), reason="MKLD-16626")
+    @pytest.mark.skipif(is_cpu_device(), reason="MKLD-13852")
     def test_det_singular_matrix_3D(self):
         a_np = numpy.array(
             [[[1, 2], [3, 4]], [[1, 2], [1, 2]], [[1, 3], [3, 1]]]
@@ -678,9 +678,9 @@ class TestInv:
         assert_raises(numpy.linalg.LinAlgError, numpy.linalg.inv, a_np)
         assert_raises(inp.linalg.LinAlgError, inp.linalg.inv, a_dp)
 
-    # TODO: remove skipif when MKLD-16626 is resolved
+    # TODO: remove skip when MKLD-13852 is resolved
     # _getrf_batch does not raise an error with singular matrices.
-    @pytest.mark.skip("MKLD-16626")
+    @pytest.mark.skip("MKLD-13852")
     def test_inv_singular_matrix_3D(self):
         a_np = numpy.array(
             [[[1, 2], [3, 4]], [[1, 2], [1, 2]], [[1, 3], [3, 1]]]
@@ -1589,10 +1589,10 @@ class TestSlogdet:
         assert_allclose(sign_expected, sign_result)
         assert_allclose(logdet_expected, logdet_result, rtol=1e-3, atol=1e-4)
 
-    # TODO: remove skipif when MKLD-16626 is resolved
+    # TODO: remove skipif when MKLD-13852 is resolved
     # _getrf_batch does not raise an error with singular matrices.
     # Skip running on cpu because dpnp uses _getrf_batch only on cpu.
-    @pytest.mark.skipif(is_cpu_device(), reason="MKLD-16626")
+    @pytest.mark.skipif(is_cpu_device(), reason="MKLD-13852")
     def test_slogdet_singular_matrix_3D(self):
         a_np = numpy.array(
             [[[1, 2], [3, 4]], [[1, 2], [1, 2]], [[1, 3], [3, 1]]]

--- a/tests/third_party/cupy/linalg_tests/test_decomposition.py
+++ b/tests/third_party/cupy/linalg_tests/test_decomposition.py
@@ -129,8 +129,9 @@ class TestCholeskyInvalid(unittest.TestCase):
             with pytest.raises(xp.linalg.LinAlgError):
                 xp.linalg.cholesky(a)
 
-    # TODO: remove skipif when MKLD-16626 is resolved
-    @pytest.mark.skipif(is_cpu_device(), reason="MKLD-16626")
+    # TODO: remove skipif when MKLD-17318 is resolved
+    # _potrf does not raise an error with singular matrices on CPU.
+    @pytest.mark.skipif(is_cpu_device(), reason="MKLD-17318")
     @testing.for_dtypes(
         [
             numpy.int32,

--- a/tests/third_party/cupy/linalg_tests/test_norms.py
+++ b/tests/third_party/cupy/linalg_tests/test_norms.py
@@ -152,10 +152,10 @@ class TestDet(unittest.TestCase):
             with pytest.raises(xp.linalg.LinAlgError):
                 xp.linalg.det(a)
 
-    # TODO: remove skipif when MKLD-16626 is resolved
+    # TODO: remove skipif when MKLD-13852 is resolved
     # _getrf_batch does not raise an error with singular matrices.
     # Skip running on cpu because dpnp uses _getrf_batch only on cpu.
-    @pytest.mark.skipif(is_cpu_device(), reason="MKLD-16626")
+    @pytest.mark.skipif(is_cpu_device(), reason="MKLD-13852")
     @testing.for_dtypes("fdFD")
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
     def test_det_singular(self, xp, dtype):

--- a/tests/third_party/cupy/linalg_tests/test_solve.py
+++ b/tests/third_party/cupy/linalg_tests/test_solve.py
@@ -172,9 +172,9 @@ class TestInvInvalid(unittest.TestCase):
             ):
                 xp.linalg.inv(a)
 
-    # TODO: remove skipif when MKLD-16626 is resolved
+    # TODO: remove skip when MKLD-13852 is resolved
     # _getrf_batch does not raise an error with singular matrices.
-    @pytest.mark.skip("MKLD-16626")
+    @pytest.mark.skip("MKLD-13852")
     @testing.for_dtypes("ifdFD")
     def test_batched_inv(self, dtype):
         for xp in (numpy, cupy):

--- a/tests/third_party/cupy/linalg_tests/test_solve.py
+++ b/tests/third_party/cupy/linalg_tests/test_solve.py
@@ -7,7 +7,6 @@ import dpnp as cupy
 from tests.helper import (
     assert_dtype_allclose,
     has_support_aspect64,
-    is_cpu_device,
 )
 from tests.third_party.cupy import testing
 from tests.third_party.cupy.testing import _condition
@@ -164,9 +163,6 @@ class TestInv(unittest.TestCase):
 
 
 class TestInvInvalid(unittest.TestCase):
-    # TODO: remove skipif when MKLD-16626 is resolved
-    # _gesv does not raise an error with singular matrices on CPU.
-    @pytest.mark.skipif(is_cpu_device(), reason="MKLD-16626")
     @testing.for_dtypes("ifdFD")
     def test_inv(self, dtype):
         for xp in (numpy, cupy):


### PR DESCRIPTION
This PR suggests unlocking skipped `linalg` tests that use `oneapi::mkl::lapack::gesv` due to bug fix for it in MKL version 2024.1. 

Also this PR updates comments for TODOs with the correct ticket number of a bug in MKL.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
