### PR TITLE
Pin compiler and MKL within range for 0.15 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.21...3.27 FATAL_ERROR)
 
 project(dpnp
+  VERSION 0.15
+  LANGUAGES CXX
   DESCRIPTION "NumPy-like API accelerated by SYCL."
 )
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,8 +1,5 @@
-{% set required_compiler_and_mkl_version = "2024.0" %}
-{% set excluded_compiler_version1 = "2024.0.1" %}
-{% set excluded_compiler_version2 = "2024.0.2" %}
-{% set excluded_compiler_version3 = "2024.0.3" %}
-{% set required_dpctl_version = "0.16.0" %}
+{% set required_compiler_and_mkl_version = "2024.2.0" %}
+{% set required_dpctl_version = "0.17.0a0" %}
 
 package:
     name: dpnp
@@ -27,8 +24,7 @@ requirements:
       - scikit-build
     build:
       - {{ compiler('cxx') }}
-      - {{ compiler('dpcpp') }} >={{ required_compiler_and_mkl_version }},!={{ excluded_compiler_version1 }},!={{ excluded_compiler_version2 }},!={{ excluded_compiler_version3 }} # [win]
-      - {{ compiler('dpcpp') }} >={{ required_compiler_and_mkl_version }},!={{ excluded_compiler_version1 }},!={{ excluded_compiler_version2 }} # [linux]
+      - {{ compiler('dpcpp') }} {{ required_compiler_and_mkl_version }}
       - sysroot_linux-64 >=2.28 # [linux]
     run:
       - python


### PR DESCRIPTION
This change pins compile-time version of the compiler to `2024.2.0`, host MKL version to `2024.2.0`, and restricts the range of compiler runtime and MKL libraries accordingly for `dpnp=0.15.0`.
Note, `dpctl` version will be pinned to `0.17.0` once it is available.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
