### PR TITLE
Fixed an issue in `dpnp.random.vonmises` function identified by running tests scope on PVC

### DIFF
--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -1820,7 +1820,7 @@ def vonmises(mu, kappa, size=None):
             pass
         elif not dpnp.isscalar(kappa):
             pass
-        elif dpnp.isnan(kappa):
+        elif numpy.isnan(kappa):
             return dpnp.nan
         elif kappa < 0:
             pass


### PR DESCRIPTION
Function `dpnp.isnan` doesn't support scalar input and raises `TypeError` exception. But the call with scalar input is using by implementation of `dpnp.random.vonmises` function.

The PR proposes to always call `numpy.isnan` there instead, because it's secured that `kappa` is a scalar by a prior check in the code.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
