### PR TITLE
Bump conda-build version to 24.5.1

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -12,7 +12,7 @@ env:
   PACKAGE_NAME: dpnp
   MODULE_NAME: dpnp
   CHANNELS: '-c dppy/label/dev -c intel -c conda-forge --override-channels'
-  CONDA_BUILD_VERSION: '24.5.0'
+  CONDA_BUILD_VERSION: '24.5.1'
   CONDA_INDEX_VERSION: '0.4.0'
   TEST_ENV_NAME: 'test'
   TEST_SCOPE: >-


### PR DESCRIPTION
The PR updates `conda-build` version from `24.5.0` to `24.5.1` in public CI.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
