### PR TITLE
Reuse `dpctl.tensor._numpy_helper` module

### DIFF
--- a/dpnp/dpnp_iface_indexing.py
+++ b/dpnp/dpnp_iface_indexing.py
@@ -41,7 +41,7 @@ import operator
 
 import dpctl.tensor as dpt
 import numpy
-from numpy.core.numeric import normalize_axis_index
+from dpctl.tensor._numpy_helper import normalize_axis_index
 
 import dpnp
 

--- a/dpnp/dpnp_iface_linearalgebra.py
+++ b/dpnp/dpnp_iface_linearalgebra.py
@@ -39,7 +39,7 @@ it contains:
 
 
 import numpy
-from numpy.core.numeric import normalize_axis_tuple
+from dpctl.tensor._numpy_helper import normalize_axis_tuple
 
 import dpnp
 

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -40,7 +40,7 @@ it contains:
 
 import dpctl.tensor as dpt
 import numpy
-from numpy.core.numeric import normalize_axis_index
+from dpctl.tensor._numpy_helper import normalize_axis_index
 
 import dpnp
 

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -48,11 +48,11 @@ import dpctl.tensor._tensor_elementwise_impl as ti
 import dpctl.tensor._type_utils as dtu
 import dpctl.utils as dpu
 import numpy
-from dpctl.tensor._type_utils import _acceptance_fn_divide
-from numpy.core.numeric import (
+from dpctl.tensor._numpy_helper import (
     normalize_axis_index,
     normalize_axis_tuple,
 )
+from dpctl.tensor._type_utils import _acceptance_fn_divide
 
 import dpnp
 import dpnp.backend.extensions.ufunc._ufunc_impl as ufi

--- a/dpnp/dpnp_iface_sorting.py
+++ b/dpnp/dpnp_iface_sorting.py
@@ -40,7 +40,7 @@ it contains:
 
 import dpctl.tensor as dpt
 import numpy
-from numpy.core.numeric import normalize_axis_index
+from dpctl.tensor._numpy_helper import normalize_axis_index
 
 import dpnp
 

--- a/dpnp/dpnp_iface_statistics.py
+++ b/dpnp/dpnp_iface_statistics.py
@@ -40,7 +40,7 @@ it contains:
 
 import dpctl.tensor as dpt
 import numpy
-from numpy.core.numeric import normalize_axis_index
+from dpctl.tensor._numpy_helper import normalize_axis_index
 
 import dpnp
 

--- a/dpnp/dpnp_utils/dpnp_algo_utils.pyx
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pyx
@@ -35,6 +35,7 @@ This module contains different helpers and utilities
 import dpctl
 import dpctl.utils as dpu
 import numpy
+from dpctl.tensor._numpy_helper import AxisError
 
 import dpnp
 import dpnp.config as config
@@ -310,7 +311,7 @@ def map_dtype_to_device(dtype, device):
 cpdef checker_throw_axis_error(function_name, param_name, param, expected):
     err_msg = f"{ERROR_PREFIX} in function {function_name}()"
     err_msg += f" axes '{param_name}' expected `{expected}`, but '{param}' provided"
-    raise numpy.AxisError(err_msg)
+    raise AxisError(err_msg)
 
 
 cpdef checker_throw_index_error(function_name, index, size):

--- a/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
+++ b/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
@@ -28,8 +28,8 @@ import dpctl.tensor as dpt
 import dpctl.tensor._tensor_impl as ti
 import dpctl.utils as dpu
 import numpy
+from dpctl.tensor._numpy_helper import normalize_axis_tuple
 from dpctl.utils import ExecutionPlacementError
-from numpy.core.numeric import normalize_axis_tuple
 
 import dpnp
 import dpnp.backend.extensions.blas._blas_impl as bi

--- a/dpnp/fft/dpnp_utils_fft.py
+++ b/dpnp/fft/dpnp_utils_fft.py
@@ -41,8 +41,8 @@ import dpctl
 import dpctl.tensor._tensor_impl as ti
 import dpctl.utils as dpu
 import numpy
+from dpctl.tensor._numpy_helper import normalize_axis_index
 from dpctl.utils import ExecutionPlacementError
-from numpy.core.numeric import normalize_axis_index
 
 import dpnp
 import dpnp.backend.extensions.fft._fft_impl as fi

--- a/dpnp/linalg/dpnp_utils_linalg.py
+++ b/dpnp/linalg/dpnp_utils_linalg.py
@@ -41,8 +41,8 @@ available as a pybind11 extension.
 import dpctl.tensor._tensor_impl as ti
 import dpctl.utils as dpu
 import numpy
+from dpctl.tensor._numpy_helper import normalize_axis_index
 from numpy import prod
-from numpy.core.numeric import normalize_axis_index
 
 import dpnp
 import dpnp.backend.extensions.lapack._lapack_impl as li

--- a/tests/test_arraymanipulation.py
+++ b/tests/test_arraymanipulation.py
@@ -1,5 +1,6 @@
 import numpy
 import pytest
+from dpctl.tensor._numpy_helper import AxisError
 from numpy.testing import (
     assert_allclose,
     assert_array_equal,
@@ -155,12 +156,8 @@ class TestConcatenate:
         assert_equal(dp_res.asnumpy(), np_res)
 
         for axis in [ndim, -(ndim + 1)]:
-            assert_raises(
-                numpy.AxisError, dpnp.concatenate, (dp_a, dp_a), axis=axis
-            )
-            assert_raises(
-                numpy.AxisError, numpy.concatenate, (np_a, np_a), axis=axis
-            )
+            assert_raises(AxisError, dpnp.concatenate, (dp_a, dp_a), axis=axis)
+            assert_raises(AxisError, numpy.concatenate, (np_a, np_a), axis=axis)
 
     def test_scalar_exceptions(self):
         assert_raises(TypeError, dpnp.concatenate, (0,))
@@ -231,7 +228,7 @@ class TestConcatenate:
         assert_array_equal(dp_res.asnumpy(), np_res)
 
         # numpy doesn't raise an exception here but probably should
-        with pytest.raises(numpy.AxisError):
+        with pytest.raises(AxisError):
             dpnp.concatenate(dp_a, axis=100)
 
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
@@ -662,8 +659,8 @@ class TestStack:
         np_arrays = numpy.array(arrays, dtype=dtype)
         dp_arrays = dpnp.array(arrays, dtype=dtype)
 
-        assert_raises(numpy.AxisError, numpy.stack, np_arrays, axis=axis)
-        assert_raises(numpy.AxisError, dpnp.stack, dp_arrays, axis=axis)
+        assert_raises(AxisError, numpy.stack, np_arrays, axis=axis)
+        assert_raises(AxisError, dpnp.stack, dp_arrays, axis=axis)
 
     @pytest.mark.parametrize("axis", [0, 1, 2, -1, -2, -3])
     @pytest.mark.parametrize(

--- a/tests/test_flipping.py
+++ b/tests/test_flipping.py
@@ -2,6 +2,7 @@ from math import prod
 
 import numpy
 import pytest
+from dpctl.tensor._numpy_helper import AxisError
 from numpy.testing import (
     assert_equal,
 )
@@ -89,7 +90,7 @@ class TestFlip:
         ],
     )
     def test_axes(self, x, axis):
-        with pytest.raises(numpy.AxisError):
+        with pytest.raises(AxisError):
             dpnp.flip(x, axis=axis)
 
 

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -2,6 +2,7 @@ import functools
 
 import numpy
 import pytest
+from dpctl.tensor._numpy_helper import AxisError
 from numpy.testing import (
     assert_,
     assert_array_equal,
@@ -85,9 +86,9 @@ class TestDiagonal:
         assert_raises(TypeError, dpnp.diagonal, a, offset=[0])
 
         # axes are out of bounds
-        assert_raises(numpy.AxisError, a.diagonal, axis1=0, axis2=5)
-        assert_raises(numpy.AxisError, a.diagonal, axis1=5, axis2=0)
-        assert_raises(numpy.AxisError, a.diagonal, axis1=5, axis2=5)
+        assert_raises(AxisError, a.diagonal, axis1=0, axis2=5)
+        assert_raises(AxisError, a.diagonal, axis1=5, axis2=0)
+        assert_raises(AxisError, a.diagonal, axis1=5, axis2=5)
 
         # same axes
         assert_raises(ValueError, a.diagonal, axis1=1, axis2=1)
@@ -704,7 +705,7 @@ class TestTakeAlongAxis:
         )
 
         # invalid axis
-        assert_raises(numpy.AxisError, xp.take_along_axis, a, ai, axis=10)
+        assert_raises(AxisError, xp.take_along_axis, a, ai, axis=10)
 
     @pytest.mark.parametrize("arr_dt", get_all_dtypes())
     @pytest.mark.parametrize("idx_dt", get_integer_dtypes())

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -4,6 +4,7 @@ import dpctl
 import dpctl.tensor as dpt
 import numpy
 import pytest
+from dpctl.tensor._numpy_helper import AxisError
 from dpctl.utils import ExecutionPlacementError
 from numpy.testing import (
     assert_allclose,
@@ -1156,7 +1157,7 @@ class TestNorm:
             with pytest.raises(ValueError):
                 inp.linalg.norm(ia, ord=ord, axis=axis)
         elif axis is not None:
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 inp.linalg.norm(ia, ord=ord, axis=axis)
         else:
             result = inp.linalg.norm(ia, ord=ord, axis=axis)

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -2,6 +2,10 @@ import dpctl
 import dpctl.tensor as dpt
 import numpy
 import pytest
+from dpctl.tensor._numpy_helper import (
+    AxisError,
+    normalize_axis_index,
+)
 from dpctl.utils import ExecutionPlacementError
 from numpy.testing import (
     assert_allclose,
@@ -244,9 +248,7 @@ class TestCumLogSumExp:
 
         if axis != None:
             if include_initial:
-                norm_axis = numpy.core.numeric.normalize_axis_index(
-                    axis, a.ndim, "axis"
-                )
+                norm_axis = normalize_axis_index(axis, a.ndim, "axis")
                 out_sh = (
                     a.shape[:norm_axis]
                     + (a.shape[norm_axis] + 1,)
@@ -500,7 +502,7 @@ class TestDiff:
     @pytest.mark.parametrize("axis", [-4, 3])
     def test_axis_error(self, xp, axis):
         a = xp.ones((10, 20, 30))
-        assert_raises(numpy.AxisError, xp.diff, a, axis=axis)
+        assert_raises(AxisError, xp.diff, a, axis=axis)
 
     @pytest.mark.parametrize("xp", [numpy, dpnp])
     def test_ndim_error(self, xp):
@@ -609,8 +611,8 @@ class TestDiff:
     @pytest.mark.parametrize("xp", [numpy, dpnp])
     def test_prepend_append_axis_error(self, xp):
         a = xp.arange(4).reshape(2, 2)
-        assert_raises(numpy.AxisError, xp.diff, a, axis=3, prepend=0)
-        assert_raises(numpy.AxisError, xp.diff, a, axis=3, append=0)
+        assert_raises(AxisError, xp.diff, a, axis=3, prepend=0)
+        assert_raises(AxisError, xp.diff, a, axis=3, append=0)
 
 
 class TestGradient:
@@ -861,7 +863,7 @@ class TestGradient:
     @pytest.mark.parametrize("xp", [numpy, dpnp])
     def test_wrong_axis(self, xp):
         x = xp.array([[1, 1], [3, 4]])
-        assert_raises(numpy.AxisError, xp.gradient, x, axis=3)
+        assert_raises(AxisError, xp.gradient, x, axis=3)
 
     @pytest.mark.parametrize(
         "size, edge_order",

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -1,5 +1,6 @@
 import numpy
 import pytest
+from dpctl.tensor._numpy_helper import AxisError
 from numpy.testing import assert_array_equal, assert_equal, assert_raises
 
 import dpnp
@@ -73,7 +74,7 @@ class TestArgsort:
         dp_array = dpnp.array(np_array)
 
         # with default axis=-1
-        with pytest.raises(numpy.AxisError):
+        with pytest.raises(AxisError):
             dpnp.argsort(dp_array)
 
         # with axis = None
@@ -322,7 +323,7 @@ class TestSort:
         dp_array = dpnp.array(np_array)
 
         # with default axis=-1
-        with pytest.raises(numpy.AxisError):
+        with pytest.raises(AxisError):
             dpnp.sort(dp_array)
 
         # with axis = None

--- a/tests/third_party/cupy/core_tests/test_ndarray.py
+++ b/tests/third_party/cupy/core_tests/test_ndarray.py
@@ -4,6 +4,7 @@ import unittest
 import dpctl
 import numpy
 import pytest
+from dpctl.tensor._numpy_helper import AxisError
 
 import dpnp as cupy
 from tests.third_party.cupy import testing
@@ -521,12 +522,12 @@ class TestNdarrayTakeErrorAxisOverRun(unittest.TestCase):
     def test_axis_overrun1(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange(self.shape, xp)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 wrap_take(a, self.indices, axis=self.axis)
 
     def test_axis_overrun2(self):
         a = testing.shaped_arange(self.shape, cupy)
-        with pytest.raises(numpy.AxisError):
+        with pytest.raises(AxisError):
             wrap_take(a, self.indices, axis=self.axis)
 
 

--- a/tests/third_party/cupy/lib_tests/test_shape_base.py
+++ b/tests/third_party/cupy/lib_tests/test_shape_base.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy
 import pytest
+from dpctl.tensor._numpy_helper import AxisError
 
 import dpnp as cupy
 from tests.third_party.cupy import testing
@@ -104,7 +105,7 @@ def test_apply_along_axis_invalid_axis():
     for xp in [numpy, cupy]:
         a = xp.ones((8, 4))
         for axis in [-3, 2]:
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 xp.apply_along_axis(xp.sum, axis, a)
 
 

--- a/tests/third_party/cupy/manipulation_tests/test_dims.py
+++ b/tests/third_party/cupy/manipulation_tests/test_dims.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy
 import pytest
+from dpctl.tensor._numpy_helper import AxisError
 
 import dpnp as cupy
 from tests.third_party.cupy import testing
@@ -130,7 +131,7 @@ class TestDims(unittest.TestCase):
     def test_expand_dims_negative2(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3), xp)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 xp.expand_dims(a, -4)
 
     @testing.with_requires("numpy>=1.18")
@@ -154,7 +155,7 @@ class TestDims(unittest.TestCase):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 2, 2), xp)
             for axis in [(1, -6), (1, 5)]:
-                with pytest.raises(numpy.AxisError):
+                with pytest.raises(AxisError):
                     xp.expand_dims(a, axis)
 
     @testing.with_requires("numpy>=1.18")
@@ -193,7 +194,7 @@ class TestDims(unittest.TestCase):
     def test_squeeze_int_axis_failure2(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((1, 2, 1, 3, 1, 1, 4, 1), xp)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 a.squeeze(axis=-9)
 
     @testing.numpy_cupy_array_equal()
@@ -231,7 +232,7 @@ class TestDims(unittest.TestCase):
     def test_squeeze_tuple_axis_failure3(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((1, 2, 1, 3, 1, 1, 4, 1), xp)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 a.squeeze(axis=(-9,))
 
     @testing.numpy_cupy_array_equal()
@@ -259,13 +260,13 @@ class TestDims(unittest.TestCase):
     def test_squeeze_scalar_failure3(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((), xp)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 a.squeeze(axis=-2)
 
     def test_squeeze_scalar_failure4(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((), cupy)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 a.squeeze(axis=1)
 
     def test_squeeze_failure(self):

--- a/tests/third_party/cupy/manipulation_tests/test_join.py
+++ b/tests/third_party/cupy/manipulation_tests/test_join.py
@@ -1,5 +1,6 @@
 import numpy
 import pytest
+from dpctl.tensor._numpy_helper import AxisError
 
 import dpnp as cupy
 from tests.helper import has_support_aspect64
@@ -396,7 +397,7 @@ class TestJoin:
 
     def test_stack_out_of_bounds2(self):
         a = testing.shaped_arange((2, 3), cupy)
-        with pytest.raises(numpy.AxisError):
+        with pytest.raises(AxisError):
             return cupy.stack([a, a], axis=3)
 
     @testing.for_all_dtypes(name="dtype")

--- a/tests/third_party/cupy/manipulation_tests/test_transpose.py
+++ b/tests/third_party/cupy/manipulation_tests/test_transpose.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy
 import pytest
+from dpctl.tensor._numpy_helper import AxisError
 
 import dpnp as cupy
 from tests.third_party.cupy import testing
@@ -42,32 +43,32 @@ class TestTranspose(unittest.TestCase):
     def test_moveaxis_invalid1_1(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3, 4), xp)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 xp.moveaxis(a, [0, 1], [1, 3])
 
     def test_moveaxis_invalid1_2(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3, 4), xp)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 xp.moveaxis(a, [0, 1], [1, 3])
 
     # dim is too small
     def test_moveaxis_invalid2_1(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3, 4), xp)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 xp.moveaxis(a, [0, -4], [1, 2])
 
     def test_moveaxis_invalid2_2(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3, 4), xp)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 xp.moveaxis(a, [0, -4], [1, 2])
 
     def test_moveaxis_invalid2_3(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3, 4), xp)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 xp.moveaxis(a, -4, 0)
 
     # len(source) != len(destination)
@@ -100,7 +101,7 @@ class TestTranspose(unittest.TestCase):
     def test_moveaxis_invalid5_1(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3, 4), xp)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 xp.moveaxis(a, [1, -1], [1, 3])
 
     def test_moveaxis_invalid5_2(self):

--- a/tests/third_party/cupy/math_tests/test_sumprod.py
+++ b/tests/third_party/cupy/math_tests/test_sumprod.py
@@ -3,6 +3,7 @@ import warnings
 
 import numpy
 import pytest
+from dpctl.tensor._numpy_helper import AxisError
 
 import dpnp as cupy
 from tests.helper import (
@@ -440,26 +441,26 @@ class TestCumsum:
     def test_invalid_axis_lower1(self, dtype):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((4, 5), xp, dtype)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 xp.cumsum(a, axis=-a.ndim - 1)
 
     @testing.for_all_dtypes()
     def test_invalid_axis_lower2(self, dtype):
         a = testing.shaped_arange((4, 5), cupy, dtype)
-        with pytest.raises(numpy.AxisError):
+        with pytest.raises(AxisError):
             return cupy.cumsum(a, axis=-a.ndim - 1)
 
     @testing.for_all_dtypes()
     def test_invalid_axis_upper1(self, dtype):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((4, 5), xp, dtype)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 xp.cumsum(a, axis=a.ndim + 1)
 
     @testing.for_all_dtypes()
     def test_invalid_axis_upper2(self, dtype):
         a = testing.shaped_arange((4, 5), cupy, dtype)
-        with pytest.raises(numpy.AxisError):
+        with pytest.raises(AxisError):
             return cupy.cumsum(a, axis=a.ndim + 1)
 
     def test_cumsum_arraylike(self):
@@ -535,27 +536,27 @@ class TestCumprod:
     def test_invalid_axis_lower1(self, dtype):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((4, 5), xp, dtype)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 xp.cumprod(a, axis=-a.ndim - 1)
 
     @testing.for_all_dtypes()
     def test_invalid_axis_lower2(self, dtype):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((4, 5), xp, dtype)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 xp.cumprod(a, axis=-a.ndim - 1)
 
     @testing.for_all_dtypes()
     def test_invalid_axis_upper1(self, dtype):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((4, 5), xp, dtype)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 return xp.cumprod(a, axis=a.ndim)
 
     @testing.for_all_dtypes()
     def test_invalid_axis_upper2(self, dtype):
         a = testing.shaped_arange((4, 5), cupy, dtype)
-        with pytest.raises(numpy.AxisError):
+        with pytest.raises(AxisError):
             return cupy.cumprod(a, axis=a.ndim)
 
     def test_cumprod_arraylike(self):
@@ -692,9 +693,9 @@ class TestDiff:
     def test_diff_invalid_axis(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3, 4), xp)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 xp.diff(a, axis=3)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 xp.diff(a, axis=-4)
 
 
@@ -843,7 +844,7 @@ class TestGradientErrors:
         for xp in [numpy, cupy]:
             x = testing.shaped_random(shape, xp)
             for axis in [-3, 2]:
-                with pytest.raises(numpy.AxisError):
+                with pytest.raises(AxisError):
                     xp.gradient(x, axis=axis)
 
     def test_gradient_bool_input(self):

--- a/tests/third_party/cupy/sorting_tests/test_sort.py
+++ b/tests/third_party/cupy/sorting_tests/test_sort.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy
 import pytest
+from dpctl.tensor._numpy_helper import AxisError
 
 import dpnp as cupy
 from tests.helper import has_support_aspect64
@@ -24,13 +25,13 @@ class TestSort(unittest.TestCase):
     def test_sort_zero_dim(self):
         for xp in (numpy, cupy):
             a = testing.shaped_random((), xp)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 a.sort()
 
     def test_external_sort_zero_dim(self):
         for xp in (numpy, cupy):
             a = testing.shaped_random((), xp)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 xp.sort(a)
 
     @testing.numpy_cupy_array_equal()
@@ -127,45 +128,45 @@ class TestSort(unittest.TestCase):
     def test_sort_invalid_axis1(self):
         for xp in (numpy, cupy):
             a = testing.shaped_random((2, 3, 3), xp)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 a.sort(axis=3)
 
     def test_sort_invalid_axis2(self):
         a = testing.shaped_random((2, 3, 3), cupy)
-        with self.assertRaises(numpy.AxisError):
+        with self.assertRaises(AxisError):
             a.sort(axis=3)
 
     def test_external_sort_invalid_axis1(self):
         for xp in (numpy, cupy):
             a = testing.shaped_random((2, 3, 3), xp)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 xp.sort(a, axis=3)
 
     def test_external_sort_invalid_axis2(self):
         a = testing.shaped_random((2, 3, 3), cupy)
-        with self.assertRaises(numpy.AxisError):
+        with self.assertRaises(AxisError):
             cupy.sort(a, axis=3)
 
     def test_sort_invalid_negative_axis1(self):
         for xp in (numpy, cupy):
             a = testing.shaped_random((2, 3, 3), xp)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 a.sort(axis=-4)
 
     def test_sort_invalid_negative_axis2(self):
         a = testing.shaped_random((2, 3, 3), cupy)
-        with self.assertRaises(numpy.AxisError):
+        with self.assertRaises(AxisError):
             a.sort(axis=-4)
 
     def test_external_sort_invalid_negative_axis1(self):
         for xp in (numpy, cupy):
             a = testing.shaped_random((2, 3, 3), xp)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 xp.sort(a, axis=-4)
 
     def test_external_sort_invalid_negative_axis2(self):
         a = testing.shaped_random((2, 3, 3), cupy)
-        with self.assertRaises(numpy.AxisError):
+        with self.assertRaises(AxisError):
             cupy.sort(a, axis=-4)
 
     # Test NaN ordering
@@ -220,7 +221,7 @@ class TestLexsort(unittest.TestCase):
     def test_lexsort_zero_dim(self):
         for xp in (numpy, cupy):
             a = testing.shaped_random((), xp)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 return xp.lexsort(a)
 
     @testing.numpy_cupy_array_equal()
@@ -351,12 +352,12 @@ class TestArgsort(unittest.TestCase):
     def test_argsort_invalid_axis1(self):
         for xp in (numpy, cupy):
             a = testing.shaped_random((2, 3, 3), xp)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 self.argsort(a, axis=3)
 
     def test_argsort_invalid_axis2(self):
         a = testing.shaped_random((2, 3, 3), cupy)
-        with self.assertRaises(numpy.AxisError):
+        with self.assertRaises(AxisError):
             return self.argsort(a, axis=3)
 
     @testing.numpy_cupy_array_equal()
@@ -368,18 +369,18 @@ class TestArgsort(unittest.TestCase):
     def test_argsort_zero_dim_invalid_axis(self):
         for xp in (numpy, cupy):
             a = testing.shaped_random((), xp)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 self.argsort(a, axis=1)
 
     def test_argsort_invalid_negative_axis1(self):
         for xp in (numpy, cupy):
             a = testing.shaped_random((2, 3, 3), xp)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 self.argsort(a, axis=-4)
 
     def test_argsort_invalid_negative_axis2(self):
         a = testing.shaped_random((2, 3, 3), cupy)
-        with self.assertRaises(numpy.AxisError):
+        with self.assertRaises(AxisError):
             return self.argsort(a, axis=-4)
 
     # Misc tests
@@ -420,7 +421,7 @@ class TestMsort(unittest.TestCase):
     def test_msort_zero_dim(self):
         for xp in (numpy, cupy):
             a = testing.shaped_random((), xp)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 xp.msort(a)
 
     @testing.for_all_dtypes()
@@ -440,7 +441,7 @@ class TestSort_complex(unittest.TestCase):
     def test_sort_complex_zero_dim(self):
         for xp in (numpy, cupy):
             a = testing.shaped_random((), xp)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 xp.sort_complex(a)
 
     @testing.for_all_dtypes()
@@ -487,7 +488,7 @@ class TestPartition(unittest.TestCase):
         for xp in (numpy, cupy):
             a = testing.shaped_random((), xp)
             kth = 2
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 self.partition(a, kth)
 
     @testing.for_all_dtypes()
@@ -586,12 +587,12 @@ class TestPartition(unittest.TestCase):
             a = testing.shaped_random((2, 2, self.length), xp)
             kth = 2
             axis = 3
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 self.partition(a, kth, axis=axis)
 
     def test_partition_invalid_axis2(self):
         a = testing.shaped_random((2, 2, self.length), cupy)
-        with self.assertRaises(numpy.AxisError):
+        with self.assertRaises(AxisError):
             kth = 2
             axis = 3
             return self.partition(a, kth, axis=axis)
@@ -601,12 +602,12 @@ class TestPartition(unittest.TestCase):
             a = testing.shaped_random((2, 2, self.length), xp)
             kth = 2
             axis = -4
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 self.partition(a, kth, axis=axis)
 
     def test_partition_invalid_negative_axis2(self):
         a = testing.shaped_random((2, 2, self.length), cupy)
-        with self.assertRaises(numpy.AxisError):
+        with self.assertRaises(AxisError):
             kth = 2
             axis = -4
             return self.partition(a, kth, axis=axis)
@@ -792,14 +793,14 @@ class TestArgpartition(unittest.TestCase):
             a = testing.shaped_random((2, 2, 2), xp, scale=100)
             kth = 1
             axis = 3
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 self.argpartition(a, kth, axis=axis)
 
     def test_argpartition_invalid_axis2(self):
         a = testing.shaped_random((2, 2, 2), cupy, scale=100)
         kth = 1
         axis = 3
-        with self.assertRaises(numpy.AxisError):
+        with self.assertRaises(AxisError):
             self.argpartition(a, kth, axis=axis)
 
     def test_argpartition_invalid_negative_axis1(self):
@@ -807,12 +808,12 @@ class TestArgpartition(unittest.TestCase):
             a = testing.shaped_random((2, 2, 2), xp, scale=100)
             kth = 1
             axis = -4
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 self.argpartition(a, kth, axis=axis)
 
     def test_argpartition_invalid_negative_axis2(self):
         a = testing.shaped_random((2, 2, 2), cupy, scale=100)
         kth = 1
         axis = -4
-        with self.assertRaises(numpy.AxisError):
+        with self.assertRaises(AxisError):
             self.argpartition(a, kth, axis=axis)

--- a/tests/third_party/cupy/statistics_tests/test_meanvar.py
+++ b/tests/third_party/cupy/statistics_tests/test_meanvar.py
@@ -1,5 +1,6 @@
 import numpy
 import pytest
+from dpctl.tensor._numpy_helper import AxisError
 
 import dpnp as cupy
 from tests.helper import has_support_aspect16, has_support_aspect64
@@ -56,16 +57,16 @@ class TestMedian:
     def test_median_invalid_axis(self):
         for xp in [numpy, cupy]:
             a = testing.shaped_random((3, 4, 5), xp)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 return xp.median(a, -a.ndim - 1, keepdims=False)
 
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 return xp.median(a, a.ndim, keepdims=False)
 
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 return xp.median(a, (-a.ndim - 1, 1), keepdims=False)
 
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 return xp.median(
                     a,
                     (

--- a/tests/third_party/cupy/testing/_loops.py
+++ b/tests/third_party/cupy/testing/_loops.py
@@ -9,6 +9,7 @@ from typing import Tuple, Type
 
 import numpy
 from dpctl import select_default_device
+from dpctl.tensor._numpy_helper import AxisError
 
 import dpnp as cupy
 from tests.third_party.cupy.testing import _array, _parameterized
@@ -116,7 +117,7 @@ _numpy_errors = [
     ValueError,
     NotImplementedError,
     DeprecationWarning,
-    numpy.AxisError,
+    AxisError,
     numpy.linalg.LinAlgError,
 ]
 


### PR DESCRIPTION
As part of the work to support numpy 2.0 we need to align with new import of `normalize_axis_index`, `normalize_axis_tuple` and `AxisError` which was changed in non-backward compatible way since numpy 2.0.

That PR proposes to use the same functionality but from `dpctl.tensor._numpy_helper` module which already adopted to support different numpy versions (including numpy 2.0).

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
