### PR TITLE
Leverage `dpnp.cumprod` through dpctl.tensor implementation

### DIFF
--- a/dpnp/dpnp_algo/dpnp_algo_mathematical.pxi
+++ b/dpnp/dpnp_algo/dpnp_algo_mathematical.pxi
@@ -36,7 +36,6 @@ and the rest of the library
 # NO IMPORTs here. All imports must be placed into main "dpnp_algo.pyx" file
 
 __all__ += [
-    "dpnp_cumprod",
     "dpnp_ediff1d",
     "dpnp_fabs",
     "dpnp_fmod",

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -721,7 +721,16 @@ class dpnp_array:
         return dpnp.copy(self, order=order)
 
     # 'ctypes',
-    # 'cumprod',
+
+    def cumprod(self, axis=None, dtype=None, out=None):
+        """
+        Return the cumulative product of the elements along the given axis.
+
+        Refer to :obj:`dpnp.cumprod` for full documentation.
+
+        """
+
+        return dpnp.cumprod(self, axis=axis, dtype=dtype, out=out)
 
     def cumsum(self, axis=None, dtype=None, out=None):
         """

--- a/dpnp/dpnp_iface_nanfunctions.py
+++ b/dpnp/dpnp_iface_nanfunctions.py
@@ -265,8 +265,8 @@ def nancumprod(x1, **kwargs):
 
     See Also
     --------
-    :obj:`dpnp.cumprod` : Return the cumulative product of elements
-                          along a given axis.
+    :obj:`dpnp.cumprod` : Cumulative product across array propagating NaNs.
+    :obj:`dpnp.isnan` : Show which elements are NaN.
 
     Examples
     --------

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -417,7 +417,7 @@ def test_meshgrid(device_x, device_y):
         ),
         pytest.param("cosh", [-5.0, -3.5, 0.0, 3.5, 5.0]),
         pytest.param("count_nonzero", [3, 0, 2, -1.2]),
-        pytest.param("cumprod", [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+        pytest.param("cumprod", [[1, 2, 3], [4, 5, 6]]),
         pytest.param("cumsum", [[1, 2, 3], [4, 5, 6]]),
         pytest.param("diff", [1.0, 2.0, 4.0, 7.0, 0.0]),
         pytest.param("ediff1d", [1.0, 2.0, 4.0, 7.0, 0.0]),

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -522,6 +522,7 @@ def test_norm(usm_type, ord, axis):
         ),
         pytest.param("cosh", [-5.0, -3.5, 0.0, 3.5, 5.0]),
         pytest.param("count_nonzero", [0, 1, 7, 0]),
+        pytest.param("cumprod", [[1, 2, 3], [4, 5, 6]]),
         pytest.param("cumsum", [[1, 2, 3], [4, 5, 6]]),
         pytest.param("diff", [1.0, 2.0, 4.0, 7.0, 0.0]),
         pytest.param("exp", [1.0, 2.0, 4.0, 7.0]),

--- a/tests/third_party/cupy/math_tests/test_sumprod.py
+++ b/tests/third_party/cupy/math_tests/test_sumprod.py
@@ -483,13 +483,11 @@ class TestCumprod:
         return res
 
     @testing.for_all_dtypes()
-    # TODO: remove type_check once proper cumprod is implemented
-    @testing.numpy_cupy_allclose(type_check=(not is_win_platform()))
+    @testing.numpy_cupy_allclose()
     def test_cumprod_1dim(self, xp, dtype):
         a = testing.shaped_arange((5,), xp, dtype)
         return self._cumprod(xp, a)
 
-    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_cumprod_out(self, xp, dtype):
@@ -498,7 +496,6 @@ class TestCumprod:
         self._cumprod(xp, a, out=out)
         return out
 
-    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_cumprod_out_noncontiguous(self, xp, dtype):
@@ -507,24 +504,18 @@ class TestCumprod:
         self._cumprod(xp, a, out=out)
         return out
 
-    # TODO: remove skip once proper cumprod is implemented
-    @pytest.mark.skipif(
-        is_win_platform(), reason="numpy has another default integral dtype"
-    )
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-6)
     def test_cumprod_2dim_without_axis(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
         return self._cumprod(xp, a)
 
-    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_cumprod_2dim_with_axis(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
         return self._cumprod(xp, a, axis=1)
 
-    @pytest.mark.skip("ndarray.cumprod() is not implemented yet")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_ndarray_cumprod_2dim_with_axis(self, xp, dtype):
@@ -535,17 +526,13 @@ class TestCumprod:
     @testing.slow
     def test_cumprod_huge_array(self):
         size = 2**32
-        # Free huge memory for slow test
-        cupy.get_default_memory_pool().free_all_blocks()
-        a = cupy.ones(size, "b")
+        a = cupy.ones(size, dtype="b")
         result = cupy.cumprod(a, dtype="b")
         del a
         assert (result == 1).all()
         # Free huge memory for slow test
         del result
-        cupy.get_default_memory_pool().free_all_blocks()
 
-    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     def test_invalid_axis_lower1(self, dtype):
         for xp in (numpy, cupy):
@@ -553,7 +540,6 @@ class TestCumprod:
             with pytest.raises(numpy.AxisError):
                 xp.cumprod(a, axis=-a.ndim - 1)
 
-    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     def test_invalid_axis_lower2(self, dtype):
         for xp in (numpy, cupy):
@@ -561,7 +547,6 @@ class TestCumprod:
             with pytest.raises(numpy.AxisError):
                 xp.cumprod(a, axis=-a.ndim - 1)
 
-    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     def test_invalid_axis_upper1(self, dtype):
         for xp in (numpy, cupy):
@@ -569,19 +554,16 @@ class TestCumprod:
             with pytest.raises(numpy.AxisError):
                 return xp.cumprod(a, axis=a.ndim)
 
-    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     def test_invalid_axis_upper2(self, dtype):
         a = testing.shaped_arange((4, 5), cupy, dtype)
         with pytest.raises(numpy.AxisError):
             return cupy.cumprod(a, axis=a.ndim)
 
-    @pytest.mark.skip("no exception is raised by numpy")
     def test_cumprod_arraylike(self):
         with pytest.raises(TypeError):
             return cupy.cumprod((1, 2, 3))
 
-    @pytest.mark.skip("no exception is raised by numpy")
     @testing.for_float_dtypes()
     def test_cumprod_numpy_array(self, dtype):
         a_numpy = numpy.arange(1, 6, dtype=dtype)


### PR DESCRIPTION
The PR is about to implement `dpnp.cumprod` through leveraging on dpctl implementation.

Note `dpnp_cumprod` is left in the backend code, because it is used by `dpnp_nancumprod` function also.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
