### PR TITLE
Update Windows version used by GitHub CI

### DIFF
--- a/.github/workflows/check-mkl-interfaces.yaml
+++ b/.github/workflows/check-mkl-interfaces.yaml
@@ -68,13 +68,13 @@ jobs:
         # python 3.13 is blocked since BLAS requires "mkl<2025.0" (see https://github.com/conda-forge/blas-feedstock/pull/128
         # which depends on resolving MKL issue https://github.com/conda-forge/intel_repack-feedstock/issues/83)
         python: ['3.12']
-        os: [ubuntu-22.04] # windows-2019 - no DFT support for Windows in oneMKL
+        os: [ubuntu-22.04] # windows-2022 - no DFT support for Windows in oneMKL
 
     runs-on: ${{ matrix.os }}
 
     defaults:
       run:
-        shell: ${{ matrix.os == 'windows-2019' && 'cmd /C CALL {0}' || 'bash -el {0}' }}
+        shell: ${{ matrix.os == 'windows-2022' && 'cmd /C CALL {0}' || 'bash -el {0}' }}
 
     steps:
       - name: Checkout DPNP repo
@@ -158,13 +158,13 @@ jobs:
         # python 3.13 is blocked since BLAS requires "mkl<2025.0" (see https://github.com/conda-forge/blas-feedstock/pull/128
         # which depends on resolving MKL issue https://github.com/conda-forge/intel_repack-feedstock/issues/83)
         python: ['3.12']
-        os: [ubuntu-22.04] # windows-2019 - no DFT support for Windows in oneMKL
+        os: [ubuntu-22.04] # windows-2022 - no DFT support for Windows in oneMKL
 
     runs-on: ${{ matrix.os }}
 
     defaults:
       run:
-        shell: ${{ matrix.os == 'windows-2019' && 'cmd /C CALL {0}' || 'bash -el {0}' }}
+        shell: ${{ matrix.os == 'windows-2022' && 'cmd /C CALL {0}' || 'bash -el {0}' }}
 
     env:
       onemkl-source-dir: '${{ github.workspace }}/onemkl/'

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -34,7 +34,7 @@ jobs:
         # python 3.13 is blocked since BLAS requires "mkl<2025.0" (see https://github.com/conda-forge/blas-feedstock/pull/128
         # which depends on resolving MKL issue https://github.com/conda-forge/intel_repack-feedstock/issues/83)
         python: ['3.9', '3.10', '3.11', '3.12']
-        os: [ubuntu-22.04, windows-2019]
+        os: [ubuntu-22.04, windows-2022]
 
     permissions:
       # Needed to cancel any previous runs that are not completed for a given workflow
@@ -44,7 +44,7 @@ jobs:
 
     defaults:
       run:
-        shell: ${{ matrix.os == 'windows-2019' && 'cmd /C CALL {0}' || 'bash -el {0}' }}
+        shell: ${{ matrix.os == 'windows-2022' && 'cmd /C CALL {0}' || 'bash -el {0}' }}
 
     env:
       build-conda-pkg-env: 'environments/build_conda_pkg.yml'
@@ -264,7 +264,7 @@ jobs:
       matrix:
         # python 3.13 is blocked due to MKL issue
         python: ['3.9', '3.10', '3.11', '3.12']
-        os: [windows-2019]
+        os: [windows-2022]
 
     env:
       dpnp-repo-path: '${{ github.workspace }}\source'
@@ -422,13 +422,13 @@ jobs:
       matrix:
         # python 3.13 is blocked due to MKL issue
         python: ['3.9', '3.10', '3.11', '3.12']
-        os: [ubuntu-22.04, windows-2019]
+        os: [ubuntu-22.04, windows-2022]
 
     runs-on: ${{ matrix.os }}
 
     defaults:
       run:
-        shell: ${{ matrix.os == 'windows-2019' && 'cmd /C CALL {0}' || 'bash -el {0}' }}
+        shell: ${{ matrix.os == 'windows-2022' && 'cmd /C CALL {0}' || 'bash -el {0}' }}
 
     env:
       upload-conda-pkg-env: 'environments/upload_cleanup_conda_pkg.yml'

--- a/.github/workflows/cron-run-tests.yaml
+++ b/.github/workflows/cron-run-tests.yaml
@@ -29,7 +29,7 @@ jobs:
 
     defaults:
       run:
-        shell: ${{ matrix.runner == 'windows-2019' && 'cmd /C CALL {0}' || 'bash -el {0}' }}
+        shell: ${{ matrix.runner == 'windows-2022' && 'cmd /C CALL {0}' || 'bash -el {0}' }}
 
     permissions:
       # Needed to cancel any previous runs that are not completed for a given workflow
@@ -41,7 +41,7 @@ jobs:
         # python 3.13 is blocked since BLAS requires "mkl<2025.0" (see https://github.com/conda-forge/blas-feedstock/pull/128
         # which depends on resolving MKL issue https://github.com/conda-forge/intel_repack-feedstock/issues/83)
         python: ['3.9', '3.10', '3.11', '3.12']
-        runner: [ubuntu-22.04, ubuntu-24.04, windows-2019]
+        runner: [ubuntu-22.04, ubuntu-24.04, windows-2022]
 
     steps:
       - name: Cancel Previous Runs
@@ -98,7 +98,7 @@ jobs:
         run: mamba list
 
       - name: Activate OCL CPU RT
-        if: matrix.runner == 'windows-2019'
+        if: matrix.runner == 'windows-2022'
         shell: pwsh
         run: |
           $script_path="$env:CONDA_PREFIX\Scripts\set-intel-ocl-icd-registry.ps1"
@@ -125,7 +125,7 @@ jobs:
           SYCL_CACHE_PERSISTENT: 1
 
       - name: ReRun tests on Linux
-        if: steps.run_tests.outcome == 'failure' && matrix.runner != 'windows-2019'
+        if: steps.run_tests.outcome == 'failure' && matrix.runner != 'windows-2022'
         id: run_tests_linux
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
@@ -142,7 +142,7 @@ jobs:
           SYCL_CACHE_PERSISTENT: 1
 
       - name: ReRun tests on Windows
-        if: steps.run_tests.outcome == 'failure' && matrix.runner == 'windows-2019'
+        if: steps.run_tests.outcome == 'failure' && matrix.runner == 'windows-2022'
         id: run_tests_win
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,5 +1,5 @@
 numpy:
-    - '1.23'
+    - '1.25'
 c_compiler:                   # [linux]
     - gcc                     # [linux]
 cxx_compiler:                 # [linux]

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,2 +1,18 @@
 numpy:
-    - 1.23
+    - '1.23'
+c_compiler:                   # [linux]
+    - gcc                     # [linux]
+cxx_compiler:                 # [linux]
+    - gxx                     # [linux]
+cxx_compiler_version:         # [linux]
+    - '14'                    # [linux]
+c_stdlib:                     # [linux]
+    - sysroot                 # [linux]
+c_stdlib_version:             # [linux]
+    - '2.28'                  # [linux]
+c_stdlib:                     # [win]
+    - vs                      # [win]
+cxx_compiler:                 # [win]
+    - vs2022                  # [win]
+c_compiler:                   # [win]
+    - vs2022                  # [win]

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -37,8 +37,8 @@ requirements:
       - tbb-devel
     build:
       - {{ compiler('cxx') }}
+      - {{ stdlib('c') }}
       - {{ compiler('dpcpp') }} >={{ required_compiler_and_mkl_version }},<{{ max_compiler_and_mkl_version }}
-      - sysroot_linux-64 >=2.28 # [linux]
     run:
       - python
       - {{ pin_compatible('dpctl', min_pin='x.x.x', max_pin=None) }}


### PR DESCRIPTION
The PR is indented to remove a temporary pinning to "windows-2019" and to revert changes from #1833.
Besides Windows 2019 GitHub image is going to be fully unsupported by June 30, 2025.

The impacted workflows are moved to use "windows-2022" GH runners.
It requires updating `conda_build_config.yaml` where the version of the compiler as well as standard libraries have to be specified.
While `{{ stdlib('c') }}` is installing into build environment as an alignment with recipe's meta yaml from conda-forge (see [dpctl#1868](https://github.com/IntelPython/dpctl/pull/1868) as for reference).

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
