### PR TITLE
organize test suit

### DIFF
--- a/tests/test_nanfunctions.py
+++ b/tests/test_nanfunctions.py
@@ -1,9 +1,12 @@
+import dpctl.tensor as dpt
 import numpy
 import pytest
 from numpy.testing import (
     assert_allclose,
     assert_almost_equal,
+    assert_array_equal,
     assert_equal,
+    assert_raises,
 )
 
 import dpnp
@@ -11,10 +14,88 @@ from tests.third_party.cupy import testing
 
 from .helper import (
     assert_dtype_allclose,
+    get_all_dtypes,
     get_complex_dtypes,
     get_float_complex_dtypes,
     get_float_dtypes,
+    has_support_aspect64,
 )
+
+
+class TestNanargmaxNanargmin:
+    @pytest.mark.parametrize("func", ["nanargmin", "nanargmax"])
+    @pytest.mark.parametrize("axis", [None, 0, 1, -1, 2, -2])
+    @pytest.mark.parametrize("keepdims", [False, True])
+    @pytest.mark.parametrize("dtype", get_float_dtypes())
+    def test_func(self, func, axis, keepdims, dtype):
+        a = numpy.arange(768, dtype=dtype).reshape((4, 4, 6, 8))
+        a[2:3, 2, 3:4, 4] = numpy.nan
+        ia = dpnp.array(a)
+
+        np_res = getattr(numpy, func)(a, axis=axis, keepdims=keepdims)
+        dpnp_res = getattr(dpnp, func)(ia, axis=axis, keepdims=keepdims)
+        assert_dtype_allclose(dpnp_res, np_res)
+
+    @pytest.mark.parametrize("func", ["nanargmin", "nanargmax"])
+    def test_out(self, func):
+        a = numpy.arange(12, dtype=numpy.float32).reshape((2, 2, 3))
+        a[1, 0, 2] = numpy.nan
+        ia = dpnp.array(a)
+
+        # out is dpnp_array
+        np_res = getattr(numpy, func)(a, axis=0)
+        dpnp_out = dpnp.empty(np_res.shape, dtype=np_res.dtype)
+        dpnp_res = getattr(dpnp, func)(ia, axis=0, out=dpnp_out)
+        assert dpnp_out is dpnp_res
+        assert_allclose(dpnp_res, np_res)
+
+        # out is usm_ndarray
+        dpt_out = dpt.empty(np_res.shape, dtype=np_res.dtype)
+        dpnp_res = getattr(dpnp, func)(ia, axis=0, out=dpt_out)
+        assert dpt_out is dpnp_res.get_array()
+        assert_allclose(dpnp_res, np_res)
+
+        # out is a numpy array -> TypeError
+        dpnp_res = numpy.empty_like(np_res)
+        with pytest.raises(TypeError):
+            getattr(dpnp, func)(ia, axis=0, out=dpnp_res)
+
+        # out shape is incorrect -> ValueError
+        dpnp_res = dpnp.array(numpy.zeros((2, 2)), dtype=dpnp.intp)
+        with pytest.raises(ValueError):
+            getattr(dpnp, func)(ia, axis=0, out=dpnp_res)
+
+    @pytest.mark.parametrize("func", ["nanargmin", "nanargmax"])
+    @pytest.mark.parametrize("arr_dt", get_all_dtypes(no_none=True))
+    @pytest.mark.parametrize("out_dt", get_all_dtypes(no_none=True))
+    def test_out_dtype(self, func, arr_dt, out_dt):
+        a = (
+            numpy.arange(12, dtype=numpy.float32)
+            .reshape((2, 2, 3))
+            .astype(dtype=arr_dt)
+        )
+        out = numpy.zeros_like(a, shape=(2, 3), dtype=out_dt)
+
+        ia = dpnp.array(a)
+        iout = dpnp.array(out)
+
+        if numpy.can_cast(out.dtype, numpy.intp, casting="safe"):
+            result = getattr(dpnp, func)(ia, out=iout, axis=1)
+            expected = getattr(numpy, func)(a, out=out, axis=1)
+            assert_array_equal(expected, result)
+            assert result is iout
+        else:
+            assert_raises(TypeError, getattr(numpy, func), a, out=out, axis=1)
+            assert_raises(TypeError, getattr(dpnp, func), ia, out=iout, axis=1)
+
+    @pytest.mark.parametrize("func", ["nanargmin", "nanargmax"])
+    def test_error(self, func):
+        ia = dpnp.arange(12, dtype=dpnp.float32).reshape((2, 2, 3))
+        ia[:, :, 2] = dpnp.nan
+
+        # All-NaN slice encountered -> ValueError
+        with pytest.raises(ValueError):
+            getattr(dpnp, func)(ia, axis=0)
 
 
 @testing.parameterize(
@@ -120,6 +201,419 @@ class TestNanCumSumProd:
         assert result is iout
 
 
+class TestNanmaxNanmin:
+    @pytest.mark.parametrize("func", ["nanmax", "nanmin"])
+    @pytest.mark.parametrize("axis", [None, 0, 1, -1, 2, -2, (1, 2), (0, -2)])
+    @pytest.mark.parametrize("keepdims", [False, True])
+    @pytest.mark.parametrize("dtype", get_float_dtypes())
+    def test_max_min(self, func, axis, keepdims, dtype):
+        a = numpy.arange(768, dtype=dtype).reshape((4, 4, 6, 8))
+        a[2:3, 2, 3:4, 4] = numpy.nan
+        ia = dpnp.array(a)
+
+        np_res = getattr(numpy, func)(a, axis=axis, keepdims=keepdims)
+        dpnp_res = getattr(dpnp, func)(ia, axis=axis, keepdims=keepdims)
+        assert_dtype_allclose(dpnp_res, np_res)
+
+    @pytest.mark.parametrize("func", ["nanmax", "nanmin"])
+    @pytest.mark.parametrize("dtype", get_float_dtypes())
+    def test_max_min_strided(self, func, dtype):
+        a = numpy.arange(20, dtype=dtype)
+        a[::3] = numpy.nan
+        ia = dpnp.array(a)
+
+        np_res = getattr(numpy, func)(a[::-1])
+        dpnp_res = getattr(dpnp, func)(ia[::-1])
+        assert_dtype_allclose(dpnp_res, np_res)
+
+        np_res = getattr(numpy, func)(a[::2])
+        dpnp_res = getattr(dpnp, func)(ia[::2])
+        assert_dtype_allclose(dpnp_res, np_res)
+
+    @pytest.mark.parametrize("func", ["nanmax", "nanmin"])
+    def test_out(self, func):
+        a = numpy.arange(12, dtype=numpy.float32).reshape((2, 2, 3))
+        a[1, 0, 2] = numpy.nan
+        ia = dpnp.array(a)
+
+        # out is dpnp_array
+        np_res = getattr(numpy, func)(a, axis=0)
+        dpnp_out = dpnp.empty(np_res.shape, dtype=np_res.dtype)
+        dpnp_res = getattr(dpnp, func)(ia, axis=0, out=dpnp_out)
+        assert dpnp_out is dpnp_res
+        assert_allclose(dpnp_res, np_res)
+
+        # out is usm_ndarray
+        dpt_out = dpt.empty(np_res.shape, dtype=np_res.dtype)
+        dpnp_res = getattr(dpnp, func)(ia, axis=0, out=dpt_out)
+        assert dpt_out is dpnp_res.get_array()
+        assert_allclose(dpnp_res, np_res)
+
+        # output is numpy array -> Error
+        dpnp_res = numpy.empty_like(np_res)
+        with pytest.raises(TypeError):
+            getattr(dpnp, func)(ia, axis=0, out=dpnp_res)
+
+        # output has incorrect shape -> Error
+        dpnp_res = dpnp.array(numpy.zeros((4, 2)))
+        with pytest.raises(ValueError):
+            getattr(dpnp, func)(ia, axis=0, out=dpnp_res)
+
+    @pytest.mark.usefixtures("suppress_complex_warning")
+    @pytest.mark.parametrize("func", ["nanmax", "nanmin"])
+    @pytest.mark.parametrize("arr_dt", get_all_dtypes(no_none=True))
+    @pytest.mark.parametrize("out_dt", get_all_dtypes(no_none=True))
+    def test_out_dtype(self, func, arr_dt, out_dt):
+        a = (
+            numpy.arange(12, dtype=numpy.float32)
+            .reshape((2, 2, 3))
+            .astype(dtype=arr_dt)
+        )
+        out = numpy.zeros_like(a, shape=(2, 3), dtype=out_dt)
+
+        ia = dpnp.array(a)
+        iout = dpnp.array(out)
+
+        result = getattr(dpnp, func)(ia, out=iout, axis=1)
+        expected = getattr(numpy, func)(a, out=out, axis=1)
+        assert_array_equal(expected, result)
+        assert result is iout
+
+    @pytest.mark.parametrize("func", ["nanmax", "nanmin"])
+    def test_error(self, func):
+        ia = dpnp.arange(5)
+        # where is not supported
+        with pytest.raises(NotImplementedError):
+            getattr(dpnp, func)(ia, where=False)
+
+        # initial is not supported
+        with pytest.raises(NotImplementedError):
+            getattr(dpnp, func)(ia, initial=6)
+
+    @pytest.mark.parametrize("func", ["nanmax", "nanmin"])
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
+    def test_nanmax_nanmin_no_NaN(self, func, dtype):
+        a = numpy.arange(768, dtype=dtype).reshape((4, 4, 6, 8))
+        ia = dpnp.array(a)
+
+        np_res = getattr(numpy, func)(a, axis=0)
+        dpnp_res = getattr(dpnp, func)(ia, axis=0)
+        assert_dtype_allclose(dpnp_res, np_res)
+
+    @pytest.mark.parametrize("func", ["nanmax", "nanmin"])
+    def test_nanmax_nanmin_all_NaN(self, recwarn, func):
+        a = numpy.arange(12, dtype=numpy.float32).reshape((2, 2, 3))
+        a[:, :, 2] = numpy.nan
+        ia = dpnp.array(a)
+
+        np_res = getattr(numpy, func)(a, axis=0)
+        dpnp_res = getattr(dpnp, func)(ia, axis=0)
+        assert_dtype_allclose(dpnp_res, np_res)
+
+        assert len(recwarn) == 2
+        assert all(
+            "All-NaN slice encountered" in str(r.message) for r in recwarn
+        )
+        assert all(r.category is RuntimeWarning for r in recwarn)
+
+
+class TestNanMean:
+    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
+    @pytest.mark.parametrize("axis", [None, 0, 1, (0, 1)])
+    @pytest.mark.parametrize("keepdims", [True, False])
+    def test_nanmean(self, dtype, axis, keepdims):
+        dp_array = dpnp.array([[0, 1, 2], [3, 4, 0]], dtype=dtype)
+        np_array = dpnp.asnumpy(dp_array)
+
+        result = dpnp.nanmean(dp_array, axis=axis, keepdims=keepdims)
+        expected = numpy.nanmean(np_array, axis=axis, keepdims=keepdims)
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
+    @pytest.mark.parametrize("axis", [0, 1])
+    def test_nanmean_out(self, dtype, axis):
+        dp_array = dpnp.array([[dpnp.nan, 1, 2], [3, dpnp.nan, 0]], dtype=dtype)
+        np_array = dpnp.asnumpy(dp_array)
+
+        expected = numpy.nanmean(np_array, axis=axis)
+        out = dpnp.empty_like(dpnp.asarray(expected))
+        result = dpnp.nanmean(dp_array, axis=axis, out=out)
+        assert out is result
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_complex_dtypes())
+    def test_nanmean_complex(self, dtype):
+        x1 = numpy.random.rand(10)
+        x2 = numpy.random.rand(10)
+        a = numpy.array(x1 + 1j * x2, dtype=dtype)
+        a[::3] = numpy.nan
+        ia = dpnp.array(a)
+
+        expected = numpy.nanmean(a)
+        result = dpnp.nanmean(ia)
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
+    def test_nanmean_dtype(self, dtype):
+        dp_array = dpnp.array([[dpnp.nan, 1, 2], [3, dpnp.nan, 0]])
+        np_array = dpnp.asnumpy(dp_array)
+
+        expected = numpy.nanmean(np_array, dtype=dtype)
+        result = dpnp.nanmean(dp_array, dtype=dtype)
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
+    def test_nanmean_strided(self, dtype):
+        dp_array = dpnp.arange(20, dtype=dtype)
+        dp_array[::3] = dpnp.nan
+        np_array = dpnp.asnumpy(dp_array)
+
+        result = dpnp.nanmean(dp_array[::-1])
+        expected = numpy.nanmean(np_array[::-1])
+        assert_dtype_allclose(result, expected)
+
+        result = dpnp.nanmean(dp_array[::2])
+        expected = numpy.nanmean(np_array[::2])
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.usefixtures("suppress_mean_empty_slice_numpy_warnings")
+    def test_nanmean_scalar(self):
+        dp_array = dpnp.array(dpnp.nan)
+        np_array = dpnp.asnumpy(dp_array)
+
+        result = dpnp.nanmean(dp_array)
+        expected = numpy.nanmean(np_array)
+        assert_allclose(expected, result)
+
+    def test_nanmean_error(self):
+        ia = dpnp.arange(5, dtype=dpnp.float32)
+        ia[0] = dpnp.nan
+        # where keyword is not implemented
+        with pytest.raises(NotImplementedError):
+            dpnp.nanmean(ia, where=False)
+
+        # dtype should be floating
+        with pytest.raises(TypeError):
+            dpnp.nanmean(ia, dtype=dpnp.int32)
+
+        # out dtype should be inexact
+        res = dpnp.empty((1,), dtype=dpnp.int32)
+        with pytest.raises(TypeError):
+            dpnp.nanmean(ia, out=res)
+
+
+class TestNanProd:
+    @pytest.mark.parametrize("axis", [None, 0, 1, -1, 2, -2, (1, 2), (0, -2)])
+    @pytest.mark.parametrize("keepdims", [False, True])
+    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
+    def test_nanprod(self, axis, keepdims, dtype):
+        a = numpy.arange(1, 13, dtype=dtype).reshape((2, 2, 3))
+        a[:, :, 2] = numpy.nan
+        ia = dpnp.array(a)
+
+        np_res = numpy.nanprod(a, axis=axis, keepdims=keepdims)
+        dpnp_res = dpnp.nanprod(ia, axis=axis, keepdims=keepdims)
+
+        assert dpnp_res.shape == np_res.shape
+        assert_allclose(dpnp_res, np_res)
+
+    @pytest.mark.usefixtures("suppress_complex_warning")
+    @pytest.mark.usefixtures("suppress_invalid_numpy_warnings")
+    @pytest.mark.parametrize("in_dtype", get_float_complex_dtypes())
+    @pytest.mark.parametrize(
+        "out_dtype", get_all_dtypes(no_bool=True, no_none=True)
+    )
+    def test_nanprod_dtype(self, in_dtype, out_dtype):
+        a = numpy.arange(1, 13, dtype=in_dtype).reshape((2, 2, 3))
+        a[:, :, 2] = numpy.nan
+        ia = dpnp.array(a)
+
+        np_res = numpy.nanprod(a, dtype=out_dtype)
+        dpnp_res = dpnp.nanprod(ia, dtype=out_dtype)
+        assert_dtype_allclose(dpnp_res, np_res)
+
+    @pytest.mark.usefixtures(
+        "suppress_overflow_encountered_in_cast_numpy_warnings"
+    )
+    def test_nanprod_out(self):
+        ia = dpnp.arange(1, 7).reshape((2, 3))
+        ia = ia.astype(dpnp.default_float_type(ia.device))
+        ia[:, 1] = dpnp.nan
+        a = dpnp.asnumpy(ia)
+
+        # output is dpnp_array
+        np_res = numpy.nanprod(a, axis=0)
+        dpnp_out = dpnp.empty(np_res.shape, dtype=np_res.dtype)
+        dpnp_res = dpnp.nanprod(ia, axis=0, out=dpnp_out)
+        assert dpnp_out is dpnp_res
+        assert_allclose(dpnp_res, np_res)
+
+        # output is usm_ndarray
+        dpt_out = dpt.empty(np_res.shape, dtype=np_res.dtype)
+        dpnp_res = dpnp.nanprod(ia, axis=0, out=dpt_out)
+        assert dpt_out is dpnp_res.get_array()
+        assert_allclose(dpnp_res, np_res)
+
+        # out is a numpy array -> TypeError
+        dpnp_res = numpy.empty_like(np_res)
+        with pytest.raises(TypeError):
+            dpnp.nanprod(ia, axis=0, out=dpnp_res)
+
+        # incorrect shape for out
+        dpnp_res = dpnp.array(numpy.empty((2, 3)))
+        with pytest.raises(ValueError):
+            dpnp.nanprod(ia, axis=0, out=dpnp_res)
+
+    @pytest.mark.usefixtures("suppress_complex_warning")
+    @pytest.mark.parametrize("arr_dt", get_all_dtypes(no_none=True))
+    @pytest.mark.parametrize("out_dt", get_all_dtypes(no_none=True))
+    @pytest.mark.parametrize("dtype", get_all_dtypes())
+    def test_nanprod_out_dtype(self, arr_dt, out_dt, dtype):
+        a = numpy.arange(10, 20).reshape((2, 5)).astype(dtype=arr_dt)
+        out = numpy.zeros_like(a, shape=(2,), dtype=out_dt)
+
+        ia = dpnp.array(a)
+        iout = dpnp.array(out)
+
+        result = dpnp.nanprod(ia, out=iout, dtype=dtype, axis=1)
+        expected = numpy.nanprod(a, out=out, dtype=dtype, axis=1)
+        assert_array_equal(expected, result)
+        assert result is iout
+
+    def test_nanprod_Error(self):
+        ia = dpnp.arange(5)
+
+        with pytest.raises(TypeError):
+            dpnp.nanprod(dpnp.asnumpy(ia))
+
+
+class TestNanStd:
+    @pytest.mark.parametrize(
+        "array",
+        [
+            [2, 0, 6, 2],
+            [2, 0, 6, 2, 5, 6, 7, 8],
+            [],
+            [2, 1, numpy.nan, 5, 3],
+            [-1, numpy.nan, 1, numpy.inf],
+            [3, 6, 0, 1],
+            [3, 6, 0, 1, 8],
+            [3, 2, 9, 6, numpy.nan],
+            [numpy.nan, numpy.nan, numpy.inf, numpy.nan],
+            [[2, 0], [6, 2]],
+            [[2, 0, 6, 2], [5, 6, 7, 8]],
+            [[[2, 0], [6, 2]], [[5, 6], [7, 8]]],
+            [[-1, numpy.nan], [1, numpy.inf]],
+            [[numpy.nan, numpy.nan], [numpy.inf, numpy.nan]],
+        ],
+        ids=[
+            "[2, 0, 6, 2]",
+            "[2, 0, 6, 2, 5, 6, 7, 8]",
+            "[]",
+            "[2, 1, np.nan, 5, 3]",
+            "[-1, np.nan, 1, np.inf]",
+            "[3, 6, 0, 1]",
+            "[3, 6, 0, 1, 8]",
+            "[3, 2, 9, 6, np.nan]",
+            "[np.nan, np.nan, np.inf, np.nan]",
+            "[[2, 0], [6, 2]]",
+            "[[2, 0, 6, 2], [5, 6, 7, 8]]",
+            "[[[2, 0], [6, 2]], [[5, 6], [7, 8]]]",
+            "[[-1, np.nan], [1, np.inf]]",
+            "[[np.nan, np.nan], [np.inf, np.nan]]",
+        ],
+    )
+    @pytest.mark.usefixtures(
+        "suppress_invalid_numpy_warnings", "suppress_dof_numpy_warnings"
+    )
+    @pytest.mark.parametrize(
+        "dtype", get_all_dtypes(no_none=True, no_bool=True)
+    )
+    def test_nanstd(self, array, dtype):
+        try:
+            a = numpy.array(array, dtype=dtype)
+        except:
+            pytest.skip("floating datat type is needed to store NaN")
+        ia = dpnp.array(a)
+        for ddof in range(a.ndim):
+            expected = numpy.nanstd(a, ddof=ddof)
+            result = dpnp.nanstd(ia, ddof=ddof)
+            assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_complex_dtypes())
+    def test_nanstd_complex(self, dtype):
+        x1 = numpy.random.rand(10)
+        x2 = numpy.random.rand(10)
+        a = numpy.array(x1 + 1j * x2, dtype=dtype)
+        a[::3] = numpy.nan
+        ia = dpnp.array(a)
+
+        expected = numpy.nanstd(a)
+        result = dpnp.nanstd(ia)
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.usefixtures("suppress_dof_numpy_warnings")
+    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
+    @pytest.mark.parametrize("axis", [None, 0, 1, 2, (0, 1), (1, 2)])
+    @pytest.mark.parametrize("keepdims", [True, False])
+    @pytest.mark.parametrize("ddof", [0, 0.5, 1, 1.5, 2, 3])
+    def test_nanstd_out(self, dtype, axis, keepdims, ddof):
+        a = numpy.arange(4 * 3 * 5, dtype=dtype)
+        a[::2] = numpy.nan
+        a = a.reshape(4, 3, 5)
+        ia = dpnp.array(a)
+
+        expected = numpy.nanstd(a, axis=axis, ddof=ddof, keepdims=keepdims)
+        if has_support_aspect64():
+            res_dtype = expected.dtype
+        else:
+            res_dtype = dpnp.default_float_type(ia.device)
+        out = dpnp.empty(expected.shape, dtype=res_dtype)
+        result = dpnp.nanstd(
+            ia, out=out, axis=axis, ddof=ddof, keepdims=keepdims
+        )
+        assert result is out
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
+    def test_nanstd_strided(self, dtype):
+        dp_array = dpnp.arange(20, dtype=dtype)
+        dp_array[::3] = dpnp.nan
+        np_array = dpnp.asnumpy(dp_array)
+
+        result = dpnp.nanstd(dp_array[::-1])
+        expected = numpy.nanstd(np_array[::-1])
+        assert_dtype_allclose(result, expected)
+
+        result = dpnp.nanstd(dp_array[::2])
+        expected = numpy.nanstd(np_array[::2])
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.usefixtures("suppress_complex_warning")
+    @pytest.mark.parametrize("dt_in", get_float_complex_dtypes())
+    @pytest.mark.parametrize("dt_out", get_float_complex_dtypes())
+    def test_nanstd_dtype(self, dt_in, dt_out):
+        a = numpy.arange(4 * 3 * 5, dtype=dt_in)
+        a[::2] = numpy.nan
+        a = a.reshape(4, 3, 5)
+        ia = dpnp.array(a)
+
+        expected = numpy.nanstd(a, dtype=dt_out)
+        result = dpnp.nanstd(ia, dtype=dt_out)
+        assert_dtype_allclose(result, expected)
+
+    def test_nanstd_error(self):
+        ia = dpnp.arange(5, dtype=dpnp.float32)
+        ia[0] = dpnp.nan
+        # where keyword is not implemented
+        with pytest.raises(NotImplementedError):
+            dpnp.nanstd(ia, where=False)
+
+        # ddof should be an integer or float
+        with pytest.raises(TypeError):
+            dpnp.nanstd(ia, ddof="1")
+
+
 class TestNanSum:
     @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
     @pytest.mark.parametrize("axis", [None, 0, 1, (0, 1)])
@@ -178,3 +672,139 @@ class TestNanSum:
         result = dpnp.nansum(dp_array[::2])
         expected = numpy.nansum(np_array[::2])
         assert_allclose(result, expected)
+
+
+class TestNanVar:
+    @pytest.mark.parametrize(
+        "array",
+        [
+            [2, 0, 6, 2],
+            [2, 0, 6, 2, 5, 6, 7, 8],
+            [],
+            [2, 1, numpy.nan, 5, 3],
+            [-1, numpy.nan, 1, numpy.inf],
+            [3, 6, 0, 1],
+            [3, 6, 0, 1, 8],
+            [3, 2, 9, 6, numpy.nan],
+            [numpy.nan, numpy.nan, numpy.inf, numpy.nan],
+            [[2, 0], [6, 2]],
+            [[2, 0, 6, 2], [5, 6, 7, 8]],
+            [[[2, 0], [6, 2]], [[5, 6], [7, 8]]],
+            [[-1, numpy.nan], [1, numpy.inf]],
+            [[numpy.nan, numpy.nan], [numpy.inf, numpy.nan]],
+        ],
+        ids=[
+            "[2, 0, 6, 2]",
+            "[2, 0, 6, 2, 5, 6, 7, 8]",
+            "[]",
+            "[2, 1, np.nan, 5, 3]",
+            "[-1, np.nan, 1, np.inf]",
+            "[3, 6, 0, 1]",
+            "[3, 6, 0, 1, 8]",
+            "[3, 2, 9, 6, np.nan]",
+            "[np.nan, np.nan, np.inf, np.nan]",
+            "[[2, 0], [6, 2]]",
+            "[[2, 0, 6, 2], [5, 6, 7, 8]]",
+            "[[[2, 0], [6, 2]], [[5, 6], [7, 8]]]",
+            "[[-1, np.nan], [1, np.inf]]",
+            "[[np.nan, np.nan], [np.inf, np.nan]]",
+        ],
+    )
+    @pytest.mark.usefixtures(
+        "suppress_invalid_numpy_warnings", "suppress_dof_numpy_warnings"
+    )
+    @pytest.mark.parametrize(
+        "dtype", get_all_dtypes(no_none=True, no_bool=True)
+    )
+    def test_nanvar(self, array, dtype):
+        try:
+            a = numpy.array(array, dtype=dtype)
+        except:
+            pytest.skip("floating datat type is needed to store NaN")
+        ia = dpnp.array(a)
+        for ddof in range(a.ndim):
+            expected = numpy.nanvar(a, ddof=ddof)
+            result = dpnp.nanvar(ia, ddof=ddof)
+            assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_complex_dtypes())
+    def test_nanvar_complex(self, dtype):
+        x1 = numpy.random.rand(10)
+        x2 = numpy.random.rand(10)
+        a = numpy.array(x1 + 1j * x2, dtype=dtype)
+        a[::3] = numpy.nan
+        ia = dpnp.array(a)
+
+        expected = numpy.nanvar(a)
+        result = dpnp.nanvar(ia)
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.usefixtures("suppress_dof_numpy_warnings")
+    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
+    @pytest.mark.parametrize("axis", [None, 0, 1, 2, (0, 1), (1, 2)])
+    @pytest.mark.parametrize("keepdims", [True, False])
+    @pytest.mark.parametrize("ddof", [0, 0.5, 1, 1.5, 2, 3])
+    def test_nanvar_out(self, dtype, axis, keepdims, ddof):
+        a = numpy.arange(4 * 3 * 5, dtype=dtype)
+        a[::2] = numpy.nan
+        a = a.reshape(4, 3, 5)
+        ia = dpnp.array(a)
+
+        expected = numpy.nanvar(a, axis=axis, ddof=ddof, keepdims=keepdims)
+        if has_support_aspect64():
+            res_dtype = expected.dtype
+        else:
+            res_dtype = dpnp.default_float_type(ia.device)
+        out = dpnp.empty(expected.shape, dtype=res_dtype)
+        result = dpnp.nanvar(
+            ia, out=out, axis=axis, ddof=ddof, keepdims=keepdims
+        )
+        assert result is out
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
+    def test_nanvar_strided(self, dtype):
+        dp_array = dpnp.arange(20, dtype=dtype)
+        dp_array[::3] = dpnp.nan
+        np_array = dpnp.asnumpy(dp_array)
+
+        result = dpnp.nanvar(dp_array[::-1])
+        expected = numpy.nanvar(np_array[::-1])
+        assert_dtype_allclose(result, expected)
+
+        result = dpnp.nanvar(dp_array[::2])
+        expected = numpy.nanvar(np_array[::2])
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.usefixtures("suppress_complex_warning")
+    @pytest.mark.parametrize("dt_in", get_float_complex_dtypes())
+    @pytest.mark.parametrize("dt_out", get_float_complex_dtypes())
+    def test_nanvar_dtype(self, dt_in, dt_out):
+        a = numpy.arange(4 * 3 * 5, dtype=dt_in)
+        a[::2] = numpy.nan
+        a = a.reshape(4, 3, 5)
+        ia = dpnp.array(a)
+
+        expected = numpy.nanvar(a, dtype=dt_out)
+        result = dpnp.nanvar(ia, dtype=dt_out)
+        assert_dtype_allclose(result, expected)
+
+    def test_nanvar_error(self):
+        ia = dpnp.arange(5, dtype=dpnp.float32)
+        ia[0] = dpnp.nan
+        # where keyword is not implemented
+        with pytest.raises(NotImplementedError):
+            dpnp.nanvar(ia, where=False)
+
+        # dtype should be floating
+        with pytest.raises(TypeError):
+            dpnp.nanvar(ia, dtype=dpnp.int32)
+
+        # out dtype should be inexact
+        res = dpnp.empty((1,), dtype=dpnp.int32)
+        with pytest.raises(TypeError):
+            dpnp.nanvar(ia, out=res)
+
+        # ddof should be an integer or float
+        with pytest.raises(TypeError):
+            dpnp.nanvar(ia, ddof="1")

--- a/tests/test_nanfunctions.py
+++ b/tests/test_nanfunctions.py
@@ -22,7 +22,7 @@ from .helper import (
 )
 
 
-class TestNanargmaxNanargmin:
+class TestNanArgmaxNanArgmin:
     @pytest.mark.parametrize("func", ["nanargmin", "nanargmax"])
     @pytest.mark.parametrize("axis", [None, 0, 1, -1, 2, -2])
     @pytest.mark.parametrize("keepdims", [False, True])
@@ -201,7 +201,7 @@ class TestNanCumSumProd:
         assert result is iout
 
 
-class TestNanmaxNanmin:
+class TestNanMaxNanMin:
     @pytest.mark.parametrize("func", ["nanmax", "nanmin"])
     @pytest.mark.parametrize("axis", [None, 0, 1, -1, 2, -2, (1, 2), (0, -2)])
     @pytest.mark.parametrize("keepdims", [False, True])

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -8,19 +8,13 @@ import dpnp
 from .helper import assert_dtype_allclose, get_all_dtypes
 
 
-class TestMaxMin:
-    @pytest.mark.parametrize(
-        "func", ["argmax", "argmin", "nanargmin", "nanargmax"]
-    )
+class TestArgmaxArgmin:
+    @pytest.mark.parametrize("func", ["argmax", "argmin"])
     @pytest.mark.parametrize("axis", [None, 0, 1, -1, 2, -2])
     @pytest.mark.parametrize("keepdims", [False, True])
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
-    def test_argmax_argmin(self, func, axis, keepdims, dtype):
+    def test_func(self, func, axis, keepdims, dtype):
         a = numpy.arange(768, dtype=dtype).reshape((4, 4, 6, 8))
-        if func in ["nanargmin", "nanargmax"] and dpnp.issubdtype(
-            a.dtype, dpnp.inexact
-        ):
-            a[2:3, 2, 3:4, 4] = numpy.nan
         ia = dpnp.array(a)
 
         np_res = getattr(numpy, func)(a, axis=axis, keepdims=keepdims)
@@ -30,7 +24,7 @@ class TestMaxMin:
     @pytest.mark.parametrize("func", ["argmax", "argmin"])
     @pytest.mark.parametrize("axis", [None, 0, 1, -1])
     @pytest.mark.parametrize("keepdims", [False, True])
-    def test_argmax_argmin_bool(self, func, axis, keepdims):
+    def test_bool(self, func, axis, keepdims):
         a = numpy.arange(2, dtype=numpy.bool_)
         a = numpy.tile(a, (2, 2))
         ia = dpnp.array(a)
@@ -39,13 +33,9 @@ class TestMaxMin:
         dpnp_res = getattr(dpnp, func)(ia, axis=axis, keepdims=keepdims)
         assert_dtype_allclose(dpnp_res, np_res)
 
-    @pytest.mark.parametrize(
-        "func", ["argmax", "argmin", "nanargmin", "nanargmax"]
-    )
-    def test_argmax_argmin_out(self, func):
+    @pytest.mark.parametrize("func", ["argmax", "argmin"])
+    def test_out(self, func):
         a = numpy.arange(12, dtype=numpy.float32).reshape((2, 2, 3))
-        if func in ["nanargmin", "nanargmax"]:
-            a[1, 0, 2] = numpy.nan
         ia = dpnp.array(a)
 
         # out is dpnp_array
@@ -71,12 +61,10 @@ class TestMaxMin:
         with pytest.raises(ValueError):
             getattr(dpnp, func)(ia, axis=0, out=dpnp_res)
 
-    @pytest.mark.parametrize(
-        "func", ["argmax", "argmin", "nanargmin", "nanargmax"]
-    )
+    @pytest.mark.parametrize("func", ["argmax", "argmin"])
     @pytest.mark.parametrize("arr_dt", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize("out_dt", get_all_dtypes(no_none=True))
-    def test_argmax_argmin_out_dtype(self, func, arr_dt, out_dt):
+    def test_out_dtype(self, func, arr_dt, out_dt):
         a = (
             numpy.arange(12, dtype=numpy.float32)
             .reshape((2, 2, 3))
@@ -98,7 +86,7 @@ class TestMaxMin:
 
     @pytest.mark.parametrize("axis", [None, 0, 1, -1])
     @pytest.mark.parametrize("keepdims", [False, True])
-    def test_ndarray_argmax_argmin(self, axis, keepdims):
+    def test_ndarray(self, axis, keepdims):
         a = numpy.arange(192, dtype=numpy.float32).reshape((4, 6, 8))
         ia = dpnp.array(a)
 
@@ -109,15 +97,6 @@ class TestMaxMin:
         np_res = a.argmin(axis=axis, keepdims=keepdims)
         dpnp_res = ia.argmin(axis=axis, keepdims=keepdims)
         assert_dtype_allclose(dpnp_res, np_res)
-
-    @pytest.mark.parametrize("func", ["nanargmin", "nanargmax"])
-    def test_nanargmax_nanargmin_error(self, func):
-        ia = dpnp.arange(12, dtype=dpnp.float32).reshape((2, 2, 3))
-        ia[:, :, 2] = dpnp.nan
-
-        # All-NaN slice encountered -> ValueError
-        with pytest.raises(ValueError):
-            getattr(dpnp, func)(ia, axis=0)
 
 
 class TestWhere:

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -33,30 +33,22 @@ def test_median(dtype, size):
 
 
 class TestMaxMin:
-    @pytest.mark.parametrize("func", ["max", "min", "nanmax", "nanmin"])
+    @pytest.mark.parametrize("func", ["max", "min"])
     @pytest.mark.parametrize("axis", [None, 0, 1, -1, 2, -2, (1, 2), (0, -2)])
     @pytest.mark.parametrize("keepdims", [False, True])
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
-    def test_max_min(self, func, axis, keepdims, dtype):
+    def test_func(self, func, axis, keepdims, dtype):
         a = numpy.arange(768, dtype=dtype).reshape((4, 4, 6, 8))
-        if func in ["nanmax", "nanmin"] and dpnp.issubdtype(
-            a.dtype, dpnp.inexact
-        ):
-            a[2:3, 2, 3:4, 4] = numpy.nan
         ia = dpnp.array(a)
 
         np_res = getattr(numpy, func)(a, axis=axis, keepdims=keepdims)
         dpnp_res = getattr(dpnp, func)(ia, axis=axis, keepdims=keepdims)
         assert_dtype_allclose(dpnp_res, np_res)
 
-    @pytest.mark.parametrize("func", ["max", "min", "nanmax", "nanmin"])
+    @pytest.mark.parametrize("func", ["max", "min"])
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
-    def test_max_min_strided(self, func, dtype):
+    def test_strided(self, func, dtype):
         a = numpy.arange(20, dtype=dtype)
-        if func in ["nanmax", "nanmin"] and dpnp.issubdtype(
-            a.dtype, dpnp.inexact
-        ):
-            a[::3] = numpy.nan
         ia = dpnp.array(a)
 
         np_res = getattr(numpy, func)(a[::-1])
@@ -70,7 +62,7 @@ class TestMaxMin:
     @pytest.mark.parametrize("func", ["max", "min"])
     @pytest.mark.parametrize("axis", [None, 0, 1, -1])
     @pytest.mark.parametrize("keepdims", [False, True])
-    def test_max_min_bool(self, func, axis, keepdims):
+    def test_bool(self, func, axis, keepdims):
         a = numpy.arange(2, dtype=numpy.bool_)
         a = numpy.tile(a, (2, 2))
         ia = dpnp.array(a)
@@ -79,11 +71,9 @@ class TestMaxMin:
         dpnp_res = getattr(dpnp, func)(ia, axis=axis, keepdims=keepdims)
         assert_dtype_allclose(dpnp_res, np_res)
 
-    @pytest.mark.parametrize("func", ["max", "min", "nanmax", "nanmin"])
-    def test_max_min_out(self, func):
+    @pytest.mark.parametrize("func", ["max", "min"])
+    def test_out(self, func):
         a = numpy.arange(12, dtype=numpy.float32).reshape((2, 2, 3))
-        if func in ["nanmax", "nanmin"]:
-            a[1, 0, 2] = numpy.nan
         ia = dpnp.array(a)
 
         # out is dpnp_array
@@ -110,10 +100,10 @@ class TestMaxMin:
             getattr(dpnp, func)(ia, axis=0, out=dpnp_res)
 
     @pytest.mark.usefixtures("suppress_complex_warning")
-    @pytest.mark.parametrize("func", ["max", "min", "nanmax", "nanmin"])
+    @pytest.mark.parametrize("func", ["max", "min"])
     @pytest.mark.parametrize("arr_dt", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize("out_dt", get_all_dtypes(no_none=True))
-    def test_max_min_out_dtype(self, func, arr_dt, out_dt):
+    def test_out_dtype(self, func, arr_dt, out_dt):
         a = (
             numpy.arange(12, dtype=numpy.float32)
             .reshape((2, 2, 3))
@@ -129,8 +119,8 @@ class TestMaxMin:
         assert_array_equal(expected, result)
         assert result is iout
 
-    @pytest.mark.parametrize("func", ["max", "min", "nanmax", "nanmin"])
-    def test_max_min_error(self, func):
+    @pytest.mark.parametrize("func", ["max", "min"])
+    def test_error(self, func):
         ia = dpnp.arange(5)
         # where is not supported
         with pytest.raises(NotImplementedError):
@@ -139,32 +129,6 @@ class TestMaxMin:
         # initial is not supported
         with pytest.raises(NotImplementedError):
             getattr(dpnp, func)(ia, initial=6)
-
-    @pytest.mark.parametrize("func", ["nanmax", "nanmin"])
-    @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
-    def test_nanmax_nanmin_no_NaN(self, func, dtype):
-        a = numpy.arange(768, dtype=dtype).reshape((4, 4, 6, 8))
-        ia = dpnp.array(a)
-
-        np_res = getattr(numpy, func)(a, axis=0)
-        dpnp_res = getattr(dpnp, func)(ia, axis=0)
-        assert_dtype_allclose(dpnp_res, np_res)
-
-    @pytest.mark.parametrize("func", ["nanmax", "nanmin"])
-    def test_nanmax_nanmin_all_NaN(self, recwarn, func):
-        a = numpy.arange(12, dtype=numpy.float32).reshape((2, 2, 3))
-        a[:, :, 2] = numpy.nan
-        ia = dpnp.array(a)
-
-        np_res = getattr(numpy, func)(a, axis=0)
-        dpnp_res = getattr(dpnp, func)(ia, axis=0)
-        assert_dtype_allclose(dpnp_res, np_res)
-
-        assert len(recwarn) == 2
-        assert all(
-            "All-NaN slice encountered" in str(r.message) for r in recwarn
-        )
-        assert all(r.category is RuntimeWarning for r in recwarn)
 
 
 class TestAverage:
@@ -373,91 +337,6 @@ class TestMean:
             dpnp.mean(ia, where=False)
 
 
-class TestNanMean:
-    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
-    @pytest.mark.parametrize("axis", [None, 0, 1, (0, 1)])
-    @pytest.mark.parametrize("keepdims", [True, False])
-    def test_nanmean(self, dtype, axis, keepdims):
-        dp_array = dpnp.array([[0, 1, 2], [3, 4, 0]], dtype=dtype)
-        np_array = dpnp.asnumpy(dp_array)
-
-        result = dpnp.nanmean(dp_array, axis=axis, keepdims=keepdims)
-        expected = numpy.nanmean(np_array, axis=axis, keepdims=keepdims)
-        assert_dtype_allclose(result, expected)
-
-    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
-    @pytest.mark.parametrize("axis", [0, 1])
-    def test_nanmean_out(self, dtype, axis):
-        dp_array = dpnp.array([[dpnp.nan, 1, 2], [3, dpnp.nan, 0]], dtype=dtype)
-        np_array = dpnp.asnumpy(dp_array)
-
-        expected = numpy.nanmean(np_array, axis=axis)
-        out = dpnp.empty_like(dpnp.asarray(expected))
-        result = dpnp.nanmean(dp_array, axis=axis, out=out)
-        assert out is result
-        assert_dtype_allclose(result, expected)
-
-    @pytest.mark.parametrize("dtype", get_complex_dtypes())
-    def test_nanmean_complex(self, dtype):
-        x1 = numpy.random.rand(10)
-        x2 = numpy.random.rand(10)
-        a = numpy.array(x1 + 1j * x2, dtype=dtype)
-        a[::3] = numpy.nan
-        ia = dpnp.array(a)
-
-        expected = numpy.nanmean(a)
-        result = dpnp.nanmean(ia)
-        assert_dtype_allclose(result, expected)
-
-    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
-    def test_nanmean_dtype(self, dtype):
-        dp_array = dpnp.array([[dpnp.nan, 1, 2], [3, dpnp.nan, 0]])
-        np_array = dpnp.asnumpy(dp_array)
-
-        expected = numpy.nanmean(np_array, dtype=dtype)
-        result = dpnp.nanmean(dp_array, dtype=dtype)
-        assert_dtype_allclose(result, expected)
-
-    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
-    def test_nanmean_strided(self, dtype):
-        dp_array = dpnp.arange(20, dtype=dtype)
-        dp_array[::3] = dpnp.nan
-        np_array = dpnp.asnumpy(dp_array)
-
-        result = dpnp.nanmean(dp_array[::-1])
-        expected = numpy.nanmean(np_array[::-1])
-        assert_dtype_allclose(result, expected)
-
-        result = dpnp.nanmean(dp_array[::2])
-        expected = numpy.nanmean(np_array[::2])
-        assert_dtype_allclose(result, expected)
-
-    @pytest.mark.usefixtures("suppress_mean_empty_slice_numpy_warnings")
-    def test_nanmean_scalar(self):
-        dp_array = dpnp.array(dpnp.nan)
-        np_array = dpnp.asnumpy(dp_array)
-
-        result = dpnp.nanmean(dp_array)
-        expected = numpy.nanmean(np_array)
-        assert_allclose(expected, result)
-
-    def test_nanmean_error(self):
-        ia = dpnp.arange(5, dtype=dpnp.float32)
-        ia[0] = dpnp.nan
-        # where keyword is not implemented
-        with pytest.raises(NotImplementedError):
-            dpnp.nanmean(ia, where=False)
-
-        # dtype should be floating
-        with pytest.raises(TypeError):
-            dpnp.nanmean(ia, dtype=dpnp.int32)
-
-        # out dtype should be inexact
-        res = dpnp.empty((1,), dtype=dpnp.int32)
-        with pytest.raises(TypeError):
-            dpnp.nanmean(ia, out=res)
-
-
 class TestVar:
     @pytest.mark.usefixtures(
         "suppress_divide_invalid_numpy_warnings", "suppress_dof_numpy_warnings"
@@ -649,269 +528,6 @@ class TestStd:
         # ddof should be an integer or float
         with pytest.raises(TypeError):
             dpnp.std(ia, ddof="1")
-
-
-class TestNanVar:
-    @pytest.mark.parametrize(
-        "array",
-        [
-            [2, 0, 6, 2],
-            [2, 0, 6, 2, 5, 6, 7, 8],
-            [],
-            [2, 1, numpy.nan, 5, 3],
-            [-1, numpy.nan, 1, numpy.inf],
-            [3, 6, 0, 1],
-            [3, 6, 0, 1, 8],
-            [3, 2, 9, 6, numpy.nan],
-            [numpy.nan, numpy.nan, numpy.inf, numpy.nan],
-            [[2, 0], [6, 2]],
-            [[2, 0, 6, 2], [5, 6, 7, 8]],
-            [[[2, 0], [6, 2]], [[5, 6], [7, 8]]],
-            [[-1, numpy.nan], [1, numpy.inf]],
-            [[numpy.nan, numpy.nan], [numpy.inf, numpy.nan]],
-        ],
-        ids=[
-            "[2, 0, 6, 2]",
-            "[2, 0, 6, 2, 5, 6, 7, 8]",
-            "[]",
-            "[2, 1, np.nan, 5, 3]",
-            "[-1, np.nan, 1, np.inf]",
-            "[3, 6, 0, 1]",
-            "[3, 6, 0, 1, 8]",
-            "[3, 2, 9, 6, np.nan]",
-            "[np.nan, np.nan, np.inf, np.nan]",
-            "[[2, 0], [6, 2]]",
-            "[[2, 0, 6, 2], [5, 6, 7, 8]]",
-            "[[[2, 0], [6, 2]], [[5, 6], [7, 8]]]",
-            "[[-1, np.nan], [1, np.inf]]",
-            "[[np.nan, np.nan], [np.inf, np.nan]]",
-        ],
-    )
-    @pytest.mark.usefixtures(
-        "suppress_invalid_numpy_warnings", "suppress_dof_numpy_warnings"
-    )
-    @pytest.mark.parametrize(
-        "dtype", get_all_dtypes(no_none=True, no_bool=True)
-    )
-    def test_nanvar(self, array, dtype):
-        try:
-            a = numpy.array(array, dtype=dtype)
-        except:
-            pytest.skip("floating datat type is needed to store NaN")
-        ia = dpnp.array(a)
-        for ddof in range(a.ndim):
-            expected = numpy.nanvar(a, ddof=ddof)
-            result = dpnp.nanvar(ia, ddof=ddof)
-            assert_dtype_allclose(result, expected)
-
-    @pytest.mark.parametrize("dtype", get_complex_dtypes())
-    def test_nanvar_complex(self, dtype):
-        x1 = numpy.random.rand(10)
-        x2 = numpy.random.rand(10)
-        a = numpy.array(x1 + 1j * x2, dtype=dtype)
-        a[::3] = numpy.nan
-        ia = dpnp.array(a)
-
-        expected = numpy.nanvar(a)
-        result = dpnp.nanvar(ia)
-        assert_dtype_allclose(result, expected)
-
-    @pytest.mark.usefixtures("suppress_dof_numpy_warnings")
-    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
-    @pytest.mark.parametrize("axis", [None, 0, 1, 2, (0, 1), (1, 2)])
-    @pytest.mark.parametrize("keepdims", [True, False])
-    @pytest.mark.parametrize("ddof", [0, 0.5, 1, 1.5, 2, 3])
-    def test_nanvar_out(self, dtype, axis, keepdims, ddof):
-        a = numpy.arange(4 * 3 * 5, dtype=dtype)
-        a[::2] = numpy.nan
-        a = a.reshape(4, 3, 5)
-        ia = dpnp.array(a)
-
-        expected = numpy.nanvar(a, axis=axis, ddof=ddof, keepdims=keepdims)
-        if has_support_aspect64():
-            res_dtype = expected.dtype
-        else:
-            res_dtype = dpnp.default_float_type(ia.device)
-        out = dpnp.empty(expected.shape, dtype=res_dtype)
-        result = dpnp.nanvar(
-            ia, out=out, axis=axis, ddof=ddof, keepdims=keepdims
-        )
-        assert result is out
-        assert_dtype_allclose(result, expected)
-
-    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
-    def test_nanvar_strided(self, dtype):
-        dp_array = dpnp.arange(20, dtype=dtype)
-        dp_array[::3] = dpnp.nan
-        np_array = dpnp.asnumpy(dp_array)
-
-        result = dpnp.nanvar(dp_array[::-1])
-        expected = numpy.nanvar(np_array[::-1])
-        assert_dtype_allclose(result, expected)
-
-        result = dpnp.nanvar(dp_array[::2])
-        expected = numpy.nanvar(np_array[::2])
-        assert_dtype_allclose(result, expected)
-
-    @pytest.mark.usefixtures("suppress_complex_warning")
-    @pytest.mark.parametrize("dt_in", get_float_complex_dtypes())
-    @pytest.mark.parametrize("dt_out", get_float_complex_dtypes())
-    def test_nanvar_dtype(self, dt_in, dt_out):
-        a = numpy.arange(4 * 3 * 5, dtype=dt_in)
-        a[::2] = numpy.nan
-        a = a.reshape(4, 3, 5)
-        ia = dpnp.array(a)
-
-        expected = numpy.nanvar(a, dtype=dt_out)
-        result = dpnp.nanvar(ia, dtype=dt_out)
-        assert_dtype_allclose(result, expected)
-
-    def test_nanvar_error(self):
-        ia = dpnp.arange(5, dtype=dpnp.float32)
-        ia[0] = dpnp.nan
-        # where keyword is not implemented
-        with pytest.raises(NotImplementedError):
-            dpnp.nanvar(ia, where=False)
-
-        # dtype should be floating
-        with pytest.raises(TypeError):
-            dpnp.nanvar(ia, dtype=dpnp.int32)
-
-        # out dtype should be inexact
-        res = dpnp.empty((1,), dtype=dpnp.int32)
-        with pytest.raises(TypeError):
-            dpnp.nanvar(ia, out=res)
-
-        # ddof should be an integer or float
-        with pytest.raises(TypeError):
-            dpnp.nanvar(ia, ddof="1")
-
-
-class TestNanStd:
-    @pytest.mark.parametrize(
-        "array",
-        [
-            [2, 0, 6, 2],
-            [2, 0, 6, 2, 5, 6, 7, 8],
-            [],
-            [2, 1, numpy.nan, 5, 3],
-            [-1, numpy.nan, 1, numpy.inf],
-            [3, 6, 0, 1],
-            [3, 6, 0, 1, 8],
-            [3, 2, 9, 6, numpy.nan],
-            [numpy.nan, numpy.nan, numpy.inf, numpy.nan],
-            [[2, 0], [6, 2]],
-            [[2, 0, 6, 2], [5, 6, 7, 8]],
-            [[[2, 0], [6, 2]], [[5, 6], [7, 8]]],
-            [[-1, numpy.nan], [1, numpy.inf]],
-            [[numpy.nan, numpy.nan], [numpy.inf, numpy.nan]],
-        ],
-        ids=[
-            "[2, 0, 6, 2]",
-            "[2, 0, 6, 2, 5, 6, 7, 8]",
-            "[]",
-            "[2, 1, np.nan, 5, 3]",
-            "[-1, np.nan, 1, np.inf]",
-            "[3, 6, 0, 1]",
-            "[3, 6, 0, 1, 8]",
-            "[3, 2, 9, 6, np.nan]",
-            "[np.nan, np.nan, np.inf, np.nan]",
-            "[[2, 0], [6, 2]]",
-            "[[2, 0, 6, 2], [5, 6, 7, 8]]",
-            "[[[2, 0], [6, 2]], [[5, 6], [7, 8]]]",
-            "[[-1, np.nan], [1, np.inf]]",
-            "[[np.nan, np.nan], [np.inf, np.nan]]",
-        ],
-    )
-    @pytest.mark.usefixtures(
-        "suppress_invalid_numpy_warnings", "suppress_dof_numpy_warnings"
-    )
-    @pytest.mark.parametrize(
-        "dtype", get_all_dtypes(no_none=True, no_bool=True)
-    )
-    def test_nanstd(self, array, dtype):
-        try:
-            a = numpy.array(array, dtype=dtype)
-        except:
-            pytest.skip("floating datat type is needed to store NaN")
-        ia = dpnp.array(a)
-        for ddof in range(a.ndim):
-            expected = numpy.nanstd(a, ddof=ddof)
-            result = dpnp.nanstd(ia, ddof=ddof)
-            assert_dtype_allclose(result, expected)
-
-    @pytest.mark.parametrize("dtype", get_complex_dtypes())
-    def test_nanstd_complex(self, dtype):
-        x1 = numpy.random.rand(10)
-        x2 = numpy.random.rand(10)
-        a = numpy.array(x1 + 1j * x2, dtype=dtype)
-        a[::3] = numpy.nan
-        ia = dpnp.array(a)
-
-        expected = numpy.nanstd(a)
-        result = dpnp.nanstd(ia)
-        assert_dtype_allclose(result, expected)
-
-    @pytest.mark.usefixtures("suppress_dof_numpy_warnings")
-    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
-    @pytest.mark.parametrize("axis", [None, 0, 1, 2, (0, 1), (1, 2)])
-    @pytest.mark.parametrize("keepdims", [True, False])
-    @pytest.mark.parametrize("ddof", [0, 0.5, 1, 1.5, 2, 3])
-    def test_nanstd_out(self, dtype, axis, keepdims, ddof):
-        a = numpy.arange(4 * 3 * 5, dtype=dtype)
-        a[::2] = numpy.nan
-        a = a.reshape(4, 3, 5)
-        ia = dpnp.array(a)
-
-        expected = numpy.nanstd(a, axis=axis, ddof=ddof, keepdims=keepdims)
-        if has_support_aspect64():
-            res_dtype = expected.dtype
-        else:
-            res_dtype = dpnp.default_float_type(ia.device)
-        out = dpnp.empty(expected.shape, dtype=res_dtype)
-        result = dpnp.nanstd(
-            ia, out=out, axis=axis, ddof=ddof, keepdims=keepdims
-        )
-        assert result is out
-        assert_dtype_allclose(result, expected)
-
-    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
-    def test_nanstd_strided(self, dtype):
-        dp_array = dpnp.arange(20, dtype=dtype)
-        dp_array[::3] = dpnp.nan
-        np_array = dpnp.asnumpy(dp_array)
-
-        result = dpnp.nanstd(dp_array[::-1])
-        expected = numpy.nanstd(np_array[::-1])
-        assert_dtype_allclose(result, expected)
-
-        result = dpnp.nanstd(dp_array[::2])
-        expected = numpy.nanstd(np_array[::2])
-        assert_dtype_allclose(result, expected)
-
-    @pytest.mark.usefixtures("suppress_complex_warning")
-    @pytest.mark.parametrize("dt_in", get_float_complex_dtypes())
-    @pytest.mark.parametrize("dt_out", get_float_complex_dtypes())
-    def test_nanstd_dtype(self, dt_in, dt_out):
-        a = numpy.arange(4 * 3 * 5, dtype=dt_in)
-        a[::2] = numpy.nan
-        a = a.reshape(4, 3, 5)
-        ia = dpnp.array(a)
-
-        expected = numpy.nanstd(a, dtype=dt_out)
-        result = dpnp.nanstd(ia, dtype=dt_out)
-        assert_dtype_allclose(result, expected)
-
-    def test_nanstd_error(self):
-        ia = dpnp.arange(5, dtype=dpnp.float32)
-        ia[0] = dpnp.nan
-        # where keyword is not implemented
-        with pytest.raises(NotImplementedError):
-            dpnp.nanstd(ia, where=False)
-
-        # ddof should be an integer or float
-        with pytest.raises(TypeError):
-            dpnp.nanstd(ia, ddof="1")
 
 
 @pytest.mark.usefixtures("allow_fall_back_on_numpy")

--- a/tests/test_sum.py
+++ b/tests/test_sum.py
@@ -1,3 +1,5 @@
+from itertools import permutations
+
 import numpy
 import pytest
 from numpy.testing import (
@@ -10,6 +12,67 @@ from tests.helper import (
     get_all_dtypes,
     get_float_dtypes,
 )
+
+
+@pytest.mark.usefixtures("suppress_complex_warning")
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (),
+        (1, 2, 3),
+        (1, 0, 2),
+        (10,),
+        (3, 3, 3),
+        (5, 5),
+        (0, 6),
+        (10, 1),
+        (1, 10),
+        (35, 40),
+        (40, 35),
+    ],
+)
+@pytest.mark.parametrize("dtype_in", get_all_dtypes())
+@pytest.mark.parametrize("dtype_out", get_all_dtypes())
+@pytest.mark.parametrize("transpose", [True, False])
+@pytest.mark.parametrize("keepdims", [True, False])
+@pytest.mark.parametrize("order", ["C", "F"])
+def test_sum(shape, dtype_in, dtype_out, transpose, keepdims, order):
+    size = numpy.prod(shape)
+    a_np = numpy.arange(size).astype(dtype_in).reshape(shape, order=order)
+    a = dpnp.asarray(a_np)
+
+    if transpose:
+        a_np = a_np.T
+        a = a.T
+
+    axes_range = list(numpy.arange(len(shape)))
+    axes = [None]
+    axes += axes_range
+    axes += permutations(axes_range, 2)
+    axes.append(tuple(axes_range))
+
+    for axis in axes:
+        numpy_res = a_np.sum(axis=axis, dtype=dtype_out, keepdims=keepdims)
+        dpnp_res = a.sum(axis=axis, dtype=dtype_out, keepdims=keepdims)
+        assert_array_equal(numpy_res, dpnp_res.asnumpy())
+
+
+@pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
+def test_sum_empty_out(dtype):
+    a = dpnp.empty((1, 2, 0, 4), dtype=dtype)
+    out = dpnp.ones((), dtype=dtype)
+    res = a.sum(out=out)
+    assert_array_equal(out.asnumpy(), res.asnumpy())
+    assert_array_equal(out.asnumpy(), numpy.array(0, dtype=dtype))
+
+
+@pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True, no_bool=True))
+@pytest.mark.parametrize("axis", [None, 0, 1, 2, 3])
+def test_sum_empty(dtype, axis):
+    a = numpy.empty((1, 2, 0, 4), dtype=dtype)
+    numpy_res = a.sum(axis=axis)
+    dpnp_res = dpnp.array(a).sum(axis=axis)
+    assert_array_equal(numpy_res, dpnp_res.asnumpy())
 
 
 @pytest.mark.parametrize("dtype", get_float_dtypes())

--- a/tests/test_umath.py
+++ b/tests/test_umath.py
@@ -2,6 +2,7 @@ import numpy
 import pytest
 from numpy.testing import (
     assert_allclose,
+    assert_raises,
 )
 
 import dpnp
@@ -10,7 +11,6 @@ from .helper import (
     assert_dtype_allclose,
     get_all_dtypes,
     get_float_complex_dtypes,
-    get_float_dtypes,
     has_support_aspect16,
     has_support_aspect64,
 )
@@ -264,10 +264,8 @@ class TestUmath:
     def test_invalid_out(self, func_params, out):
         func_name = func_params["func_name"]
         a = dpnp.arange(10)
-        numpy.testing.assert_raises(TypeError, getattr(dpnp, func_name), a, out)
-        numpy.testing.assert_raises(
-            TypeError, getattr(numpy, func_name), a.asnumpy(), out
-        )
+        assert_raises(TypeError, getattr(dpnp, func_name), a, out)
+        assert_raises(TypeError, getattr(numpy, func_name), a.asnumpy(), out)
 
 
 class TestCbrt:
@@ -351,7 +349,7 @@ class TestRsqrt:
     )
     def test_invalid_out(self, out):
         a = dpnp.arange(10)
-        numpy.testing.assert_raises(TypeError, dpnp.rsqrt, a, out)
+        assert_raises(TypeError, dpnp.rsqrt, a, out)
 
 
 class TestSquare:
@@ -395,8 +393,8 @@ class TestSquare:
     def test_invalid_out(self, out):
         a = dpnp.arange(10)
 
-        numpy.testing.assert_raises(TypeError, dpnp.square, a, out)
-        numpy.testing.assert_raises(TypeError, numpy.square, a.asnumpy(), out)
+        assert_raises(TypeError, dpnp.square, a, out)
+        assert_raises(TypeError, numpy.square, a.asnumpy(), out)
 
 
 class TestReciprocal:

--- a/tests/test_umath.py
+++ b/tests/test_umath.py
@@ -95,7 +95,7 @@ def test_umaths(test_cases):
     assert_allclose(result, expected, rtol=1e-6)
 
 
-def _get_numpy_arrays(func_name, dtype, range):
+def _get_numpy_arrays_1in_1out(func_name, dtype, range):
     """
     Return a sample array and an output array.
 
@@ -119,6 +119,38 @@ def _get_numpy_arrays(func_name, dtype, range):
         result = getattr(numpy, func_name)(np_array)
 
     return np_array, result
+
+
+def _get_numpy_arrays_2in_1out(func_name, dtype, range):
+    """
+    Return two sample arrays and an output array.
+
+    Create two appropriate arrays specified by `dtype` and `range` which are
+    used as inputs for a function specified by `func_name` to obtain the output.
+    """
+    low = range[0]
+    high = range[1]
+    size = range[2]
+    if dtype == numpy.bool_:
+        np_array1 = numpy.arange(2, dtype=dtype)
+        np_array2 = numpy.arange(2, dtype=dtype)
+        result = getattr(numpy, func_name)(np_array1, np_array2)
+    elif dpnp.issubdtype(dtype, dpnp.complexfloating):
+        a = numpy.random.uniform(low=low, high=high, size=size)
+        b = numpy.random.uniform(low=low, high=high, size=size)
+        np_array1 = numpy.array(a + 1j * b, dtype=dtype)
+        a = numpy.random.uniform(low=low, high=high, size=size)
+        b = numpy.random.uniform(low=low, high=high, size=size)
+        np_array2 = numpy.array(a + 1j * b, dtype=dtype)
+        result = getattr(numpy, func_name)(np_array1, np_array2)
+    else:
+        a = numpy.random.uniform(low=low, high=high, size=size)
+        np_array1 = numpy.array(a, dtype=dtype)
+        a = numpy.random.uniform(low=low, high=high, size=size)
+        np_array2 = numpy.array(a, dtype=dtype)
+        result = getattr(numpy, func_name)(np_array1, np_array2)
+
+    return np_array1, np_array2, result
 
 
 def _get_output_data_type(dtype):
@@ -181,7 +213,7 @@ class TestUmath:
             "sinh",
             "sqrt",
             "tan",
-            "tnah",
+            "tanh",
         ],
     )
     def func_params(self, request):
@@ -192,7 +224,9 @@ class TestUmath:
     def test_out(self, func_params, dtype):
         func_name = func_params["func_name"]
         input_values = func_params["input_values"]
-        np_array, expected = _get_numpy_arrays(func_name, dtype, input_values)
+        np_array, expected = _get_numpy_arrays_1in_1out(
+            func_name, dtype, input_values
+        )
 
         dp_array = dpnp.array(np_array)
         out_dtype = _get_output_data_type(dtype)
@@ -231,12 +265,17 @@ class TestUmath:
         func_name = func_params["func_name"]
         a = dpnp.arange(10)
         numpy.testing.assert_raises(TypeError, getattr(dpnp, func_name), a, out)
+        numpy.testing.assert_raises(
+            TypeError, getattr(numpy, func_name), a.asnumpy(), out
+        )
 
 
 class TestCbrt:
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
     def test_cbrt(self, dtype):
-        np_array, expected = _get_numpy_arrays("cbrt", dtype, [-5, 5, 10])
+        np_array, expected = _get_numpy_arrays_1in_1out(
+            "cbrt", dtype, [-5, 5, 10]
+        )
 
         dp_array = dpnp.array(np_array)
         out_dtype = _get_output_data_type(dtype)
@@ -272,7 +311,9 @@ class TestRsqrt:
     @pytest.mark.usefixtures("suppress_divide_numpy_warnings")
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
     def test_rsqrt(self, dtype):
-        np_array, expected = _get_numpy_arrays("sqrt", dtype, [0, 10, 10])
+        np_array, expected = _get_numpy_arrays_1in_1out(
+            "sqrt", dtype, [0, 10, 10]
+        )
         expected = numpy.reciprocal(expected)
 
         dp_array = dpnp.array(np_array)
@@ -316,7 +357,9 @@ class TestRsqrt:
 class TestSquare:
     @pytest.mark.parametrize("dtype", get_all_dtypes())
     def test_square(self, dtype):
-        np_array, expected = _get_numpy_arrays("square", dtype, [-5, 5, 10])
+        np_array, expected = _get_numpy_arrays_1in_1out(
+            "square", dtype, [-5, 5, 10]
+        )
 
         dp_array = dpnp.array(np_array)
         out_dtype = numpy.int8 if dtype == numpy.bool_ else dtype
@@ -359,7 +402,9 @@ class TestSquare:
 class TestReciprocal:
     @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
     def test_reciprocal(self, dtype):
-        np_array, expected = _get_numpy_arrays("reciprocal", dtype, [-5, 5, 10])
+        np_array, expected = _get_numpy_arrays_1in_1out(
+            "reciprocal", dtype, [-5, 5, 10]
+        )
 
         dp_array = dpnp.array(np_array)
         out_dtype = _get_output_data_type(dtype)
@@ -375,9 +420,7 @@ class TestReciprocal:
         dp_array = dpnp.arange(10, dtype=dpnp_dtype)
         dp_out = dpnp.empty(10, dtype=dtype)
 
-        # TODO: change it to ValueError, when dpctl
-        # is being used in internal CI
-        with pytest.raises((TypeError, ValueError)):
+        with pytest.raises(ValueError):
             dpnp.reciprocal(dp_array, out=dp_out)
 
     @pytest.mark.parametrize(
@@ -394,9 +437,9 @@ class TestReciprocal:
 class TestArctan2:
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
     def test_arctan2(self, dtype):
-        np_array1, _ = _get_numpy_arrays("array", dtype, [-5, 5, 10])
-        np_array2, _ = _get_numpy_arrays("array", dtype, [-5, 5, 10])
-        expected = numpy.arctan2(np_array1, np_array2)
+        np_array1, np_array2, expected = _get_numpy_arrays_2in_1out(
+            "arctan2", dtype, [0, 10, 10]
+        )
 
         dp_array1 = dpnp.array(np_array1)
         dp_array2 = dpnp.array(np_array2)
@@ -431,9 +474,9 @@ class TestArctan2:
 class TestCopySign:
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
     def test_copysign(self, dtype):
-        np_array1, _ = _get_numpy_arrays("array", dtype, [1, 10, 10])
-        np_array2, _ = _get_numpy_arrays("array", dtype, [-10, -1, 10])
-        expected = numpy.copysign(np_array1, np_array2)
+        np_array1, np_array2, expected = _get_numpy_arrays_2in_1out(
+            "copysign", dtype, [0, 10, 10]
+        )
 
         dp_array1 = dpnp.array(np_array1)
         dp_array2 = dpnp.array(np_array2)
@@ -467,9 +510,9 @@ class TestCopySign:
 class TestLogaddexp:
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
     def test_logaddexp(self, dtype):
-        np_array1, _ = _get_numpy_arrays("array", dtype, [-5, 5, 10])
-        np_array2, _ = _get_numpy_arrays("array", dtype, [-5, 5, 10])
-        expected = numpy.logaddexp(np_array1, np_array2)
+        np_array1, np_array2, expected = _get_numpy_arrays_2in_1out(
+            "logaddexp", dtype, [0, 10, 10]
+        )
 
         dp_array1 = dpnp.array(np_array1)
         dp_array2 = dpnp.array(np_array2)


### PR DESCRIPTION
In this PR, test are re-organized as below:

* Classes for `TestNanstd`, `TestNanvar`,  and `TestNanmean`, and tests related to `dpnp.nanmin` and `dpnp.nanmax` are moved from `tests/test_statistics.py` to `tests/test_nanfunctions.py`.
* Tests related to `dpnp.nanargmin` and `dpnp.nanargmax` are moved from `tests/test_search.py` to `tests/test_nanfunctions.py`.
* Tests related to `dpnp.nanprod` are moved from `tests/test_mathematical.py` to `tests/test_nanfunctions.py`.
* Tests related to `dpnp.sum` are moved from `tests/test_mathematical.py` to `tests/test_sum.py`.
* elementwise tests are updated to reduce duplication.


- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
