### PR TITLE
Pin `dpctl` version to a final release tag

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set required_compiler_and_mkl_version = "2024.2.0" %}
-{% set required_dpctl_version = "0.17.0a0" %}
+{% set required_dpctl_version = "0.17.0" %}
 
 package:
     name: dpnp


### PR DESCRIPTION
The PR sets host and run-time pinning to the final release tag of `dpctl = 0.17.0`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
