### PR TITLE
Remove Python 3.8 from list of Programming Languages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ Programming Language :: C++
 Programming Language :: Cython
 Programming Language :: Python
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3.10
 Programming Language :: Python :: 3.11


### PR DESCRIPTION
The PR removes `Python 3.8` as a `Programming Language` from the meta data, because `dpnp` package for python 3.8 will no longer be provided.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
