### PR TITLE
Improve performance for dpnp.diag()

### DIFF
--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -996,9 +996,9 @@ def diagflat(v, /, k=0, *, device=None, usm_type=None, sycl_queue=None):
 
     See Also
     --------
-    :obj:`diag` : Return the extracted diagonal or constructed diagonal array.
-    :obj:`diagonal` : Return specified diagonals.
-    :obj:`trace` : Return sum along diagonals.
+    :obj:`dpnp.diag` : Extract a diagonal or construct a diagonal array.
+    :obj:`dpnp.diagonal` : Return specified diagonals.
+    :obj:`dpnp.trace` : Return sum along diagonals.
 
     Examples
     --------
@@ -1311,6 +1311,11 @@ def eye(
     ``None``.
     Parameter `like` is supported only with default value ``None``.
     Otherwise, the function raises `NotImplementedError` exception.
+
+    See Also
+    --------
+    :obj:`dpnp.identity` : Return the identity array.
+    :obj:`dpnp.diag` : Extract a diagonal or construct a diagonal array.
 
     Examples
     --------
@@ -2252,7 +2257,7 @@ def identity(
     :obj:`dpnp.eye` : Return a 2-D array with ones on the diagonal and zeros
                       elsewhere.
     :obj:`dpnp.ones` : Return a new array setting values to one.
-    :obj:`dpnp.diag` : Return diagonal 2-D array from an input 1-D array.
+    :obj:`dpnp.diag` : Extract a diagonal or construct a diagonal array.
 
     Examples
     --------

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -949,12 +949,7 @@ def diag(v, /, k=0, *, device=None, usm_type=None, sycl_queue=None):
 
     if v.ndim == 1:
         size = v.shape[0] + abs(k)
-        ret = dpnp.zeros(
-            (size, size),
-            dtype=v.dtype,
-            usm_type=v.usm_type,
-            sycl_queue=v.sycl_queue,
-        )
+        ret = dpnp.zeros_like(v, shape=(size, size))
         ret.diagonal(k)[:] = v
         return ret
 

--- a/tests/third_party/cupy/creation_tests/test_matrix.py
+++ b/tests/third_party/cupy/creation_tests/test_matrix.py
@@ -27,35 +27,35 @@ class TestMatrix(unittest.TestCase):
     def test_diag_extraction_from_nested_list(self, xp):
         a = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
         r = xp.diag(a, 1)
-        self.assertIsInstance(r, xp.ndarray)
+        assert isinstance(r, xp.ndarray)
         return r
 
     @testing.numpy_cupy_array_equal()
     def test_diag_extraction_from_nested_tuple(self, xp):
         a = ((1, 2, 3), (4, 5, 6), (7, 8, 9))
         r = xp.diag(a, -1)
-        self.assertIsInstance(r, xp.ndarray)
+        assert isinstance(r, xp.ndarray)
         return r
 
     @testing.numpy_cupy_array_equal()
     def test_diag_construction(self, xp):
         a = testing.shaped_arange((3,), xp)
         r = xp.diag(a)
-        self.assertIsInstance(r, xp.ndarray)
+        assert isinstance(r, xp.ndarray)
         return r
 
     @testing.numpy_cupy_array_equal()
     def test_diag_construction_from_list(self, xp):
         a = [1, 2, 3]
         r = xp.diag(a)
-        self.assertIsInstance(r, xp.ndarray)
+        assert isinstance(r, xp.ndarray)
         return r
 
     @testing.numpy_cupy_array_equal()
     def test_diag_construction_from_tuple(self, xp):
         a = (1, 2, 3)
         r = xp.diag(a)
-        self.assertIsInstance(r, xp.ndarray)
+        assert isinstance(r, xp.ndarray)
         return r
 
     def test_diag_scaler(self):


### PR DESCRIPTION
This PR suggests to update `dpnp.diag()` implementation with a reuse of `dpnp.diagonal()` and return a read/write view instead of copy if the input array is an instance of {`dpnp.ndarray`, `usm_ndarray`} for the default case ( `device` ,`usm_type`, `sycl_queue` are `None`).
These changes greatly improve performance compared to the old implementation

![image](https://github.com/IntelPython/dpnp/assets/68376232/a64ccfc7-f5fe-467b-81de-7d3f3cc6a8e4)




- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
