### PR TITLE
update clang-format version

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - name: Set up clang-format
         run: |
-          sudo apt-get install -y clang-format-12
+          sudo apt-get install -y clang-format-15
           sudo unlink /usr/bin/clang-format
-          sudo ln -s /usr/bin/clang-format-12 /usr/bin/clang-format
+          sudo ln -s /usr/bin/clang-format-15 /usr/bin/clang-format
           clang-format --version
 
       - name: Set up pip packages

--- a/dpnp/backend/extensions/blas/gemm_batch.cpp
+++ b/dpnp/backend/extensions/blas/gemm_batch.cpp
@@ -358,7 +358,8 @@ struct GemmBatchContigFactory
     fnT get()
     {
         if constexpr (types::GemmBatchTypePairSupportFactory<Tab,
-                                                             Tc>::is_defined) {
+                                                             Tc>::is_defined)
+        {
             return gemm_batch_impl<Tab, Tc>;
         }
         else {

--- a/dpnp/backend/extensions/blas/gemv.cpp
+++ b/dpnp/backend/extensions/blas/gemv.cpp
@@ -223,7 +223,8 @@ std::pair<sycl::event, sycl::event>
     const int vectorY_typenum = vectorY.get_typenum();
 
     if (matrixA_typenum != vectorX_typenum ||
-        matrixA_typenum != vectorY_typenum) {
+        matrixA_typenum != vectorY_typenum)
+    {
         throw py::value_error("Given arrays must be of the same type.");
     }
 

--- a/dpnp/backend/extensions/elementwise_functions/elementwise_functions.hpp
+++ b/dpnp/backend/extensions/elementwise_functions/elementwise_functions.hpp
@@ -178,7 +178,8 @@ std::pair<sycl::event, sycl::event>
                              simplified_dst_strides, src_offset, dst_offset);
 
     if (nd == 1 && simplified_src_strides[0] == 1 &&
-        simplified_dst_strides[0] == 1) {
+        simplified_dst_strides[0] == 1)
+    {
         // Special case of contiguous data
         auto contig_fn = contig_dispatch_vector[src_typeid];
 

--- a/dpnp/backend/extensions/elementwise_functions/simplify_iteration_space.cpp
+++ b/dpnp/backend/extensions/elementwise_functions/simplify_iteration_space.cpp
@@ -181,7 +181,8 @@ void simplify_iteration_space_3(
         simplified_dst_strides.reserve(nd);
 
         if ((src1_strides[0] < 0) && (src2_strides[0] < 0) &&
-            (dst_strides[0] < 0)) {
+            (dst_strides[0] < 0))
+        {
             simplified_src1_strides.push_back(-src1_strides[0]);
             simplified_src2_strides.push_back(-src2_strides[0]);
             simplified_dst_strides.push_back(-dst_strides[0]);

--- a/dpnp/backend/extensions/lapack/linalg_exceptions.hpp
+++ b/dpnp/backend/extensions/lapack/linalg_exceptions.hpp
@@ -40,10 +40,7 @@ class LinAlgError : public std::exception
 public:
     explicit LinAlgError(const char *message) : msg_(message) {}
 
-    const char *what() const noexcept override
-    {
-        return msg_.c_str();
-    }
+    const char *what() const noexcept override { return msg_.c_str(); }
 
 private:
     std::string msg_;

--- a/dpnp/backend/extensions/sycl_ext/dispatcher_utils.hpp
+++ b/dpnp/backend/extensions/sycl_ext/dispatcher_utils.hpp
@@ -330,10 +330,7 @@ struct elements_count
 template <typename T>
 struct elements_count<std::tuple<T>>
 {
-    static constexpr int count()
-    {
-        return std::tuple_size_v<T>;
-    }
+    static constexpr int count() { return std::tuple_size_v<T>; }
 };
 
 template <typename T, typename... Axis>
@@ -354,10 +351,7 @@ struct get_linear_id
 template <typename T>
 struct get_linear_id<std::tuple<T>>
 {
-    static int get(const int *data)
-    {
-        return data[0];
-    }
+    static int get(const int *data) { return data[0]; }
 };
 
 template <typename T, typename... Axis>

--- a/dpnp/backend/extensions/ufunc/elementwise_functions/common.cpp
+++ b/dpnp/backend/extensions/ufunc/elementwise_functions/common.cpp
@@ -34,8 +34,5 @@ namespace dpnp::extensions::ufunc
 /**
  * @brief Add elementwise functions to Python module
  */
-void init_elementwise_functions(py::module_ m)
-{
-    init_fabs(m);
-}
+void init_elementwise_functions(py::module_ m) { init_fabs(m); }
 } // namespace dpnp::extensions::ufunc

--- a/dpnp/backend/extensions/ufunc/elementwise_functions/populate.hpp
+++ b/dpnp/backend/extensions/ufunc/elementwise_functions/populate.hpp
@@ -49,7 +49,8 @@
         fnT get()                                                              \
         {                                                                      \
             if constexpr (std::is_same_v<typename OutputType<T>::value_type,   \
-                                         void>) {                              \
+                                         void>)                                \
+            {                                                                  \
                 fnT fn = nullptr;                                              \
                 return fn;                                                     \
             }                                                                  \
@@ -93,7 +94,8 @@
         fnT get()                                                              \
         {                                                                      \
             if constexpr (std::is_same_v<typename OutputType<T>::value_type,   \
-                                         void>) {                              \
+                                         void>)                                \
+            {                                                                  \
                 fnT fn = nullptr;                                              \
                 return fn;                                                     \
             }                                                                  \

--- a/dpnp/backend/extensions/ufunc/ufunc_py.cpp
+++ b/dpnp/backend/extensions/ufunc/ufunc_py.cpp
@@ -30,7 +30,4 @@
 namespace py = pybind11;
 namespace ufunc_ns = dpnp::extensions::ufunc;
 
-PYBIND11_MODULE(_ufunc_impl, m)
-{
-    ufunc_ns::init_elementwise_functions(m);
-}
+PYBIND11_MODULE(_ufunc_impl, m) { ufunc_ns::init_elementwise_functions(m); }

--- a/dpnp/backend/extensions/vm/common.hpp
+++ b/dpnp/backend/extensions/vm/common.hpp
@@ -255,7 +255,8 @@ bool need_to_call_binary_ufunc(sycl::queue &exec_q,
         fnT get()                                                              \
         {                                                                      \
             if constexpr (std::is_same_v<typename OutputType<T>::value_type,   \
-                                         void>) {                              \
+                                         void>)                                \
+            {                                                                  \
                 return nullptr;                                                \
             }                                                                  \
             else {                                                             \

--- a/dpnp/backend/kernels/dpnp_krnl_bitwise.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_bitwise.cpp
@@ -101,7 +101,8 @@ DPCTLSyclEventRef dpnp_invert_c(DPCTLSyclQueueRef q_ref,
         }
         else {
             for (size_t k = start + sg.get_local_id()[0]; k < size;
-                 k += max_sg_size) {
+                 k += max_sg_size)
+            {
                 if constexpr (std::is_same_v<_DataType, bool>) {
                     result[k] = !(input_data[k]);
                 }

--- a/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
@@ -1253,7 +1253,8 @@ static void func_map_init_elemwise_1arg_1type(func_map_t &fmap)
                     }                                                          \
                     else {                                                     \
                         for (size_t k = start + sg.get_local_id()[0];          \
-                             k < result_size; k += max_sg_size) {              \
+                             k < result_size; k += max_sg_size)                \
+                        {                                                      \
                             const _DataType_output input1_elem =               \
                                 input1_data[k];                                \
                             const _DataType_output input2_elem =               \

--- a/dpnp/backend/kernels/dpnp_krnl_fft.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_fft.cpp
@@ -123,7 +123,8 @@ static void dpnp_fft_fft_sycl_c(DPCTLSyclQueueRef q_ref,
 
             if (it < input_shape[axis]) {
                 if constexpr (std::is_same<_DataType_input,
-                                           std::complex<double>>::value) {
+                                           std::complex<double>>::value)
+                {
                     const _DataType_input *cmplx_ptr = array_1 + input_it;
                     const double *dbl_ptr =
                         reinterpret_cast<const double *>(cmplx_ptr);
@@ -131,7 +132,8 @@ static void dpnp_fft_fft_sycl_c(DPCTLSyclQueueRef q_ref,
                     in_imag = *(dbl_ptr + 1);
                 }
                 else if constexpr (std::is_same<_DataType_input,
-                                                std::complex<float>>::value) {
+                                                std::complex<float>>::value)
+                {
                     const _DataType_input *cmplx_ptr = array_1 + input_it;
                     const float *dbl_ptr =
                         reinterpret_cast<const float *>(cmplx_ptr);

--- a/dpnp/backend/kernels/dpnp_krnl_logic.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_logic.cpp
@@ -187,17 +187,20 @@ static sycl::event dpnp_allclose(sycl::queue &q,
                     continue;
                 }
                 else if (array1[i] ==
-                         -std::numeric_limits<_DataType1>::infinity()) {
+                         -std::numeric_limits<_DataType1>::infinity())
+                {
                     partial &= (array1[i] == array2[i]);
                     continue;
                 }
                 else if (array2[i] ==
-                         std::numeric_limits<_DataType2>::infinity()) {
+                         std::numeric_limits<_DataType2>::infinity())
+                {
                     partial &= (array1[i] == array2[i]);
                     continue;
                 }
                 else if (array2[i] ==
-                         -std::numeric_limits<_DataType2>::infinity()) {
+                         -std::numeric_limits<_DataType2>::infinity())
+                {
                     partial &= (array1[i] == array2[i]);
                     continue;
                 }

--- a/dpnp/backend/kernels/dpnp_krnl_mathematical.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_mathematical.cpp
@@ -190,7 +190,8 @@ DPCTLSyclEventRef
             }
             else {
                 for (size_t k = start + sg.get_local_id()[0]; k < size;
-                     k += max_sg_size) {
+                     k += max_sg_size)
+                {
                     result[k] = std::abs(array1[k]);
                 }
             }

--- a/dpnp/backend/kernels/dpnp_krnl_sorting.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_sorting.cpp
@@ -33,10 +33,7 @@
 template <typename _DataType, typename _idx_DataType>
 struct _argsort_less
 {
-    _argsort_less(_DataType *data_ptr)
-    {
-        _data_ptr = data_ptr;
-    }
+    _argsort_less(_DataType *data_ptr) { _data_ptr = data_ptr; }
 
     inline bool operator()(const _idx_DataType &idx1, const _idx_DataType &idx2)
     {
@@ -136,7 +133,8 @@ DPCTLSyclEventRef dpnp_partition_c(DPCTLSyclQueueRef q_ref,
     DPCTLSyclEventRef event_ref = nullptr;
 
     if ((array1_in == nullptr) || (array2_in == nullptr) ||
-        (result1 == nullptr)) {
+        (result1 == nullptr))
+    {
         return event_ref;
     }
 

--- a/dpnp/backend/kernels/dpnp_krnl_statistics.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_statistics.cpp
@@ -968,7 +968,8 @@ DPCTLSyclEventRef dpnp_nanvar_c(DPCTLSyclQueueRef q_ref,
     DPCTLSyclEventRef event_ref = nullptr;
 
     if ((array1_in == nullptr) || (mask_arr1 == nullptr) ||
-        (result1 == nullptr)) {
+        (result1 == nullptr))
+    {
         return event_ref;
     }
 

--- a/dpnp/backend/kernels/elementwise_functions/fabs.hpp
+++ b/dpnp/backend/kernels/elementwise_functions/fabs.hpp
@@ -41,9 +41,6 @@ struct FabsFunctor
     // do both argT and resT support sugroup store/load operation
     using supports_sg_loadstore = typename std::true_type;
 
-    resT operator()(const argT &x) const
-    {
-        return sycl::fabs(x);
-    }
+    resT operator()(const argT &x) const { return sycl::fabs(x); }
 };
 } // namespace dpnp::kernels::fabs

--- a/dpnp/backend/src/dpnp_fptr.hpp
+++ b/dpnp/backend/src/dpnp_fptr.hpp
@@ -257,7 +257,8 @@ public:
                 ret = (b.imag() != b.imag() && a.imag() == a.imag());
             }
             else if (a.real() == b.real() ||
-                     (a.real() != a.real() && b.real() != b.real())) {
+                     (a.real() != a.real() && b.real() != b.real()))
+            {
                 ret = (a.imag() < b.imag() ||
                        (b.imag() != b.imag() && a.imag() == a.imag()));
             }

--- a/dpnp/backend/src/dpnp_iface_fptr.cpp
+++ b/dpnp/backend/src/dpnp_iface_fptr.cpp
@@ -108,7 +108,8 @@ void *get_backend_function_name(const char *func_name, const char *type_name)
     /** of coerce it will be converted into std::map later */
     if (!strncmp(func_name, supported_func_name, strlen(supported_func_name))) {
         if (!strncmp(type_name, supported_type1_name,
-                     strlen(supported_type1_name))) {
+                     strlen(supported_type1_name)))
+        {
             return reinterpret_cast<void *>(
                 dpnp_dot_default_c<double, double, double>);
         }

--- a/dpnp/backend/src/dpnp_iterator.hpp
+++ b/dpnp/backend/src/dpnp_iterator.hpp
@@ -69,15 +69,9 @@ public:
 
     DPNP_USM_iterator() = delete;
 
-    inline reference operator*() const
-    {
-        return *ptr();
-    }
+    inline reference operator*() const { return *ptr(); }
 
-    inline pointer operator->() const
-    {
-        return ptr();
-    }
+    inline pointer operator->() const { return ptr(); }
 
     /// prefix increment
     inline DPNP_USM_iterator &operator++()
@@ -116,10 +110,7 @@ public:
     // TODO need more operators
 
     // Random access iterator requirements
-    inline reference operator[](size_type __n) const
-    {
-        return *ptr(__n);
-    }
+    inline reference operator[](size_type __n) const { return *ptr(__n); }
 
     inline difference_type operator-(const DPNP_USM_iterator &__rhs) const
     {
@@ -151,10 +142,7 @@ public:
     }
 
 private:
-    inline pointer ptr() const
-    {
-        return ptr(iter_id);
-    }
+    inline pointer ptr() const { return ptr(iter_id); }
 
     inline pointer ptr(size_type iteration_id) const
     {
@@ -163,7 +151,8 @@ private:
         if (iteration_shape_size > 0) {
             long reminder = iteration_id;
             for (size_t it = 0; it < static_cast<size_t>(iteration_shape_size);
-                 ++it) {
+                 ++it)
+            {
                 const size_type axis_val = iteration_shape_strides[it];
                 size_type xyz_id = reminder / axis_val;
                 offset += (xyz_id * axes_shape_strides[it]);
@@ -275,16 +264,10 @@ public:
 
     DPNPC_id() = delete;
 
-    ~DPNPC_id()
-    {
-        free_memory();
-    }
+    ~DPNPC_id() { free_memory(); }
 
     /// this function return number of elements in output
-    inline size_type get_output_size() const
-    {
-        return output_size;
-    }
+    inline size_type get_output_size() const { return output_size; }
 
     inline void broadcast_to_shape(const size_type *__shape,
                                    const size_type __shape_size)
@@ -371,10 +354,7 @@ public:
      *
      * @param [in]  __axis    Axis in a shape of input array.
      */
-    inline void set_axis(shape_elem_type __axis)
-    {
-        set_axes({__axis});
-    }
+    inline void set_axis(shape_elem_type __axis) { set_axes({__axis}); }
 
     inline void set_axes(const shape_elem_type *__axes, const size_t axes_ndim)
     {
@@ -458,7 +438,8 @@ public:
             axes_shape_strides = reinterpret_cast<size_type *>(
                 dpnp_memory_alloc_c(queue_ref, iteration_shape_size_in_bytes));
             for (size_t i = 0; i < static_cast<size_t>(iteration_shape_size);
-                 ++i) {
+                 ++i)
+            {
                 axes_shape_strides[i] = input_shape_strides[axes[i]];
             }
         }
@@ -603,7 +584,8 @@ private:
                 size_type *broadcast_axes_end =
                     broadcast_axes + broadcast_axes_size;
                 if (std::find(broadcast_axes, broadcast_axes_end, orit) ==
-                    broadcast_axes_end) {
+                    broadcast_axes_end)
+                {
                     const size_type output_xyz_id = get_xyz_id_by_id_inkernel(
                         output_global_id, output_shape_strides,
                         output_shape_size, orit);
@@ -617,10 +599,7 @@ private:
     }
 
     /// this function is designed for SYCL environment execution
-    size_type get_iteration_size() const
-    {
-        return iteration_size;
-    }
+    size_type get_iteration_size() const { return iteration_size; }
 
     void free_axes_memory()
     {

--- a/dpnp/backend/src/dpnp_utils.hpp
+++ b/dpnp/backend/src/dpnp_utils.hpp
@@ -409,7 +409,8 @@ static inline std::vector<shape_elem_type>
 
         if (!__allow_duplicate) {
             if (std::find(result.begin(), result.end(), positive_axis) !=
-                result.end()) { // find axis duplication
+                result.end())
+            { // find axis duplication
                 goto err;
             }
         }

--- a/dpnp/backend/src/dpnpc_memory_adapter.hpp
+++ b/dpnp/backend/src/dpnpc_memory_adapter.hpp
@@ -137,7 +137,8 @@ public:
                 return true;
             }
             else if (target_no_queue &&
-                     src_ptr_type == sycl::usm::alloc::device) {
+                     src_ptr_type == sycl::usm::alloc::device)
+            {
                 return true;
             }
         }

--- a/dpnp/backend/src/queue_sycl.hpp
+++ b/dpnp/backend/src/queue_sycl.hpp
@@ -27,10 +27,10 @@
 #ifndef QUEUE_SYCL_H // Cython compatibility
 #define QUEUE_SYCL_H
 
-//#pragma clang diagnostic push
-//#pragma clang diagnostic ignored "-Wpass-failed"
+// #pragma clang diagnostic push
+// #pragma clang diagnostic ignored "-Wpass-failed"
 #include <sycl/sycl.hpp>
-//#pragma clang diagnostic pop
+// #pragma clang diagnostic pop
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-parameter"

--- a/dpnp/backend/tests/test_random.cpp
+++ b/dpnp/backend/tests/test_random.cpp
@@ -40,10 +40,7 @@
 class RandomTestCase : public ::testing::Test
 {
 public:
-    static void SetUpTestCase()
-    {
-        _get_device_mem();
-    }
+    static void SetUpTestCase() { _get_device_mem(); }
 
     static void TearDownTestCase()
     {


### PR DESCRIPTION
The PR proposes to update clang-format version.

There is a hard dependency to run the check with `clang-format-15`, since [it is the latest version available for Ubuntu 22.04](https://packages.ubuntu.com/search?keywords=clang-format#:~:text=Package%20clang%2Dformat%2D15) ([at the moment, `ubuntu_latest` is Ubuntu 22.04](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources:~:text=Standard%20GitHub%2Dhosted%20runners%20for%20Public%20repositories)).
Need to note that different versions of clang-format might be incompatible with each other and so format C++ code differently.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
