### PR TITLE
Add conditional run of test which fails with older numpy

### DIFF
--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -2407,6 +2407,7 @@ class TestLogSumExp:
 
         assert_allclose(res, exp, rtol=1e-06)
 
+    @testing.with_requires("numpy>=1.26.4")
     @pytest.mark.usefixtures("suppress_invalid_numpy_warnings")
     @pytest.mark.parametrize(
         "arr_dt", get_all_dtypes(no_none=True, no_complex=True)


### PR DESCRIPTION
The PR implements a conditional run of `tests/test_mathematical.py::TestLogSumExp::test_logsumexp_out_dtype` test which fails with `numpy < 1.26.4` due to exception raised:
```python
exp = numpy.logaddexp.reduce(a, out=out, axis=1)
E   OverflowError: cannot convert float infinity to integer
```

The PR proposes to run the test only with `numpy >= 1.26.4` which contains a fix for that.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
