### PR TITLE
Skip test_distr in TestNormal and TestRandN

### DIFF
--- a/tests/test_random_state.py
+++ b/tests/test_random_state.py
@@ -36,8 +36,8 @@ def get_default_floating():
 
 class TestNormal:
     # TODO: Temporary skip due to incorrect results in public CI
-    # (ARM architecture) with the new MKL package 2024.2.0
-    @pytest.mark.skipif(is_cpu_device(), reason="Fails in public CI")
+    # (ARM architecture) with the new MKL package 2024.2.0 (SAT-7080)
+    @pytest.mark.skipif(is_cpu_device(), reason="SAT-7080")
     @pytest.mark.parametrize(
         "dtype",
         [dpnp.float32, dpnp.float64, dpnp.float, None],
@@ -609,8 +609,8 @@ class TestRandInt:
 
 class TestRandN:
     # TODO: Temporary skip due to incorrect results in public CI
-    # (ARM architecture) with the new MKL package 2024.2.0
-    @pytest.mark.skipif(is_cpu_device(), reason="Fails in public CI")
+    # (ARM architecture) with the new MKL package 2024.2.0 (SAT-7080)
+    @pytest.mark.skipif(is_cpu_device(), reason="SAT-7080")
     @pytest.mark.parametrize(
         "usm_type",
         ["host", "device", "shared"],

--- a/tests/test_random_state.py
+++ b/tests/test_random_state.py
@@ -35,6 +35,9 @@ def get_default_floating():
 
 
 class TestNormal:
+    # TODO: Temporary skip due to incorrect results in public CI
+    # (ARM architecture) with the new MKL package 2024.2.0
+    @pytest.mark.skipif(is_cpu_device(), reason="Fails in public CI")
     @pytest.mark.parametrize(
         "dtype",
         [dpnp.float32, dpnp.float64, dpnp.float, None],
@@ -605,6 +608,9 @@ class TestRandInt:
 
 
 class TestRandN:
+    # TODO: Temporary skip due to incorrect results in public CI
+    # (ARM architecture) with the new MKL package 2024.2.0
+    @pytest.mark.skipif(is_cpu_device(), reason="Fails in public CI")
     @pytest.mark.parametrize(
         "usm_type",
         ["host", "device", "shared"],


### PR DESCRIPTION
This PR suggests temporarily skipping `test_distr`  in `TestNormal` and `TestRandN` from `test_random_state.py` due to incorrect results observed in public CI on ARM architecture with MKL package version 2024.2.0 to unlock GitHub Actions while this issue is investigated.



- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
