### PR TITLE
Extend pre-commit hooks with codespell

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,10 +18,11 @@ jobs:
           sudo ln -s /usr/bin/clang-format-12 /usr/bin/clang-format
           clang-format --version
 
-      - name: Set up pylint
+      - name: Set up pip packages
         uses: BSFishy/pip-action@8f2d471d809dc20b6ada98c91910b6ae6243f318 # v1
         with:
           packages: |
+            codespell
             pylint
 
       - name: Checkout DPNP repo

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/PyCQA/bandit
-    rev: '1.7.7'
+    rev: '1.7.8'
     hooks:
     -   id: bandit
         pass_filenames: false
@@ -49,7 +49,7 @@ repos:
         additional_dependencies:
             - tomli
 -   repo: https://github.com/psf/black
-    rev: 23.12.1
+    rev: 24.4.0
     hooks:
     -   id: black
         args: ["--check", "--diff", "--color"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,12 @@ repos:
     -   id: rst-directive-colons
     -   id: rst-inline-touching-normal
     -   id: text-unicode-replacement-char
+-   repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+    -   id: codespell
+        additional_dependencies:
+            - tomli
 -   repo: https://github.com/psf/black
     rev: 23.12.1
     hooks:

--- a/doc/_templates/autosummary/class.rst
+++ b/doc/_templates/autosummary/class.rst
@@ -41,7 +41,7 @@
 {% endblock %}
 
    ..
-      Atributes
+      Attributes
 
 {% block attributes %} {% if attributes %}
 

--- a/doc/docstring_template.py
+++ b/doc/docstring_template.py
@@ -42,7 +42,7 @@ According to this template docstrings should consist of below sections:
 
 Recommendations:
 1. Short description
-   maybe partially taken/combinated from `numpy` and `cupy` docstrings.
+   maybe partially taken/combined from `numpy` and `cupy` docstrings.
 2. Limitations basically should be described according to the code,
    paying attention to raised exceptions and fallback to `numpy`.
 3. See Also may include links to similar functionality in `dpnp`

--- a/dpnp/backend/cmake/Modules/IntelSYCLConfig.cmake
+++ b/dpnp/backend/cmake/Modules/IntelSYCLConfig.cmake
@@ -188,7 +188,7 @@ function(SYCL_FEATURE_TEST_RUN TEST_EXE)
     set(IntelSYCL_FOUND False)
     set(SYCL_REASON_FAILURE "SYCL: feature test execution failed!!")
   endif()
-  # TODO: what iff the result is false.. error or ignore?
+  # TODO: what if the result is false.. error or ignore?
 
   set( test_result "${result}" PARENT_SCOPE)
   set( test_output "${output}" PARENT_SCOPE)

--- a/dpnp/backend/examples/example_bs.cpp
+++ b/dpnp/backend/examples/example_bs.cpp
@@ -144,13 +144,13 @@ void black_scholes(double *price,
     dpnp_memory_free_c(w1);
     double *halfs_mul_erf_w1 =
         (double *)dpnp_memory_alloc_c(size * sizeof(double));
-    // halfs_mul_erf_w1 = halfs * erf_w1
+    // halfs_mul_erf_w1 = half * erf_w1
     dpnp_multiply_c<double, double, double>(halfs_mul_erf_w1, half, scalar_size,
                                             &scalar_size, ndim, erf_w1, size,
                                             &size, ndim, NULL);
     dpnp_memory_free_c(erf_w1);
     double *d1 = (double *)dpnp_memory_alloc_c(size * sizeof(double));
-    // d1 = halfs + halfs_mul_erf_w1
+    // d1 = half + halfs_mul_erf_w1
     dpnp_add_c<double, double, double>(d1, half, scalar_size, &scalar_size,
                                        ndim, halfs_mul_erf_w1, size, &size,
                                        ndim, NULL);
@@ -161,13 +161,13 @@ void black_scholes(double *price,
     dpnp_memory_free_c(w2);
     double *halfs_mul_erf_w2 =
         (double *)dpnp_memory_alloc_c(size * sizeof(double));
-    // halfs_mul_erf_w2 = halfs * erf_w2
+    // halfs_mul_erf_w2 = half * erf_w2
     dpnp_multiply_c<double, double, double>(halfs_mul_erf_w2, half, scalar_size,
                                             &scalar_size, ndim, erf_w2, size,
                                             &size, ndim, NULL);
     dpnp_memory_free_c(erf_w2);
     double *d2 = (double *)dpnp_memory_alloc_c(size * sizeof(double));
-    // d2 = halfs + halfs_mul_erf_w2
+    // d2 = half + halfs_mul_erf_w2
     dpnp_add_c<double, double, double>(d2, half, scalar_size, &scalar_size,
                                        ndim, halfs_mul_erf_w2, size, &size,
                                        ndim, NULL);

--- a/dpnp/backend/extensions/blas/gemm.cpp
+++ b/dpnp/backend/extensions/blas/gemm.cpp
@@ -181,7 +181,7 @@ std::pair<sycl::event, sycl::event>
     }
     if (b_shape[1] != c_shape[1]) {
         throw py::value_error("The number of columns in B must be equal to "
-                              "the number of coulmns in result array.");
+                              "the number of columns in result array.");
     }
 
     size_t src_nelems = m * n;

--- a/dpnp/backend/extensions/blas/gemm_batch.cpp
+++ b/dpnp/backend/extensions/blas/gemm_batch.cpp
@@ -198,7 +198,7 @@ std::pair<sycl::event, sycl::event>
     }
     if (b_shape[matrixB_nd - 1] != c_shape[resultC_nd - 1]) {
         throw py::value_error("The number of columns in B must be equal to "
-                              "the number of coulmns in result array.");
+                              "the number of columns in result array.");
     }
 
     bool shapes_equal = true;

--- a/dpnp/backend/extensions/sycl_ext/dispatcher_utils.hpp
+++ b/dpnp/backend/extensions/sycl_ext/dispatcher_utils.hpp
@@ -300,11 +300,11 @@ struct coord_in_space<DispatchT, Matcher, std::tuple<CurrentAxis>>
     }
 };
 
-template <typename DispatchT, typename Matcher, typename... Axises>
-struct coord_in_space<DispatchT, Matcher, std::tuple<Axises...>>
+template <typename DispatchT, typename Matcher, typename... Axes>
+struct coord_in_space<DispatchT, Matcher, std::tuple<Axes...>>
 {
-    using CurrentAxis = typename pop_tuple_type<std::tuple<Axises...>>::element;
-    using OtherAxises = typename pop_tuple_type<std::tuple<Axises...>>::rest;
+    using CurrentAxis = typename pop_tuple_type<std::tuple<Axes...>>::element;
+    using OtherAxises = typename pop_tuple_type<std::tuple<Axes...>>::rest;
 
     static bool get(const DispatchT *data, int *result)
     {

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -1410,9 +1410,11 @@ def result_type(*arrays_and_dtypes):
     """
 
     usm_arrays_and_dtypes = [
-        dpnp.get_usm_ndarray(X)
-        if isinstance(X, (dpnp_array, dpt.usm_ndarray))
-        else X
+        (
+            dpnp.get_usm_ndarray(X)
+            if isinstance(X, (dpnp_array, dpt.usm_ndarray))
+            else X
+        )
         for X in arrays_and_dtypes
     ]
     return dpt.result_type(*usm_arrays_and_dtypes)

--- a/examples/example4.py
+++ b/examples/example4.py
@@ -28,7 +28,7 @@
 """Example 1.
 
 This example shows input and output types of specified function
-This is usefull for development
+This is useful for development
 
 """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,12 @@
 line-length = 80
 target-version = ['py38', 'py39', 'py310']
 
+[tool.codespell]
+builtin = "clear,rare,informal,names"
+check-filenames = true
+ignore-words-list="amin,arange,elemt,fro,hist,ith,mone,nd,nin,sinc,vart"
+quiet-level = 3
+
 [tool.pylint.basic]
 include-naming-hint = true
 

--- a/scripts/build_deps_dpctl_win.bat
+++ b/scripts/build_deps_dpctl_win.bat
@@ -10,7 +10,7 @@ set DPCTL_DIST=%CD%\dist_dpctl
 
 call conda uninstall -y dpctl
 
-echo +++++++++++++++++++++++++ Downlowd DPCTL +++++++++++++++++++++++++++
+echo +++++++++++++++++++++++++ Download DPCTL +++++++++++++++++++++++++++
 call git clone https://github.com/IntelPython/dpctl.git
 cd dpctl
 

--- a/scripts/gen_coverage.py
+++ b/scripts/gen_coverage.py
@@ -46,7 +46,7 @@ def run(
             "LLVM_TOOLS_HOME": bin_llvm,
         }
 
-    # extend with global enviroment variables
+    # extend with global environment variables
     env.update({k: v for k, v in os.environ.items() if k != "PATH"})
 
     if verbose:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ version_mod = imm.SourceFileLoader(
 __version__ = version_mod.get_versions()["version"]
 
 """
-Set project auxilary data like readme and licence files
+Set project auxiliary data like readme and licence files
 """
 with open("README.md") as f:
     __readme_file__ = f.read()

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -235,7 +235,7 @@ def is_cpu_device(device=None):
 
 def is_win_platform():
     """
-    Return True if a test is runing on Windows OS, False otherwise.
+    Return True if a test is running on Windows OS, False otherwise.
     """
     return platform.startswith("win")
 

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -510,7 +510,7 @@ class TestEigenvalue:
         # NumPy with OneMKL and with rocSOLVER sorts in ascending order,
         # so w's should be directly comparable.
         # However, both OneMKL and rocSOLVER pick a different convention for
-        # constructing eigenvectors, so v's are not directly comparible and
+        # constructing eigenvectors, so v's are not directly comparable and
         # we verify them through the eigen equation A*v=w*v.
         if func in ("eig", "eigh"):
             w, _ = getattr(numpy.linalg, func)(a_order)

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -297,8 +297,8 @@ def test_logical_not(dtype):
 @pytest.mark.parametrize("x2", [5, [1, 2, 5, 6]], ids=["5", "[1, 2, 5, 6]"])
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
 def test_elemwise_comparison(op, x1, x2, dtype):
-    create_func = (
-        lambda xp, a: xp.asarray(a, dtype=dtype)
+    create_func = lambda xp, a: (
+        xp.asarray(a, dtype=dtype)
         if not numpy.isscalar(a)
         else numpy.dtype(dtype=dtype).type(a)
     )

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -1139,7 +1139,7 @@ class TestPermutationsTestShuffle:
         ],
     )
     def test_shuffle1(self, conv):
-        # `conv` contans test lists, arrays (of various dtypes), and multidimensional
+        # `conv` contains test lists, arrays (of various dtypes), and multidimensional
         # versions of both, c-contiguous or not.
         #
         # This test is a modification of the original tests of `numpy.random` (both the same):

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -43,7 +43,7 @@ for device in available_devices:
     elif device.device_type.name not in list_of_device_type_str:
         pass
     elif device.backend.name in "opencl" and device.is_gpu:
-        # due to reproted crash on Windows: CMPLRLLVM-55640
+        # due to reported crash on Windows: CMPLRLLVM-55640
         pass
     else:
         valid_devices.append(device)

--- a/tests/third_party/cupy/indexing_tests/test_indexing.py
+++ b/tests/third_party/cupy/indexing_tests/test_indexing.py
@@ -235,7 +235,7 @@ class TestChoose(unittest.TestCase):
             a = xp.array([0, 3, -1, 5])
             c = testing.shaped_arange((3, 4), xp, numpy.float32)
             with pytest.raises(ValueError):
-                a.choose(c, mode="unknow")
+                a.choose(c, mode="unknown")
 
     def test_raise(self):
         a = cupy.array([2])

--- a/tests/third_party/cupy/linalg_tests/test_eigenvalue.py
+++ b/tests/third_party/cupy/linalg_tests/test_eigenvalue.py
@@ -78,7 +78,7 @@ class TestEigenvalue:
         # NumPy, cuSOLVER, rocSOLVER all sort in ascending order,
         # so w's should be directly comparable. However, both cuSOLVER
         # and rocSOLVER pick a different convention for constructing
-        # eigenvectors, so v's are not directly comparible and we verify
+        # eigenvectors, so v's are not directly comparable and we verify
         # them through the eigen equation A*v=w*v.
         A = _get_hermitian(xp, a, self.UPLO)
         for i in range(a.shape[0]):
@@ -102,7 +102,7 @@ class TestEigenvalue:
         # NumPy, cuSOLVER, rocSOLVER all sort in ascending order,
         # so w's should be directly comparable. However, both cuSOLVER
         # and rocSOLVER pick a different convention for constructing
-        # eigenvectors, so v's are not directly comparible and we verify
+        # eigenvectors, so v's are not directly comparable and we verify
         # them through the eigen equation A*v=w*v.
         A = _get_hermitian(xp, a, self.UPLO)
 

--- a/tests/third_party/cupy/manipulation_tests/test_tiling.py
+++ b/tests/third_party/cupy/manipulation_tests/test_tiling.py
@@ -44,7 +44,6 @@ class TestRepeatRepeatsNdarray(unittest.TestCase):
 )
 @pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestRepeatListBroadcast(unittest.TestCase):
-
     """Test for `repeats` argument using single element list.
 
     This feature is only supported in NumPy 1.10 or later.
@@ -76,7 +75,6 @@ class TestRepeat1D(unittest.TestCase):
     {"repeats": [2], "axis": 0},
 )
 class TestRepeat1DListBroadcast(unittest.TestCase):
-
     """See comment in TestRepeatListBroadcast class."""
 
     @testing.numpy_cupy_array_equal()

--- a/tests/third_party/cupy/sorting_tests/test_search.py
+++ b/tests/third_party/cupy/sorting_tests/test_search.py
@@ -709,7 +709,7 @@ class TestSearchSortedNanInf:
 
 
 class TestSearchSortedInvalid:
-    # Cant test unordered bins due to numpy undefined
+    # Can't test unordered bins due to numpy undefined
     # behavior for searchsorted
 
     def test_searchsorted_ndbins(self):

--- a/tests/third_party/cupy/testing/_condition.py
+++ b/tests/third_party/cupy/testing/_condition.py
@@ -65,7 +65,7 @@ def repeat_with_success_at_least(times, min_success):
                 result = QuietTestRunner().run(suite)
                 if len(result.skipped) == 1:
                     # "Skipped" is a special case of "Successful".
-                    # When the test has been skipped, immedeately quit the
+                    # When the test has been skipped, immediately quit the
                     # test regardleess of `times` and `min_success` by raising
                     # SkipTest exception using the original reason.
                     instance.skipTest(result.skipped[0][1])

--- a/tests/third_party/cupy/testing/_helper.py
+++ b/tests/third_party/cupy/testing/_helper.py
@@ -216,7 +216,7 @@ def generate_matrix(
             matrices. It must be broadcastable to shape :math:`(B..., K)`.
 
     Returns:
-        numpy.ndarray or cupy.ndarray: A random matrix that has specifiec
+        numpy.ndarray or cupy.ndarray: A random matrix that has specific
         singular values.
     """
 
@@ -264,7 +264,7 @@ def assert_warns(expected):
     except AttributeError:
         exc_name = str(expected)
 
-    raise AssertionError("%s not triggerred" % exc_name)
+    raise AssertionError("%s not triggered" % exc_name)
 
 
 class NumpyAliasTestBase(unittest.TestCase):

--- a/tests/third_party/cupy/testing/_loops.py
+++ b/tests/third_party/cupy/testing/_loops.py
@@ -349,7 +349,7 @@ numpy: {}""".format(
                             )
                         )
 
-            # Check contiguities
+            # Check contiguous
             if contiguous_check:
                 for cupy_r, numpy_r in zip(cupy_result, numpy_result):
                     if isinstance(numpy_r, numpy.ndarray):
@@ -1149,7 +1149,7 @@ def for_signed_dtypes(name="dtype"):
 
 
 def for_unsigned_dtypes(name="dtype"):
-    """Decorator that checks the fixture with unsinged dtypes.
+    """Decorator that checks the fixture with unsigned dtypes.
 
     Args:
          name(str): Argument name to which specified dtypes are passed.

--- a/tests_external/numpy/runtests.py
+++ b/tests_external/numpy/runtests.py
@@ -137,7 +137,7 @@ def replace_kwarg_value(f, arg_name, in_values, out_value):
     return wrapper
 
 
-# setting some dummy attrubutes to dpnp
+# setting some dummy attributes to dpnp
 unsupported_classes = [
     "byte",
     "bytes_",
@@ -278,7 +278,7 @@ dpnp.zeros = replace_kwarg_value(
     None,
 )
 
-# setting some dummy attrubutes to dpnp
+# setting some dummy attributes to dpnp
 dpnp.add.reduce = dummy_func
 dpnp.allclose = dummy_func
 dpnp.csingle = dpnp.complex64
@@ -318,7 +318,7 @@ dpnp.linalg._umath_linalg = dummymodule
 dpnp.ufunc = types.FunctionType
 
 
-# setting some numpy attrubutes to dpnp
+# setting some numpy attributes to dpnp
 NUMPY_ONLY_ATTRS = [
     "BUFSIZE",
     "_NoValue",


### PR DESCRIPTION
The PR add a pre-commit hook with `codespell` check to identify possible common misspelling in the code.

_Note_, the versions of other hooks were updated to the latest releases.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
