### PR TITLE
Limit rerun of the tests in GitHub action by 2 attempts

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -14,7 +14,7 @@ env:
   CHANNELS: '-c dppy/label/dev -c intel -c conda-forge --override-channels'
   CONDA_BUILD_VERSION: '24.5.1'
   CONDA_INDEX_VERSION: '0.4.0'
-  RUN_TESTS_MAX_ATTEMPTS: 5
+  RUN_TESTS_MAX_ATTEMPTS: 2
   TEST_ENV_NAME: 'test'
   TEST_SCOPE: >-
       test_absolute.py

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -14,6 +14,7 @@ env:
   CHANNELS: '-c dppy/label/dev -c intel -c conda-forge --override-channels'
   CONDA_BUILD_VERSION: '24.5.1'
   CONDA_INDEX_VERSION: '0.4.0'
+  RUN_TESTS_MAX_ATTEMPTS: 5
   TEST_ENV_NAME: 'test'
   TEST_SCOPE: >-
       test_absolute.py
@@ -264,7 +265,7 @@ jobs:
         with:
           shell: bash
           timeout_minutes: 10
-          max_attempts: 5
+          max_attempts: ${{ env.RUN_TESTS_MAX_ATTEMPTS }}
           retry_on: any
           command: |
             . $CONDA/etc/profile.d/conda.sh
@@ -420,7 +421,7 @@ jobs:
         with:
           shell: cmd
           timeout_minutes: 15
-          max_attempts: 5
+          max_attempts: ${{ env.RUN_TESTS_MAX_ATTEMPTS }}
           retry_on: any
           command: >-
             mamba activate ${{ env.TEST_ENV_NAME }}


### PR DESCRIPTION
The tests are much more stable now in public CI (through GitHub actions), so the PR proposes to limit rerun attempts by only 2 number.
Also it would help to reduce the action execution time in case of real issue, when some test is failed due to an issue in dpnp, which must be addressed before merging any PR.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
