### PR TITLE
Leverage `dpnp.trace` implementation through existing calls

### DIFF
--- a/dpnp/backend/include/dpnp_iface_fptr.hpp
+++ b/dpnp/backend/include/dpnp_iface_fptr.hpp
@@ -115,8 +115,6 @@ enum class DPNPFuncName : size_t
     DPNP_FN_DIAG_INDICES_EXT, /**< Used in numpy.diag_indices() impl, requires
                                  extra parameters */
     DPNP_FN_DIAGONAL,         /**< Used in numpy.diagonal() impl  */
-    DPNP_FN_DIAGONAL_EXT,     /**< Used in numpy.diagonal() impl, requires extra
-                                 parameters */
     DPNP_FN_DIVIDE,           /**< Used in numpy.divide() impl  */
     DPNP_FN_DOT,              /**< Used in numpy.dot() impl  */
     DPNP_FN_DOT_EXT, /**< Used in numpy.dot() impl, requires extra parameters */
@@ -343,8 +341,6 @@ enum class DPNPFuncName : size_t
     DPNP_FN_TANH,         /**< Used in numpy.tanh() impl  */
     DPNP_FN_TRANSPOSE,    /**< Used in numpy.transpose() impl  */
     DPNP_FN_TRACE,        /**< Used in numpy.trace() impl  */
-    DPNP_FN_TRACE_EXT,    /**< Used in numpy.trace() impl, requires extra
-                             parameters */
     DPNP_FN_TRAPZ,        /**< Used in numpy.trapz() impl  */
     DPNP_FN_TRAPZ_EXT,    /**< Used in numpy.trapz() impl, requires extra
                              parameters */

--- a/dpnp/backend/kernels/dpnp_krnl_arraycreation.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_arraycreation.cpp
@@ -723,15 +723,6 @@ void (*dpnp_trace_default_c)(const void *,
                              const size_t) =
     dpnp_trace_c<_DataType, _ResultType>;
 
-template <typename _DataType, typename _ResultType>
-DPCTLSyclEventRef (*dpnp_trace_ext_c)(DPCTLSyclQueueRef,
-                                      const void *,
-                                      void *,
-                                      const shape_elem_type *,
-                                      const size_t,
-                                      const DPCTLEventVectorRef) =
-    dpnp_trace_c<_DataType, _ResultType>;
-
 template <typename _DataType>
 class dpnp_tri_c_kernel;
 
@@ -1287,39 +1278,6 @@ void func_map_init_arraycreation(func_map_t &fmap)
         eft_DBL, (void *)dpnp_trace_default_c<float, double>};
     fmap[DPNPFuncName::DPNP_FN_TRACE][eft_DBL][eft_DBL] = {
         eft_DBL, (void *)dpnp_trace_default_c<double, double>};
-
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_INT][eft_INT] = {
-        eft_INT, (void *)dpnp_trace_ext_c<int32_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_LNG][eft_INT] = {
-        eft_INT, (void *)dpnp_trace_ext_c<int64_t, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_FLT][eft_INT] = {
-        eft_INT, (void *)dpnp_trace_ext_c<float, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_DBL][eft_INT] = {
-        eft_INT, (void *)dpnp_trace_ext_c<double, int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_INT][eft_LNG] = {
-        eft_LNG, (void *)dpnp_trace_ext_c<int32_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_LNG][eft_LNG] = {
-        eft_LNG, (void *)dpnp_trace_ext_c<int64_t, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_FLT][eft_LNG] = {
-        eft_LNG, (void *)dpnp_trace_ext_c<float, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_DBL][eft_LNG] = {
-        eft_LNG, (void *)dpnp_trace_ext_c<double, int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_INT][eft_FLT] = {
-        eft_FLT, (void *)dpnp_trace_ext_c<int32_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_LNG][eft_FLT] = {
-        eft_FLT, (void *)dpnp_trace_ext_c<int64_t, float>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_FLT][eft_FLT] = {
-        eft_FLT, (void *)dpnp_trace_ext_c<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_DBL][eft_FLT] = {
-        eft_FLT, (void *)dpnp_trace_ext_c<double, float>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_INT][eft_DBL] = {
-        eft_DBL, (void *)dpnp_trace_ext_c<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_LNG][eft_DBL] = {
-        eft_DBL, (void *)dpnp_trace_ext_c<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_FLT][eft_DBL] = {
-        eft_DBL, (void *)dpnp_trace_ext_c<float, double>};
-    fmap[DPNPFuncName::DPNP_FN_TRACE_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void *)dpnp_trace_ext_c<double, double>};
 
     fmap[DPNPFuncName::DPNP_FN_TRI][eft_INT][eft_INT] = {
         eft_INT, (void *)dpnp_tri_default_c<int32_t>};

--- a/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
@@ -294,18 +294,6 @@ void (*dpnp_diagonal_default_c)(void *,
                                 const size_t) = dpnp_diagonal_c<_DataType>;
 
 template <typename _DataType>
-DPCTLSyclEventRef (*dpnp_diagonal_ext_c)(DPCTLSyclQueueRef,
-                                         void *,
-                                         const size_t,
-                                         void *,
-                                         const size_t,
-                                         shape_elem_type *,
-                                         shape_elem_type *,
-                                         const size_t,
-                                         const DPCTLEventVectorRef) =
-    dpnp_diagonal_c<_DataType>;
-
-template <typename _DataType>
 DPCTLSyclEventRef
     dpnp_fill_diagonal_c(DPCTLSyclQueueRef q_ref,
                          void *array1_in,
@@ -926,19 +914,6 @@ void func_map_init_indexing_func(func_map_t &fmap)
         eft_FLT, (void *)dpnp_diagonal_default_c<float>};
     fmap[DPNPFuncName::DPNP_FN_DIAGONAL][eft_DBL][eft_DBL] = {
         eft_DBL, (void *)dpnp_diagonal_default_c<double>};
-
-    fmap[DPNPFuncName::DPNP_FN_DIAGONAL_EXT][eft_INT][eft_INT] = {
-        eft_INT, (void *)dpnp_diagonal_ext_c<int32_t>};
-    fmap[DPNPFuncName::DPNP_FN_DIAGONAL_EXT][eft_LNG][eft_LNG] = {
-        eft_LNG, (void *)dpnp_diagonal_ext_c<int64_t>};
-    fmap[DPNPFuncName::DPNP_FN_DIAGONAL_EXT][eft_FLT][eft_FLT] = {
-        eft_FLT, (void *)dpnp_diagonal_ext_c<float>};
-    fmap[DPNPFuncName::DPNP_FN_DIAGONAL_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void *)dpnp_diagonal_ext_c<double>};
-    fmap[DPNPFuncName::DPNP_FN_DIAGONAL_EXT][eft_C64][eft_C64] = {
-        eft_C64, (void *)dpnp_diagonal_ext_c<std::complex<float>>};
-    fmap[DPNPFuncName::DPNP_FN_DIAGONAL_EXT][eft_C128][eft_C128] = {
-        eft_C128, (void *)dpnp_diagonal_ext_c<std::complex<double>>};
 
     fmap[DPNPFuncName::DPNP_FN_FILL_DIAGONAL][eft_INT][eft_INT] = {
         eft_INT, (void *)dpnp_fill_diagonal_default_c<int32_t>};

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -39,7 +39,6 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_CORRELATE_EXT
         DPNP_FN_DEGREES_EXT
         DPNP_FN_DIAG_INDICES_EXT
-        DPNP_FN_DIAGONAL_EXT
         DPNP_FN_EDIFF1D_EXT
         DPNP_FN_ERF_EXT
         DPNP_FN_FABS_EXT
@@ -90,7 +89,6 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_RNG_WALD_EXT
         DPNP_FN_RNG_WEIBULL_EXT
         DPNP_FN_RNG_ZIPF_EXT
-        DPNP_FN_TRACE_EXT
         DPNP_FN_TRAPZ_EXT
 
 cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncType":  # need this namespace for Enum import

--- a/dpnp/dpnp_algo/dpnp_algo_arraycreation.pxi
+++ b/dpnp/dpnp_algo/dpnp_algo_arraycreation.pxi
@@ -37,7 +37,6 @@ and the rest of the library
 
 __all__ += [
     "dpnp_copy",
-    "dpnp_trace",
 ]
 
 
@@ -73,59 +72,7 @@ ctypedef c_dpctl.DPCTLSyclEventRef(*custom_indexing_1out_func_ptr_t)(c_dpctl.DPC
                                                                      const size_t ,
                                                                      const int,
                                                                      const c_dpctl.DPCTLEventVectorRef) except +
-ctypedef c_dpctl.DPCTLSyclEventRef(*fptr_dpnp_trace_t)(c_dpctl.DPCTLSyclQueueRef,
-                                                       const void *,
-                                                       void * ,
-                                                       const shape_elem_type * ,
-                                                       const size_t,
-                                                       const c_dpctl.DPCTLEventVectorRef) except +
 
 
 cpdef utils.dpnp_descriptor dpnp_copy(utils.dpnp_descriptor x1):
     return call_fptr_1in_1out_strides(DPNP_FN_COPY_EXT, x1)
-
-
-cpdef utils.dpnp_descriptor dpnp_trace(utils.dpnp_descriptor arr, offset=0, axis1=0, axis2=1, dtype=None, out=None):
-    if dtype is None:
-        dtype_ = arr.dtype
-    else:
-        dtype_ = dtype
-
-    cdef utils.dpnp_descriptor diagonal_arr = dpnp_diagonal(arr, offset)
-    cdef size_t diagonal_ndim = diagonal_arr.ndim
-    cdef shape_type_c diagonal_shape = diagonal_arr.shape
-
-    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(arr.dtype)
-    cdef DPNPFuncType param2_type = dpnp_dtype_to_DPNPFuncType(dtype_)
-
-    cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_TRACE_EXT, param1_type, param2_type)
-
-    arr_obj = arr.get_array()
-
-    # create result array with type given by FPTR data
-    cdef shape_type_c result_shape = diagonal_shape[:-1]
-    cdef utils.dpnp_descriptor result = utils.create_output_descriptor(result_shape,
-                                                                       kernel_data.return_type,
-                                                                       None,
-                                                                       device=arr_obj.sycl_device,
-                                                                       usm_type=arr_obj.usm_type,
-                                                                       sycl_queue=arr_obj.sycl_queue)
-
-    result_sycl_queue = result.get_array().sycl_queue
-
-    cdef c_dpctl.SyclQueue q = <c_dpctl.SyclQueue> result_sycl_queue
-    cdef c_dpctl.DPCTLSyclQueueRef q_ref = q.get_queue_ref()
-
-    cdef fptr_dpnp_trace_t func = <fptr_dpnp_trace_t > kernel_data.ptr
-
-    cdef c_dpctl.DPCTLSyclEventRef event_ref = func(q_ref,
-                                                    diagonal_arr.get_data(),
-                                                    result.get_data(),
-                                                    diagonal_shape.data(),
-                                                    diagonal_ndim,
-                                                    NULL)  # dep_events_ref
-
-    with nogil: c_dpctl.DPCTLEvent_WaitAndThrow(event_ref)
-    c_dpctl.DPCTLEvent_Delete(event_ref)
-
-    return result

--- a/dpnp/dpnp_algo/dpnp_algo_indexing.pxi
+++ b/dpnp/dpnp_algo/dpnp_algo_indexing.pxi
@@ -53,15 +53,6 @@ ctypedef c_dpctl.DPCTLSyclEventRef(*fptr_dpnp_choose_t)(c_dpctl.DPCTLSyclQueueRe
 ctypedef c_dpctl.DPCTLSyclEventRef(*fptr_dpnp_diag_indices)(c_dpctl.DPCTLSyclQueueRef,
                                                             void * , size_t,
                                                             const c_dpctl.DPCTLEventVectorRef)
-ctypedef c_dpctl.DPCTLSyclEventRef(*custom_indexing_2in_1out_func_ptr_t_)(c_dpctl.DPCTLSyclQueueRef,
-                                                                          void * ,
-                                                                          const size_t,
-                                                                          void * ,
-                                                                          const size_t,
-                                                                          shape_elem_type * ,
-                                                                          shape_elem_type *,
-                                                                          const size_t,
-                                                                          const c_dpctl.DPCTLEventVectorRef)
 ctypedef c_dpctl.DPCTLSyclEventRef(*custom_indexing_2in_func_ptr_t)(c_dpctl.DPCTLSyclQueueRef,
                                                                     void *, void * , shape_elem_type * , const size_t,
                                                                     const c_dpctl.DPCTLEventVectorRef)
@@ -144,62 +135,6 @@ cpdef tuple dpnp_diag_indices(n, ndim):
         res_list.append(res_arr.get_pyobj())
 
     return tuple(res_list)
-
-
-cpdef utils.dpnp_descriptor dpnp_diagonal(dpnp_descriptor x1, offset=0):
-    cdef shape_type_c x1_shape = x1.shape
-
-    n = min(x1.shape[0], x1.shape[1])
-    res_shape = [None] * (x1.ndim - 1)
-
-    if x1.ndim > 2:
-        for i in range(x1.ndim - 2):
-            res_shape[i] = x1.shape[i + 2]
-
-    if (n + offset) > x1.shape[1]:
-        res_shape[-1] = x1.shape[1] - offset
-    elif (n + offset) > x1.shape[0]:
-        res_shape[-1] = x1.shape[0]
-    else:
-        res_shape[-1] = n + offset
-
-    cdef shape_type_c result_shape = res_shape
-    res_ndim = len(res_shape)
-
-    cdef DPNPFuncType param1_type = dpnp_dtype_to_DPNPFuncType(x1.dtype)
-
-    cdef DPNPFuncData kernel_data = get_dpnp_function_ptr(DPNP_FN_DIAGONAL_EXT, param1_type, param1_type)
-
-    x1_obj = x1.get_array()
-
-    cdef utils.dpnp_descriptor result = utils.create_output_descriptor(result_shape,
-                                                                       kernel_data.return_type,
-                                                                       None,
-                                                                       device=x1_obj.sycl_device,
-                                                                       usm_type=x1_obj.usm_type,
-                                                                       sycl_queue=x1_obj.sycl_queue)
-
-    result_sycl_queue = result.get_array().sycl_queue
-
-    cdef c_dpctl.SyclQueue q = <c_dpctl.SyclQueue> result_sycl_queue
-    cdef c_dpctl.DPCTLSyclQueueRef q_ref = q.get_queue_ref()
-
-    cdef custom_indexing_2in_1out_func_ptr_t_ func = <custom_indexing_2in_1out_func_ptr_t_ > kernel_data.ptr
-
-    cdef c_dpctl.DPCTLSyclEventRef event_ref = func(q_ref,
-                                                    x1.get_data(),
-                                                    x1.size,
-                                                    result.get_data(),
-                                                    offset,
-                                                    x1_shape.data(),
-                                                    result_shape.data(),
-                                                    res_ndim,
-                                                    NULL)  # dep_events_ref
-
-    with nogil: c_dpctl.DPCTLEvent_WaitAndThrow(event_ref)
-    c_dpctl.DPCTLEvent_Delete(event_ref)
-
-    return result
 
 
 cpdef dpnp_fill_diagonal(dpnp_descriptor x1, val):

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -1393,7 +1393,18 @@ class dpnp_array:
     # 'tofile',
     # 'tolist',
     # 'tostring',
-    # 'trace',
+
+    def trace(self, offset=0, axis1=0, axis2=1, dtype=None, out=None):
+        """
+        Return the sum along diagonals of the array.
+
+        Refer to :obj:`dpnp.trace` for full documentation.
+
+        """
+
+        return dpnp.trace(
+            self, offset=offset, axis1=axis1, axis2=axis2, dtype=dtype, out=out
+        )
 
     def transpose(self, *axes):
         """

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -45,18 +45,11 @@ import numpy
 import dpnp
 from dpnp import dpnp_container
 
-# pylint: disable=no-name-in-module
-from .dpnp_algo import (
-    dpnp_trace,
-)
 from .dpnp_algo.dpnp_arraycreation import (
     dpnp_geomspace,
     dpnp_linspace,
     dpnp_logspace,
     dpnp_nd_grid,
-)
-from .dpnp_utils import (
-    call_origin,
 )
 
 __all__ = [
@@ -141,7 +134,7 @@ def arange(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is "device".
+        Default: ``"device"``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -231,7 +224,7 @@ def array(
         The desired dtype for the array. If not given, a default dtype will be
         used that can represent the values (by considering Promotion Type Rule
         and device capabilities when necessary).
-    copy : {bool}, optional
+    copy : bool, optional
         If ``True`` (default), then the object is copied.
     order : {"C", "F", "A", "K"}, optional
         Memory layout of the newly output array. Default: "K".
@@ -244,7 +237,7 @@ def array(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is ``None``.
+        Default: ``None``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -357,7 +350,7 @@ def asanyarray(
         The desired dtype for the array. If not given, a default dtype will be
         used that can represent the values (by considering Promotion Type Rule
         and device capabilities when necessary).
-    order : {"C", "F", "A", "K"}, optional
+    order : {None, "C", "F", "A", "K"}, optional
         Memory layout of the newly output array. Default: "K".
     device : {None, string, SyclDevice, SyclQueue}, optional
         An array API concept of device where the output array is created.
@@ -368,7 +361,7 @@ def asanyarray(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is ``None``.
+        Default: ``None``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -453,7 +446,7 @@ def asarray(
         The desired dtype for the array. If not given, a default dtype will be
         used that can represent the values (by considering Promotion Type Rule
         and device capabilities when necessary).
-    order : {"C", "F", "A", "K"}, optional
+    order : {None, "C", "F", "A", "K"}, optional
         Memory layout of the newly output array. Default: "K".
     device : {None, string, SyclDevice, SyclQueue}, optional
         An array API concept of device where the output array is created.
@@ -464,7 +457,7 @@ def asarray(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is ``None``.
+        Default: ``None``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -553,7 +546,7 @@ def ascontiguousarray(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is ``None``.
+        Default: ``None``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -663,7 +656,7 @@ def asfortranarray(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is ``None``.
+        Default: ``None``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -775,7 +768,7 @@ def copy(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is ``None``.
+        Default: ``None``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -886,7 +879,7 @@ def diag(v, /, k=0, *, device=None, usm_type=None, sycl_queue=None):
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is ``None``.
+        Default: ``None``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -985,7 +978,7 @@ def diagflat(v, /, k=0, *, device=None, usm_type=None, sycl_queue=None):
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is ``None``.
+        Default: ``None``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -1073,7 +1066,7 @@ def empty(
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
-    order : {"C", "F", None}, optional
+    order : {None, "C", "F"}, optional
         Memory layout of the newly output array. Default: "C".
     device : {None, string, SyclDevice, SyclQueue}, optional
         An array API concept of device where the output array is created.
@@ -1084,7 +1077,7 @@ def empty(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is "device".
+        Default: ``"device"``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -1164,16 +1157,16 @@ def empty_like(
 
     Parameters
     ----------
-    a : {dpnp_array, usm_ndarray}
+    a : {dpnp.ndarray, usm_ndarray}
         The shape and dtype of `a` define these same attributes
         of the returned array.
     dtype : {None, dtype}, optional
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
-    order : {"C", "F", None}, optional
+    order : {None, "C", "F"}, optional
         Memory layout of the newly output array. Default: "C".
-    shape : {int, sequence of ints}
+    shape : {None, int, sequence of ints}
         Overrides the shape of the result.
     device : {None, string, SyclDevice, SyclQueue}, optional
         An array API concept of device where the output array is created.
@@ -1184,7 +1177,7 @@ def empty_like(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is ``None``.
+        Default: ``None``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -1274,7 +1267,7 @@ def eye(
     ----------
     N : int
         Number of rows in the output.
-    M : int, optional
+    M : {None, int}, optional
         Number of columns in the output. If None, defaults to `N`.
     k : int, optional
         Index of the diagonal: 0 (the default) refers to the main diagonal,
@@ -1284,7 +1277,7 @@ def eye(
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
-    order : {"C", "F", None}, optional
+    order : {None, "C", "F"}, optional
         Memory layout of the newly output array. Default: "C".
     device : {None, string, SyclDevice, SyclQueue}, optional
         An array API concept of device where the output array is created.
@@ -1295,7 +1288,7 @@ def eye(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is "device".
+        Default: ``"device"``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -1402,7 +1395,7 @@ def frombuffer(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is "device".
+        Default: ``"device"``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -1476,7 +1469,7 @@ def fromfile(
     Construct an array from data in a text or binary file.
 
     A highly efficient way of reading binary data with a known data-type,
-    as well as parsing simply formatted text files.  Data written using the
+    as well as parsing simply formatted text files. Data written using the
     `tofile` method can be read using this function.
 
     For full documentation refer to :obj:`numpy.fromfile`.
@@ -1512,7 +1505,7 @@ def fromfile(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is "device".
+        Default: ``"device"``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -1627,7 +1620,7 @@ def fromfunction(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is "device".
+        Default: ``"device"``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -1721,7 +1714,7 @@ def fromiter(
     dtype : data-type
         The data-type of the returned array.
     count : int, optional
-        The number of items to read from *iterable*.  The default is -1,
+        The number of items to read from *iterable*. The default is -1,
         which means all data is read.
     device : {None, string, SyclDevice, SyclQueue}, optional
         An array API concept of device where the output array is created.
@@ -1732,7 +1725,7 @@ def fromiter(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is "device".
+        Default: ``"device"``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -1828,7 +1821,7 @@ def fromstring(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is "device".
+        Default: ``"device"``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -1899,7 +1892,7 @@ def full(
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
-    order : {"C", "F", None}, optional
+    order : {None, "C", "F"}, optional
         Memory layout of the newly output array. Default: "C".
     device : {None, string, SyclDevice, SyclQueue}, optional
         An array API concept of device where the output array is created.
@@ -1910,7 +1903,7 @@ def full(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is ``None``.
+        Default: ``None``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -1989,7 +1982,7 @@ def full_like(
 
     Parameters
     ----------
-    a : {dpnp_array, usm_ndarray}
+    a : {dpnp.ndarray, usm_ndarray}
         The shape and dtype of `a` define these same attributes
         of the returned array.
     fill_value : {scalar, array_like}
@@ -2000,9 +1993,9 @@ def full_like(
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
-    order : {"C", "F", None}, optional
+    order : {None, "C", "F"}, optional
         Memory layout of the newly output array. Default: "C".
-    shape : {int, sequence of ints}
+    shape : {None, int, sequence of ints}
         Overrides the shape of the result.
     device : {None, string, SyclDevice, SyclQueue}, optional
         An array API concept of device where the output array is created.
@@ -2013,7 +2006,7 @@ def full_like(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is ``None``.
+        Default: ``None``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -2127,13 +2120,13 @@ def geomspace(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is ``None``.
+        Default: ``None``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
-    endpoint : {bool}, optional
+    endpoint : bool, optional
         If ``True``, `stop` is the last sample. Otherwise, it is not included.
         Default is ``True``.
-    axis : {int}, optional
+    axis : int, optional
         The axis in the result to store the samples. Relevant only if start or
         stop are array-like. By default (0), the samples will be along a new
         axis inserted at the beginning. Use -1 to get an axis at the end.
@@ -2237,7 +2230,7 @@ def identity(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is "device".
+        Default: ``"device"``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -2348,16 +2341,16 @@ def linspace(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is ``None``.
+        Default: ``None``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
-    endpoint : {bool}, optional
+    endpoint : bool, optional
         If ``True``, `stop` is the last sample. Otherwise, it is not included.
         Default is ``True``.
-    retstep : {bool}, optional
+    retstep : bool, optional
         If ``True``, return (samples, step), where step is the spacing between
         samples.
-    axis : {int}, optional
+    axis : int, optional
         The axis in the result to store the samples. Relevant only if start or
         stop are array-like. By default (0), the samples will be along a new
         axis inserted at the beginning. Use -1 to get an axis at the end.
@@ -2458,7 +2451,7 @@ def loadtxt(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is "device".
+        Default: ``"device"``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -2566,7 +2559,7 @@ def logspace(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is ``None``.
+        Default: ``None``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
     endpoint : {bool}, optional
@@ -2584,7 +2577,7 @@ def logspace(
         The desired dtype for the array. If not given, a default dtype will be
         used that can represent the values (by considering Promotion Type Rule
         and device capabilities when necessary).
-    axis : {int}, optional
+    axis : int, optional
         The axis in the result to store the samples. Relevant only if start,
         stop, or base are array-like. By default (0), the samples will be along
         a new axis inserted at the beginning. Use -1 to get an axis at the end.
@@ -2667,13 +2660,15 @@ def meshgrid(*xi, copy=True, sparse=False, indexing="xy"):
         1-D arrays representing the coordinates of a grid.
     indexing : {'xy', 'ij'}, optional
         Cartesian (``'xy'``, default) or matrix (``'ij'``) indexing of output.
-    sparse : {bool}, optional
-        If True the shape of the returned coordinate array for dimension `i`
+    sparse : bool, optional
+        If ``True`` the shape of the returned coordinate array for dimension `i`
         is reduced from ``(N1, ..., Ni, ... Nn)`` to
-        ``(1, ..., 1, Ni, 1, ..., 1)``. Default is False.
-    copy : {bool}, optional
-        If False, a view into the original arrays are returned in order to
-        conserve memory.  Default is True.
+        ``(1, ..., 1, Ni, 1, ..., 1)``.
+        Default: ``False``.
+    copy : bool, optional
+        If ``False``, a view into the original arrays are returned in order to
+        conserve memory.
+        Default: ``True``.
 
     Returns
     -------
@@ -2760,7 +2755,7 @@ class MGridClass:
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is "device".
+        Default: ``"device"``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -2833,7 +2828,7 @@ class OGridClass:
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is "device".
+        Default: ``"device"``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -2905,7 +2900,7 @@ def ones(
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
-    order : {"C", "F", None}, optional
+    order : {None, "C", "F"}, optional
         Memory layout of the newly output array. Default: "C".
     device : {None, string, SyclDevice, SyclQueue}, optional
         An array API concept of device where the output array is created.
@@ -2916,7 +2911,7 @@ def ones(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is "device".
+        Default: ``"device"``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -3002,16 +2997,16 @@ def ones_like(
 
     Parameters
     ----------
-    a : {dpnp_array, usm_ndarray}
+    a : {dpnp.ndarray, usm_ndarray}
         The shape and dtype of `a` define these same attributes
         of the returned array.
     dtype : {None, dtype}, optional
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
-    order : {"C", "F", None}, optional
+    order : {None, "C", "F"}, optional
         Memory layout of the newly output array. Default: "C".
-    shape : {int, sequence of ints}
+    shape : {None, int, sequence of ints}
         Overrides the shape of the result.
     device : {None, string, SyclDevice, SyclQueue}, optional
         An array API concept of device where the output array is created.
@@ -3022,7 +3017,7 @@ def ones_like(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is ``None``.
+        Default: ``None``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -3090,38 +3085,66 @@ def ones_like(
     )
 
 
-def trace(x1, offset=0, axis1=0, axis2=1, dtype=None, out=None):
+def trace(a, offset=0, axis1=0, axis2=1, dtype=None, out=None):
     """
     Return the sum along diagonals of the array.
 
     For full documentation refer to :obj:`numpy.trace`.
 
-    Limitations
-    -----------
-    Input array is supported as :obj:`dpnp.ndarray`.
-    Parameters `axis1`, `axis2`, `out` and `dtype` are supported only with
-    default values.
+    Parameters
+    ----------
+    a : {dpnp.ndarray, usm_ndarray}
+        Input array, from which the diagonals are taken.
+    offset : int, optional
+        Offset of the diagonal from the main diagonal. Can be both positive and
+        negative.
+        Default: ``0``.
+    axis1, axis2 : int, optional
+        Axes to be used as the first and second axis of the 2-D sub-arrays from
+        which the diagonals should be taken. Defaults are the first two axes of
+        `a`.
+    dtype : dtype, optional
+        Determines the data-type of the returned array and of the accumulator
+        where the elements are summed. If `dtype` has the value ``None`` and
+        `a` is of integer type of precision less than the default integer
+        precision, then the default integer precision is used. Otherwise, the
+        precision is the same as that of `a`.
+        Default: ``None``.
+    out : {dpnp.ndarray, usm_ndarray}, optional
+        Array into which the output is placed. Its type is preserved and it
+        must be of the right shape to hold the output.
+        Default: ``None``.
+
+    Returns
+    -------
+    sum_along_diagonals : dpnp.ndarray
+        If `a` is 2-D, the sum along the diagonal is returned. If `a` has
+        larger dimensions, then an array of sums along diagonals is returned.
+
+    See Also
+    --------
+    :obj:`dpnp.diag` : Extract a diagonal or construct a diagonal array.
+    :obj:`dpnp.diagonal` : Return specified diagonals.
+    :obj:`dpnp.diagflat` : Create a 2-D array with the flattened input as
+                           a diagonal.
+
+    Examples
+    --------
+    >>> import dpnp as np
+    >>> np.trace(np.eye(3))
+    array(3.)
+    >>> a = np.arange(8).reshape((2, 2, 2))
+    >>> np.trace(a)
+    array([6, 8])
+
+    >>> a = np.arange(24).reshape((2, 2, 2, 3))
+    >>> np.trace(a).shape
+    (2, 3)
 
     """
 
-    x1_desc = dpnp.get_dpnp_descriptor(x1, copy_when_nondefault_queue=False)
-    if x1_desc:
-        if x1_desc.size == 0:
-            pass
-        elif x1_desc.ndim < 2:
-            pass
-        elif axis2 != 1:
-            pass
-        elif axis1 != 0:
-            pass
-        elif out is not None:
-            pass
-        else:
-            return dpnp_trace(
-                x1_desc, offset, axis1, axis2, dtype, out
-            ).get_pyobj()
-
-    return call_origin(numpy.trace, x1, offset, axis1, axis2, dtype, out)
+    d = dpnp.diagonal(a, offset=offset, axis1=axis1, axis2=axis2)
+    return dpnp.sum(d, axis=-1, dtype=dtype, out=out, keepdims=False)
 
 
 # pylint: disable=invalid-name
@@ -3145,7 +3168,7 @@ def tri(
     ----------
     N : int
         Number of rows in the array.
-    M : int, optional
+    M : {None, int}, optional
         Number of columns in the array. By default, `M` is taken equal to `N`.
     k : int, optional
         The sub-diagonal at and below which the array is filled. k = 0 is
@@ -3164,7 +3187,7 @@ def tri(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is "device".
+        Default: ``"device"``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -3258,7 +3281,7 @@ def tril(m, /, *, k=0):
 
     Parameters
     ----------
-    m : {dpnp_array, usm_ndarray}, shape (…, M, N)
+    m : {dpnp.ndarray, usm_ndarray}, shape (…, M, N)
         Input array.
     k : int, optional
         Diagonal above which to zero elements. k = 0 (the default) is
@@ -3311,7 +3334,7 @@ def triu(m, /, *, k=0):
 
     Parameters
     ----------
-    m : {dpnp_array, usm_ndarray}, shape (…, M, N)
+    m : {dpnp.ndarray, usm_ndarray}, shape (…, M, N)
         Input array.
     k : int, optional
         Diagonal below which to zero elements. k = 0 (the default) is
@@ -3375,10 +3398,10 @@ def vander(
         1-D input array, in any form that can be converted to an array. This
         includes scalars, lists, lists of tuples, tuples, tuples of tuples,
         tuples of lists, and ndarrays.
-    N : int, optional
+    N : {None, int}, optional
         Number of columns in the output. If `N` is not specified, a square
         array is returned ``(N = len(x))``.
-    increasing : {bool}, optional
+    increasing : bool, optional
         Order of the powers of the columns. If ``True,`` the powers increase
         from left to right, if ``False`` (the default) they are reversed.
     device : {None, string, SyclDevice, SyclQueue}, optional
@@ -3390,7 +3413,7 @@ def vander(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is ``None``.
+        Default: ``None``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -3496,7 +3519,7 @@ def zeros(
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
-    order : {"C", "F", None}, optional
+    order : {None, "C", "F"}, optional
         Memory layout of the newly output array. Default: "C".
     device : {None, string, SyclDevice, SyclQueue}, optional
         An array API concept of device where the output array is created.
@@ -3507,7 +3530,7 @@ def zeros(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is "device".
+        Default: ``"device"``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 
@@ -3593,16 +3616,16 @@ def zeros_like(
 
     Parameters
     ----------
-    a : {dpnp_array, usm_ndarray}
+    a : {dpnp.ndarray, usm_ndarray}
         The shape and dtype of `a` define these same attributes
         of the returned array.
     dtype : {None, dtype}, optional
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
-    order : {"C", "F", None}, optional
+    order : {None, "C", "F"}, optional
         Memory layout of the newly output array. Default: "C".
-    shape : {int, sequence of ints}
+    shape : {None, int, sequence of ints}
         Overrides the shape of the result.
     device : {None, string, SyclDevice, SyclQueue}, optional
         An array API concept of device where the output array is created.
@@ -3613,7 +3636,7 @@ def zeros_like(
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
-        Default is ``None``.
+        Default: ``None``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying.
 

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -471,6 +471,9 @@ def test_meshgrid(device_x, device_y):
             "tan", [-dpnp.pi / 2, -dpnp.pi / 4, 0.0, dpnp.pi / 4, dpnp.pi / 2]
         ),
         pytest.param("tanh", [-5.0, -3.5, 0.0, 3.5, 5.0]),
+        pytest.param(
+            "trace", [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+        ),
         pytest.param("trapz", [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]),
         pytest.param("trunc", [-1.7, -1.5, -0.2, 0.2, 1.5, 1.7, 2.0]),
         pytest.param("var", [1.0, 2.0, 4.0, 7.0]),

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -588,6 +588,9 @@ def test_norm(usm_type, ord, axis):
             "tan", [-dp.pi / 2, -dp.pi / 4, 0.0, dp.pi / 4, dp.pi / 2]
         ),
         pytest.param("tanh", [-5.0, -3.5, 0.0, 3.5, 5.0]),
+        pytest.param(
+            "trace", [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+        ),
         pytest.param("trunc", [-1.7, -1.5, -0.2, 0.2, 1.5, 1.7, 2.0]),
         pytest.param("var", [1.0, 2.0, 4.0, 7.0]),
     ],

--- a/tests/third_party/cupy/linalg_tests/test_norms.py
+++ b/tests/third_party/cupy/linalg_tests/test_norms.py
@@ -8,6 +8,21 @@ from tests.helper import is_cpu_device
 from tests.third_party.cupy import testing
 
 
+class TestTrace(unittest.TestCase):
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_trace(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4, 5), xp, dtype)
+        return a.trace(1, 3, 2)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_external_trace(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4, 5), xp, dtype)
+        return xp.trace(a, 1, 3, 2)
+
+
 @testing.parameterize(
     *testing.product(
         {
@@ -73,7 +88,7 @@ class TestNorm(unittest.TestCase):
     )
 )
 class TestMatrixRank(unittest.TestCase):
-    @testing.for_all_dtypes(no_float16=True)
+    @testing.for_all_dtypes(no_float16=True, no_complex=True)
     @testing.numpy_cupy_array_equal(type_check=True)
     def test_matrix_rank(self, xp, dtype):
         a = xp.array(self.array, dtype=dtype)
@@ -88,64 +103,64 @@ class TestMatrixRank(unittest.TestCase):
 
 
 class TestDet(unittest.TestCase):
-    @testing.for_dtypes("fdFD")
+    @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
     def test_det(self, xp, dtype):
         a = testing.shaped_arange((2, 2), xp, dtype) + 1
         return xp.linalg.det(a)
 
-    @testing.for_dtypes("fdFD")
+    @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
     def test_det_3(self, xp, dtype):
         a = testing.shaped_arange((2, 2, 2), xp, dtype) + 1
         return xp.linalg.det(a)
 
-    @testing.for_dtypes("fdFD")
+    @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
     def test_det_4(self, xp, dtype):
         a = testing.shaped_arange((2, 2, 2, 2), xp, dtype) + 1
         return xp.linalg.det(a)
 
-    @testing.for_dtypes("fdFD")
+    @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
     def test_det_empty_batch(self, xp, dtype):
         a = xp.empty((2, 0, 3, 3), dtype=dtype)
         return xp.linalg.det(a)
 
-    @testing.for_dtypes("fdFD")
+    @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
     def test_det_empty_matrix(self, xp, dtype):
         a = xp.empty((0, 0), dtype=dtype)
         return xp.linalg.det(a)
 
-    @testing.for_dtypes("fdFD")
+    @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
     def test_det_empty_matrices(self, xp, dtype):
         a = xp.empty((2, 3, 0, 0), dtype=dtype)
         return xp.linalg.det(a)
 
-    @testing.for_dtypes("fdFD")
+    @testing.for_float_dtypes(no_float16=True)
     def test_det_different_last_two_dims(self, dtype):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3, 2), xp, dtype)
             with pytest.raises(xp.linalg.LinAlgError):
                 xp.linalg.det(a)
 
-    @testing.for_dtypes("fdFD")
+    @testing.for_float_dtypes(no_float16=True)
     def test_det_different_last_two_dims_empty_batch(self, dtype):
         for xp in (numpy, cupy):
             a = xp.empty((0, 3, 2), dtype=dtype)
             with pytest.raises(xp.linalg.LinAlgError):
                 xp.linalg.det(a)
 
-    @testing.for_dtypes("fdFD")
+    @testing.for_float_dtypes(no_float16=True)
     def test_det_one_dim(self, dtype):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2,), xp, dtype)
             with pytest.raises(xp.linalg.LinAlgError):
                 xp.linalg.det(a)
 
-    @testing.for_dtypes("fdFD")
+    @testing.for_float_dtypes(no_float16=True)
     def test_det_zero_dim(self, dtype):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((), xp, dtype)
@@ -156,14 +171,13 @@ class TestDet(unittest.TestCase):
     # _getrf_batch does not raise an error with singular matrices.
     # Skip running on cpu because dpnp uses _getrf_batch only on cpu.
     @pytest.mark.skipif(is_cpu_device(), reason="MKLD-13852")
-    @testing.for_dtypes("fdFD")
+    @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
     def test_det_singular(self, xp, dtype):
         a = xp.zeros((2, 3, 3), dtype=dtype)
         return xp.linalg.det(a)
 
 
-@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestSlogdet(unittest.TestCase):
     @testing.for_dtypes("fdFD")
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)


### PR DESCRIPTION
The PR proposes to implement `dpnp.trace` through two consequence call of `diagonal` and `sum` functions.
The similar approach is implemented in numpy and cupy.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
