### PR TITLE
Fix dpnp.linalg.eigh() hang with complex dtypes on CPU

### DIFF
--- a/dpnp/linalg/dpnp_utils_linalg.py
+++ b/dpnp/linalg/dpnp_utils_linalg.py
@@ -147,12 +147,12 @@ def _batched_eigh(a, UPLO, eigen_mode, w_type, v_type):
         )
 
         # TODO: Remove this w/a when MKLD-17201 is solved.
-        # Waiting for a host task executing an OneMKL LAPACK syevd call
+        # Waiting for a host task executing an OneMKL LAPACK syevd/heevd call
         # on CPU causes deadlock due to serialization of all host tasks
         # in the queue.
-        # We need to wait for each host tasks before calling _seyvd
+        # We need to wait for each host tasks before calling _seyvd and _heevd
         # to avoid deadlock.
-        if lapack_func == "_syevd" and is_cpu_device:
+        if is_cpu_device:
             ht_list_ev[2 * i].wait()
 
         # call LAPACK extension function to get eigenvalues and


### PR DESCRIPTION
This PR suggests adding a temporary w/a as waiting also for each host task before calling `oneapi::mkl::lapack::heevd` to avoid a deadlock for batch implementation of  `dpnp.linalg.eigh` for complex data types on CPU with the prerelease version of MKL.


- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
