### PR TITLE
Support `out` parameter for `dpnp.all/any()`

### DIFF
--- a/dpnp/dpnp_iface_logic.py
+++ b/dpnp/dpnp_iface_logic.py
@@ -128,7 +128,7 @@ def all(a, /, axis=None, out=None, keepdims=False, *, where=True):
     Notes
     -----
     Not a Number (NaN), positive infinity and negative infinity
-    evaluate to `True` because these are not equal to zero.
+    evaluate to ``True`` because these are not equal to zero.
 
     Examples
     --------
@@ -156,11 +156,10 @@ def all(a, /, axis=None, out=None, keepdims=False, *, where=True):
     >>> z is o
     True
     >>> id(z), id(o) # identity of `z` and `o`
-    (139884456208480, 139884456208480, array(True)) # may vary
+    (139884456208480, 139884456208480) # may vary
 
     """
 
-    dpnp.check_supported_arrays_type(a)
     dpnp.check_limitations(where=where)
 
     dpt_array = dpnp.get_usm_ndarray(a)
@@ -319,7 +318,7 @@ def any(a, /, axis=None, out=None, keepdims=False, *, where=True):
     Notes
     -----
     Not a Number (NaN), positive infinity and negative infinity evaluate
-    to `True` because these are not equal to zero.
+    to ``True`` because these are not equal to zero.
 
     Examples
     --------
@@ -351,7 +350,6 @@ def any(a, /, axis=None, out=None, keepdims=False, *, where=True):
 
     """
 
-    dpnp.check_supported_arrays_type(a)
     dpnp.check_limitations(where=where)
 
     dpt_array = dpnp.get_usm_ndarray(a)

--- a/dpnp/dpnp_iface_logic.py
+++ b/dpnp/dpnp_iface_logic.py
@@ -46,7 +46,7 @@ it contains:
 
 
 import dpctl.tensor as dpt
-import dpctl.tensor._tensor_elementwise_impl as ti
+import dpctl.tensor._tensor_elementwise_impl as tei
 import numpy
 
 import dpnp
@@ -76,25 +76,48 @@ __all__ = [
 ]
 
 
-def all(x, /, axis=None, out=None, keepdims=False, *, where=True):
+def all(a, /, axis=None, out=None, keepdims=False, *, where=True):
     """
     Test whether all array elements along a given axis evaluate to True.
 
     For full documentation refer to :obj:`numpy.all`.
 
+    Parameters
+    ----------
+    a : {dpnp.ndarray, usm_ndarray}
+        Input array.
+    axis : {None, int, tuple of ints}, optional
+        Axis or axes along which a logical AND reduction is performed.
+        The default is to perform a logical AND over all the dimensions
+        of the input array.`axis` may be negative, in which case it counts
+        from the last to the first axis.
+        Default: ``None``.
+    out : {None, dpnp.ndarray, usm_ndarray}, optional
+        Alternative output array in which to place the result. It must have
+        the same shape as the expected output but the type (of the returned
+        values) will be cast if necessary.
+        Default: ``None``.
+    keepdims : bool, optional
+        If ``True``, the reduced axes (dimensions) are included in the result
+        as singleton dimensions, so that the returned array remains
+        compatible with the input array according to Array Broadcasting
+        rules. Otherwise, if ``False``, the reduced axes are not included in
+        the returned array.
+        Default: ``False``.
+
     Returns
     -------
     out : dpnp.ndarray
         An array with a data type of `bool`
-        containing the results of the logical AND reduction.
+        containing the results of the logical AND reduction is returned
+        unless `out` is specified. Otherwise, a reference to `out` is returned.
+        The result has the same shape as `a` if `axis` is not ``None``
+        or `a` is a 0-d array.
 
     Limitations
     -----------
-    Parameters `x` is supported either as :class:`dpnp.ndarray`
-    or :class:`dpctl.tensor.usm_ndarray`.
-    Parameters `out` and `where` are supported with default value.
-    Input array data types are limited by supported DPNP :ref:`Data types`.
-    Otherwise the function will be executed sequentially on CPU.
+    Parameters `where` is only supported with its default value.
+    Otherwise ``NotImplementedError`` exception will be raised.
 
     See Also
     --------
@@ -125,22 +148,28 @@ def all(x, /, axis=None, out=None, keepdims=False, *, where=True):
     >>> np.all(x3)
     array(True)
 
+    >>> o = np.array(False)
+    >>> z = np.all(x2, out=o)
+    >>> z, o
+    (array(True), array(True))
+    >>> # Check now that `z` is a reference to `o`
+    >>> z is o
+    True
+    >>> id(z), id(o) # identity of `z` and `o`
+    (139884456208480, 139884456208480, array(True)) # may vary
+
     """
 
-    if dpnp.is_supported_array_type(x):
-        if out is not None:
-            pass
-        elif where is not True:
-            pass
-        else:
-            dpt_array = dpnp.get_usm_ndarray(x)
-            return dpnp_array._create_from_usm_ndarray(
-                dpt.all(dpt_array, axis=axis, keepdims=keepdims)
-            )
+    dpnp.check_supported_arrays_type(a)
+    dpnp.check_limitations(where=where)
 
-    return call_origin(
-        numpy.all, x, axis=axis, out=out, keepdims=keepdims, where=where
+    dpt_array = dpnp.get_usm_ndarray(a)
+    result = dpnp_array._create_from_usm_ndarray(
+        dpt.all(dpt_array, axis=axis, keepdims=keepdims)
     )
+    # TODO: temporary solution until dpt.all supports out parameter
+    result = dpnp.get_result_array(result, out)
+    return result
 
 
 def allclose(a, b, rtol=1.0e-5, atol=1.0e-8, **kwargs):
@@ -238,25 +267,48 @@ def allclose(a, b, rtol=1.0e-5, atol=1.0e-8, **kwargs):
     return call_origin(numpy.allclose, a, b, rtol=rtol, atol=atol, **kwargs)
 
 
-def any(x, /, axis=None, out=None, keepdims=False, *, where=True):
+def any(a, /, axis=None, out=None, keepdims=False, *, where=True):
     """
     Test whether any array element along a given axis evaluates to True.
 
     For full documentation refer to :obj:`numpy.any`.
 
+    Parameters
+    ----------
+    a : {dpnp.ndarray, usm_ndarray}
+        Input array.
+    axis : {None, int, tuple of ints}, optional
+        Axis or axes along which a logical OR reduction is performed.
+        The default is to perform a logical OR over all the dimensions
+        of the input array.`axis` may be negative, in which case it counts
+        from the last to the first axis.
+        Default: ``None``.
+    out : {None, dpnp.ndarray, usm_ndarray}, optional
+        Alternative output array in which to place the result. It must have
+        the same shape as the expected output but the type (of the returned
+        values) will be cast if necessary.
+        Default: ``None``.
+    keepdims : bool, optional
+        If ``True``, the reduced axes (dimensions) are included in the result
+        as singleton dimensions, so that the returned array remains
+        compatible with the input array according to Array Broadcasting
+        rules. Otherwise, if ``False``, the reduced axes are not included in
+        the returned array.
+        Default: ``False``.
+
     Returns
     -------
     out : dpnp.ndarray
         An array with a data type of `bool`
-        containing the results of the logical OR reduction.
+        containing the results of the logical OR reduction is returned
+        unless `out` is specified. Otherwise, a reference to `out` is returned.
+        The result has the same shape as `a` if `axis` is not ``None``
+        or `a` is a 0-d array.
 
     Limitations
     -----------
-    Parameters `x` is supported either as :class:`dpnp.ndarray`
-    or :class:`dpctl.tensor.usm_ndarray`.
-    Parameters `out` and `where` are supported with default value.
-    Input array data types are limited by supported DPNP :ref:`Data types`.
-    Otherwise the function will be executed sequentially on CPU.
+    Parameters `where` is only supported with its default value.
+    Otherwise ``NotImplementedError`` exception will be raised.
 
     See Also
     --------
@@ -279,30 +331,36 @@ def any(x, /, axis=None, out=None, keepdims=False, *, where=True):
     >>> np.any(x, axis=0)
     array([ True,  True])
 
-    >>> x2 = np.array([0, 0, 0])
+    >>> x2 = np.array([-1, 0, 5])
     >>> np.any(x2)
-    array(False)
+    array(True)
 
     >>> x3 = np.array([1.0, np.nan])
     >>> np.any(x3)
     array(True)
 
+    >>> o = np.array(False)
+    >>> z = np.any(x2, out=o)
+    >>> z, o
+    (array(True), array(True))
+    >>> # Check now that `z` is a reference to `o`
+    >>> z is o
+    True
+    >>> id(z), id(o) # identity of `z` and `o`
+    >>> (140053638309840, 140053638309840) # may vary
+
     """
 
-    if dpnp.is_supported_array_type(x):
-        if out is not None:
-            pass
-        elif where is not True:
-            pass
-        else:
-            dpt_array = dpnp.get_usm_ndarray(x)
-            return dpnp_array._create_from_usm_ndarray(
-                dpt.any(dpt_array, axis=axis, keepdims=keepdims)
-            )
+    dpnp.check_supported_arrays_type(a)
+    dpnp.check_limitations(where=where)
 
-    return call_origin(
-        numpy.any, x, axis=axis, out=out, keepdims=keepdims, where=where
+    dpt_array = dpnp.get_usm_ndarray(a)
+    result = dpnp_array._create_from_usm_ndarray(
+        dpt.any(dpt_array, axis=axis, keepdims=keepdims)
     )
+    # TODO: temporary solution until dpt.any supports out parameter
+    result = dpnp.get_result_array(result, out)
+    return result
 
 
 _EQUAL_DOCSTRING = """
@@ -368,8 +426,8 @@ array([ True,  True, False])
 
 equal = DPNPBinaryFunc(
     "equal",
-    ti._equal_result_type,
-    ti._equal,
+    tei._equal_result_type,
+    tei._equal,
     _EQUAL_DOCSTRING,
 )
 
@@ -431,8 +489,8 @@ array([ True, False])
 
 greater = DPNPBinaryFunc(
     "greater",
-    ti._greater_result_type,
-    ti._greater,
+    tei._greater_result_type,
+    tei._greater,
     _GREATER_DOCSTRING,
 )
 
@@ -495,8 +553,8 @@ array([ True,  True, False])
 
 greater_equal = DPNPBinaryFunc(
     "greater",
-    ti._greater_equal_result_type,
-    ti._greater_equal,
+    tei._greater_equal_result_type,
+    tei._greater_equal,
     _GREATER_EQUAL_DOCSTRING,
 )
 
@@ -597,8 +655,8 @@ array([False,  True, False])
 
 isfinite = DPNPUnaryFunc(
     "isfinite",
-    ti._isfinite_result_type,
-    ti._isfinite,
+    tei._isfinite_result_type,
+    tei._isfinite,
     _ISFINITE_DOCSTRING,
 )
 
@@ -650,8 +708,8 @@ array([ True, False,  True])
 
 isinf = DPNPUnaryFunc(
     "isinf",
-    ti._isinf_result_type,
-    ti._isinf,
+    tei._isinf_result_type,
+    tei._isinf,
     _ISINF_DOCSTRING,
 )
 
@@ -704,8 +762,8 @@ array([False, False,  True])
 
 isnan = DPNPUnaryFunc(
     "isnan",
-    ti._isnan_result_type,
-    ti._isnan,
+    tei._isnan_result_type,
+    tei._isnan,
     _ISNAN_DOCSTRING,
 )
 
@@ -767,8 +825,8 @@ array([ True, False])
 
 less = DPNPBinaryFunc(
     "less",
-    ti._less_result_type,
-    ti._less,
+    tei._less_result_type,
+    tei._less,
     _LESS_DOCSTRING,
 )
 
@@ -830,8 +888,8 @@ array([False,  True,  True])
 
 less_equal = DPNPBinaryFunc(
     "less_equal",
-    ti._less_equal_result_type,
-    ti._less_equal,
+    tei._less_equal_result_type,
+    tei._less_equal,
     _LESS_EQUAL_DOCSTRING,
 )
 
@@ -895,8 +953,8 @@ array([False, False])
 
 logical_and = DPNPBinaryFunc(
     "logical_and",
-    ti._logical_and_result_type,
-    ti._logical_and,
+    tei._logical_and_result_type,
+    tei._logical_and,
     _LOGICAL_AND_DOCSTRING,
 )
 
@@ -947,8 +1005,8 @@ array([False, False, False,  True,  True])
 
 logical_not = DPNPUnaryFunc(
     "logical_not",
-    ti._logical_not_result_type,
-    ti._logical_not,
+    tei._logical_not_result_type,
+    tei._logical_not,
     _LOGICAL_NOT_DOCSTRING,
 )
 
@@ -1012,8 +1070,8 @@ array([ True, False])
 
 logical_or = DPNPBinaryFunc(
     "logical_or",
-    ti._logical_or_result_type,
-    ti._logical_or,
+    tei._logical_or_result_type,
+    tei._logical_or,
     _LOGICAL_OR_DOCSTRING,
 )
 
@@ -1075,8 +1133,8 @@ array([[ True, False],
 
 logical_xor = DPNPBinaryFunc(
     "logical_xor",
-    ti._logical_xor_result_type,
-    ti._logical_xor,
+    tei._logical_xor_result_type,
+    tei._logical_xor,
     _LOGICAL_XOR_DOCSTRING,
 )
 
@@ -1138,7 +1196,7 @@ array([False,  True])
 
 not_equal = DPNPBinaryFunc(
     "not_equal",
-    ti._not_equal_result_type,
-    ti._not_equal,
+    tei._not_equal_result_type,
+    tei._not_equal,
     _NOT_EQUAL_DOCSTRING,
 )

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1,47 +1,85 @@
 import numpy
 import pytest
-from numpy.testing import assert_allclose, assert_equal
+from numpy.testing import assert_allclose, assert_equal, assert_raises
 
 import dpnp
 
 from .helper import (
     get_all_dtypes,
     get_float_complex_dtypes,
-    has_support_aspect64,
 )
 
 
-@pytest.mark.parametrize("type", get_all_dtypes())
-@pytest.mark.parametrize(
-    "shape",
-    [(0,), (4,), (2, 3), (2, 2, 2)],
-    ids=["(0,)", "(4,)", "(2,3)", "(2,2,2)"],
-)
-def test_all(type, shape):
-    size = 1
-    for i in range(len(shape)):
-        size *= shape[i]
+class TestAllAny:
+    @pytest.mark.parametrize("func", ["all", "any"])
+    @pytest.mark.parametrize("dtype", get_all_dtypes())
+    @pytest.mark.parametrize("axis", [None, 0, 1, (0, 1)])
+    @pytest.mark.parametrize("keepdims", [True, False])
+    def test_all_any(self, func, dtype, axis, keepdims):
+        dp_array = dpnp.array([[0, 1, 2], [3, 4, 0]], dtype=dtype)
+        np_array = dpnp.asnumpy(dp_array)
 
-    for i in range(2**size):
-        t = i
+        expected = getattr(numpy, func)(np_array, axis=axis, keepdims=keepdims)
+        result = getattr(dpnp, func)(dp_array, axis=axis, keepdims=keepdims)
+        assert_allclose(result, expected)
 
-        a = numpy.empty(size, dtype=type)
+    @pytest.mark.parametrize("func", ["all", "any"])
+    @pytest.mark.parametrize("a_dtype", get_all_dtypes())
+    @pytest.mark.parametrize("out_dtype", get_all_dtypes())
+    def test_all_any_out(self, func, a_dtype, out_dtype):
+        dp_array = dpnp.array([[0, 1, 2], [3, 4, 0]], dtype=a_dtype)
+        np_array = dpnp.asnumpy(dp_array)
 
-        for j in range(size):
-            a[j] = 0 if t % 2 == 0 else j + 1
-            t = t >> 1
+        expected = getattr(numpy, func)(np_array)
+        out = dpnp.empty(expected.shape, dtype=out_dtype)
+        result = getattr(dpnp, func)(dp_array, out=out)
+        assert out is result
+        assert_allclose(result, expected)
 
-        a = a.reshape(shape)
+    @pytest.mark.parametrize("func", ["all", "any"])
+    @pytest.mark.parametrize("axis", [None, 0, 1, (0, 1)])
+    @pytest.mark.parametrize("shape", [(2, 3), (2, 0), (0, 3)])
+    def test_all_any_empty(self, func, axis, shape):
+        dp_array = dpnp.empty(shape, dtype=dpnp.int64)
+        np_array = dpnp.asnumpy(dp_array)
 
-        ia = dpnp.array(a)
+        result = getattr(dpnp, func)(dp_array, axis=axis)
+        expected = getattr(numpy, func)(np_array, axis=axis)
+        assert_allclose(result, expected)
 
-        np_res = numpy.all(a)
-        dpnp_res = dpnp.all(ia)
-        assert_allclose(dpnp_res, np_res)
+    @pytest.mark.parametrize("func", ["all", "any"])
+    def test_all_any_scalar(self, func):
+        dp_array = dpnp.array(0)
+        np_array = dpnp.asnumpy(dp_array)
 
-        np_res = a.all()
-        dpnp_res = ia.all()
-        assert_allclose(dpnp_res, np_res)
+        result = getattr(dp_array, func)()
+        expected = getattr(np_array, func)()
+        assert_allclose(result, expected)
+
+    @pytest.mark.parametrize("func", ["all", "any"])
+    @pytest.mark.parametrize("axis", [None, 0, 1])
+    @pytest.mark.parametrize("keepdims", [True, False])
+    def test_all_any_nan_inf(self, func, axis, keepdims):
+        dp_array = dpnp.array([[dpnp.nan, 1, 2], [dpnp.inf, -dpnp.inf, 0]])
+        np_array = dpnp.asnumpy(dp_array)
+
+        expected = getattr(numpy, func)(np_array, axis=axis, keepdims=keepdims)
+        result = getattr(dpnp, func)(dp_array, axis=axis, keepdims=keepdims)
+        assert_allclose(result, expected)
+
+    @pytest.mark.parametrize("func", ["all", "any"])
+    def test_all_any_error(self, func):
+        def check_raises(func_name, exception, *args, **kwargs):
+            assert_raises(
+                exception, lambda: getattr(dpnp, func_name)(*args, **kwargs)
+            )
+
+        a = dpnp.arange(5)
+        # unsupported where parameter
+        check_raises(func, NotImplementedError, a, where=False)
+        # unsupported type
+        check_raises(func, TypeError, dpnp.asnumpy(a))
+        check_raises(func, TypeError, [0, 1, 2, 3])
 
 
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True))

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -394,6 +394,8 @@ def test_meshgrid(device_x, device_y):
 @pytest.mark.parametrize(
     "func,data",
     [
+        pytest.param("all", [-1.0, 0.0, 1.0]),
+        pytest.param("any", [-1.0, 0.0, 1.0]),
         pytest.param("average", [1.0, 2.0, 4.0, 7.0]),
         pytest.param("abs", [-1.2, 1.2]),
         pytest.param("angle", [[1.0 + 1.0j, 2.0 + 3.0j]]),

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -510,6 +510,8 @@ def test_norm(usm_type, ord, axis):
 @pytest.mark.parametrize(
     "func,data",
     [
+        pytest.param("all", [-1.0, 0.0, 1.0]),
+        pytest.param("any", [-1.0, 0.0, 1.0]),
         pytest.param("average", [1.0, 2.0, 4.0, 7.0]),
         pytest.param("abs", [-1.2, 1.2]),
         pytest.param("angle", [[1.0 + 1.0j, 2.0 + 3.0j]]),

--- a/tests/third_party/cupy/logic_tests/test_truth.py
+++ b/tests/third_party/cupy/logic_tests/test_truth.py
@@ -1,7 +1,6 @@
 import unittest
 
 import numpy
-import pytest
 
 from tests.third_party.cupy import testing
 
@@ -47,7 +46,6 @@ class TestAllAny(unittest.TestCase):
         x = xp.asarray(self.x).astype(dtype)
         return getattr(xp, self.f)(x, self.axis, None, self.keepdims)
 
-    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_with_out(self, xp, dtype):
@@ -80,7 +78,6 @@ class TestAllAnyWithNaN(unittest.TestCase):
         x = xp.asarray(self.x).astype(dtype)
         return getattr(xp, self.f)(x, self.axis, None, self.keepdims)
 
-    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     @testing.for_dtypes((*testing._loops._float_dtypes, numpy.bool_))
     @testing.numpy_cupy_array_equal()
     def test_with_out(self, xp, dtype):


### PR DESCRIPTION
This PR suggests adding support `out` parameter for `dpnp.all()` and `dpnp.any()` functions using `dpnp.get_result_array()` as a W/A until `dpctl` adds support `out` parameter.
This also updates docstings and adds new tests to cover the new implementation


- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
