### PR TITLE
Remove skip in test_digitize

### DIFF
--- a/tests/third_party/cupy/statistics_tests/test_histogram.py
+++ b/tests/third_party/cupy/statistics_tests/test_histogram.py
@@ -366,8 +366,6 @@ class TestDigitize:
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
     @testing.numpy_cupy_array_equal()
     def test_digitize(self, xp, dtype):
-        if self.shape == () and not self.increasing:
-            pytest.skip("dpctl issue #1689")
         x = testing.shaped_arange(self.shape, xp, dtype)
         bins = self.bins
         if not self.increasing:


### PR DESCRIPTION
This PR suggests removing a previously skipped test in `TestDigitize` in  case when `shape =()` and `increasing=False` since [#1689](https://github.com/IntelPython/dpctl/issues/1689) is resolved and `dpctl` package with this fix is available in the internal channel. 

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
