### PR TITLE
Rework implementation of `dpnp.deg2rad` and `dpnp.radians` functions

### DIFF
--- a/doc/reference/ufunc.rst
+++ b/doc/reference/ufunc.rst
@@ -54,6 +54,8 @@ Math operations
 
 Trigonometric functions
 ~~~~~~~~~~~~~~~~~~~~~~~
+All trigonometric functions use radians when an angle is called for.
+The ratio of degrees to radians is :math:`180^{\circ}/\pi.`
 
 .. autosummary::
    :toctree: generated/
@@ -73,6 +75,8 @@ Trigonometric functions
    dpnp.arcsinh
    dpnp.arccosh
    dpnp.arctanh
+   dpnp.degrees
+   dpnp.radians
    dpnp.deg2rad
    dpnp.rad2deg
 

--- a/dpnp/backend/extensions/ufunc/CMakeLists.txt
+++ b/dpnp/backend/extensions/ufunc/CMakeLists.txt
@@ -29,6 +29,7 @@ set(_elementwise_sources
     ${CMAKE_CURRENT_SOURCE_DIR}/elementwise_functions/fmax.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/elementwise_functions/fmin.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/elementwise_functions/fmod.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/elementwise_functions/radians.cpp
 )
 
 set(python_module_name _ufunc_impl)

--- a/dpnp/backend/extensions/ufunc/elementwise_functions/fmax.cpp
+++ b/dpnp/backend/extensions/ufunc/elementwise_functions/fmax.cpp
@@ -41,20 +41,17 @@
 #include "kernels/elementwise_functions/maximum.hpp"
 #include "utils/type_dispatch.hpp"
 
-namespace py = pybind11;
-
 namespace dpnp::extensions::ufunc
 {
-namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
-namespace max_ns = dpctl::tensor::kernels::maximum;
+namespace py = pybind11;
 namespace py_int = dpnp::extensions::py_internal;
 namespace td_ns = dpctl::tensor::type_dispatch;
 
-using ew_cmn_ns::unary_contig_impl_fn_ptr_t;
-using ew_cmn_ns::unary_strided_impl_fn_ptr_t;
-
 namespace impl
 {
+namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+namespace max_ns = dpctl::tensor::kernels::maximum;
+
 // Supports the same types table as for maximum function in dpctl
 template <typename T1, typename T2>
 using OutputType = max_ns::MaximumOutputType<T1, T2>;

--- a/dpnp/backend/extensions/ufunc/elementwise_functions/fmin.cpp
+++ b/dpnp/backend/extensions/ufunc/elementwise_functions/fmin.cpp
@@ -41,20 +41,17 @@
 #include "kernels/elementwise_functions/minimum.hpp"
 #include "utils/type_dispatch.hpp"
 
-namespace py = pybind11;
-
 namespace dpnp::extensions::ufunc
 {
-namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
-namespace min_ns = dpctl::tensor::kernels::minimum;
+namespace py = pybind11;
 namespace py_int = dpnp::extensions::py_internal;
 namespace td_ns = dpctl::tensor::type_dispatch;
 
-using ew_cmn_ns::unary_contig_impl_fn_ptr_t;
-using ew_cmn_ns::unary_strided_impl_fn_ptr_t;
-
 namespace impl
 {
+namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+namespace min_ns = dpctl::tensor::kernels::minimum;
+
 // Supports the same types table as for minimum function in dpctl
 template <typename T1, typename T2>
 using OutputType = min_ns::MinimumOutputType<T1, T2>;

--- a/dpnp/backend/extensions/ufunc/elementwise_functions/fmod.cpp
+++ b/dpnp/backend/extensions/ufunc/elementwise_functions/fmod.cpp
@@ -40,19 +40,16 @@
 #include "kernels/elementwise_functions/common.hpp"
 #include "utils/type_dispatch.hpp"
 
-namespace py = pybind11;
-
 namespace dpnp::extensions::ufunc
 {
-namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+namespace py = pybind11;
 namespace py_int = dpnp::extensions::py_internal;
-namespace td_ns = dpctl::tensor::type_dispatch;
-
-using ew_cmn_ns::unary_contig_impl_fn_ptr_t;
-using ew_cmn_ns::unary_strided_impl_fn_ptr_t;
 
 namespace impl
 {
+namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+namespace td_ns = dpctl::tensor::type_dispatch;
+
 /**
  * @brief A factory to define pairs of supported types for which
  * sycl::fmod<T> function is available.

--- a/dpnp/backend/extensions/ufunc/elementwise_functions/radians.cpp
+++ b/dpnp/backend/extensions/ufunc/elementwise_functions/radians.cpp
@@ -27,9 +27,9 @@
 
 #include "dpctl4pybind11.hpp"
 
-#include "fabs.hpp"
-#include "kernels/elementwise_functions/fabs.hpp"
+#include "kernels/elementwise_functions/radians.hpp"
 #include "populate.hpp"
+#include "radians.hpp"
 
 // include a local copy of elementwise common header from dpctl tensor:
 // dpctl/tensor/libtensor/source/elementwise_functions/elementwise_functions.hpp
@@ -52,7 +52,7 @@ namespace td_ns = dpctl::tensor::type_dispatch;
 
 /**
  * @brief A factory to define pairs of supported types for which
- * sycl::fabs<T> function is available.
+ * sycl::radians<T> function is available.
  *
  * @tparam T Type of input vector `a` and of result vector `y`.
  */
@@ -66,7 +66,7 @@ struct OutputType
                                   td_ns::DefaultResultEntry<void>>::result_type;
 };
 
-using dpnp::kernels::fabs::FabsFunctor;
+using dpnp::kernels::radians::RadiansFunctor;
 
 template <typename argT,
           typename resT = argT,
@@ -75,51 +75,53 @@ template <typename argT,
           bool enable_sg_loadstore = true>
 using ContigFunctor = ew_cmn_ns::UnaryContigFunctor<argT,
                                                     resT,
-                                                    FabsFunctor<argT, resT>,
+                                                    RadiansFunctor<argT, resT>,
                                                     vec_sz,
                                                     n_vecs,
                                                     enable_sg_loadstore>;
 
 template <typename argTy, typename resTy, typename IndexerT>
 using StridedFunctor = ew_cmn_ns::
-    UnaryStridedFunctor<argTy, resTy, IndexerT, FabsFunctor<argTy, resTy>>;
+    UnaryStridedFunctor<argTy, resTy, IndexerT, RadiansFunctor<argTy, resTy>>;
 
 using ew_cmn_ns::unary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::unary_strided_impl_fn_ptr_t;
 
-static unary_contig_impl_fn_ptr_t fabs_contig_dispatch_vector[td_ns::num_types];
-static int fabs_output_typeid_vector[td_ns::num_types];
+static unary_contig_impl_fn_ptr_t
+    radians_contig_dispatch_vector[td_ns::num_types];
+static int radians_output_typeid_vector[td_ns::num_types];
 static unary_strided_impl_fn_ptr_t
-    fabs_strided_dispatch_vector[td_ns::num_types];
+    radians_strided_dispatch_vector[td_ns::num_types];
 
-MACRO_POPULATE_DISPATCH_VECTORS(fabs);
+MACRO_POPULATE_DISPATCH_VECTORS(radians);
 } // namespace impl
 
-void init_fabs(py::module_ m)
+void init_radians(py::module_ m)
 {
     using arrayT = dpctl::tensor::usm_ndarray;
     using event_vecT = std::vector<sycl::event>;
     {
-        impl::populate_fabs_dispatch_vectors();
-        using impl::fabs_contig_dispatch_vector;
-        using impl::fabs_output_typeid_vector;
-        using impl::fabs_strided_dispatch_vector;
+        impl::populate_radians_dispatch_vectors();
+        using impl::radians_contig_dispatch_vector;
+        using impl::radians_output_typeid_vector;
+        using impl::radians_strided_dispatch_vector;
 
-        auto fabs_pyapi = [&](const arrayT &src, const arrayT &dst,
-                              sycl::queue &exec_q,
-                              const event_vecT &depends = {}) {
-            return py_int::py_unary_ufunc(
-                src, dst, exec_q, depends, fabs_output_typeid_vector,
-                fabs_contig_dispatch_vector, fabs_strided_dispatch_vector);
+        auto radians_pyapi = [&](const arrayT &src, const arrayT &dst,
+                                 sycl::queue &exec_q,
+                                 const event_vecT &depends = {}) {
+            return py_int::py_unary_ufunc(src, dst, exec_q, depends,
+                                          radians_output_typeid_vector,
+                                          radians_contig_dispatch_vector,
+                                          radians_strided_dispatch_vector);
         };
-        m.def("_fabs", fabs_pyapi, "", py::arg("src"), py::arg("dst"),
+        m.def("_radians", radians_pyapi, "", py::arg("src"), py::arg("dst"),
               py::arg("sycl_queue"), py::arg("depends") = py::list());
 
-        auto fabs_result_type_pyapi = [&](const py::dtype &dtype) {
+        auto radians_result_type_pyapi = [&](const py::dtype &dtype) {
             return py_int::py_unary_ufunc_result_type(
-                dtype, fabs_output_typeid_vector);
+                dtype, radians_output_typeid_vector);
         };
-        m.def("_fabs_result_type", fabs_result_type_pyapi);
+        m.def("_radians_result_type", radians_result_type_pyapi);
     }
 }
 } // namespace dpnp::extensions::ufunc

--- a/dpnp/backend/extensions/ufunc/elementwise_functions/radians.hpp
+++ b/dpnp/backend/extensions/ufunc/elementwise_functions/radians.hpp
@@ -23,27 +23,13 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //*****************************************************************************
 
-#include <pybind11/pybind11.h>
+#pragma once
 
-#include "fabs.hpp"
-#include "fmax.hpp"
-#include "fmin.hpp"
-#include "fmod.hpp"
-#include "radians.hpp"
+#include <pybind11/pybind11.h>
 
 namespace py = pybind11;
 
 namespace dpnp::extensions::ufunc
 {
-/**
- * @brief Add elementwise functions to Python module
- */
-void init_elementwise_functions(py::module_ m)
-{
-    init_fabs(m);
-    init_fmax(m);
-    init_fmin(m);
-    init_fmod(m);
-    init_radians(m);
-}
+void init_radians(py::module_ m);
 } // namespace dpnp::extensions::ufunc

--- a/dpnp/backend/include/dpnp_gen_1arg_2type_tbl.hpp
+++ b/dpnp/backend/include/dpnp_gen_1arg_2type_tbl.hpp
@@ -89,9 +89,6 @@ MACRO_1ARG_2TYPES_OP(dpnp_copyto_c, input_elem, q.submit(kernel_func))
 MACRO_1ARG_2TYPES_OP(dpnp_degrees_c,
                      sycl::degrees(input_elem),
                      q.submit(kernel_func))
-MACRO_1ARG_2TYPES_OP(dpnp_radians_c,
-                     sycl::radians(input_elem),
-                     q.submit(kernel_func))
 MACRO_1ARG_2TYPES_OP(dpnp_sqrt_c,
                      sycl::sqrt(input_elem),
                      oneapi::mkl::vm::sqrt(q, input1_size, input1_data, result))

--- a/dpnp/backend/include/dpnp_iface_fptr.hpp
+++ b/dpnp/backend/include/dpnp_iface_fptr.hpp
@@ -116,9 +116,6 @@ enum class DPNPFuncName : size_t
     DPNP_FN_PARTITION_EXT, /**< Used in numpy.partition() impl, requires extra
                               parameters */
     DPNP_FN_PROD,          /**< Used in numpy.prod() impl  */
-    DPNP_FN_RADIANS,       /**< Used in numpy.radians() impl  */
-    DPNP_FN_RADIANS_EXT,   /**< Used in numpy.radians() impl, requires extra
-                              parameters */
     DPNP_FN_RNG_BETA,      /**< Used in numpy.random.beta() impl  */
     DPNP_FN_RNG_BETA_EXT,  /**< Used in numpy.random.beta() impl, requires extra
                               parameters */

--- a/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
@@ -337,36 +337,6 @@ static void func_map_init_elemwise_1arg_2type(func_map_t &fmap)
     fmap[DPNPFuncName::DPNP_FN_DEGREES_EXT][eft_DBL][eft_DBL] = {
         eft_DBL, (void *)dpnp_degrees_c_ext<double, double>};
 
-    fmap[DPNPFuncName::DPNP_FN_RADIANS][eft_INT][eft_INT] = {
-        eft_DBL, (void *)dpnp_radians_c_default<int32_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_RADIANS][eft_LNG][eft_LNG] = {
-        eft_DBL, (void *)dpnp_radians_c_default<int64_t, double>};
-    fmap[DPNPFuncName::DPNP_FN_RADIANS][eft_FLT][eft_FLT] = {
-        eft_FLT, (void *)dpnp_radians_c_default<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_RADIANS][eft_DBL][eft_DBL] = {
-        eft_DBL, (void *)dpnp_radians_c_default<double, double>};
-
-    fmap[DPNPFuncName::DPNP_FN_RADIANS_EXT][eft_INT][eft_INT] = {
-        get_default_floating_type(),
-        (void *)dpnp_radians_c_ext<
-            int32_t, func_type_map_t::find_type<get_default_floating_type()>>,
-        get_default_floating_type<std::false_type>(),
-        (void *)dpnp_radians_c_ext<
-            int32_t, func_type_map_t::find_type<
-                         get_default_floating_type<std::false_type>()>>};
-    fmap[DPNPFuncName::DPNP_FN_RADIANS_EXT][eft_LNG][eft_LNG] = {
-        get_default_floating_type(),
-        (void *)dpnp_radians_c_ext<
-            int64_t, func_type_map_t::find_type<get_default_floating_type()>>,
-        get_default_floating_type<std::false_type>(),
-        (void *)dpnp_radians_c_ext<
-            int64_t, func_type_map_t::find_type<
-                         get_default_floating_type<std::false_type>()>>};
-    fmap[DPNPFuncName::DPNP_FN_RADIANS_EXT][eft_FLT][eft_FLT] = {
-        eft_FLT, (void *)dpnp_radians_c_ext<float, float>};
-    fmap[DPNPFuncName::DPNP_FN_RADIANS_EXT][eft_DBL][eft_DBL] = {
-        eft_DBL, (void *)dpnp_radians_c_ext<double, double>};
-
     fmap[DPNPFuncName::DPNP_FN_SQRT][eft_INT][eft_INT] = {
         eft_DBL, (void *)dpnp_sqrt_c_default<int32_t, double>};
     fmap[DPNPFuncName::DPNP_FN_SQRT][eft_LNG][eft_LNG] = {

--- a/dpnp/backend/kernels/elementwise_functions/fabs.hpp
+++ b/dpnp/backend/kernels/elementwise_functions/fabs.hpp
@@ -38,7 +38,7 @@ struct FabsFunctor
     // constexpr resT constant_value = resT{};
     // is function defined for sycl::vec
     using supports_vec = typename std::false_type;
-    // do both argT and resT support sugroup store/load operation
+    // do both argT and resT support subgroup store/load operation
     using supports_sg_loadstore = typename std::true_type;
 
     resT operator()(const argT &x) const

--- a/dpnp/backend/kernels/elementwise_functions/radians.hpp
+++ b/dpnp/backend/kernels/elementwise_functions/radians.hpp
@@ -38,7 +38,7 @@ struct RadiansFunctor
     // constexpr resT constant_value = resT{};
     // is function defined for sycl::vec
     using supports_vec = typename std::true_type;
-    // do both argT and resT support sugroup store/load operation
+    // do both argT and resT support subgroup store/load operation
     using supports_sg_loadstore = typename std::true_type;
 
     resT operator()(const argT &x) const

--- a/dpnp/backend/kernels/elementwise_functions/radians.hpp
+++ b/dpnp/backend/kernels/elementwise_functions/radians.hpp
@@ -23,27 +23,33 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //*****************************************************************************
 
-#include <pybind11/pybind11.h>
+#pragma once
 
-#include "fabs.hpp"
-#include "fmax.hpp"
-#include "fmin.hpp"
-#include "fmod.hpp"
-#include "radians.hpp"
+#include <sycl/sycl.hpp>
 
-namespace py = pybind11;
-
-namespace dpnp::extensions::ufunc
+namespace dpnp::kernels::radians
 {
-/**
- * @brief Add elementwise functions to Python module
- */
-void init_elementwise_functions(py::module_ m)
+template <typename argT, typename resT>
+struct RadiansFunctor
 {
-    init_fabs(m);
-    init_fmax(m);
-    init_fmin(m);
-    init_fmod(m);
-    init_radians(m);
-}
-} // namespace dpnp::extensions::ufunc
+    // is function constant for given argT
+    using is_constant = typename std::false_type;
+    // constant value, if constant
+    // constexpr resT constant_value = resT{};
+    // is function defined for sycl::vec
+    using supports_vec = typename std::true_type;
+    // do both argT and resT support sugroup store/load operation
+    using supports_sg_loadstore = typename std::true_type;
+
+    resT operator()(const argT &x) const
+    {
+        return sycl::radians(x);
+    }
+
+    template <int vec_sz>
+    sycl::vec<resT, vec_sz> operator()(const sycl::vec<argT, vec_sz> &x) const
+    {
+        return sycl::radians(x);
+    }
+};
+} // namespace dpnp::kernels::radians

--- a/dpnp/dpnp_algo/dpnp_algo.pxd
+++ b/dpnp/dpnp_algo/dpnp_algo.pxd
@@ -44,7 +44,6 @@ cdef extern from "dpnp_iface_fptr.hpp" namespace "DPNPFuncName":  # need this na
         DPNP_FN_MEDIAN_EXT
         DPNP_FN_MODF_EXT
         DPNP_FN_PARTITION_EXT
-        DPNP_FN_RADIANS_EXT
         DPNP_FN_RNG_BETA_EXT
         DPNP_FN_RNG_BINOMIAL_EXT
         DPNP_FN_RNG_CHISQUARE_EXT
@@ -172,4 +171,3 @@ cpdef dpnp_descriptor dpnp_isclose(dpnp_descriptor input1, dpnp_descriptor input
 Trigonometric functions
 """
 cpdef dpnp_descriptor dpnp_degrees(dpnp_descriptor array1)
-cpdef dpnp_descriptor dpnp_radians(dpnp_descriptor array1)

--- a/dpnp/dpnp_algo/dpnp_algo_trigonometric.pxi
+++ b/dpnp/dpnp_algo/dpnp_algo_trigonometric.pxi
@@ -37,17 +37,12 @@ and the rest of the library
 
 __all__ += [
     'dpnp_degrees',
-    'dpnp_radians',
     'dpnp_unwrap'
 ]
 
 
 cpdef utils.dpnp_descriptor dpnp_degrees(utils.dpnp_descriptor x1):
     return call_fptr_1in_1out_strides(DPNP_FN_DEGREES_EXT, x1)
-
-
-cpdef utils.dpnp_descriptor dpnp_radians(utils.dpnp_descriptor x1):
-    return call_fptr_1in_1out_strides(DPNP_FN_RADIANS_EXT, x1)
 
 
 cpdef utils.dpnp_descriptor dpnp_unwrap(utils.dpnp_descriptor array1):

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -36,7 +36,6 @@ tests/third_party/cupy/fft_tests/test_fft.py::TestFftn_param_23_{axes=None, norm
 tests/third_party/intel/test_zero_copy_test1.py::test_dpnp_interaction_with_dpctl_memory
 
 tests/test_strides.py::test_strides_1arg[(10,)-None-degrees]
-tests/test_strides.py::test_strides_1arg[(10,)-None-radians]
 
 tests/test_umath.py::test_umaths[('divmod', 'ii')]
 tests/test_umath.py::test_umaths[('divmod', 'll')]

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -451,6 +451,7 @@ def test_meshgrid(device):
         pytest.param("positive", [1.0, 0.0, -1.0]),
         pytest.param("prod", [1.0, 2.0]),
         pytest.param("ptp", [1.0, 2.0, 4.0, 7.0]),
+        pytest.param("radians", [180, 90, 45, 0]),
         pytest.param(
             "real", [complex(1.0, 2.0), complex(3.0, 4.0), complex(5.0, 6.0)]
         ),

--- a/tests/test_umath.py
+++ b/tests/test_umath.py
@@ -169,6 +169,293 @@ def _get_output_data_type(dtype):
     return out_dtype
 
 
+class TestArctan2:
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
+    def test_arctan2(self, dtype):
+        np_array1, np_array2, expected = _get_numpy_arrays_2in_1out(
+            "arctan2", dtype, [0, 10, 10]
+        )
+
+        dp_array1 = dpnp.array(np_array1)
+        dp_array2 = dpnp.array(np_array2)
+        out_dtype = _get_output_data_type(dtype)
+        dp_out = dpnp.empty(expected.shape, dtype=out_dtype)
+        result = dpnp.arctan2(dp_array1, dp_array2, out=dp_out)
+
+        assert result is dp_out
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize(
+        "dtype", get_all_dtypes(no_complex=True, no_none=True)[:-1]
+    )
+    def test_invalid_dtype(self, dtype):
+        dpnp_dtype = get_all_dtypes(no_complex=True, no_none=True)[-1]
+        dp_array = dpnp.arange(10, dtype=dpnp_dtype)
+        dp_out = dpnp.empty(10, dtype=dtype)
+
+        with pytest.raises(ValueError):
+            dpnp.arctan2(dp_array, dp_array, out=dp_out)
+
+    @pytest.mark.parametrize(
+        "shape", [(0,), (15,), (2, 2)], ids=["(0,)", "(15, )", "(2,2)"]
+    )
+    def test_invalid_shape(self, shape):
+        dp_array = dpnp.arange(10)
+        dp_out = dpnp.empty(shape)
+        with pytest.raises(ValueError):
+            dpnp.arctan2(dp_array, dp_array, out=dp_out)
+
+
+class TestCbrt:
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
+    def test_cbrt(self, dtype):
+        np_array, expected = _get_numpy_arrays_1in_1out(
+            "cbrt", dtype, [-5, 5, 10]
+        )
+
+        dp_array = dpnp.array(np_array)
+        out_dtype = _get_output_data_type(dtype)
+        dp_out = dpnp.empty(expected.shape, dtype=out_dtype)
+        result = dpnp.cbrt(dp_array, out=dp_out)
+
+        assert result is dp_out
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize(
+        "dtype", get_all_dtypes(no_complex=True, no_none=True)[:-1]
+    )
+    def test_invalid_dtype(self, dtype):
+        dpnp_dtype = get_all_dtypes(no_complex=True, no_none=True)[-1]
+        dp_array = dpnp.arange(10, dtype=dpnp_dtype)
+        dp_out = dpnp.empty(10, dtype=dtype)
+
+        with pytest.raises(ValueError):
+            dpnp.cbrt(dp_array, out=dp_out)
+
+    @pytest.mark.parametrize(
+        "shape", [(0,), (15,), (2, 2)], ids=["(0,)", "(15, )", "(2,2)"]
+    )
+    def test_invalid_shape(self, shape):
+        dp_array = dpnp.arange(10)
+        dp_out = dpnp.empty(shape)
+
+        with pytest.raises(ValueError):
+            dpnp.cbrt(dp_array, out=dp_out)
+
+
+class TestCopySign:
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
+    def test_copysign(self, dtype):
+        np_array1, np_array2, expected = _get_numpy_arrays_2in_1out(
+            "copysign", dtype, [0, 10, 10]
+        )
+
+        dp_array1 = dpnp.array(np_array1)
+        dp_array2 = dpnp.array(np_array2)
+        out_dtype = _get_output_data_type(dtype)
+        dp_out = dpnp.empty(expected.shape, dtype=out_dtype)
+        result = dpnp.copysign(dp_array1, dp_array2, out=dp_out)
+
+        assert result is dp_out
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize(
+        "dtype", get_all_dtypes(no_complex=True, no_none=True)[:-1]
+    )
+    def test_invalid_dtype(self, dtype):
+        dpnp_dtype = get_all_dtypes(no_complex=True, no_none=True)[-1]
+        dp_array = dpnp.arange(10, dtype=dpnp_dtype)
+        dp_out = dpnp.empty(10, dtype=dtype)
+        with pytest.raises(ValueError):
+            dpnp.copysign(dp_array, dp_array, out=dp_out)
+
+    @pytest.mark.parametrize(
+        "shape", [(0,), (15,), (2, 2)], ids=["(0,)", "(15, )", "(2,2)"]
+    )
+    def test_invalid_shape(self, shape):
+        dp_array = dpnp.arange(10)
+        dp_out = dpnp.empty(shape)
+        with pytest.raises(ValueError):
+            dpnp.copysign(dp_array, dp_array, out=dp_out)
+
+
+class TestLogaddexp:
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
+    def test_logaddexp(self, dtype):
+        np_array1, np_array2, expected = _get_numpy_arrays_2in_1out(
+            "logaddexp", dtype, [0, 10, 10]
+        )
+
+        dp_array1 = dpnp.array(np_array1)
+        dp_array2 = dpnp.array(np_array2)
+        out_dtype = _get_output_data_type(dtype)
+        dp_out = dpnp.empty(expected.shape, dtype=out_dtype)
+        result = dpnp.logaddexp(dp_array1, dp_array2, out=dp_out)
+
+        assert result is dp_out
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize(
+        "dtype", get_all_dtypes(no_complex=True, no_none=True)[:-1]
+    )
+    def test_invalid_dtype(self, dtype):
+        dpnp_dtype = get_all_dtypes(no_complex=True, no_none=True)[-1]
+        dp_array = dpnp.arange(10, dtype=dpnp_dtype)
+        dp_out = dpnp.empty(10, dtype=dtype)
+        with pytest.raises(ValueError):
+            dpnp.logaddexp(dp_array, dp_array, out=dp_out)
+
+    @pytest.mark.parametrize(
+        "shape", [(0,), (15,), (2, 2)], ids=["(0,)", "(15, )", "(2,2)"]
+    )
+    def test_invalid_shape(self, shape):
+        dp_array = dpnp.arange(10)
+        dp_out = dpnp.empty(shape)
+        with pytest.raises(ValueError):
+            dpnp.logaddexp(dp_array, dp_array, out=dp_out)
+
+
+class TestRadians:
+    @pytest.mark.parametrize(
+        "dtype", get_all_dtypes(no_none=True, no_complex=True)
+    )
+    def test_radians(self, dtype):
+        a = numpy.array([180.0, -90.0], dtype=dtype)
+        ia = dpnp.array(a)
+
+        result = dpnp.radians(ia)
+        expected = numpy.radians(a)
+        assert_dtype_allclose(result, expected)
+
+
+class TestReciprocal:
+    @pytest.mark.usefixtures("suppress_divide_numpy_warnings")
+    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
+    def test_reciprocal(self, dtype):
+        np_array, expected = _get_numpy_arrays_1in_1out(
+            "reciprocal", dtype, [-5, 5, 10]
+        )
+
+        dp_array = dpnp.array(np_array)
+        out_dtype = _get_output_data_type(dtype)
+        dp_out = dpnp.empty(expected.shape, dtype=out_dtype)
+        result = dpnp.reciprocal(dp_array, out=dp_out)
+
+        assert result is dp_out
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_float_complex_dtypes()[:-1])
+    def test_invalid_dtype(self, dtype):
+        dpnp_dtype = get_float_complex_dtypes()[-1]
+        dp_array = dpnp.arange(10, dtype=dpnp_dtype)
+        dp_out = dpnp.empty(10, dtype=dtype)
+
+        with pytest.raises(ValueError):
+            dpnp.reciprocal(dp_array, out=dp_out)
+
+    @pytest.mark.parametrize(
+        "shape", [(0,), (15,), (2, 2)], ids=["(0,)", "(15, )", "(2,2)"]
+    )
+    def test_invalid_shape(self, shape):
+        dp_array = dpnp.arange(10)
+        dp_out = dpnp.empty(shape)
+
+        with pytest.raises(ValueError):
+            dpnp.reciprocal(dp_array, out=dp_out)
+
+
+class TestRsqrt:
+    @pytest.mark.usefixtures("suppress_divide_numpy_warnings")
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
+    def test_rsqrt(self, dtype):
+        np_array, expected = _get_numpy_arrays_1in_1out(
+            "sqrt", dtype, [0, 10, 10]
+        )
+        expected = numpy.reciprocal(expected)
+
+        dp_array = dpnp.array(np_array)
+        out_dtype = _get_output_data_type(dtype)
+        dp_out = dpnp.empty(expected.shape, dtype=out_dtype)
+        result = dpnp.rsqrt(dp_array, out=dp_out)
+
+        assert result is dp_out
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize(
+        "dtype", get_all_dtypes(no_complex=True, no_none=True)[:-1]
+    )
+    def test_invalid_dtype(self, dtype):
+        dpnp_dtype = get_all_dtypes(no_complex=True, no_none=True)[-1]
+        dp_array = dpnp.arange(10, dtype=dpnp_dtype)
+        dp_out = dpnp.empty(10, dtype=dtype)
+
+        with pytest.raises(ValueError):
+            dpnp.rsqrt(dp_array, out=dp_out)
+
+    @pytest.mark.parametrize(
+        "shape", [(0,), (15,), (2, 2)], ids=["(0,)", "(15, )", "(2,2)"]
+    )
+    def test_invalid_shape(self, shape):
+        dp_array = dpnp.arange(10)
+        dp_out = dpnp.empty(shape)
+        with pytest.raises(ValueError):
+            dpnp.rsqrt(dp_array, out=dp_out)
+
+    @pytest.mark.parametrize(
+        "out",
+        [4, (), [], (3, 7), [2, 4]],
+        ids=["4", "()", "[]", "(3, 7)", "[2, 4]"],
+    )
+    def test_invalid_out(self, out):
+        a = dpnp.arange(10)
+        assert_raises(TypeError, dpnp.rsqrt, a, out)
+
+
+class TestSquare:
+    @pytest.mark.parametrize("dtype", get_all_dtypes())
+    def test_square(self, dtype):
+        np_array, expected = _get_numpy_arrays_1in_1out(
+            "square", dtype, [-5, 5, 10]
+        )
+
+        dp_array = dpnp.array(np_array)
+        out_dtype = numpy.int8 if dtype == numpy.bool_ else dtype
+        dp_out = dpnp.empty(expected.shape, dtype=out_dtype)
+        result = dpnp.square(dp_array, out=dp_out)
+
+        assert result is dp_out
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True)[:-1])
+    def test_invalid_dtype(self, dtype):
+        dpnp_dtype = get_all_dtypes(no_none=True)[-1]
+        dp_array = dpnp.arange(10, dtype=dpnp_dtype)
+        dp_out = dpnp.empty(10, dtype=dtype)
+
+        with pytest.raises(ValueError):
+            dpnp.square(dp_array, out=dp_out)
+
+    @pytest.mark.parametrize(
+        "shape", [(0,), (15,), (2, 2)], ids=["(0,)", "(15, )", "(2,2)"]
+    )
+    def test_invalid_shape(self, shape):
+        dp_array = dpnp.arange(10)
+        dp_out = dpnp.empty(shape)
+        with pytest.raises(ValueError):
+            dpnp.square(dp_array, out=dp_out)
+
+    @pytest.mark.parametrize(
+        "out",
+        [4, (), [], (3, 7), [2, 4]],
+        ids=["4", "()", "[]", "(3, 7)", "[2, 4]"],
+    )
+    def test_invalid_out(self, out):
+        a = dpnp.arange(10)
+
+        assert_raises(TypeError, dpnp.square, a, out)
+        assert_raises(TypeError, numpy.square, a.asnumpy(), out)
+
+
 class TestUmath:
     @pytest.fixture(
         params=[
@@ -266,277 +553,3 @@ class TestUmath:
         a = dpnp.arange(10)
         assert_raises(TypeError, getattr(dpnp, func_name), a, out)
         assert_raises(TypeError, getattr(numpy, func_name), a.asnumpy(), out)
-
-
-class TestCbrt:
-    @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
-    def test_cbrt(self, dtype):
-        np_array, expected = _get_numpy_arrays_1in_1out(
-            "cbrt", dtype, [-5, 5, 10]
-        )
-
-        dp_array = dpnp.array(np_array)
-        out_dtype = _get_output_data_type(dtype)
-        dp_out = dpnp.empty(expected.shape, dtype=out_dtype)
-        result = dpnp.cbrt(dp_array, out=dp_out)
-
-        assert result is dp_out
-        assert_dtype_allclose(result, expected)
-
-    @pytest.mark.parametrize(
-        "dtype", get_all_dtypes(no_complex=True, no_none=True)[:-1]
-    )
-    def test_invalid_dtype(self, dtype):
-        dpnp_dtype = get_all_dtypes(no_complex=True, no_none=True)[-1]
-        dp_array = dpnp.arange(10, dtype=dpnp_dtype)
-        dp_out = dpnp.empty(10, dtype=dtype)
-
-        with pytest.raises(ValueError):
-            dpnp.cbrt(dp_array, out=dp_out)
-
-    @pytest.mark.parametrize(
-        "shape", [(0,), (15,), (2, 2)], ids=["(0,)", "(15, )", "(2,2)"]
-    )
-    def test_invalid_shape(self, shape):
-        dp_array = dpnp.arange(10)
-        dp_out = dpnp.empty(shape)
-
-        with pytest.raises(ValueError):
-            dpnp.cbrt(dp_array, out=dp_out)
-
-
-class TestRsqrt:
-    @pytest.mark.usefixtures("suppress_divide_numpy_warnings")
-    @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
-    def test_rsqrt(self, dtype):
-        np_array, expected = _get_numpy_arrays_1in_1out(
-            "sqrt", dtype, [0, 10, 10]
-        )
-        expected = numpy.reciprocal(expected)
-
-        dp_array = dpnp.array(np_array)
-        out_dtype = _get_output_data_type(dtype)
-        dp_out = dpnp.empty(expected.shape, dtype=out_dtype)
-        result = dpnp.rsqrt(dp_array, out=dp_out)
-
-        assert result is dp_out
-        assert_dtype_allclose(result, expected)
-
-    @pytest.mark.parametrize(
-        "dtype", get_all_dtypes(no_complex=True, no_none=True)[:-1]
-    )
-    def test_invalid_dtype(self, dtype):
-        dpnp_dtype = get_all_dtypes(no_complex=True, no_none=True)[-1]
-        dp_array = dpnp.arange(10, dtype=dpnp_dtype)
-        dp_out = dpnp.empty(10, dtype=dtype)
-
-        with pytest.raises(ValueError):
-            dpnp.rsqrt(dp_array, out=dp_out)
-
-    @pytest.mark.parametrize(
-        "shape", [(0,), (15,), (2, 2)], ids=["(0,)", "(15, )", "(2,2)"]
-    )
-    def test_invalid_shape(self, shape):
-        dp_array = dpnp.arange(10)
-        dp_out = dpnp.empty(shape)
-        with pytest.raises(ValueError):
-            dpnp.rsqrt(dp_array, out=dp_out)
-
-    @pytest.mark.parametrize(
-        "out",
-        [4, (), [], (3, 7), [2, 4]],
-        ids=["4", "()", "[]", "(3, 7)", "[2, 4]"],
-    )
-    def test_invalid_out(self, out):
-        a = dpnp.arange(10)
-        assert_raises(TypeError, dpnp.rsqrt, a, out)
-
-
-class TestSquare:
-    @pytest.mark.parametrize("dtype", get_all_dtypes())
-    def test_square(self, dtype):
-        np_array, expected = _get_numpy_arrays_1in_1out(
-            "square", dtype, [-5, 5, 10]
-        )
-
-        dp_array = dpnp.array(np_array)
-        out_dtype = numpy.int8 if dtype == numpy.bool_ else dtype
-        dp_out = dpnp.empty(expected.shape, dtype=out_dtype)
-        result = dpnp.square(dp_array, out=dp_out)
-
-        assert result is dp_out
-        assert_dtype_allclose(result, expected)
-
-    @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True)[:-1])
-    def test_invalid_dtype(self, dtype):
-        dpnp_dtype = get_all_dtypes(no_none=True)[-1]
-        dp_array = dpnp.arange(10, dtype=dpnp_dtype)
-        dp_out = dpnp.empty(10, dtype=dtype)
-
-        with pytest.raises(ValueError):
-            dpnp.square(dp_array, out=dp_out)
-
-    @pytest.mark.parametrize(
-        "shape", [(0,), (15,), (2, 2)], ids=["(0,)", "(15, )", "(2,2)"]
-    )
-    def test_invalid_shape(self, shape):
-        dp_array = dpnp.arange(10)
-        dp_out = dpnp.empty(shape)
-        with pytest.raises(ValueError):
-            dpnp.square(dp_array, out=dp_out)
-
-    @pytest.mark.parametrize(
-        "out",
-        [4, (), [], (3, 7), [2, 4]],
-        ids=["4", "()", "[]", "(3, 7)", "[2, 4]"],
-    )
-    def test_invalid_out(self, out):
-        a = dpnp.arange(10)
-
-        assert_raises(TypeError, dpnp.square, a, out)
-        assert_raises(TypeError, numpy.square, a.asnumpy(), out)
-
-
-class TestReciprocal:
-    @pytest.mark.usefixtures("suppress_divide_numpy_warnings")
-    @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
-    def test_reciprocal(self, dtype):
-        np_array, expected = _get_numpy_arrays_1in_1out(
-            "reciprocal", dtype, [-5, 5, 10]
-        )
-
-        dp_array = dpnp.array(np_array)
-        out_dtype = _get_output_data_type(dtype)
-        dp_out = dpnp.empty(expected.shape, dtype=out_dtype)
-        result = dpnp.reciprocal(dp_array, out=dp_out)
-
-        assert result is dp_out
-        assert_dtype_allclose(result, expected)
-
-    @pytest.mark.parametrize("dtype", get_float_complex_dtypes()[:-1])
-    def test_invalid_dtype(self, dtype):
-        dpnp_dtype = get_float_complex_dtypes()[-1]
-        dp_array = dpnp.arange(10, dtype=dpnp_dtype)
-        dp_out = dpnp.empty(10, dtype=dtype)
-
-        with pytest.raises(ValueError):
-            dpnp.reciprocal(dp_array, out=dp_out)
-
-    @pytest.mark.parametrize(
-        "shape", [(0,), (15,), (2, 2)], ids=["(0,)", "(15, )", "(2,2)"]
-    )
-    def test_invalid_shape(self, shape):
-        dp_array = dpnp.arange(10)
-        dp_out = dpnp.empty(shape)
-
-        with pytest.raises(ValueError):
-            dpnp.reciprocal(dp_array, out=dp_out)
-
-
-class TestArctan2:
-    @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
-    def test_arctan2(self, dtype):
-        np_array1, np_array2, expected = _get_numpy_arrays_2in_1out(
-            "arctan2", dtype, [0, 10, 10]
-        )
-
-        dp_array1 = dpnp.array(np_array1)
-        dp_array2 = dpnp.array(np_array2)
-        out_dtype = _get_output_data_type(dtype)
-        dp_out = dpnp.empty(expected.shape, dtype=out_dtype)
-        result = dpnp.arctan2(dp_array1, dp_array2, out=dp_out)
-
-        assert result is dp_out
-        assert_dtype_allclose(result, expected)
-
-    @pytest.mark.parametrize(
-        "dtype", get_all_dtypes(no_complex=True, no_none=True)[:-1]
-    )
-    def test_invalid_dtype(self, dtype):
-        dpnp_dtype = get_all_dtypes(no_complex=True, no_none=True)[-1]
-        dp_array = dpnp.arange(10, dtype=dpnp_dtype)
-        dp_out = dpnp.empty(10, dtype=dtype)
-
-        with pytest.raises(ValueError):
-            dpnp.arctan2(dp_array, dp_array, out=dp_out)
-
-    @pytest.mark.parametrize(
-        "shape", [(0,), (15,), (2, 2)], ids=["(0,)", "(15, )", "(2,2)"]
-    )
-    def test_invalid_shape(self, shape):
-        dp_array = dpnp.arange(10)
-        dp_out = dpnp.empty(shape)
-        with pytest.raises(ValueError):
-            dpnp.arctan2(dp_array, dp_array, out=dp_out)
-
-
-class TestCopySign:
-    @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
-    def test_copysign(self, dtype):
-        np_array1, np_array2, expected = _get_numpy_arrays_2in_1out(
-            "copysign", dtype, [0, 10, 10]
-        )
-
-        dp_array1 = dpnp.array(np_array1)
-        dp_array2 = dpnp.array(np_array2)
-        out_dtype = _get_output_data_type(dtype)
-        dp_out = dpnp.empty(expected.shape, dtype=out_dtype)
-        result = dpnp.copysign(dp_array1, dp_array2, out=dp_out)
-
-        assert result is dp_out
-        assert_dtype_allclose(result, expected)
-
-    @pytest.mark.parametrize(
-        "dtype", get_all_dtypes(no_complex=True, no_none=True)[:-1]
-    )
-    def test_invalid_dtype(self, dtype):
-        dpnp_dtype = get_all_dtypes(no_complex=True, no_none=True)[-1]
-        dp_array = dpnp.arange(10, dtype=dpnp_dtype)
-        dp_out = dpnp.empty(10, dtype=dtype)
-        with pytest.raises(ValueError):
-            dpnp.copysign(dp_array, dp_array, out=dp_out)
-
-    @pytest.mark.parametrize(
-        "shape", [(0,), (15,), (2, 2)], ids=["(0,)", "(15, )", "(2,2)"]
-    )
-    def test_invalid_shape(self, shape):
-        dp_array = dpnp.arange(10)
-        dp_out = dpnp.empty(shape)
-        with pytest.raises(ValueError):
-            dpnp.copysign(dp_array, dp_array, out=dp_out)
-
-
-class TestLogaddexp:
-    @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
-    def test_logaddexp(self, dtype):
-        np_array1, np_array2, expected = _get_numpy_arrays_2in_1out(
-            "logaddexp", dtype, [0, 10, 10]
-        )
-
-        dp_array1 = dpnp.array(np_array1)
-        dp_array2 = dpnp.array(np_array2)
-        out_dtype = _get_output_data_type(dtype)
-        dp_out = dpnp.empty(expected.shape, dtype=out_dtype)
-        result = dpnp.logaddexp(dp_array1, dp_array2, out=dp_out)
-
-        assert result is dp_out
-        assert_dtype_allclose(result, expected)
-
-    @pytest.mark.parametrize(
-        "dtype", get_all_dtypes(no_complex=True, no_none=True)[:-1]
-    )
-    def test_invalid_dtype(self, dtype):
-        dpnp_dtype = get_all_dtypes(no_complex=True, no_none=True)[-1]
-        dp_array = dpnp.arange(10, dtype=dpnp_dtype)
-        dp_out = dpnp.empty(10, dtype=dtype)
-        with pytest.raises(ValueError):
-            dpnp.logaddexp(dp_array, dp_array, out=dp_out)
-
-    @pytest.mark.parametrize(
-        "shape", [(0,), (15,), (2, 2)], ids=["(0,)", "(15, )", "(2,2)"]
-    )
-    def test_invalid_shape(self, shape):
-        dp_array = dpnp.arange(10)
-        dp_out = dpnp.empty(shape)
-        with pytest.raises(ValueError):
-            dpnp.logaddexp(dp_array, dp_array, out=dp_out)

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -585,6 +585,7 @@ def test_norm(usm_type, ord, axis):
         pytest.param("prod", [1.0, 2.0]),
         pytest.param("proj", [complex(1.0, 2.0), complex(dp.inf, -1.0)]),
         pytest.param("ptp", [1.0, 2.0, 4.0, 7.0]),
+        pytest.param("radians", [180, 90, 45, 0]),
         pytest.param(
             "real", [complex(1.0, 2.0), complex(3.0, 4.0), complex(5.0, 6.0)]
         ),


### PR DESCRIPTION
The PR proposes to rework implementation of `dpnp.deg2rad` and `dpnp.radians` functions which are quite limited now.
Both functions are completely equivalent to one another.

The implementation is done by adding new binary universal function `_radians` to `_ufunc_impl` pybind11 extension.
The all affected tests are updated to cover different use cases.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
