### PR TITLE
Enable `continue-on-error` option for GitHub action with `Conda build package`

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -79,7 +79,7 @@ jobs:
       run:
         shell: ${{ matrix.os == 'windows-latest' && 'cmd /C CALL {0}' || 'bash -l {0}' }}
 
-    continue-on-error: false
+    continue-on-error: true
 
     steps:
       - name: Cancel Previous Runs


### PR DESCRIPTION
The build for Windows is temporary broken due to missing system libraries.
The PR propose to enable `continue-on-error` option to unblock the build on Linux.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
