### PR TITLE
Replaced windows-latest with windows-2019 to fix windows builds

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.9', '3.10', '3.11']
-        os: [ubuntu-20.04, windows-latest]
+        os: [ubuntu-20.04, windows-2019]
 
     permissions:
       # Needed to cancel any previous runs that are not completed for a given workflow
@@ -77,7 +77,7 @@ jobs:
 
     defaults:
       run:
-        shell: ${{ matrix.os == 'windows-latest' && 'cmd /C CALL {0}' || 'bash -l {0}' }}
+        shell: ${{ matrix.os == 'windows-2019' && 'cmd /C CALL {0}' || 'bash -l {0}' }}
 
     continue-on-error: false
 
@@ -253,11 +253,11 @@ jobs:
             python -m pytest -q -ra --disable-warnings -vv ${{ env.TEST_SCOPE }}
 
   test_windows:
-    name: Test ['windows-latest', python='${{ matrix.python }}']
+    name: Test ['windows-2019', python='${{ matrix.python }}']
 
     needs: build
 
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     defaults:
       run:
@@ -409,7 +409,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.9', '3.10', '3.11']
-        os: [ubuntu-20.04, windows-latest]
+        os: [ubuntu-20.04, windows-2019]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Based on experimentation, switching from using `"windows-latest"` image to `"windows-2019"` fixes MS compiler use for Python packages.
The PR implements the proposed temporary pinning to `"windows-2019"`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
