### PR TITLE
Backport pull/1851 to maintenance/0.15.x

### DIFF
--- a/tests/third_party/cupy/statistics_tests/test_histogram.py
+++ b/tests/third_party/cupy/statistics_tests/test_histogram.py
@@ -366,8 +366,6 @@ class TestDigitize:
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
     @testing.numpy_cupy_array_equal()
     def test_digitize(self, xp, dtype):
-        if self.shape == () and not self.increasing:
-            pytest.skip("dpctl issue #1689")
         x = testing.shaped_arange(self.shape, xp, dtype)
         bins = self.bins
         if not self.increasing:


### PR DESCRIPTION
The #1851 enables the previously skipped test in `TestDigitize` scope for a case when `shape =()` and `increasing=False` since the appropriate `dpctl` fix is available in internal channel.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
