### PR TITLE
Resolve a possible race condition in dpnp.inv() implemenetation

### DIFF
--- a/dpnp/linalg/dpnp_utils_linalg.py
+++ b/dpnp/linalg/dpnp_utils_linalg.py
@@ -2091,7 +2091,10 @@ def dpnp_inv(a):
         usm_a_f = a_f.T.get_array()
         usm_b_f = b_f.T.get_array()
 
-    ht_ev, gesv_ev = li._gesv(a_sycl_queue, usm_a_f, usm_b_f, depends=[copy_ev])
+    # depends on copy_ev and an event from dpt.eye() call
+    ht_ev, gesv_ev = li._gesv(
+        a_sycl_queue, usm_a_f, usm_b_f, depends=_manager.submitted_events
+    )
     _manager.add_event_pair(ht_ev, gesv_ev)
 
     return b_f


### PR DESCRIPTION
The PR proposes to implement a fix preventing possible race condition inside `dpnp.inv` function.

It assumes `_gesv` call depends on both copy event and event produced above `dpnp.eye` call and so it is mandatory to pass `depends=_manager.submitted_events` there.

The issue was caught during the analysis of failed tests in GitHub actions. No need to implement any dedicated test to cover that use case.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
