### PR TITLE
Build conda enviroment for build docs action without `intel` channel

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -160,7 +160,9 @@ jobs:
         working-directory: doc
 
       - name: Build docs
-        run: make html
+        run: |
+          [ -f /opt/intel/oneapi/setvars.sh ] && source /opt/intel/oneapi/setvars.sh
+          make html
         working-directory: doc
 
       - name: Set a project number to current release

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -78,6 +78,7 @@ jobs:
         run: |
           sudo apt-get install intel-oneapi-mkl                \
                                intel-oneapi-mkl-devel          \
+                               intel-oneapi-tbb-devel          \
                                intel-oneapi-libdpstd-devel     \
                                intel-oneapi-compiler-dpcpp-cpp
 

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -148,6 +148,11 @@ jobs:
       - name: Conda list
         run: mamba list
 
+      - name: Activate oneAPI enviroment
+        if: env.INSTALL_ONE_API == 'yes'
+        run: |
+          [ -f /opt/intel/oneapi/setvars.sh ] && source /opt/intel/oneapi/setvars.sh
+
       - name: Build library
         run: python scripts/build_locally.py
 

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -149,17 +149,14 @@ jobs:
         run: mamba list
 
       - name: Build library
-        if: env.INSTALL_ONE_API == 'yes'
         run: |
           [ -f /opt/intel/oneapi/setvars.sh ] && source /opt/intel/oneapi/setvars.sh
           python scripts/build_locally.py
 
-      - name: Build library
-        if: env.INSTALL_ONE_API != 'yes'
-        run: python scripts/build_locally.py
-
       - name: Run a spelling checker for docs
-        run: make spelling
+        run: |
+          [ -f /opt/intel/oneapi/setvars.sh ] && source /opt/intel/oneapi/setvars.sh
+          make spelling
         working-directory: doc
 
       - name: Build docs

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -38,6 +38,9 @@ jobs:
     env:
       python-ver: '3.9'
       CHANNELS: '-c dppy/label/dev -c intel -c conda-forge --override-channels'
+      NO_INTEL_CHANNELS: '-c dppy/label/dev -c conda-forge --override-channels'
+      # Install the latest oneAPI compiler to work around an issue
+      INSTALL_ONE_API: 'yes'
 
     steps:
       - name: Cancel Previous Runs
@@ -75,6 +78,7 @@ jobs:
         run: |
           sudo apt-get install intel-oneapi-mkl                \
                                intel-oneapi-mkl-devel          \
+                               intel-oneapi-libdpstd-devel     \
                                intel-oneapi-compiler-dpcpp-cpp
 
       # required by sphinxcontrib-spelling extension
@@ -124,6 +128,12 @@ jobs:
             pyenchant sphinxcontrib-spelling
 
       - name: Install dpnp dependencies
+        if: env.INSTALL_ONE_API == 'yes'
+        run: |
+          mamba install numpy"<1.24" dpctl">=0.18.0dev0" cmake cython pytest ninja scikit-build ${{ env.NO_INTEL_CHANNELS }}
+
+      - name: Install dpnp dependencies
+        if: env.INSTALL_ONE_API != 'yes'
         run: |
           mamba install numpy"<1.24" dpctl">=0.18.0dev0" mkl-devel-dpcpp onedpl-devel tbb-devel dpcpp_linux-64 \
               cmake cython pytest ninja scikit-build ${{ env.CHANNELS }}

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -148,12 +148,14 @@ jobs:
       - name: Conda list
         run: mamba list
 
-      - name: Activate oneAPI enviroment
+      - name: Build library
         if: env.INSTALL_ONE_API == 'yes'
         run: |
           [ -f /opt/intel/oneapi/setvars.sh ] && source /opt/intel/oneapi/setvars.sh
+          python scripts/build_locally.py
 
       - name: Build library
+        if: env.INSTALL_ONE_API != 'yes'
         run: python scripts/build_locally.py
 
       - name: Run a spelling checker for docs

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -50,6 +50,7 @@ jobs:
         run: |
           sudo apt-get install intel-oneapi-compiler-dpcpp-cpp
           sudo apt-get install intel-oneapi-mkl-devel
+          sudo apt-get install intel-oneapi-libdpstd-devel
           sudo apt-get install intel-oneapi-tbb-devel
 
       - name: Install Lcov
@@ -81,7 +82,7 @@ jobs:
         if: env.INSTALL_ONE_API == 'yes'
         run: |
           mamba install cython llvm cmake">=3.21" scikit-build ninja pytest pytest-cov coverage[toml] \
-              dpctl">=0.18.0dev0" onedpl-devel ${{ env.CHANNELS }}
+              dpctl">=0.18.0dev0" -c dppy/label/dev
 
       - name: Install dpnp dependencies
         if: env.INSTALL_ONE_API != 'yes'

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -22,6 +22,7 @@ jobs:
     env:
       python-ver: '3.11'
       CHANNELS: '-c dppy/label/dev -c intel -c conda-forge --override-channels'
+      NO_INTEL_CHANNELS: '-c dppy/label/dev -c conda-forge --override-channels'
       # Install the latest oneAPI compiler to work around an issue
       INSTALL_ONE_API: 'yes'
 
@@ -82,7 +83,7 @@ jobs:
         if: env.INSTALL_ONE_API == 'yes'
         run: |
           mamba install cython llvm cmake">=3.21" scikit-build ninja pytest pytest-cov coverage[toml] \
-              dpctl">=0.18.0dev0" -c dppy/label/dev -c conda-forge --override-channels
+              dpctl">=0.18.0dev0" ${{ env.NO_INTEL_CHANNELS }}
 
       - name: Install dpnp dependencies
         if: env.INSTALL_ONE_API != 'yes'

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -20,7 +20,7 @@ jobs:
         shell: bash -l {0}
 
     env:
-      python-ver: '3.10'
+      python-ver: '3.11'
       CHANNELS: '-c dppy/label/dev -c intel -c conda-forge --override-channels'
       # Install the latest oneAPI compiler to work around an issue
       INSTALL_ONE_API: 'yes'

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -49,10 +49,11 @@ jobs:
       - name: Install latest Intel OneAPI
         if: env.INSTALL_ONE_API == 'yes'
         run: |
-          sudo apt-get install intel-oneapi-compiler-dpcpp-cpp
-          sudo apt-get install intel-oneapi-mkl-devel
-          sudo apt-get install intel-oneapi-libdpstd-devel
-          sudo apt-get install intel-oneapi-tbb-devel
+          sudo apt-get install intel-oneapi-mkl                \
+                               intel-oneapi-mkl-devel          \
+                               intel-oneapi-tbb-devel          \
+                               intel-oneapi-libdpstd-devel     \
+                               intel-oneapi-compiler-dpcpp-cpp
 
       - name: Install Lcov
         run: |

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -82,7 +82,7 @@ jobs:
         if: env.INSTALL_ONE_API == 'yes'
         run: |
           mamba install cython llvm cmake">=3.21" scikit-build ninja pytest pytest-cov coverage[toml] \
-              dpctl">=0.18.0dev0" -c dppy/label/dev
+              dpctl">=0.18.0dev0" -c dppy/label/dev -c conda-forge --override-channels
 
       - name: Install dpnp dependencies
         if: env.INSTALL_ONE_API != 'yes'

--- a/tests/third_party/cupy/fft_tests/test_fft.py
+++ b/tests/third_party/cupy/fft_tests/test_fft.py
@@ -26,7 +26,7 @@ class TestFft(unittest.TestCase):
         rtol=1e-4,
         atol=1e-7,
         accept_error=ValueError,
-        type_check=has_support_aspect64(),
+        type_check=False,
         contiguous_check=False,
     )
     def test_fft(self, xp, dtype):
@@ -40,7 +40,7 @@ class TestFft(unittest.TestCase):
         rtol=1e-4,
         atol=1e-7,
         accept_error=ValueError,
-        type_check=has_support_aspect64(),
+        type_check=False,
         contiguous_check=False,
     )
     def test_ifft(self, xp, dtype):

--- a/tests/third_party/cupy/fft_tests/test_fft.py
+++ b/tests/third_party/cupy/fft_tests/test_fft.py
@@ -178,7 +178,7 @@ class TestRfft(unittest.TestCase):
     @testing.numpy_cupy_allclose(
         rtol=1e-4,
         atol=1e-7,
-        type_check=has_support_aspect64(),
+        type_check=False,
     )
     def test_rfft(self, xp, dtype):
         a = testing.shaped_random(self.shape, xp, dtype)


### PR DESCRIPTION
The conda channel `intel` is temporary inaccessible.

Due to that the PR attempts to unblock GH action with building dpnp documentation. It proposes to use only `dppy/label/dev` and `conda-forge` channels. While `onedpl-devel` and `tbb-devel` conda packages are assuming to be installed now from latest Intel OneAPI by installing `intel-oneapi-libdpstd-devel` and `intel-oneapi-tbb-devel` respectively.

The new behavior will be controlled by action environment variable `INSTALL_ONE_API`. It is implemented in that way to provide a fast solution to switch back to `intel` channel approach.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
