### PR TITLE
Leverage on `out` keyword in reduction and `where` functions of `dpctl.tensor`

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -27,11 +27,13 @@ env:
       test_logic.py
       test_manipulation.py
       test_mathematical.py
+      test_nanfunctions.py
       test_product.py
       test_random_state.py
       test_sort.py
       test_special.py
       test_statistics.py
+      test_sum.py
       test_sycl_queue.py
       test_umath.py
       test_usm_type.py

--- a/doc/known_words.txt
+++ b/doc/known_words.txt
@@ -25,6 +25,7 @@ Frobenius
 Hypergeometric
 iinfo
 Infs
+intp
 iterable
 Lomax
 Mersenne

--- a/dpnp/dpnp_algo/dpnp_arraycreation.py
+++ b/dpnp/dpnp_algo/dpnp_arraycreation.py
@@ -281,7 +281,7 @@ class dpnp_nd_grid:
 
     Parameters
     ----------
-    sparse : bool, optional
+    sparse : {bool}, optional
         Whether the grid is sparse or not. Default is False.
 
     """

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -525,7 +525,8 @@ class dpnp_array:
         Refer to :obj:`dpnp.argmax` for full documentation.
 
         """
-        return dpnp.argmax(self, axis, out, keepdims=keepdims)
+
+        return dpnp.argmax(self, axis=axis, out=out, keepdims=keepdims)
 
     def argmin(self, axis=None, out=None, *, keepdims=False):
         """
@@ -534,7 +535,8 @@ class dpnp_array:
         Refer to :obj:`dpnp.argmin` for full documentation.
 
         """
-        return dpnp.argmin(self, axis, out, keepdims=keepdims)
+
+        return dpnp.argmin(self, axis=axis, out=out, keepdims=keepdims)
 
     # 'argpartition',
 
@@ -951,7 +953,14 @@ class dpnp_array:
 
         """
 
-        return dpnp.max(self, axis, out, keepdims, initial, where)
+        return dpnp.max(
+            self,
+            axis=axis,
+            out=out,
+            keepdims=keepdims,
+            initial=initial,
+            where=where,
+        )
 
     def mean(
         self, axis=None, dtype=None, out=None, keepdims=False, *, where=True
@@ -980,7 +989,14 @@ class dpnp_array:
 
         """
 
-        return dpnp.min(self, axis, out, keepdims, initial, where)
+        return dpnp.min(
+            self,
+            axis=axis,
+            out=out,
+            keepdims=keepdims,
+            initial=initial,
+            where=where,
+        )
 
     @property
     def nbytes(self):
@@ -1054,7 +1070,15 @@ class dpnp_array:
 
         """
 
-        return dpnp.prod(self, axis, dtype, out, keepdims, initial, where)
+        return dpnp.prod(
+            self,
+            axis=axis,
+            dtype=dtype,
+            out=out,
+            keepdims=keepdims,
+            initial=initial,
+            where=where,
+        )
 
     def put(self, indices, vals, /, *, axis=None, mode="wrap"):
         """
@@ -1295,13 +1319,11 @@ class dpnp_array:
 
     def sum(
         self,
-        /,
-        *,
         axis=None,
         dtype=None,
-        keepdims=False,
         out=None,
-        initial=0,
+        keepdims=False,
+        initial=None,
         where=True,
     ):
         """

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -590,7 +590,7 @@ class dpnp_array:
             - 'same_kind' means only safe casts or casts within a kind, like float64 to float32, are allowed.
             - 'unsafe' means any data conversions may be done.
 
-        copy : bool, optional
+        copy : {bool}, optional
             By default, ``astype`` always returns a newly allocated array. If
             this is set to ``False``, and the `dtype`, `order`, and `subok`
             requirements are satisfied, the input array is returned instead of

--- a/dpnp/dpnp_iface.py
+++ b/dpnp/dpnp_iface.py
@@ -209,7 +209,7 @@ def astype(x1, dtype, order="K", casting="unsafe", copy=True):
               float64 to float32, are allowed.
             - 'unsafe' means any data conversions may be done.
 
-    copy : bool, optional
+    copy : {bool}, optional
         By default, ``astype`` always returns a newly allocated array. If this
         is set to ``False``, and the `dtype`, `order`, and `subok` requirements
         are satisfied, the input array is returned instead of a copy.

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -128,7 +128,7 @@ def arange(
     step : {int, real}, optional
         Spacing between values. The default `step` size is 1. If `step`
         is specified as a position argument, `start` must also be given.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         The desired dtype for the array. If not given, a default dtype will be
         used that can represent the values (by considering Promotion Type Rule
         and device capabilities when necessary).
@@ -227,11 +227,11 @@ def array(
         Input data, in any form that can be converted to an array. This
         includes scalars, lists, lists of tuples, tuples, tuples of tuples,
         tuples of lists, and ndarrays.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         The desired dtype for the array. If not given, a default dtype will be
         used that can represent the values (by considering Promotion Type Rule
         and device capabilities when necessary).
-    copy : bool, optional
+    copy : {bool}, optional
         If ``True`` (default), then the object is copied.
     order : {"C", "F", "A", "K"}, optional
         Memory layout of the newly output array. Default: "K".
@@ -353,7 +353,7 @@ def asanyarray(
         Input data, in any form that can be converted to an array. This
         includes scalars, lists, lists of tuples, tuples, tuples of tuples,
         tuples of lists, and ndarrays.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         The desired dtype for the array. If not given, a default dtype will be
         used that can represent the values (by considering Promotion Type Rule
         and device capabilities when necessary).
@@ -449,7 +449,7 @@ def asarray(
         Input data, in any form that can be converted to an array. This
         includes scalars, lists, lists of tuples, tuples, tuples of tuples,
         tuples of lists, and ndarrays.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         The desired dtype for the array. If not given, a default dtype will be
         used that can represent the values (by considering Promotion Type Rule
         and device capabilities when necessary).
@@ -540,7 +540,7 @@ def ascontiguousarray(
         Input data, in any form that can be converted to an array. This
         includes scalars, lists, lists of tuples, tuples, tuples of tuples,
         tuples of lists, and ndarrays.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         The desired dtype for the array. If not given, a default dtype will be
         used that can represent the values (by considering Promotion Type Rule
         and device capabilities when necessary).
@@ -650,7 +650,7 @@ def asfortranarray(
         Input data, in any form that can be converted to an array. This
         includes scalars, lists, lists of tuples, tuples, tuples of tuples,
         tuples of lists, and ndarrays.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         The desired dtype for the array. If not given, a default dtype will be
         used that can represent the values (by considering Promotion Type Rule
         and device capabilities when necessary).
@@ -1081,7 +1081,7 @@ def empty(
     ----------
     shape : {int, sequence of ints}
         Shape of the new array, e.g., (2, 3) or 2.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
@@ -1179,7 +1179,7 @@ def empty_like(
     a : {dpnp_array, usm_ndarray}
         The shape and dtype of `a` define these same attributes
         of the returned array.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
@@ -1292,7 +1292,7 @@ def eye(
         Index of the diagonal: 0 (the default) refers to the main diagonal,
         a positive value refers to an upper diagonal, and a negative value to
         a lower diagonal.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
@@ -1902,7 +1902,7 @@ def full(
         Fill value, in any form that can be converted to an array. This
         includes scalars, lists, lists of tuples, tuples, tuples of tuples,
         tuples of lists, and ndarrays.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
@@ -2003,7 +2003,7 @@ def full_like(
         Fill value, in any form that can be converted to an array. This
         includes scalars, lists, lists of tuples, tuples, tuples of tuples,
         tuples of lists, and ndarrays.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
@@ -2121,7 +2121,7 @@ def geomspace(
         all but the last (a sequence of length `num`) are returned.
     num : int, optional
         Number of samples to generate. Default is 50.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         The desired dtype for the array. If not given, a default dtype will be
         used that can represent the values (by considering Promotion Type Rule
         and device capabilities when necessary).
@@ -2137,10 +2137,10 @@ def geomspace(
         Default is ``None``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
-    endpoint : bool, optional
+    endpoint : {bool}, optional
         If ``True``, `stop` is the last sample. Otherwise, it is not included.
         Default is ``True``.
-    axis : int, optional
+    axis : {int}, optional
         The axis in the result to store the samples. Relevant only if start or
         stop are array-like. By default (0), the samples will be along a new
         axis inserted at the beginning. Use -1 to get an axis at the end.
@@ -2231,7 +2231,7 @@ def identity(
     ----------
     n : int
         Number of rows (and columns) in `n` x `n` output.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
@@ -2342,7 +2342,7 @@ def linspace(
         of tuples, tuples of lists, and ndarrays. If `endpoint` is set to
         ``False`` the sequence consists of all but the last of ``num + 1``
         evenly spaced samples, so that `stop` is excluded.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         The desired dtype for the array. If not given, a default dtype will be
         used that can represent the values (by considering Promotion Type Rule
         and device capabilities when necessary).
@@ -2358,13 +2358,13 @@ def linspace(
         Default is ``None``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
-    endpoint : bool, optional
+    endpoint : {bool}, optional
         If ``True``, `stop` is the last sample. Otherwise, it is not included.
         Default is ``True``.
-    retstep : bool, optional
+    retstep : {bool}, optional
         If ``True``, return (samples, step), where step is the spacing between
         samples.
-    axis : int, optional
+    axis : {int}, optional
         The axis in the result to store the samples. Relevant only if start or
         stop are array-like. By default (0), the samples will be along a new
         axis inserted at the beginning. Use -1 to get an axis at the end.
@@ -2576,10 +2576,10 @@ def logspace(
         Default is ``None``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
-    endpoint : bool, optional
+    endpoint : {bool}, optional
         If ``True``, stop is the last sample. Otherwise, it is not included.
         Default is ``True``.
-    base : array_like, optional
+    base : {array_like}, optional
         Input data, in any form that can be converted to an array. This
         includes scalars, lists, lists of tuples, tuples, tuples of tuples,
         tuples of lists, and ndarrays. The base of the log space, in any form
@@ -2587,11 +2587,11 @@ def logspace(
         of tuples, tuples, tuples of tuples, tuples of lists, and ndarrays.
         The `step` size between the elements in ``ln(samples) / ln(base)``
         (or log_base(samples)) is uniform. Default is 10.0.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         The desired dtype for the array. If not given, a default dtype will be
         used that can represent the values (by considering Promotion Type Rule
         and device capabilities when necessary).
-    axis : int, optional
+    axis : {int}, optional
         The axis in the result to store the samples. Relevant only if start,
         stop, or base are array-like. By default (0), the samples will be along
         a new axis inserted at the beginning. Use -1 to get an axis at the end.
@@ -2674,11 +2674,11 @@ def meshgrid(*xi, copy=True, sparse=False, indexing="xy"):
         1-D arrays representing the coordinates of a grid.
     indexing : {'xy', 'ij'}, optional
         Cartesian (``'xy'``, default) or matrix (``'ij'``) indexing of output.
-    sparse : bool, optional
+    sparse : {bool}, optional
         If True the shape of the returned coordinate array for dimension `i`
         is reduced from ``(N1, ..., Ni, ... Nn)`` to
         ``(1, ..., 1, Ni, 1, ..., 1)``. Default is False.
-    copy : bool, optional
+    copy : {bool}, optional
         If False, a view into the original arrays are returned in order to
         conserve memory.  Default is True.
 
@@ -2908,7 +2908,7 @@ def ones(
     ----------
     shape : {int, sequence of ints}
         Shape of the new array, e.g., (2, 3) or 2.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
@@ -3012,7 +3012,7 @@ def ones_like(
     a : {dpnp_array, usm_ndarray}
         The shape and dtype of `a` define these same attributes
         of the returned array.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
@@ -3158,7 +3158,7 @@ def tri(
         The sub-diagonal at and below which the array is filled. k = 0 is
         the main diagonal, while k < 0 is below it, and k > 0 is above.
         The default is 0.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
@@ -3385,7 +3385,7 @@ def vander(
     N : int, optional
         Number of columns in the output. If `N` is not specified, a square
         array is returned ``(N = len(x))``.
-    increasing : bool, optional
+    increasing : {bool}, optional
         Order of the powers of the columns. If ``True,`` the powers increase
         from left to right, if ``False`` (the default) they are reversed.
     device : {None, string, SyclDevice, SyclQueue}, optional
@@ -3499,7 +3499,7 @@ def zeros(
     ----------
     shape : {int, sequence of ints}
         Shape of the new array, e.g., (2, 3) or 2.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
@@ -3603,7 +3603,7 @@ def zeros_like(
     a : {dpnp_array, usm_ndarray}
         The shape and dtype of `a` define these same attributes
         of the returned array.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.

--- a/dpnp/dpnp_iface_indexing.py
+++ b/dpnp/dpnp_iface_indexing.py
@@ -397,9 +397,9 @@ def indices(
     ----------
     dimensions : sequence of ints
         The shape of the grid.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         Data type of the result.
-    sparse : boolean, optional
+    sparse : {None, boolean}, optional
         Return a sparse representation of the grid instead of a dense
         representation. Default is ``False``.
     device : {None, string, SyclDevice, SyclQueue}, optional

--- a/dpnp/dpnp_iface_linearalgebra.py
+++ b/dpnp/dpnp_iface_linearalgebra.py
@@ -404,7 +404,7 @@ def matmul(
         Alternative output array in which to place the result. It must have
         a shape that matches the signature `(n,k),(k,m)->(n,m)` but the type
         (of the calculated values) will be cast if necessary. Default: ``None``.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         Type to use in computing the matrix product. By default, the returned
         array will have data type that is determined by considering
         Promotion Type Rule and device capabilities.
@@ -413,7 +413,7 @@ def matmul(
     order : {"C", "F", "A", "K", None}, optional
         Memory layout of the newly output array, if parameter `out` is ``None``.
         Default: "K".
-    axes : list of tuples, optional
+    axes : {list of tuples}, optional
         A list of tuples with indices of axes the matrix product should operate
         on. For instance, for the signature of ``(i,j),(j,k)->(i,k)``, the base
         elements are 2d matrices and these are taken to be stored in the two

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -1322,7 +1322,7 @@ def reshape(a, /, newshape, order="C", copy=None):
         changing fastest, and the last index changing slowest. Note that
         the ``"C"`` and ``"F"`` options take no account of the memory layout of
         the underlying array, and only refer to the order of indexing.
-    copy : bool, optional
+    copy : {None, bool}, optional
         Boolean indicating whether or not to copy the input array.
         If ``True``, the result array will always be a copy of input `a`.
         If ``False``, the result array can never be a copy
@@ -1434,12 +1434,12 @@ def roll(x, shift, axis=None):
     ----------
     a : {dpnp.ndarray, usm_ndarray}
         Input array.
-    shift : int or tuple of ints
+    shift : {int, tuple of ints}
         The number of places by which elements are shifted. If a tuple, then
         `axis` must be a tuple of the same size, and each of the given axes
         is shifted by the corresponding number. If an integer while `axis` is
         a tuple of integers, then the same value is used for all given axes.
-    axis : int or tuple of ints, optional
+    axis : {None, int, tuple of ints}, optional
         Axis or axes along which elements are shifted. By default, the
         array is flattened before shifting, after which the original
         shape is restored.

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -2249,20 +2249,49 @@ def prod(
 
     For full documentation refer to :obj:`numpy.prod`.
 
+    Parameters
+    ----------
+    a : {dpnp.ndarray, usm_ndarray}
+        Input array.
+    axis : {None, int or tuple of ints}, optional
+        Axis or axes along which a product is performed. The default,
+        ``axis=None``, will calculate the product of all the elements in the
+        input array. If `axis` is negative it counts from the last to the first
+        axis.
+        If `axis` is a tuple of integers, a product is performed on all of the
+        axes specified in the tuple instead of a single axis or all the axes as
+        before.
+        Default: ``None``.
+    dtype : dtype, optional
+        The type of the returned array, as well as of the accumulator in which
+        the elements are multiplied. The dtype of `a` is used by default unless
+        `a` has an integer dtype of less precision than the default platform
+        integer. In that case, if `a` is signed then the platform integer is
+        used while if `a` is unsigned then an unsigned integer of the same
+        precision as the platform integer is used.
+        Default: ``None``.
+    out : {None, dpnp.ndarray, usm_ndarray}, optional
+        Alternative output array in which to place the result. It must have
+        the same shape as the expected output, but the type of the output
+        values will be cast if necessary.
+        Default: ``None``.
+    keepdims : bool, optional
+        If this is set to ``True``, the axes which are reduced are left in the
+        result as dimensions with size one. With this option, the result will
+        broadcast correctly against the input array.
+        Default: ``False``.
+
     Returns
     -------
     out : dpnp.ndarray
-        A new array holding the result is returned unless `out` is specified,
-        in which case it is returned.
+        An array shaped as `a` but with the specified axis removed.
+        Returns a reference to `out` if specified.
 
     Limitations
     -----------
-    Input array is only supported as either :class:`dpnp.ndarray` or
-    :class:`dpctl.tensor.usm_ndarray`.
-    Parameters `initial`, and `where` are only supported with their default
+    Parameters `initial` and `where` are only supported with their default
     values.
     Otherwise ``NotImplementedError`` exception will be raised.
-    Input array data types are limited by DPNP :ref:`Data types`.
 
     See Also
     --------
@@ -2290,20 +2319,33 @@ def prod(
 
     """
 
-    if initial is not None:
-        raise NotImplementedError(
-            "initial keyword argument is only supported with its default value."
-        )
-    if where is not True:
-        raise NotImplementedError(
-            "where keyword argument is only supported with its default value."
-        )
-    dpt_array = dpnp.get_usm_ndarray(a)
-    result = dpnp_array._create_from_usm_ndarray(
-        dpt.prod(dpt_array, axis=axis, dtype=dtype, keepdims=keepdims)
-    )
+    dpnp.check_limitations(initial=initial, where=where)
+    usm_a = dpnp.get_usm_ndarray(a)
 
-    return dpnp.get_result_array(result, out)
+    input_out = out
+    if out is None:
+        usm_out = None
+    else:
+        dpnp.check_supported_arrays_type(out)
+
+        # get dtype used by dpctl for result array in cumulative_sum
+        if dtype is None:
+            res_dt = dtu._default_accumulation_dtype(a.dtype, a.sycl_queue)
+        else:
+            res_dt = dpnp.dtype(dtype)
+            res_dt = dtu._to_device_supported_dtype(res_dt, a.sycl_device)
+
+        # dpctl requires strict data type matching of out array with the result
+        if out.dtype != res_dt:
+            out = dpnp.astype(out, dtype=res_dt, copy=False)
+
+        usm_out = dpnp.get_usm_ndarray(out)
+
+    res_usm = dpt.prod(
+        usm_a, axis=axis, dtype=dtype, out=usm_out, keepdims=keepdims
+    )
+    res = dpnp_array._create_from_usm_ndarray(res_usm)
+    return dpnp.get_result_array(res, input_out, casting="unsafe")
 
 
 _PROJ_DOCSTRING = """
@@ -2743,13 +2785,11 @@ subtract = DPNPBinaryFunc(
 
 def sum(
     a,
-    /,
-    *,
     axis=None,
     dtype=None,
-    keepdims=False,
     out=None,
-    initial=0,
+    keepdims=False,
+    initial=None,
     where=True,
 ):
     """
@@ -2761,39 +2801,40 @@ def sum(
     ----------
     a : {dpnp.ndarray, usm_ndarray}
         Input array.
-    axis : int or tuple of ints, optional
-        Axis or axes along which sums must be computed. If a tuple
-        of unique integers, sums are computed over multiple axes.
-        If ``None``, the sum is computed over the entire array.
+    axis : {None, int or tuple of ints}, optional
+        Axis or axes along which a sum is performed. The default,
+        ``axis=None``, will sum all of the elements of the input array. If axis
+        is negative it counts from the last to the first axis.
+        If `axis` is a tuple of integers, a sum is performed on all of the axes
+        specified in the tuple instead of a single axis or all the axes as
+        before.
         Default: ``None``.
     dtype : dtype, optional
-        Data type of the returned array. If ``None``, it defaults to the dtype
-        of `a`, unless `a` has an integer dtype with a precision less than that
-        of the default platform integer. In that case, the default platform
-        integer is used.
-        If the data type (either specified or resolved) differs from the
-        data type of `a`, the input array elements are cast to the
-        specified data type before computing the sum.
+        The type of the returned array and of the accumulator in which the
+        elements are summed. The dtype of `a` is used by default unless `a` has
+        an integer dtype of less precision than the default platform integer.
+        In that case, if `a` is signed then the platform integer is used while
+        if `a` is unsigned then an unsigned integer of the same precision as
+        the platform integer is used.
         Default: ``None``.
     out : {None, dpnp.ndarray, usm_ndarray}, optional
-        Alternative output array in which to place the result. It must
-        have the same shape as the expected output, but the type of
-        the output values will be cast if necessary.
+        Alternative output array in which to place the result. It must have the
+        same shape as the expected output, but the type of the output values
+        will be cast if necessary.
         Default: ``None``.
     keepdims : bool, optional
-        If ``True``, the reduced axes (dimensions) are included in the result
-        as singleton dimensions, so that the returned array remains
-        compatible with the input array according to Array Broadcasting
-        rules. Otherwise, if ``False``, the reduced axes are not included in
-        the returned array. Default: ``False``.
+        If this is set to ``True``, the axes which are reduced are left in the
+        result as dimensions with size one. With this option, the result will
+        broadcast correctly against the input array.
+        Default: ``False``.
 
     Returns
     -------
     out : dpnp.ndarray
-        An array containing the sums. If the sum is computed over the
-        entire array, a zero-dimensional array is returned. The returned
-        array has the data type as described in the `dtype` parameter
-        description above.
+        An array with the same shape as `a`, with the specified axis removed.
+        If `a` is a 0-d array, or if `axis` is ``None``, a zero-dimensional
+        array is returned. If an output array is specified, a reference to
+        `out` is returned.
 
     Limitations
     -----------
@@ -2827,20 +2868,7 @@ def sum(
 
     """
 
-    if axis is not None:
-        if not isinstance(axis, (tuple, list)):
-            axis = (axis,)
-
-        axis = normalize_axis_tuple(axis, a.ndim, "axis")
-
-    if initial != 0:
-        raise NotImplementedError(
-            "initial keyword argument is only supported with its default value."
-        )
-    if where is not True:
-        raise NotImplementedError(
-            "where keyword argument is only supported with its default value."
-        )
+    dpnp.check_limitations(initial=initial, where=where)
 
     sycl_sum_call = False
     if len(a.shape) == 2 and a.itemsize == 4:
@@ -2859,6 +2887,12 @@ def sum(
         sycl_sum_call = c_contiguous_rules or f_contiguous_rules
 
     if sycl_sum_call:
+        if axis is not None:
+            if not isinstance(axis, (tuple, list)):
+                axis = (axis,)
+
+            axis = normalize_axis_tuple(axis, a.ndim, "axis")
+
         input = a
         if axis == (1,):
             input = input.T
@@ -2888,11 +2922,32 @@ def sum(
 
             return result
 
-    y = dpt.sum(
-        dpnp.get_usm_ndarray(a), axis=axis, dtype=dtype, keepdims=keepdims
+    usm_a = dpnp.get_usm_ndarray(a)
+
+    input_out = out
+    if out is None:
+        usm_out = None
+    else:
+        dpnp.check_supported_arrays_type(out)
+
+        # get dtype used by dpctl for result array in cumulative_sum
+        if dtype is None:
+            res_dt = dtu._default_accumulation_dtype(a.dtype, a.sycl_queue)
+        else:
+            res_dt = dpnp.dtype(dtype)
+            res_dt = dtu._to_device_supported_dtype(res_dt, a.sycl_device)
+
+        # dpctl requires strict data type matching of out array with the result
+        if out.dtype != res_dt:
+            out = dpnp.astype(out, dtype=res_dt, copy=False)
+
+        usm_out = dpnp.get_usm_ndarray(out)
+
+    res_usm = dpt.sum(
+        usm_a, axis=axis, dtype=dtype, out=usm_out, keepdims=keepdims
     )
-    result = dpnp_array._create_from_usm_ndarray(y)
-    return dpnp.get_result_array(result, out, casting="same_kind")
+    res = dpnp_array._create_from_usm_ndarray(res_usm)
+    return dpnp.get_result_array(res, input_out, casting="unsafe")
 
 
 def trapz(y1, x1=None, dx=1.0, axis=-1):

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -850,7 +850,7 @@ def cumsum(a, axis=None, dtype=None, out=None):
     ----------
     a : {dpnp.ndarray, usm_ndarray}
         Input array.
-    axis : {int}, optional
+    axis : {None, int}, optional
         Axis along which the cumulative sum is computed. It defaults to compute
         the cumulative sum over the flattened array.
         Default: ``None``.
@@ -2285,8 +2285,10 @@ def prod(
     Returns
     -------
     out : dpnp.ndarray
-        An array shaped as `a` but with the specified axis removed.
-        Returns a reference to `out` if specified.
+        An array with the same shape as `a`, with the specified axis removed.
+        If `a` is a 0-d array, or if `axis` is ``None``, a zero-dimensional
+        array is returned. If an output array is specified, a reference to
+        `out` is returned.
 
     Limitations
     -----------

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -159,12 +159,7 @@ def _append_to_diff_array(a, axis, combined, values):
 
 
 def _wrap_reduction_call(a, dtype, out, _reduction_fn, *args, **kwargs):
-    """
-    TODO: add a description
-
-    TBA.
-
-    """
+    """Wrap a call of reduction functions from dpctl.tensor interface."""
 
     input_out = out
     if out is None:
@@ -876,7 +871,7 @@ def cumsum(a, axis=None, dtype=None, out=None):
     axis : int, optional
         Axis along which the cumulative sum is computed. The default (``None``)
         is to compute the cumulative sum over the flattened array.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         Type of the returned array and of the accumulator in which the elements
         are summed. If `dtype` is not specified, it defaults to the dtype of
         `a`, unless `a` has an integer dtype with a precision less than that of
@@ -2277,7 +2272,7 @@ def prod(
         axes specified in the tuple instead of a single axis or all the axes as
         before.
         Default: ``None``.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         The type of the returned array, as well as of the accumulator in which
         the elements are multiplied. The dtype of `a` is used by default unless
         `a` has an integer dtype of less precision than the default platform
@@ -2290,7 +2285,7 @@ def prod(
         the same shape as the expected output, but the type of the output
         values will be cast if necessary.
         Default: ``None``.
-    keepdims : bool, optional
+    keepdims : {None, bool}, optional
         If this is set to ``True``, the axes which are reduced are left in the
         result as dimensions with size one. With this option, the result will
         broadcast correctly against the input array.
@@ -2803,7 +2798,7 @@ def sum(
         specified in the tuple instead of a single axis or all the axes as
         before.
         Default: ``None``.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         The type of the returned array and of the accumulator in which the
         elements are summed. The dtype of `a` is used by default unless `a` has
         an integer dtype of less precision than the default platform integer.
@@ -2816,7 +2811,7 @@ def sum(
         same shape as the expected output, but the type of the output values
         will be cast if necessary.
         Default: ``None``.
-    keepdims : bool, optional
+    keepdims : {None, bool}, optional
         If this is set to ``True``, the axes which are reduced are left in the
         result as dimensions with size one. With this option, the result will
         broadcast correctly against the input array.

--- a/dpnp/dpnp_iface_nanfunctions.py
+++ b/dpnp/dpnp_iface_nanfunctions.py
@@ -301,7 +301,7 @@ def nancumsum(a, axis=None, dtype=None, out=None):
     ----------
     a : {dpnp.ndarray, usm_ndarray}
         Input array.
-    axis : {int}, optional
+    axis : {None, int}, optional
         Axis along which the cumulative sum is computed. The default (``None``)
         is to compute the cumulative sum over the flattened array.
     dtype : {None, dtype}, optional

--- a/dpnp/dpnp_iface_nanfunctions.py
+++ b/dpnp/dpnp_iface_nanfunctions.py
@@ -301,7 +301,7 @@ def nancumsum(a, axis=None, dtype=None, out=None):
     ----------
     a : {dpnp.ndarray, usm_ndarray}
         Input array.
-    axis : int, optional
+    axis : {int}, optional
         Axis along which the cumulative sum is computed. The default (``None``)
         is to compute the cumulative sum over the flattened array.
     dtype : {None, dtype}, optional
@@ -310,7 +310,7 @@ def nancumsum(a, axis=None, dtype=None, out=None):
         `a`, unless `a` has an integer dtype with a precision less than that of
         the default platform integer. In that case, the default platform
         integer is used.
-    out : {dpnp.ndarray, usm_ndarray}, optional
+    out : {None, dpnp.ndarray, usm_ndarray}, optional
         Alternative output array in which to place the result. It must have the
         same shape and buffer length as the expected output but the type will
         be cast if necessary.

--- a/dpnp/dpnp_iface_nanfunctions.py
+++ b/dpnp/dpnp_iface_nanfunctions.py
@@ -124,7 +124,7 @@ def nanargmax(a, axis=None, out=None, *, keepdims=False):
         If provided, the result will be inserted into this array. It should be
         of the appropriate shape and dtype.
         Default: ``None``.
-    keepdims : bool, optional
+    keepdims : {None, bool}, optional
         If this is set to ``True``, the axes which are reduced are left in the
         result as dimensions with size one. With this option, the result will
         broadcast correctly against the array.
@@ -195,7 +195,7 @@ def nanargmin(a, axis=None, out=None, *, keepdims=False):
         If provided, the result will be inserted into this array. It should be
         of the appropriate shape and dtype.
         Default: ``None``.
-    keepdims : bool, optional
+    keepdims : {None, bool}, optional
         If this is set to ``True``, the axes which are reduced are left in the
         result as dimensions with size one. With this option, the result will
         broadcast correctly against the array.
@@ -304,7 +304,7 @@ def nancumsum(a, axis=None, dtype=None, out=None):
     axis : int, optional
         Axis along which the cumulative sum is computed. The default (``None``)
         is to compute the cumulative sum over the flattened array.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         Type of the returned array and of the accumulator in which the elements
         are summed. If `dtype` is not specified, it defaults to the dtype of
         `a`, unless `a` has an integer dtype with a precision less than that of
@@ -363,7 +363,7 @@ def nanmax(a, axis=None, out=None, keepdims=False, initial=None, where=True):
     ----------
     a : {dpnp.ndarray, usm_ndarray}
         Input array.
-    axis : int or tuple of ints, optional
+    axis : {None, int, tuple of ints}, optional
         Axis or axes along which maximum values must be computed. By default,
         the maximum value must be computed over the entire array. If a tuple
         of integers, maximum values must be computed over multiple axes.
@@ -371,7 +371,7 @@ def nanmax(a, axis=None, out=None, keepdims=False, initial=None, where=True):
     out : {None, dpnp.ndarray, usm_ndarray}, optional
         If provided, the result will be inserted into this array. It should
         be of the appropriate shape and dtype.
-    keepdims : bool
+    keepdims : {None, bool}, optional
         If ``True``, the reduced axes (dimensions) must be included in the
         result as singleton dimensions, and, accordingly, the result must be
         compatible with the input array. Otherwise, if ``False``, the reduced
@@ -453,12 +453,12 @@ def nanmean(a, axis=None, dtype=None, out=None, keepdims=False, *, where=True):
     ----------
     a : {dpnp.ndarray, usm_ndarray}
         Input array.
-    axis : int or tuple of ints, optional
+    axis : {None, int, tuple of ints}, optional
         Axis or axes along which the arithmetic means must be computed. If
         a tuple of unique integers, the means are computed over multiple
         axes. If ``None``, the mean is computed over the entire array.
         Default: ``None``.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         Type to use in computing the mean. By default, if `a` has a
         floating-point data type, the returned array will have
         the same data type as `a`.
@@ -469,7 +469,7 @@ def nanmean(a, axis=None, dtype=None, out=None, keepdims=False, *, where=True):
         Alternative output array in which to place the result. It must have
         the same shape as the expected output but the type (of the calculated
         values) will be cast if necessary. Default: ``None``.
-    keepdims : bool, optional
+    keepdims : {None, bool}, optional
         If ``True``, the reduced axes (dimensions) are included in the result
         as singleton dimensions, so that the returned array remains
         compatible with the input array according to Array Broadcasting
@@ -564,7 +564,7 @@ def nanmin(a, axis=None, out=None, keepdims=False, initial=None, where=True):
     ----------
     a : {dpnp.ndarray, usm_ndarray}
         Input array.
-    axis : int or tuple of ints, optional
+    axis : {None, int, tuple of ints}, optional
         Axis or axes along which minimum values must be computed. By default,
         the minimum value must be computed over the entire array. If a tuple
         of integers, minimum values must be computed over multiple axes.
@@ -572,7 +572,7 @@ def nanmin(a, axis=None, out=None, keepdims=False, initial=None, where=True):
     out : {None, dpnp.ndarray, usm_ndarray}, optional
         If provided, the result will be inserted into this array. It should
         be of the appropriate shape and dtype.
-    keepdims : bool, optional
+    keepdims : {None, bool}, optional
         If ``True``, the reduced axes (dimensions) must be included in the
         result as singleton dimensions, and, accordingly, the result must be
         compatible with the input array. Otherwise, if ``False``, the reduced
@@ -667,7 +667,7 @@ def nanprod(
         Axis or axes along which the product is computed. The default is to
         compute the product of the flattened array.
         Default: ``None``.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         The type of the returned array and of the accumulator in which the
         elements are multiplied. By default, the dtype of `a` is used. An
         exception is when `a` has an integer type with less precision than
@@ -681,7 +681,7 @@ def nanprod(
         cast if necessary. The casting of NaN to integer
         can yield unexpected results.
         Default: ``None``.
-    keepdims : bool, optional
+    keepdims : {None, bool}, optional
         If ``True``, the axes which are reduced are left in the result as
         dimensions with size one. With this option, the result will broadcast
         correctly against the original `a`.
@@ -760,7 +760,7 @@ def nansum(
         Axis or axes along which the sum is computed. The default is to compute
         the sum of the flattened array.
         Default: ``None``.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         The type of the returned array and of the accumulator in which the
         elements are summed. By default, the dtype of `a` is used. An exception
         is when `a` has an integer type with less precision than the platform
@@ -774,7 +774,7 @@ def nansum(
         cast if necessary. The casting of NaN to integer can yield unexpected
         results.
         Default: ``None``.
-    keepdims : bool, optional
+    keepdims : {None, bool}, optional
         If this is set to ``True``, the axes which are reduced are left in the
         result as dimensions with size one. With this option, the result will
         broadcast correctly against the original `a`.
@@ -850,13 +850,13 @@ def nanstd(
     ----------
     a : {dpnp.ndarray, usm_ndarray}
         Input array.
-    axis : int or tuple of ints, optional
+    axis : {None, int, tuple of ints}, optional
         Axis or axes along which the standard deviations must be computed.
         If a tuple of unique integers is given, the standard deviations
         are computed over multiple axes. If ``None``, the standard deviation
         is computed over the entire array.
         Default: ``None``.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         Type to use in computing the standard deviation. By default,
         if `a` has a floating-point data type, the returned array
         will have the same data type as `a`.
@@ -871,7 +871,7 @@ def nanstd(
         Means Delta Degrees of Freedom. The divisor used in calculations
         is ``N - ddof``, where ``N`` the number of non-NaN elements.
         Default: `0.0`.
-    keepdims : bool, optional
+    keepdims : {None, bool}, optional
         If ``True``, the reduced axes (dimensions) are included in the result
         as singleton dimensions, so that the returned array remains
         compatible with the input array according to Array Broadcasting
@@ -951,12 +951,12 @@ def nanvar(
     ----------
     a : {dpnp.ndarray, usm_ndarray}
         Input array.
-    axis : int or tuple of ints, optional
+    axis : {None, int, tuple of ints}, optional
         axis or axes along which the variances must be computed. If a tuple
         of unique integers is given, the variances are computed over multiple
         axes. If ``None``, the variance is computed over the entire array.
         Default: ``None``.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         Type to use in computing the variance. By default, if `a` has a
         floating-point data type, the returned array will have
         the same data type as `a`.
@@ -971,7 +971,7 @@ def nanvar(
         Means Delta Degrees of Freedom.  The divisor used in calculations
         is ``N - ddof``, where ``N`` represents the number of non-NaN elements.
         Default: `0.0`.
-    keepdims : bool, optional
+    keepdims : {None, bool}, optional
         If ``True``, the reduced axes (dimensions) are included in the result
         as singleton dimensions, so that the returned array remains
         compatible with the input array according to Array Broadcasting

--- a/dpnp/dpnp_iface_nanfunctions.py
+++ b/dpnp/dpnp_iface_nanfunctions.py
@@ -117,18 +117,17 @@ def nanargmax(a, axis=None, out=None, *, keepdims=False):
     ----------
     a : {dpnp.ndarray, usm_ndarray}
         Input array.
-    axis : int, optional
-        Axis along which to search. If ``None``, the function must return
-        the index of the maximum value of the flattened array.
+    axis : {None, int}, optional
+        Axis along which to operate. By default flattened input is used.
         Default: ``None``.
     out : {None, dpnp.ndarray, usm_ndarray}, optional
-        If provided, the result will be inserted into this array. It should
-        be of the appropriate shape and dtype.
-    keepdims : bool
-        If ``True``, the reduced axes (dimensions) must be included in the
-        result as singleton dimensions, and, accordingly, the result must be
-        compatible with the input array. Otherwise, if ``False``, the reduced
-        axes (dimensions) must not be included in the result.
+        If provided, the result will be inserted into this array. It should be
+        of the appropriate shape and dtype.
+        Default: ``None``.
+    keepdims : bool, optional
+        If this is set to ``True``, the axes which are reduced are left in the
+        result as dimensions with size one. With this option, the result will
+        broadcast correctly against the array.
         Default: ``False``.
 
     Returns
@@ -189,18 +188,17 @@ def nanargmin(a, axis=None, out=None, *, keepdims=False):
     ----------
     a : {dpnp.ndarray, usm_ndarray}
         Input array.
-    axis : int, optional
-        Axis along which to search. If ``None``, the function must return
-        the index of the minimum value of the flattened array.
+    axis : {None, int}, optional
+        Axis along which to operate. By default flattened input is used.
         Default: ``None``.
     out : {None, dpnp.ndarray, usm_ndarray}, optional
-        If provided, the result will be inserted into this array. It should
-        be of the appropriate shape and dtype.
-    keepdims : bool
-        If ``True``, the reduced axes (dimensions) must be included in the
-        result as singleton dimensions, and, accordingly, the result must be
-        compatible with the input array. Otherwise, if ``False``, the reduced
-        axes (dimensions) must not be included in the result.
+        If provided, the result will be inserted into this array. It should be
+        of the appropriate shape and dtype.
+        Default: ``None``.
+    keepdims : bool, optional
+        If this is set to ``True``, the axes which are reduced are left in the
+        result as dimensions with size one. With this option, the result will
+        broadcast correctly against the array.
         Default: ``False``.
 
     Returns
@@ -661,6 +659,34 @@ def nanprod(
 
     For full documentation refer to :obj:`numpy.nanprod`.
 
+    Parameters
+    ----------
+    a : {dpnp.ndarray, usm_ndarray}
+        Input array.
+    axis : {None, int or tuple of ints}, optional
+        Axis or axes along which the product is computed. The default is to
+        compute the product of the flattened array.
+        Default: ``None``.
+    dtype : dtype, optional
+        The type of the returned array and of the accumulator in which the
+        elements are multiplied. By default, the dtype of `a` is used. An
+        exception is when `a` has an integer type with less precision than
+        the platform (u)intp. In that case, the default will be either (u)int32
+        or (u)int64 depending on whether the platform is 32 or 64 bits. For
+        inexact inputs, dtype must be inexact.
+        Default: ``None``.
+    out : {None, dpnp.ndarray, usm_ndarray}, optional
+        Alternate output array in which to place the result. If provided, it
+        must have the same shape as the expected output, but the type will be
+        cast if necessary. The casting of NaN to integer
+        can yield unexpected results.
+        Default: ``None``.
+    keepdims : bool, optional
+        If ``True``, the axes which are reduced are left in the result as
+        dimensions with size one. With this option, the result will broadcast
+        correctly against the original `a`.
+        Default: ``False``.
+
     Returns
     -------
     out : dpnp.ndarray
@@ -713,13 +739,11 @@ def nanprod(
 
 def nansum(
     a,
-    /,
-    *,
     axis=None,
     dtype=None,
-    keepdims=False,
     out=None,
-    initial=0,
+    keepdims=False,
+    initial=None,
     where=True,
 ):
     """
@@ -732,39 +756,36 @@ def nansum(
     ----------
     a : {dpnp.ndarray, usm_ndarray}
         Input array.
-    axis : int or tuple of ints, optional
-        Axis or axes along which sums must be computed. If a tuple
-        of unique integers, sums are computed over multiple axes.
-        If ``None``, the sum is computed over the entire array.
+    axis : {None, int or tuple of ints}, optional
+        Axis or axes along which the sum is computed. The default is to compute
+        the sum of the flattened array.
         Default: ``None``.
     dtype : dtype, optional
-        Data type of the returned array. If ``None``, it defaults to the dtype
-        of `a`, unless `a` has an integer dtype with a precision less than that
-        of the default platform integer. In that case, the default platform
-        integer is used.
-        If the data type (either specified or resolved) differs from the
-        data type of `a`, the input array elements are cast to the
-        specified data type before computing the sum.
+        The type of the returned array and of the accumulator in which the
+        elements are summed. By default, the dtype of `a` is used. An exception
+        is when `a` has an integer type with less precision than the platform
+        (u)intp. In that case, the default will be either (u)int32 or (u)int64
+        depending on whether the platform is 32 or 64 bits. For inexact inputs,
+        dtype must be inexact.
         Default: ``None``.
     out : {None, dpnp.ndarray, usm_ndarray}, optional
-        Alternative output array in which to place the result. It must have
-        the same shape as the expected output but the type (of the calculated
-        values) will be cast if necessary. Default: ``None``.
+        Alternate output array in which to place the result. If provided, it
+        must have the same shape as the expected output, but the type will be
+        cast if necessary. The casting of NaN to integer can yield unexpected
+        results.
+        Default: ``None``.
     keepdims : bool, optional
-        If ``True``, the reduced axes (dimensions) are included in the result
-        as singleton dimensions, so that the returned array remains
-        compatible with the input array according to Array Broadcasting
-        rules. Otherwise, if ``False``, the reduced axes are not included in
-        the returned array. Default: ``False``.
+        If this is set to ``True``, the axes which are reduced are left in the
+        result as dimensions with size one. With this option, the result will
+        broadcast correctly against the original `a`.
+        Default: ``False``.
 
     Returns
     -------
     out : dpnp.ndarray
-        An array containing the sums. If the sum is computed over the
-        entire array, a zero-dimensional array is returned. The returned
-        array has the data type as described in the `dtype` parameter
-        description above. Zero is returned for slices that are all-NaN
-        or empty.
+        A new array holding the result is returned unless `out` is specified,
+        in which it is returned. The result has the same size as `a`, and the
+        same shape as `a` if `axis` is not ``None`` or `a` is a 1-d array.
 
     Limitations
     -----------

--- a/dpnp/dpnp_iface_searching.py
+++ b/dpnp/dpnp_iface_searching.py
@@ -331,7 +331,7 @@ def searchsorted(a, v, side="left", sorter=None):
     )
 
 
-def where(condition, x=None, y=None, /):
+def where(condition, x=None, y=None, /, *, order="K", out=None):
     """
     Return elements chosen from `x` or `y` depending on `condition`.
 
@@ -347,6 +347,14 @@ def where(condition, x=None, y=None, /):
     x, y : {dpnp.ndarray, usm_ndarray, scalar}, optional
         Values from which to choose. `x`, `y` and `condition` need to be
         broadcastable to some shape.
+    order : {"K", "C", "F", "A"}, optional
+        Memory layout of the new output arra, if keyword `out` is ``None``.
+        Default: ``"K"``.
+    out : {None, dpnp.ndarray, usm_ndarray}, optional
+        The array into which the result is written. The data type of `out` must
+        match the expected shape and the expected data type of the result.
+        If ``None`` then a new array is returned.
+        Default: ``None``.
 
     Returns
     -------
@@ -413,6 +421,8 @@ def where(condition, x=None, y=None, /):
     if dpnp.isscalar(usm_y):
         usm_y = dpt.asarray(usm_y, usm_type=usm_type, sycl_queue=queue)
 
-    return dpnp_array._create_from_usm_ndarray(
-        dpt.where(usm_condition, usm_x, usm_y)
+    usm_out = None if out is None else dpnp.get_usm_ndarray(out)
+    result = dpnp_array._create_from_usm_ndarray(
+        dpt.where(usm_condition, usm_x, usm_y, order=order, out=usm_out)
     )
+    return dpnp.get_result_array(result, out)

--- a/dpnp/dpnp_iface_searching.py
+++ b/dpnp/dpnp_iface_searching.py
@@ -37,6 +37,7 @@ it contains:
 
 """
 
+# pylint: disable=no-name-in-module
 
 import dpctl.tensor as dpt
 import dpctl.tensor._tensor_impl as dti
@@ -44,8 +45,6 @@ import dpctl.tensor._tensor_impl as dti
 import dpnp
 
 from .dpnp_array import dpnp_array
-
-# pylint: disable=no-name-in-module
 from .dpnp_utils import (
     get_usm_allocations,
 )

--- a/dpnp/dpnp_iface_searching.py
+++ b/dpnp/dpnp_iface_searching.py
@@ -54,12 +54,7 @@ __all__ = ["argmax", "argmin", "searchsorted", "where"]
 
 
 def _wrap_search_call(a, out, _search_fn, *args, **kwargs):
-    """
-    TODO: add a description
-
-    TBA.
-
-    """
+    """Wrap a call of search functions from dpctl.tensor interface."""
 
     input_out = out
     if out is None:
@@ -107,7 +102,7 @@ def argmax(a, axis=None, out=None, *, keepdims=False):
         If provided, the result will be inserted into this array. It should be
         of the appropriate shape and dtype.
         Default: ``None``.
-    keepdims : bool, optional
+    keepdims : {None, bool}, optional
         If this is set to ``True``, the axes which are reduced are left in the
         result as dimensions with size one. With this option, the result will
         broadcast correctly against the array.
@@ -191,7 +186,7 @@ def argmin(a, axis=None, out=None, *, keepdims=False):
         If provided, the result will be inserted into this array. It should be
         of the appropriate shape and dtype.
         Default: ``None``.
-    keepdims : bool, optional
+    keepdims : {None, bool}, optional
         If this is set to ``True``, the axes which are reduced are left in the
         result as dimensions with size one. With this option, the result will
         broadcast correctly against the array.

--- a/dpnp/dpnp_iface_statistics.py
+++ b/dpnp/dpnp_iface_statistics.py
@@ -84,7 +84,7 @@ def _count_reduce_items(arr, axis, where=True):
     ----------
     arr : {dpnp.ndarray, usm_ndarray}
         Input array.
-    axis : int or tuple of ints, optional
+    axis : {None, int, tuple of ints}, optional
         axis or axes along which the number of items used in a reduction
         operation must be counted. If a tuple of unique integers is given,
         the items are counted over multiple axes. If ``None``, the variance
@@ -119,12 +119,7 @@ def _count_reduce_items(arr, axis, where=True):
 
 
 def _wrap_comparison_call(a, out, _comparison_fn, *args, **kwargs):
-    """
-    TODO: add a description
-
-    TBA.
-
-    """
+    """Wrap a call of comparison functions from dpctl.tensor interface."""
 
     input_out = out
     if out is None:
@@ -193,12 +188,12 @@ def average(a, axis=None, weights=None, returned=False, *, keepdims=False):
     ----------
     a : {dpnp.ndarray, usm_ndarray}
         Input array.
-    axis : int or tuple of ints, optional
+    axis : {None, int, tuple of ints}, optional
         Axis or axes along which the averages must be computed. If
         a tuple of unique integers, the averages are computed over multiple
         axes. If ``None``, the average is computed over the entire array.
         Default: ``None``.
-    weights : array_like, optional
+    weights : {array_like}, optional
         An array of weights associated with the values in `a`. Each value in
         `a` contributes to the average according to its associated weight.
         The weights array can either be 1-D (in which case its length must be
@@ -209,12 +204,12 @@ def average(a, axis=None, weights=None, returned=False, *, keepdims=False):
             avg = sum(a * weights) / sum(weights)
 
         The only constraint on `weights` is that `sum(weights)` must not be 0.
-    returned : bool, optional
+    returned : {bool}, optional
         Default is ``False``. If ``True``, the tuple (`average`,
         `sum_of_weights`) is returned, otherwise only the average is returned.
         If `weights=None`, `sum_of_weights` is equivalent to the number of
         elements over which the average is taken.
-    keepdims : bool, optional
+    keepdims : {None, bool}, optional
         If ``True``, the reduced axes (dimensions) are included in the result
         as singleton dimensions, so that the returned array remains
         compatible with the input array according to Array Broadcasting
@@ -499,7 +494,7 @@ def max(a, axis=None, out=None, keepdims=False, initial=None, where=True):
         Alternative output array in which to place the result. Must be of the
         same shape and buffer length as the expected output.
         Default: ``None``.
-    keepdims : bool
+    keepdims : {None, bool}, optional
         If this is set to ``True``, the axes which are reduced are left in the
         result as dimensions with size one. With this option, the result will
         broadcast correctly against the input array.
@@ -568,12 +563,12 @@ def mean(a, /, axis=None, dtype=None, out=None, keepdims=False, *, where=True):
     ----------
     a : {dpnp.ndarray, usm_ndarray}
         Input array.
-    axis : int or tuple of ints, optional
+    axis : {None, int, tuple of ints}, optional
         Axis or axes along which the arithmetic means must be computed. If
         a tuple of unique integers, the means are computed over multiple
         axes. If ``None``, the mean is computed over the entire array.
         Default: ``None``.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         Type to use in computing the mean. By default, if `a` has a
         floating-point data type, the returned array will have
         the same data type as `a`.
@@ -584,7 +579,7 @@ def mean(a, /, axis=None, dtype=None, out=None, keepdims=False, *, where=True):
         Alternative output array in which to place the result. It must have
         the same shape as the expected output but the type (of the calculated
         values) will be cast if necessary. Default: ``None``.
-    keepdims : bool, optional
+    keepdims : {None, bool}, optional
         If ``True``, the reduced axes (dimensions) are included in the result
         as singleton dimensions, so that the returned array remains
         compatible with the input array according to Array Broadcasting
@@ -708,7 +703,7 @@ def min(a, axis=None, out=None, keepdims=False, initial=None, where=True):
         Alternative output array in which to place the result. Must be of the
         same shape and buffer length as the expected output.
         Default: ``None``.
-    keepdims : bool, optional
+    keepdims : {None, bool}, optional
         If this is set to ``True``, the axes which are reduced are left in the
         result as dimensions with size one. With this option, the result will
         broadcast correctly against the input array.
@@ -823,13 +818,13 @@ def std(
     ----------
     a : {dpnp.ndarray, usm_ndarray}
         Input array.
-    axis : int or tuple of ints, optional
+    axis : {None, int, tuple of ints}, optional
         Axis or axes along which the standard deviations must be computed.
         If a tuple of unique integers is given, the standard deviations
         are computed over multiple axes. If ``None``, the standard deviation
         is computed over the entire array.
         Default: ``None``.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         Type to use in computing the standard deviation. By default,
         if `a` has a floating-point data type, the returned array
         will have the same data type as `a`.
@@ -845,7 +840,7 @@ def std(
         is ``N - ddof``, where ``N`` corresponds to the total
         number of elements over which the standard deviation is calculated.
         Default: `0.0`.
-    keepdims : bool, optional
+    keepdims : {None, bool}, optional
         If ``True``, the reduced axes (dimensions) are included in the result
         as singleton dimensions, so that the returned array remains
         compatible with the input array according to Array Broadcasting
@@ -937,12 +932,12 @@ def var(
     ----------
     a : {dpnp.ndarray, usm_ndarray}
         Input array.
-    axis : int or tuple of ints, optional
+    axis : {None, int, tuple of ints}, optional
         axis or axes along which the variances must be computed. If a tuple
         of unique integers is given, the variances are computed over multiple
         axes. If ``None``, the variance is computed over the entire array.
         Default: ``None``.
-    dtype : dtype, optional
+    dtype : {None, dtype}, optional
         Type to use in computing the variance. By default, if `a` has a
         floating-point data type, the returned array will have
         the same data type as `a`.
@@ -958,7 +953,7 @@ def var(
         is ``N - ddof``, where ``N`` corresponds to the total
         number of elements over which the variance is calculated.
         Default: `0.0`.
-    keepdims : bool, optional
+    keepdims : {None, bool}, optional
         If ``True``, the reduced axes (dimensions) are included in the result
         as singleton dimensions, so that the returned array remains
         compatible with the input array according to Array Broadcasting

--- a/dpnp/dpnp_iface_trigonometric.py
+++ b/dpnp/dpnp_iface_trigonometric.py
@@ -98,12 +98,7 @@ __all__ = [
 
 
 def _wrap_accumulation_call(a, dtype, out, _accumulation_fn, *args, **kwargs):
-    """
-    TODO: add a description
-
-    TBA.
-
-    """
+    """Wrap a call of accumulation functions from dpctl.tensor interface."""
 
     input_out = out
     if out is None:
@@ -1279,7 +1274,7 @@ def logsumexp(x, /, *, axis=None, dtype=None, keepdims=False, out=None):
         integers, values are computed over multiple axes. If ``None``, the
         result is computed over the entire array.
         Default: ``None``.
-    dtype : data type, optional
+    dtype : {None, dtype}, optional
         Data type of the returned array. If ``None``, the default data type is
         inferred from the "kind" of the input array data type.
 
@@ -1295,7 +1290,7 @@ def logsumexp(x, /, *, axis=None, dtype=None, keepdims=False, out=None):
         type of `x`, the input array elements are cast to the specified data
         type before computing the result.
         Default: ``None``.
-    keepdims : bool
+    keepdims : {None, bool}, optional
         If ``True``, the reduced axes (dimensions) are included in the result
         as singleton dimensions, so that the returned array remains compatible
         with the input arrays according to Array Broadcasting rules. Otherwise,
@@ -1406,7 +1401,7 @@ def reduce_hypot(x, /, *, axis=None, dtype=None, keepdims=False, out=None):
         integers, values are computed over multiple axes. If ``None``, the
         result is computed over the entire array.
         Default: ``None``.
-    dtype : data type, optional
+    dtype : {None, dtype}, optional
         Data type of the returned array. If ``None``, the default data type is
         inferred from the "kind" of the input array data type.
 
@@ -1422,7 +1417,7 @@ def reduce_hypot(x, /, *, axis=None, dtype=None, keepdims=False, out=None):
         type of `x`, the input array elements are cast to the specified data
         type before computing the result.
         Default: ``None``.
-    keepdims : bool
+    keepdims : {None, bool}, optional
         If ``True``, the reduced axes (dimensions) are included in the result
         as singleton dimensions, so that the returned array remains compatible
         with the input arrays according to Array Broadcasting rules. Otherwise,

--- a/dpnp/dpnp_iface_trigonometric.py
+++ b/dpnp/dpnp_iface_trigonometric.py
@@ -1448,8 +1448,8 @@ def reduce_hypot(x, /, *, axis=None, dtype=None, keepdims=False, out=None):
     return dpnp_wrap_reduction_call(
         x,
         out,
-        dpt.logsumexp,
-        reduce_hypot,
+        dpt.reduce_hypot,
+        _get_accumulation_res_dt,
         usm_x,
         axis=axis,
         dtype=dtype,

--- a/dpnp/dpnp_utils/dpnp_utils_reduction.py
+++ b/dpnp/dpnp_utils/dpnp_utils_reduction.py
@@ -1,0 +1,55 @@
+# *****************************************************************************
+# Copyright (c) 2024, Intel Corporation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# - Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+# *****************************************************************************
+
+
+import dpnp
+from dpnp.dpnp_array import dpnp_array
+
+__all__ = ["dpnp_wrap_reduction_call"]
+
+
+def dpnp_wrap_reduction_call(a, out, _reduction_fn, _get_res_dt_fn, *args, **kwargs):
+    """Wrap a reduction call from dpctl.tensor interface."""
+
+    input_out = out
+    if out is None:
+        usm_out = None
+    else:
+        dpnp.check_supported_arrays_type(out)
+
+        # fetch dtype from the passsed kwargs to the reduction call
+        dtype = kwargs.get("dtype", None)
+
+        # dpctl requires strict data type matching of out array with the result
+        res_dt = _get_res_dt_fn(a, dtype, out)
+        if out.dtype != res_dt:
+            out = dpnp.astype(out, dtype=res_dt, copy=False)
+
+        usm_out = dpnp.get_usm_ndarray(out)
+
+    kwargs["out"] = usm_out
+    res_usm = _reduction_fn(*args, **kwargs)
+    res = dpnp_array._create_from_usm_ndarray(res_usm)
+    return dpnp.get_result_array(res, input_out, casting="unsafe")

--- a/dpnp/dpnp_utils/dpnp_utils_reduction.py
+++ b/dpnp/dpnp_utils/dpnp_utils_reduction.py
@@ -30,7 +30,9 @@ from dpnp.dpnp_array import dpnp_array
 __all__ = ["dpnp_wrap_reduction_call"]
 
 
-def dpnp_wrap_reduction_call(a, out, _reduction_fn, _get_res_dt_fn, *args, **kwargs):
+def dpnp_wrap_reduction_call(
+    a, out, _reduction_fn, _get_res_dt_fn, *args, **kwargs
+):
     """Wrap a reduction call from dpctl.tensor interface."""
 
     input_out = out
@@ -39,7 +41,7 @@ def dpnp_wrap_reduction_call(a, out, _reduction_fn, _get_res_dt_fn, *args, **kwa
     else:
         dpnp.check_supported_arrays_type(out)
 
-        # fetch dtype from the passsed kwargs to the reduction call
+        # fetch dtype from the passed kwargs to the reduction call
         dtype = kwargs.get("dtype", None)
 
         # dpctl requires strict data type matching of out array with the result

--- a/dpnp/dpnp_utils/dpnp_utils_statistics.py
+++ b/dpnp/dpnp_utils/dpnp_utils_statistics.py
@@ -64,7 +64,7 @@ def dpnp_cov(m, y=None, rowvar=True, dtype=None):
         return x
 
     # input arrays must follow CFD paradigm
-    usm_type, queue = get_usm_allocations((m,) if y is None else (m, y))
+    _, queue = get_usm_allocations((m,) if y is None else (m, y))
 
     # calculate a type of result array if not passed explicitly
     if dtype is None:

--- a/dpnp/linalg/dpnp_iface_linalg.py
+++ b/dpnp/linalg/dpnp_iface_linalg.py
@@ -106,7 +106,7 @@ def cholesky(a, upper=False):
     a : (..., M, M) {dpnp.ndarray, usm_ndarray}
         Hermitian (symmetric if all elements are real), positive-definite
         input matrix.
-    upper : bool, optional
+    upper : {bool}, optional
         If ``True``, the result must be the upper-triangular Cholesky factor.
         If ``False``, the result must be the lower-triangular Cholesky factor.
         Default: ``False``.
@@ -749,7 +749,7 @@ def matrix_rank(A, tol=None, hermitian=False):
         None, and ``S`` is an array with singular values for `M`, and
         ``eps`` is the epsilon value for datatype of ``S``, then `tol` is
         set to ``S.max() * max(M.shape) * eps``.
-    hermitian : bool, optional
+    hermitian : {bool}, optional
         If True, `A` is assumed to be Hermitian (symmetric if real-valued),
         enabling a more efficient method for finding singular values.
         Defaults to False.
@@ -869,7 +869,7 @@ def pinv(a, rcond=1e-15, hermitian=False):
         Singular values less than or equal to ``rcond * largest_singular_value``
         are set to zero. Broadcasts against the stack of matrices.
         Default: ``1e-15``.
-    hermitian : bool, optional
+    hermitian : {bool}, optional
         If ``True``, a is assumed to be Hermitian (symmetric if real-valued),
         enabling a more efficient method for finding singular values.
         Default: ``False``.
@@ -922,7 +922,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
         are computed.  If `axis` is ``None`` then either a vector norm (when
         `x` is 1-D) or a matrix norm (when `x` is 2-D) is returned.
         The default is ``None``.
-    keepdims : bool, optional
+    keepdims : {None, bool}, optional
         If this is set to ``True``, the axes which are normed over are left in
         the result as dimensions with size one. With this option the result
         will broadcast correctly against the original `x`.
@@ -1141,14 +1141,14 @@ def svd(a, full_matrices=True, compute_uv=True, hermitian=False):
     ----------
     a : (..., M, N) {dpnp.ndarray, usm_ndarray}
         Input array with ``a.ndim >= 2``.
-    full_matrices : bool, optional
+    full_matrices : {bool}, optional
         If ``True``, it returns `u` and `Vh` with full-sized matrices.
         If ``False``, the matrices are reduced in size.
         Default: ``True``.
-    compute_uv : bool, optional
+    compute_uv : {bool}, optional
         If ``False``, it only returns singular values.
         Default: ``True``.
-    hermitian : bool, optional
+    hermitian : {bool}, optional
         If True, a is assumed to be Hermitian (symmetric if real-valued),
         enabling a more efficient method for finding singular values.
         Default: ``False``.

--- a/dpnp/linalg/dpnp_iface_linalg.py
+++ b/dpnp/linalg/dpnp_iface_linalg.py
@@ -1021,11 +1021,13 @@ def qr(a, mode="reduced"):
         The input array with the dimensionality of at least 2.
     mode : {"reduced", "complete", "r", "raw"}, optional
         If K = min(M, N), then
+
         - "reduced" : returns Q, R with dimensions (…, M, K), (…, K, N)
         - "complete" : returns Q, R with dimensions (…, M, M), (…, M, N)
         - "r" : returns R only with dimensions (…, K, N)
         - "raw" : returns h, tau with dimensions (…, N, M), (…, K,)
-        Default: "reduced".
+
+        Default: ``"reduced"``.
 
     Returns
     -------

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -875,6 +875,23 @@ class TestProd:
         with pytest.raises(ValueError):
             getattr(dpnp, func)(ia, axis=0, out=dpnp_res)
 
+    @pytest.mark.usefixtures("suppress_complex_warning")
+    @pytest.mark.parametrize("func", ["prod", "nanprod"])
+    @pytest.mark.parametrize("arr_dt", get_all_dtypes(no_none=True))
+    @pytest.mark.parametrize("out_dt", get_all_dtypes(no_none=True))
+    @pytest.mark.parametrize("dtype", get_all_dtypes())
+    def test_prod_out_dtype(self, func, arr_dt, out_dt, dtype):
+        a = numpy.arange(10, 20).reshape((2, 5)).astype(dtype=arr_dt)
+        out = numpy.zeros_like(a, shape=(2,), dtype=out_dt)
+
+        ia = dpnp.array(a)
+        iout = dpnp.array(out)
+
+        result = getattr(dpnp, func)(ia, out=iout, dtype=dtype, axis=1)
+        expected = getattr(numpy, func)(a, out=out, dtype=dtype, axis=1)
+        assert_array_equal(expected, result)
+        assert result is iout
+
     def test_prod_nanprod_Error(self):
         ia = dpnp.arange(5)
 
@@ -1960,6 +1977,26 @@ class TestLogSumExp:
 
         assert_allclose(res, exp, rtol=1e-06)
 
+    @pytest.mark.usefixtures("suppress_invalid_numpy_warnings")
+    @pytest.mark.parametrize(
+        "arr_dt", get_all_dtypes(no_none=True, no_complex=True)
+    )
+    @pytest.mark.parametrize(
+        "out_dt", get_all_dtypes(no_none=True, no_complex=True)
+    )
+    @pytest.mark.parametrize("dtype", get_all_dtypes())
+    def test_logsumexp_out_dtype(self, arr_dt, out_dt, dtype):
+        a = numpy.arange(10, 20).reshape((2, 5)).astype(dtype=arr_dt)
+        out = numpy.zeros_like(a, shape=(2,), dtype=out_dt)
+
+        ia = dpnp.array(a)
+        iout = dpnp.array(out)
+
+        result = dpnp.logsumexp(ia, out=iout, dtype=dtype, axis=1)
+        exp = numpy.logaddexp.reduce(a, out=out, axis=1)
+        assert_allclose(result, exp.astype(dtype), rtol=1e-06)
+        assert result is iout
+
 
 class TestReduceHypot:
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
@@ -2009,6 +2046,25 @@ class TestReduceHypot:
         exp = exp.astype(out_dtype)
 
         assert_allclose(res, exp, rtol=1e-06)
+
+    @pytest.mark.parametrize(
+        "arr_dt", get_all_dtypes(no_none=True, no_complex=True)
+    )
+    @pytest.mark.parametrize(
+        "out_dt", get_all_dtypes(no_none=True, no_complex=True)
+    )
+    @pytest.mark.parametrize("dtype", get_all_dtypes())
+    def test_reduce_hypot_out_dtype(self, arr_dt, out_dt, dtype):
+        a = numpy.arange(10, 20).reshape((2, 5)).astype(dtype=arr_dt)
+        out = numpy.zeros_like(a, shape=(2,), dtype=out_dt)
+
+        ia = dpnp.array(a)
+        iout = dpnp.array(out)
+
+        result = dpnp.reduce_hypot(ia, out=iout, dtype=dtype, axis=1)
+        exp = numpy.hypot.reduce(a, out=out, axis=1)
+        assert_allclose(result, exp.astype(dtype), rtol=1e-06)
+        assert result is iout
 
 
 class TestMaximum:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -8,90 +8,116 @@ import dpnp
 from .helper import assert_dtype_allclose, get_all_dtypes
 
 
-@pytest.mark.parametrize("func", ["argmax", "argmin", "nanargmin", "nanargmax"])
-@pytest.mark.parametrize("axis", [None, 0, 1, -1, 2, -2])
-@pytest.mark.parametrize("keepdims", [False, True])
-@pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
-def test_argmax_argmin(func, axis, keepdims, dtype):
-    a = numpy.arange(768, dtype=dtype).reshape((4, 4, 6, 8))
-    if func in ["nanargmin", "nanargmax"] and dpnp.issubdtype(
-        a.dtype, dpnp.inexact
-    ):
-        a[2:3, 2, 3:4, 4] = numpy.nan
-    ia = dpnp.array(a)
+class TestMaxMin:
+    @pytest.mark.parametrize(
+        "func", ["argmax", "argmin", "nanargmin", "nanargmax"]
+    )
+    @pytest.mark.parametrize("axis", [None, 0, 1, -1, 2, -2])
+    @pytest.mark.parametrize("keepdims", [False, True])
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
+    def test_argmax_argmin(self, func, axis, keepdims, dtype):
+        a = numpy.arange(768, dtype=dtype).reshape((4, 4, 6, 8))
+        if func in ["nanargmin", "nanargmax"] and dpnp.issubdtype(
+            a.dtype, dpnp.inexact
+        ):
+            a[2:3, 2, 3:4, 4] = numpy.nan
+        ia = dpnp.array(a)
 
-    np_res = getattr(numpy, func)(a, axis=axis, keepdims=keepdims)
-    dpnp_res = getattr(dpnp, func)(ia, axis=axis, keepdims=keepdims)
-    assert_dtype_allclose(dpnp_res, np_res)
+        np_res = getattr(numpy, func)(a, axis=axis, keepdims=keepdims)
+        dpnp_res = getattr(dpnp, func)(ia, axis=axis, keepdims=keepdims)
+        assert_dtype_allclose(dpnp_res, np_res)
 
+    @pytest.mark.parametrize("func", ["argmax", "argmin"])
+    @pytest.mark.parametrize("axis", [None, 0, 1, -1])
+    @pytest.mark.parametrize("keepdims", [False, True])
+    def test_argmax_argmin_bool(self, func, axis, keepdims):
+        a = numpy.arange(2, dtype=numpy.bool_)
+        a = numpy.tile(a, (2, 2))
+        ia = dpnp.array(a)
 
-@pytest.mark.parametrize("func", ["argmax", "argmin"])
-@pytest.mark.parametrize("axis", [None, 0, 1, -1])
-@pytest.mark.parametrize("keepdims", [False, True])
-def test_argmax_argmin_bool(func, axis, keepdims):
-    a = numpy.arange(2, dtype=numpy.bool_)
-    a = numpy.tile(a, (2, 2))
-    ia = dpnp.array(a)
+        np_res = getattr(numpy, func)(a, axis=axis, keepdims=keepdims)
+        dpnp_res = getattr(dpnp, func)(ia, axis=axis, keepdims=keepdims)
+        assert_dtype_allclose(dpnp_res, np_res)
 
-    np_res = getattr(numpy, func)(a, axis=axis, keepdims=keepdims)
-    dpnp_res = getattr(dpnp, func)(ia, axis=axis, keepdims=keepdims)
-    assert_dtype_allclose(dpnp_res, np_res)
+    @pytest.mark.parametrize(
+        "func", ["argmax", "argmin", "nanargmin", "nanargmax"]
+    )
+    def test_argmax_argmin_out(self, func):
+        a = numpy.arange(12, dtype=numpy.float32).reshape((2, 2, 3))
+        if func in ["nanargmin", "nanargmax"]:
+            a[1, 0, 2] = numpy.nan
+        ia = dpnp.array(a)
 
+        # out is dpnp_array
+        np_res = getattr(numpy, func)(a, axis=0)
+        dpnp_out = dpnp.empty(np_res.shape, dtype=np_res.dtype)
+        dpnp_res = getattr(dpnp, func)(ia, axis=0, out=dpnp_out)
+        assert dpnp_out is dpnp_res
+        assert_allclose(dpnp_res, np_res)
 
-@pytest.mark.parametrize("func", ["argmax", "argmin", "nanargmin", "nanargmax"])
-def test_argmax_argmin_out(func):
-    a = numpy.arange(12, dtype=numpy.float32).reshape((2, 2, 3))
-    if func in ["nanargmin", "nanargmax"]:
-        a[1, 0, 2] = numpy.nan
-    ia = dpnp.array(a)
+        # out is usm_ndarray
+        dpt_out = dpt.empty(np_res.shape, dtype=np_res.dtype)
+        dpnp_res = getattr(dpnp, func)(ia, axis=0, out=dpt_out)
+        assert dpt_out is dpnp_res.get_array()
+        assert_allclose(dpnp_res, np_res)
 
-    # out is dpnp_array
-    np_res = getattr(numpy, func)(a, axis=0)
-    dpnp_out = dpnp.empty(np_res.shape, dtype=np_res.dtype)
-    dpnp_res = getattr(dpnp, func)(ia, axis=0, out=dpnp_out)
-    assert dpnp_out is dpnp_res
-    assert_allclose(dpnp_res, np_res)
+        # out is a numpy array -> TypeError
+        dpnp_res = numpy.empty_like(np_res)
+        with pytest.raises(TypeError):
+            getattr(dpnp, func)(ia, axis=0, out=dpnp_res)
 
-    # out is usm_ndarray
-    dpt_out = dpt.empty(np_res.shape, dtype=np_res.dtype)
-    dpnp_res = getattr(dpnp, func)(ia, axis=0, out=dpt_out)
-    assert dpt_out is dpnp_res.get_array()
-    assert_allclose(dpnp_res, np_res)
+        # out shape is incorrect -> ValueError
+        dpnp_res = dpnp.array(numpy.zeros((2, 2)), dtype=dpnp.intp)
+        with pytest.raises(ValueError):
+            getattr(dpnp, func)(ia, axis=0, out=dpnp_res)
 
-    # out is a numpy array -> TypeError
-    dpnp_res = numpy.empty_like(np_res)
-    with pytest.raises(TypeError):
-        getattr(dpnp, func)(ia, axis=0, out=dpnp_res)
+    @pytest.mark.parametrize(
+        "func", ["argmax", "argmin", "nanargmin", "nanargmax"]
+    )
+    @pytest.mark.parametrize("arr_dt", get_all_dtypes(no_none=True))
+    @pytest.mark.parametrize("out_dt", get_all_dtypes(no_none=True))
+    def test_argmax_argmin_out_dtype(self, func, arr_dt, out_dt):
+        a = (
+            numpy.arange(12, dtype=numpy.float32)
+            .reshape((2, 2, 3))
+            .astype(dtype=arr_dt)
+        )
+        out = numpy.zeros_like(a, shape=(2, 3), dtype=out_dt)
 
-    # out shape is incorrect -> ValueError
-    dpnp_res = dpnp.array(numpy.empty((2, 2)))
-    with pytest.raises(ValueError):
-        getattr(dpnp, func)(ia, axis=0, out=dpnp_res)
+        ia = dpnp.array(a)
+        iout = dpnp.array(out)
 
+        if numpy.can_cast(out.dtype, numpy.intp, casting="safe"):
+            result = getattr(dpnp, func)(ia, out=iout, axis=1)
+            expected = getattr(numpy, func)(a, out=out, axis=1)
+            assert_array_equal(expected, result)
+            assert result is iout
+        else:
+            assert_raises(TypeError, getattr(numpy, func), a, out=out, axis=1)
+            assert_raises(TypeError, getattr(dpnp, func), ia, out=iout, axis=1)
 
-@pytest.mark.parametrize("axis", [None, 0, 1, -1])
-@pytest.mark.parametrize("keepdims", [False, True])
-def test_ndarray_argmax_argmin(axis, keepdims):
-    a = numpy.arange(192, dtype=numpy.float32).reshape((4, 6, 8))
-    ia = dpnp.array(a)
+    @pytest.mark.parametrize("axis", [None, 0, 1, -1])
+    @pytest.mark.parametrize("keepdims", [False, True])
+    def test_ndarray_argmax_argmin(self, axis, keepdims):
+        a = numpy.arange(192, dtype=numpy.float32).reshape((4, 6, 8))
+        ia = dpnp.array(a)
 
-    np_res = a.argmax(axis=axis, keepdims=keepdims)
-    dpnp_res = ia.argmax(axis=axis, keepdims=keepdims)
-    assert_dtype_allclose(dpnp_res, np_res)
+        np_res = a.argmax(axis=axis, keepdims=keepdims)
+        dpnp_res = ia.argmax(axis=axis, keepdims=keepdims)
+        assert_dtype_allclose(dpnp_res, np_res)
 
-    np_res = a.argmin(axis=axis, keepdims=keepdims)
-    dpnp_res = ia.argmin(axis=axis, keepdims=keepdims)
-    assert_dtype_allclose(dpnp_res, np_res)
+        np_res = a.argmin(axis=axis, keepdims=keepdims)
+        dpnp_res = ia.argmin(axis=axis, keepdims=keepdims)
+        assert_dtype_allclose(dpnp_res, np_res)
 
+    @pytest.mark.parametrize("func", ["nanargmin", "nanargmax"])
+    def test_nanargmax_nanargmin_error(self, func):
+        ia = dpnp.arange(12, dtype=dpnp.float32).reshape((2, 2, 3))
+        ia[:, :, 2] = dpnp.nan
 
-@pytest.mark.parametrize("func", ["nanargmin", "nanargmax"])
-def test_nanargmax_nanargmin_error(func):
-    ia = dpnp.arange(12, dtype=dpnp.float32).reshape((2, 2, 3))
-    ia[:, :, 2] = dpnp.nan
-
-    # All-NaN slice encountered -> ValueError
-    with pytest.raises(ValueError):
-        getattr(dpnp, func)(ia, axis=0)
+        # All-NaN slice encountered -> ValueError
+        with pytest.raises(ValueError):
+            getattr(dpnp, func)(ia, axis=0)
 
 
 class TestWhere:

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -105,9 +105,29 @@ class TestMaxMin:
             getattr(dpnp, func)(ia, axis=0, out=dpnp_res)
 
         # output has incorrect shape -> Error
-        dpnp_res = dpnp.array(numpy.empty((4, 2)))
+        dpnp_res = dpnp.array(numpy.zeros((4, 2)))
         with pytest.raises(ValueError):
             getattr(dpnp, func)(ia, axis=0, out=dpnp_res)
+
+    @pytest.mark.usefixtures("suppress_complex_warning")
+    @pytest.mark.parametrize("func", ["max", "min", "nanmax", "nanmin"])
+    @pytest.mark.parametrize("arr_dt", get_all_dtypes(no_none=True))
+    @pytest.mark.parametrize("out_dt", get_all_dtypes(no_none=True))
+    def test_max_min_out_dtype(self, func, arr_dt, out_dt):
+        a = (
+            numpy.arange(12, dtype=numpy.float32)
+            .reshape((2, 2, 3))
+            .astype(dtype=arr_dt)
+        )
+        out = numpy.zeros_like(a, shape=(2, 3), dtype=out_dt)
+
+        ia = dpnp.array(a)
+        iout = dpnp.array(out)
+
+        result = getattr(dpnp, func)(ia, out=iout, axis=1)
+        expected = getattr(numpy, func)(a, out=out, axis=1)
+        assert_array_equal(expected, result)
+        assert result is iout
 
     @pytest.mark.parametrize("func", ["max", "min", "nanmax", "nanmin"])
     def test_max_min_error(self, func):

--- a/tests/test_sum.py
+++ b/tests/test_sum.py
@@ -67,6 +67,23 @@ def test_sum_out(dtype, axis):
     assert_array_equal(expected, res.asnumpy())
 
 
+@pytest.mark.usefixtures("suppress_complex_warning")
+@pytest.mark.parametrize("arr_dt", get_all_dtypes(no_none=True))
+@pytest.mark.parametrize("out_dt", get_all_dtypes(no_none=True))
+@pytest.mark.parametrize("dtype", get_all_dtypes())
+def test_sum_out_dtype(arr_dt, out_dt, dtype):
+    a = numpy.arange(10, 20).reshape((2, 5)).astype(dtype=arr_dt)
+    out = numpy.zeros_like(a, shape=(2,), dtype=out_dt)
+
+    ia = dpnp.array(a)
+    iout = dpnp.array(out)
+
+    result = dpnp.sum(ia, out=iout, dtype=dtype, axis=1)
+    expected = numpy.sum(a, out=out, dtype=dtype, axis=1)
+    assert_array_equal(expected, result)
+    assert result is iout
+
+
 def test_sum_NotImplemented():
     ia = dpnp.arange(5)
     with pytest.raises(NotImplementedError):


### PR DESCRIPTION
The PR implements of `out` keywords of reduction functions from `dpctl.tensor` interface and `out` and `order` keywords of `dpctl.tensor.where` function (see [gh-1643](https://github.com/IntelPython/dpctl/pull/1643) for more details how it was implemented in dpctl).

Additionally the PR adds some improvements to docstrings of dpnp functions which were identified during the implementation.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
