### PR TITLE
Replace `intel` channel for `Conda package` action

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -11,7 +11,8 @@ permissions: read-all
 env:
   PACKAGE_NAME: dpnp
   MODULE_NAME: dpnp
-  CHANNELS: '-c dppy/label/dev -c intel -c conda-forge --override-channels'
+  # CHANNELS: '-c dppy/label/dev -c intel -c conda-forge --override-channels'
+  CHANNELS: '-c dppy/label/dev -c https://software.repos.intel.com/python/conda/ -c conda-forge --override-channels'
   CONDA_BUILD_VERSION: '24.5.1'
   CONDA_INDEX_VERSION: '0.5.0'
   RUN_TESTS_MAX_ATTEMPTS: 2

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -11,6 +11,7 @@ permissions: read-all
 env:
   PACKAGE_NAME: dpnp
   MODULE_NAME: dpnp
+  # Follow oneAPI installation instruction for conda, since intel channel is not longer available
   # CHANNELS: '-c dppy/label/dev -c intel -c conda-forge --override-channels'
   CHANNELS: '-c dppy/label/dev -c https://software.repos.intel.com/python/conda/ -c conda-forge --override-channels'
   CONDA_BUILD_VERSION: '24.5.1'


### PR DESCRIPTION
The conda channel `intel` is temporary inaccessible.

Due to that the PR attempts to unblock GH action with `Conda package` run. It proposes to follow oneAPI installation instruction via the conda package manager ([link](https://www.intel.com/content/www/us/en/docs/oneapi/installation-guide-linux/2024-2/conda.html#GUID-BAA00723-86B2-4E54-9343-E817171F8A39)) and to replace `intel` channel with `https://software.repos.intel.com/python/conda/` one.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
