### PR TITLE
Add `dpnp.trim_zeros` implementation

### DIFF
--- a/doc/reference/manipulation.rst
+++ b/doc/reference/manipulation.rst
@@ -131,6 +131,7 @@ Adding and removing elements
    dpnp.resize
    dpnp.unique
    dpnp.trim_zeros
+   dpnp.pad
 
 
 Rearranging elements

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -82,6 +82,7 @@ __all__ = [
     "swapaxes",
     "tile",
     "transpose",
+    "trim_zeros",
     "unique",
     "vstack",
 ]
@@ -1925,6 +1926,71 @@ def transpose(a, axes=None):
     if axes is None:
         return array.transpose()
     return array.transpose(*axes)
+
+
+def trim_zeros(filt, trim="fb"):
+    """
+    Trim the leading and/or trailing zeros from a 1-D array.
+
+    For full documentation refer to :obj:`numpy.trim_zeros`.
+
+    Parameters
+    ----------
+    filt : {dpnp.ndarray, usm_ndarray}
+        Input 1-D array.
+    trim : str, optional
+        A string with 'f' representing trim from front and 'b' to trim from
+        back. By defaults, trim zeros from both front and back of the array.
+        Default: ``"fb"``.
+
+    Returns
+    -------
+    out : dpnp.ndarray
+        The result of trimming the input.
+
+    Examples
+    --------
+    >>> import dpnp as np
+    >>> a = np.array((0, 0, 0, 1, 2, 3, 0, 2, 1, 0))
+    >>> np.trim_zeros(a)
+    array([1, 2, 3, 0, 2, 1])
+
+    >>> np.trim_zeros(a, 'b')
+    array([0, 0, 0, 1, 2, 3, 0, 2, 1])
+
+    """
+
+    dpnp.check_supported_arrays_type(filt)
+    if filt.ndim == 0:
+        raise TypeError("0-d array cannot be trimmed")
+    if filt.ndim > 1:
+        raise ValueError("Multi-dimensional trim is not supported")
+
+    if not isinstance(trim, str):
+        raise TypeError("only string trim is supported")
+
+    trim = trim.upper()
+    if not any(x in trim for x in "FB"):
+        return filt  # no trim rule is specified
+
+    if filt.size == 0:
+        return filt  # no trailing zeros in empty array
+
+    a = dpnp.nonzero(filt)[0]
+    a_size = a.size
+    if a_size == 0:
+        # 'filt' is array of zeros
+        return dpnp.empty_like(filt, shape=(0,))
+
+    first = 0
+    if "F" in trim:
+        first = a[0]
+
+    last = filt.size
+    if "B" in trim:
+        last = a[-1] + 1
+
+    return filt[first:last]
 
 
 def unique(ar, **kwargs):

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -475,6 +475,7 @@ def test_meshgrid(device):
             "trace", [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
         ),
         pytest.param("trapz", [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]),
+        pytest.param("trim_zeros", [0, 0, 0, 1, 2, 3, 0, 2, 1, 0]),
         pytest.param("trunc", [-1.7, -1.5, -0.2, 0.2, 1.5, 1.7, 2.0]),
         pytest.param("var", [1.0, 2.0, 4.0, 7.0]),
     ],

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -610,6 +610,7 @@ def test_norm(usm_type, ord, axis):
         pytest.param(
             "trace", [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
         ),
+        pytest.param("trim_zeros", [0, 0, 0, 1, 2, 3, 0, 2, 1, 0]),
         pytest.param("trunc", [-1.7, -1.5, -0.2, 0.2, 1.5, 1.7, 2.0]),
         pytest.param("var", [1.0, 2.0, 4.0, 7.0]),
     ],

--- a/tests/third_party/cupy/manipulation_tests/test_add_remove.py
+++ b/tests/third_party/cupy/manipulation_tests/test_add_remove.py
@@ -1,0 +1,360 @@
+import unittest
+
+import numpy
+import pytest
+
+import dpnp as cupy
+from tests.third_party.cupy import testing
+from tests.third_party.cupy.testing._loops import (
+    _complex_dtypes,
+    _regular_float_dtypes,
+)
+
+
+@pytest.mark.skip("delete() is not implemented yet")
+class TestDelete(unittest.TestCase):
+    @testing.numpy_cupy_array_equal()
+    def test_delete_with_no_axis(self, xp):
+        arr = xp.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        indices = xp.array([0, 2, 4, 6, 8])
+
+        return xp.delete(arr, indices)
+
+    @testing.numpy_cupy_array_equal()
+    def test_delete_with_axis_zero(self, xp):
+        arr = xp.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]])
+        indices = xp.array([0, 2])
+
+        return xp.delete(arr, indices, axis=0)
+
+    @testing.numpy_cupy_array_equal()
+    def test_delete_with_axis_one(self, xp):
+        arr = xp.array([[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]])
+        indices = xp.array([0, 2, 4])
+
+        return xp.delete(arr, indices, axis=1)
+
+    @testing.numpy_cupy_array_equal()
+    def test_delete_with_indices_as_bool_array(self, xp):
+        arr = xp.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        indices = xp.array(
+            [True, False, True, False, True, False, True, False, True, False]
+        )
+
+        return xp.delete(arr, indices)
+
+    @testing.numpy_cupy_array_equal()
+    def test_delete_with_indices_as_slice(self, xp):
+        arr = xp.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        indices = slice(None, None, 2)
+        return xp.delete(arr, indices)
+
+    @testing.numpy_cupy_array_equal()
+    def test_delete_with_indices_as_int(self, xp):
+        arr = xp.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        indices = 5
+        if cupy.cuda.runtime.is_hip:
+            pytest.xfail("HIP may have a bug")
+        return xp.delete(arr, indices)
+
+
+@pytest.mark.skip("append() is not implemented yet")
+class TestAppend(unittest.TestCase):
+    @testing.for_all_dtypes_combination(
+        names=["dtype1", "dtype2"], no_bool=True
+    )
+    @testing.numpy_cupy_array_equal()
+    def test(self, xp, dtype1, dtype2):
+        a = testing.shaped_random((3, 4, 5), xp, dtype1)
+        b = testing.shaped_random((6, 7), xp, dtype2)
+        return xp.append(a, b)
+
+    @testing.for_all_dtypes_combination(
+        names=["dtype1", "dtype2"], no_bool=True
+    )
+    @testing.numpy_cupy_array_equal()
+    def test_scalar_lhs(self, xp, dtype1, dtype2):
+        scalar = xp.dtype(dtype1).type(10).item()
+        return xp.append(scalar, xp.arange(20, dtype=dtype2))
+
+    @testing.for_all_dtypes_combination(
+        names=["dtype1", "dtype2"], no_bool=True
+    )
+    @testing.numpy_cupy_array_equal()
+    def test_scalar_rhs(self, xp, dtype1, dtype2):
+        scalar = xp.dtype(dtype2).type(10).item()
+        return xp.append(xp.arange(20, dtype=dtype1), scalar)
+
+    @testing.for_all_dtypes_combination(
+        names=["dtype1", "dtype2"], no_bool=True
+    )
+    @testing.numpy_cupy_array_equal()
+    def test_numpy_scalar_lhs(self, xp, dtype1, dtype2):
+        scalar = xp.dtype(dtype1).type(10)
+        return xp.append(scalar, xp.arange(20, dtype=dtype2))
+
+    @testing.for_all_dtypes_combination(
+        names=["dtype1", "dtype2"], no_bool=True
+    )
+    @testing.numpy_cupy_array_equal()
+    def test_numpy_scalar_rhs(self, xp, dtype1, dtype2):
+        scalar = xp.dtype(dtype2).type(10)
+        return xp.append(xp.arange(20, dtype=dtype1), scalar)
+
+    @testing.numpy_cupy_array_equal()
+    def test_scalar_both(self, xp):
+        return xp.append(10, 10)
+
+    @testing.numpy_cupy_array_equal()
+    def test_axis(self, xp):
+        a = testing.shaped_random((3, 4, 5), xp, xp.float32)
+        b = testing.shaped_random((3, 10, 5), xp, xp.float32)
+        return xp.append(a, b, axis=1)
+
+    @testing.numpy_cupy_array_equal()
+    def test_zerodim(self, xp):
+        return xp.append(xp.array(0), xp.arange(10))
+
+    @testing.numpy_cupy_array_equal()
+    def test_empty(self, xp):
+        return xp.append(xp.array([]), xp.arange(10))
+
+
+@pytest.mark.skip("resize() is not implemented yet")
+class TestResize(unittest.TestCase):
+    @testing.numpy_cupy_array_equal()
+    def test(self, xp):
+        return xp.resize(xp.arange(10), (10, 10))
+
+    @testing.numpy_cupy_array_equal()
+    def test_remainder(self, xp):
+        return xp.resize(xp.arange(8), (10, 10))
+
+    @testing.numpy_cupy_array_equal()
+    def test_shape_int(self, xp):
+        return xp.resize(xp.arange(10), 15)
+
+    @testing.numpy_cupy_array_equal()
+    def test_scalar(self, xp):
+        return xp.resize(2, (10, 10))
+
+    @testing.numpy_cupy_array_equal()
+    def test_scalar_shape_int(self, xp):
+        return xp.resize(2, 10)
+
+    @testing.numpy_cupy_array_equal()
+    def test_typed_scalar(self, xp):
+        return xp.resize(xp.float32(10.0), (10, 10))
+
+    @testing.numpy_cupy_array_equal()
+    def test_zerodim(self, xp):
+        return xp.resize(xp.array(0), (10, 10))
+
+    @testing.numpy_cupy_array_equal()
+    def test_empty(self, xp):
+        return xp.resize(xp.array([]), (10, 10))
+
+
+@pytest.mark.skip("unique() is not implemented yet")
+class TestUnique:
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_unique_no_axis(self, xp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        return xp.unique(a)
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_unique(self, xp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        return xp.unique(a, axis=1)
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_unique_index_no_axis(self, xp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        return xp.unique(a, return_index=True)[1]
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_unique_index(self, xp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        return xp.unique(a, return_index=True, axis=0)[1]
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_unique_inverse_no_axis(self, xp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        res = xp.unique(a, return_inverse=True)[1]
+        if xp is numpy and numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0":
+            res = res.reshape(a.shape)
+        return res
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_unique_inverse(self, xp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        return xp.unique(a, return_inverse=True, axis=1)[1]
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_unique_counts_no_axis(self, xp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        return xp.unique(a, return_counts=True)[1]
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_unique_counts(self, xp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        return xp.unique(a, return_counts=True, axis=0)[1]
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_unique_return_all_no_axis(self, xp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        res = xp.unique(
+            a, return_index=True, return_inverse=True, return_counts=True
+        )
+        if xp is numpy and numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0":
+            res = res[:2] + (res[2].reshape(a.shape),) + res[3:]
+        return res
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_unique_return_all(self, xp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        return xp.unique(
+            a,
+            return_index=True,
+            return_inverse=True,
+            return_counts=True,
+            axis=1,
+        )
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_unique_empty_no_axis(self, xp, dtype):
+        a = xp.empty((0,), dtype=dtype)
+        return xp.unique(a)
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_unique_empty(self, xp, dtype):
+        a = xp.empty((0,), dtype=dtype)
+        return xp.unique(a, axis=0)
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_unique_empty_return_all_no_axis(self, xp, dtype):
+        a = xp.empty((3, 0, 2), dtype=dtype)
+        res = xp.unique(
+            a, return_index=True, return_inverse=True, return_counts=True
+        )
+        if xp is numpy and numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0":
+            res = res[:2] + (res[2].reshape(a.shape),) + res[3:]
+        return res
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_unique_empty_return_all(self, xp, dtype):
+        a = xp.empty((3, 0, 2), dtype=dtype)
+        return xp.unique(
+            a,
+            return_index=True,
+            return_inverse=True,
+            return_counts=True,
+            axis=2,
+        )
+
+    @pytest.mark.parametrize("equal_nan", [True, False])
+    @testing.for_dtypes_combination(_regular_float_dtypes + _complex_dtypes)
+    @testing.numpy_cupy_array_equal()
+    @testing.with_requires("numpy>=1.23.1")
+    def test_unique_equal_nan_no_axis(self, xp, dtype, equal_nan):
+        if xp.dtype(dtype).kind == "c":
+            # Nan and Nan+Nan*1j are collapsed when equal_nan=True
+            a = xp.array(
+                [
+                    complex(xp.nan, 3),
+                    2,
+                    complex(7, xp.nan),
+                    xp.nan,
+                    complex(xp.nan, xp.nan),
+                    2,
+                    xp.nan,
+                    1,
+                ],
+                dtype=dtype,
+            )
+        else:
+            a = xp.array([2, xp.nan, 2, xp.nan, 1], dtype=dtype)
+        return xp.unique(a, equal_nan=equal_nan)
+
+    @pytest.mark.parametrize("equal_nan", [True, False])
+    @testing.for_dtypes_combination(_regular_float_dtypes + _complex_dtypes)
+    @testing.numpy_cupy_array_equal()
+    @testing.with_requires("numpy>=1.23.1")
+    def test_unique_equal_nan(self, xp, dtype, equal_nan):
+        if xp.dtype(dtype).kind == "c":
+            # Nan and Nan+Nan*1j are collapsed when equal_nan=True
+            a = xp.array(
+                [
+                    [complex(xp.nan, 3), 2, complex(7, xp.nan)],
+                    [xp.nan, complex(xp.nan, xp.nan), 2],
+                    [xp.nan, 1, complex(xp.nan, -1)],
+                ],
+                dtype=dtype,
+            )
+        else:
+            a = xp.array(
+                [[2, xp.nan, 2], [xp.nan, 1, xp.nan], [xp.nan, 1, xp.nan]],
+                dtype=dtype,
+            )
+        return xp.unique(a, axis=0, equal_nan=equal_nan)
+
+
+@testing.parameterize(*testing.product({"trim": ["fb", "f", "b"]}))
+class TestTrim_zeros(unittest.TestCase):
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_trim_non_zeros(self, xp, dtype):
+        a = xp.array([-1, 2, -3, 7]).astype(dtype)
+        return xp.trim_zeros(a, trim=self.trim)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_trim_trimmed(self, xp, dtype):
+        a = xp.array([1, 0, 2, 3, 0, 5], dtype=dtype)
+        return xp.trim_zeros(a, trim=self.trim)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_trim_all_zeros(self, xp, dtype):
+        a = xp.zeros(shape=(1000,), dtype=dtype)
+        return xp.trim_zeros(a, trim=self.trim)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_trim_front_zeros(self, xp, dtype):
+        a = xp.array([0, 0, 4, 1, 0, 2, 3, 0, 5], dtype=dtype)
+        return xp.trim_zeros(a, trim=self.trim)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_trim_back_zeros(self, xp, dtype):
+        a = xp.array([1, 0, 2, 3, 0, 5, 0, 0, 0], dtype=dtype)
+        return xp.trim_zeros(a, trim=self.trim)
+
+    @testing.for_all_dtypes()
+    def test_trim_zero_dim(self, dtype):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((), xp, dtype)
+            with pytest.raises(TypeError):
+                xp.trim_zeros(a, trim=self.trim)
+
+    @testing.for_all_dtypes()
+    def test_trim_ndim(self, dtype):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3), xp, dtype=dtype)
+            with pytest.raises(ValueError):
+                xp.trim_zeros(a, trim=self.trim)


### PR DESCRIPTION
The PR adds implementation of `dpnp.trim_zeros` function.

All test scenarios are covered with new tests. Additionally `tests/third_party/cupy/manipulation_tests/test_add_remove.py` is included to verify with third party tests.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
