### PR TITLE
Implement `dpnp.logaddexp2` function

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
     rev: 24.4.2
     hooks:
     -   id: black
-        args: ["--check", "--diff", "--color"]
+        args: ["--color"]
 -   repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
     rev: 24.4.2
     hooks:
     -   id: black
-        args: ["--color"]
+        args: ["--check", "--diff", "--color"]
 -   repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:

--- a/dpnp/backend/extensions/ufunc/CMakeLists.txt
+++ b/dpnp/backend/extensions/ufunc/CMakeLists.txt
@@ -30,6 +30,7 @@ set(_elementwise_sources
     ${CMAKE_CURRENT_SOURCE_DIR}/elementwise_functions/fmax.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/elementwise_functions/fmin.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/elementwise_functions/fmod.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/elementwise_functions/logaddexp2.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/elementwise_functions/radians.cpp
 )
 

--- a/dpnp/backend/extensions/ufunc/elementwise_functions/logaddexp2.cpp
+++ b/dpnp/backend/extensions/ufunc/elementwise_functions/logaddexp2.cpp
@@ -1,0 +1,136 @@
+//*****************************************************************************
+// Copyright (c) 2024, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// maxification, are permitted provided that the following conditions are met:
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//*****************************************************************************
+
+#include <sycl/sycl.hpp>
+
+#include "dpctl4pybind11.hpp"
+
+#include "kernels/elementwise_functions/logaddexp2.hpp"
+#include "logaddexp2.hpp"
+#include "populate.hpp"
+
+// include a local copy of elementwise common header from dpctl tensor:
+// dpctl/tensor/libtensor/source/elementwise_functions/elementwise_functions.hpp
+// TODO: replace by including dpctl header once available
+#include "../../elementwise_functions/elementwise_functions.hpp"
+
+// dpctl tensor headers
+#include "kernels/elementwise_functions/common.hpp"
+#include "kernels/elementwise_functions/logaddexp.hpp"
+#include "utils/type_dispatch.hpp"
+
+namespace dpnp::extensions::ufunc
+{
+namespace py = pybind11;
+namespace py_int = dpnp::extensions::py_internal;
+namespace td_ns = dpctl::tensor::type_dispatch;
+
+namespace impl
+{
+namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+namespace logaddexp_ns = dpctl::tensor::kernels::logaddexp;
+
+// Supports the same types table as for logaddexp function in dpctl
+template <typename T1, typename T2>
+using OutputType = logaddexp_ns::LogAddExpOutputType<T1, T2>;
+
+using dpnp::kernels::logaddexp2::Logaddexp2Functor;
+
+template <typename argT1,
+          typename argT2,
+          typename resT,
+          unsigned int vec_sz = 4,
+          unsigned int n_vecs = 2,
+          bool enable_sg_loadstore = true>
+using ContigFunctor =
+    ew_cmn_ns::BinaryContigFunctor<argT1,
+                                   argT2,
+                                   resT,
+                                   Logaddexp2Functor<argT1, argT2, resT>,
+                                   vec_sz,
+                                   n_vecs,
+                                   enable_sg_loadstore>;
+
+template <typename argT1, typename argT2, typename resT, typename IndexerT>
+using StridedFunctor =
+    ew_cmn_ns::BinaryStridedFunctor<argT1,
+                                    argT2,
+                                    resT,
+                                    IndexerT,
+                                    Logaddexp2Functor<argT1, argT2, resT>>;
+
+using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
+using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
+
+static binary_contig_impl_fn_ptr_t
+    logaddexp2_contig_dispatch_table[td_ns::num_types][td_ns::num_types];
+static int logaddexp2_output_typeid_table[td_ns::num_types][td_ns::num_types];
+static binary_strided_impl_fn_ptr_t
+    logaddexp2_strided_dispatch_table[td_ns::num_types][td_ns::num_types];
+
+MACRO_POPULATE_DISPATCH_TABLES(logaddexp2);
+} // namespace impl
+
+void init_logaddexp2(py::module_ m)
+{
+    using arrayT = dpctl::tensor::usm_ndarray;
+    using event_vecT = std::vector<sycl::event>;
+    {
+        impl::populate_logaddexp2_dispatch_tables();
+        using impl::logaddexp2_contig_dispatch_table;
+        using impl::logaddexp2_output_typeid_table;
+        using impl::logaddexp2_strided_dispatch_table;
+
+        auto logaddexp2_pyapi = [&](const arrayT &src1, const arrayT &src2,
+                                    const arrayT &dst, sycl::queue &exec_q,
+                                    const event_vecT &depends = {}) {
+            return py_int::py_binary_ufunc(
+                src1, src2, dst, exec_q, depends,
+                logaddexp2_output_typeid_table,
+                logaddexp2_contig_dispatch_table,
+                logaddexp2_strided_dispatch_table,
+                // no support of C-contig row with broadcasting in OneMKL
+                td_ns::NullPtrTable<
+                    impl::
+                        binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t>{},
+                td_ns::NullPtrTable<
+                    impl::
+                        binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{});
+        };
+        m.def("_logaddexp2", logaddexp2_pyapi, "", py::arg("src1"),
+              py::arg("src2"), py::arg("dst"), py::arg("sycl_queue"),
+              py::arg("depends") = py::list());
+
+        auto logaddexp2_result_type_pyapi = [&](const py::dtype &dtype1,
+                                                const py::dtype &dtype2) {
+            return py_int::py_binary_ufunc_result_type(
+                dtype1, dtype2, logaddexp2_output_typeid_table);
+        };
+        m.def("_logaddexp2_result_type", logaddexp2_result_type_pyapi);
+    }
+}
+} // namespace dpnp::extensions::ufunc

--- a/dpnp/backend/extensions/ufunc/elementwise_functions/logaddexp2.hpp
+++ b/dpnp/backend/extensions/ufunc/elementwise_functions/logaddexp2.hpp
@@ -23,31 +23,13 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //*****************************************************************************
 
-#include <pybind11/pybind11.h>
+#pragma once
 
-#include "degrees.hpp"
-#include "fabs.hpp"
-#include "fmax.hpp"
-#include "fmin.hpp"
-#include "fmod.hpp"
-#include "logaddexp2.hpp"
-#include "radians.hpp"
+#include <pybind11/pybind11.h>
 
 namespace py = pybind11;
 
 namespace dpnp::extensions::ufunc
 {
-/**
- * @brief Add elementwise functions to Python module
- */
-void init_elementwise_functions(py::module_ m)
-{
-    init_degrees(m);
-    init_fabs(m);
-    init_fmax(m);
-    init_fmin(m);
-    init_fmod(m);
-    init_logaddexp2(m);
-    init_radians(m);
-}
+void init_logaddexp2(py::module_ m);
 } // namespace dpnp::extensions::ufunc

--- a/dpnp/dpnp_iface_trigonometric.py
+++ b/dpnp/dpnp_iface_trigonometric.py
@@ -82,6 +82,7 @@ __all__ = [
     "log1p",
     "log2",
     "logaddexp",
+    "logaddexp2",
     "logsumexp",
     "rad2deg",
     "radians",
@@ -1409,6 +1410,83 @@ logaddexp = DPNPBinaryFunc(
     ti._logaddexp_result_type,
     ti._logaddexp,
     _LOGADDEXP_DOCSTRING,
+)
+
+
+_LOGADDEXP2_DOCSTRING = """
+Calculates the logarithm of the sum of exponents for each element `x1_i`
+of the input array `x1` with the respective element `x2_i` of the input
+array `x2`.
+
+    Logarithm of the sum of exponentiations of the inputs in base-2.
+
+    Calculates ``log2(2**x1 + 2**x2)``. This function is useful in machine
+    learning when the calculated probabilities of events may be so small as
+    to exceed the range of normal floating point numbers.  In such cases
+    the base-2 logarithm of the calculated probability can be used instead.
+    This function allows adding probabilities stored in such a fashion.
+
+This function calculates `log2(2**x1 + 2**x2)`. It is useful in machine
+learning when the calculated probabilities of events may be so small as
+to exceed the range of normal floating point numbers.  In such cases the base-2
+logarithm of the calculated probability can be used instead. This function
+allows adding probabilities stored in such a fashion.
+
+For full documentation refer to :obj:`numpy.logaddexp2`.
+
+Parameters
+----------
+x1 : {dpnp.ndarray, usm_ndarray, scalar}
+    First input array, expected to have a real-valued floating-point
+    data type.
+    Both inputs `x1` and `x2` can not be scalars at the same time.
+x2 : {dpnp.ndarray, usm_ndarray, scalar}
+    Second input array, also expected to have a real-valued
+    floating-point data type.
+    Both inputs `x1` and `x2` can not be scalars at the same time.
+out : {None, dpnp.ndarray, usm_ndarray}, optional
+    Output array to populate.
+    Array must have the correct shape and the expected data type.
+    Default: ``None``.
+order : {"C", "F", "A", "K"}, optional
+    Memory layout of the newly output array, if parameter `out` is ``None``.
+    Default: ``"K"``.
+
+Returns
+-------
+out : dpnp.ndarray
+    An array containing the element-wise results. The data type
+    of the returned array is determined by the Type Promotion Rules.
+
+Limitations
+-----------
+Parameters `where` and `subok` are supported with their default values.
+Keyword arguments `kwargs` are currently unsupported.
+Otherwise ``NotImplementedError`` exception will be raised.
+
+See Also
+--------
+:obj:`dpnp.log` : Natural logarithm, element-wise.
+:obj:`dpnp.exp` : Exponential, element-wise.
+:obj:`dpnp.logsumdexp` : Logarithm of the sum of exponents of elements in the input array.
+
+Examples
+--------
+>>> import dpnp as np
+>>> prob1 = np.log2(np.array(1e-50))
+>>> prob2 = np.log2(np.array(2.5e-50))
+>>> prob12 = np.logaddexp2(prob1, prob2)
+>>> prob1, prob2, prob12
+(array(-166.09640474), array(-164.77447665), array(-164.28904982))
+>>> 2**prob12
+array(3.5e-50)
+"""
+
+logaddexp2 = DPNPBinaryFunc(
+    "logaddexp2",
+    ufi._logaddexp2_result_type,
+    ufi._logaddexp2,
+    _LOGADDEXP2_DOCSTRING,
 )
 
 

--- a/dpnp/dpnp_iface_trigonometric.py
+++ b/dpnp/dpnp_iface_trigonometric.py
@@ -1202,7 +1202,7 @@ Otherwise ``NotImplementedError`` exception will be raised.
 See Also
 --------
 :obj:`dpnp.log` : Natural logarithm, element-wise.
-:obj:`dpnp.log2` : Return the base 2 logarithm of the input array, element-wise.
+:obj:`dpnp.log2` : Return the base-2 logarithm of the input array, element-wise.
 :obj:`dpnp.log1p` : Return the natural logarithm of one plus the input array, element-wise.
 
 Examples
@@ -1263,7 +1263,7 @@ See Also
 :obj:`dpnp.expm1` : ``exp(x) - 1``, the inverse of :obj:`dpnp.log1p`.
 :obj:`dpnp.log` : Natural logarithm, element-wise.
 :obj:`dpnp.log10` : Return the base 10 logarithm of the input array, element-wise.
-:obj:`dpnp.log2` : Return the base 2 logarithm of the input array, element-wise.
+:obj:`dpnp.log2` : Return the base-2 logarithm of the input array, element-wise.
 
 Examples
 --------
@@ -1391,7 +1391,10 @@ See Also
 --------
 :obj:`dpnp.log` : Natural logarithm, element-wise.
 :obj:`dpnp.exp` : Exponential, element-wise.
-:obj:`dpnp.logsumdexp` : Logarithm of the sum of exponents of elements in the input array.
+:obj:`dpnp.logaddexp2`: Logarithm of the sum of exponentiations of inputs in
+                        base-2, element-wise.
+:obj:`dpnp.logsumexp` : Logarithm of the sum of exponents of elements in the
+                        input array.
 
 Examples
 --------
@@ -1414,21 +1417,13 @@ logaddexp = DPNPBinaryFunc(
 
 
 _LOGADDEXP2_DOCSTRING = """
-Calculates the logarithm of the sum of exponents for each element `x1_i`
-of the input array `x1` with the respective element `x2_i` of the input
+Calculates the logarithm of the sum of exponents in base-2 for each element
+`x1_i` of the input array `x1` with the respective element `x2_i` of the input
 array `x2`.
-
-    Logarithm of the sum of exponentiations of the inputs in base-2.
-
-    Calculates ``log2(2**x1 + 2**x2)``. This function is useful in machine
-    learning when the calculated probabilities of events may be so small as
-    to exceed the range of normal floating point numbers.  In such cases
-    the base-2 logarithm of the calculated probability can be used instead.
-    This function allows adding probabilities stored in such a fashion.
 
 This function calculates `log2(2**x1 + 2**x2)`. It is useful in machine
 learning when the calculated probabilities of events may be so small as
-to exceed the range of normal floating point numbers.  In such cases the base-2
+to exceed the range of normal floating point numbers. In such cases the base-2
 logarithm of the calculated probability can be used instead. This function
 allows adding probabilities stored in such a fashion.
 
@@ -1466,9 +1461,9 @@ Otherwise ``NotImplementedError`` exception will be raised.
 
 See Also
 --------
-:obj:`dpnp.log` : Natural logarithm, element-wise.
-:obj:`dpnp.exp` : Exponential, element-wise.
-:obj:`dpnp.logsumdexp` : Logarithm of the sum of exponents of elements in the input array.
+:obj:`dpnp.logaddexp`: Natural logarithm of the sum of exponentiations of
+                       inputs, element-wise.
+:obj:`dpnp.logsumexp` : Logarithm of the sum of exponentiations of the inputs.
 
 Examples
 --------
@@ -1550,6 +1545,8 @@ def logsumexp(x, /, *, axis=None, dtype=None, keepdims=False, out=None):
     :obj:`dpnp.exp` : Exponential, element-wise.
     :obj:`dpnp.logaddexp` : Logarithm of the sum of exponents of
                             the inputs, element-wise.
+    :obj:`dpnp.logaddexp2` : Logarithm of the sum of exponents of
+                            the inputs in base-2, element-wise.
 
     Examples
     --------

--- a/dpnp/dpnp_iface_trigonometric.py
+++ b/dpnp/dpnp_iface_trigonometric.py
@@ -1546,7 +1546,7 @@ def logsumexp(x, /, *, axis=None, dtype=None, keepdims=False, out=None):
     :obj:`dpnp.logaddexp` : Logarithm of the sum of exponents of
                             the inputs, element-wise.
     :obj:`dpnp.logaddexp2` : Logarithm of the sum of exponents of
-                            the inputs in base-2, element-wise.
+                             the inputs in base-2, element-wise.
 
     Examples
     --------

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -52,8 +52,6 @@ tests/test_umath.py::test_umaths[('ldexp', 'fi')]
 tests/test_umath.py::test_umaths[('ldexp', 'fl')]
 tests/test_umath.py::test_umaths[('ldexp', 'di')]
 tests/test_umath.py::test_umaths[('ldexp', 'dl')]
-tests/test_umath.py::test_umaths[('logaddexp2', 'ff')]
-tests/test_umath.py::test_umaths[('logaddexp2', 'dd')]
 tests/test_umath.py::test_umaths[('spacing', 'f')]
 tests/test_umath.py::test_umaths[('spacing', 'd')]
 

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -209,9 +209,6 @@ tests/third_party/cupy/manipulation_tests/test_dims.py::TestInvalidBroadcast_par
 tests/third_party/cupy/manipulation_tests/test_dims.py::TestInvalidBroadcast_param_2_{shapes=[(3, 2), (3, 4)]}::test_invalid_broadcast
 tests/third_party/cupy/manipulation_tests/test_dims.py::TestInvalidBroadcast_param_3_{shapes=[(0,), (2,)]}::test_invalid_broadcast
 
-tests/third_party/cupy/math_tests/test_explog.py::TestExplog::test_logaddexp2
-tests/third_party/cupy/math_tests/test_explog.py::TestExplog::test_logaddexp2_infinities
-
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_negative
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_for_old_numpy

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -263,9 +263,6 @@ tests/third_party/cupy/manipulation_tests/test_dims.py::TestInvalidBroadcast_par
 tests/third_party/cupy/manipulation_tests/test_dims.py::TestInvalidBroadcast_param_2_{shapes=[(3, 2), (3, 4)]}::test_invalid_broadcast
 tests/third_party/cupy/manipulation_tests/test_dims.py::TestInvalidBroadcast_param_3_{shapes=[(0,), (2,)]}::test_invalid_broadcast
 
-tests/third_party/cupy/math_tests/test_explog.py::TestExplog::test_logaddexp2
-tests/third_party/cupy/math_tests/test_explog.py::TestExplog::test_logaddexp2_infinities
-
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_negative
 tests/third_party/cupy/math_tests/test_misc.py::TestMisc::test_nan_to_num_for_old_numpy

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -35,8 +35,6 @@ tests/test_umath.py::test_umaths[('ldexp', 'fi')]
 tests/test_umath.py::test_umaths[('ldexp', 'fl')]
 tests/test_umath.py::test_umaths[('ldexp', 'di')]
 tests/test_umath.py::test_umaths[('ldexp', 'dl')]
-tests/test_umath.py::test_umaths[('logaddexp2', 'ff')]
-tests/test_umath.py::test_umaths[('logaddexp2', 'dd')]
 tests/test_umath.py::test_umaths[('spacing', 'f')]
 tests/test_umath.py::test_umaths[('spacing', 'd')]
 

--- a/tests/test_strides.py
+++ b/tests/test_strides.py
@@ -221,6 +221,7 @@ def test_angle(dtype):
         "fmin",
         "hypot",
         "logaddexp",
+        "logaddexp2",
         "maximum",
         "minimum",
         "multiply",

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -679,6 +679,7 @@ def test_reduce_hypot(device):
         pytest.param("inner", [1.0, 2.0, 3.0], [4.0, 5.0, 6.0]),
         pytest.param("kron", [3.0, 4.0, 5.0], [1.0, 2.0]),
         pytest.param("logaddexp", [[-1, 2, 5, 9]], [[4, -3, 2, -8]]),
+        pytest.param("logaddexp2", [[-1, 2, 5, 9]], [[4, -3, 2, -8]]),
         pytest.param(
             "matmul", [[1.0, 0.0], [0.0, 1.0]], [[4.0, 1.0], [1.0, 2.0]]
         ),

--- a/tests/test_umath.py
+++ b/tests/test_umath.py
@@ -2,6 +2,8 @@ import numpy
 import pytest
 from numpy.testing import (
     assert_allclose,
+    assert_almost_equal,
+    assert_equal,
     assert_raises,
 )
 
@@ -345,6 +347,83 @@ class TestLogaddexp:
         dp_out = dpnp.empty(shape)
         with pytest.raises(ValueError):
             dpnp.logaddexp(dp_array, dp_array, out=dp_out)
+
+    @pytest.mark.usefixtures("suppress_invalid_numpy_warnings")
+    @pytest.mark.parametrize(
+        "val1, val2",
+        [
+            pytest.param(numpy.nan, numpy.inf),
+            pytest.param(numpy.inf, numpy.nan),
+            pytest.param(numpy.nan, 0),
+            pytest.param(0, numpy.nan),
+            pytest.param(numpy.nan, numpy.nan),
+        ],
+    )
+    def test_nan(self, val1, val2):
+        a = numpy.array(val1)
+        b = numpy.array(val2)
+        ia, ib = dpnp.array(a), dpnp.array(b)
+
+        result = dpnp.logaddexp(ia, ib)
+        expected = numpy.logaddexp(a, b)
+        assert_equal(result, expected)
+
+
+class TestLogAddExp2:
+    @pytest.mark.parametrize(
+        "dt", get_all_dtypes(no_none=True, no_complex=True)
+    )
+    def test_values(self, dt):
+        a = numpy.log2(numpy.array([1, 2, 3, 4, 5], dtype=dt))
+        b = numpy.log2(numpy.array([5, 4, 3, 2, 1], dtype=dt))
+        ia, ib = dpnp.array(a), dpnp.array(b)
+
+        result = dpnp.logaddexp2(ia, ib)
+        expected = numpy.logaddexp2(a, b)
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize(
+        "dt", get_all_dtypes(no_none=True, no_complex=True)
+    )
+    def test_range(self, dt):
+        a = numpy.array([1000000, -1000000, 1000200, -1000200], dtype=dt)
+        b = numpy.array([1000200, -1000200, 1000000, -1000000], dtype=dt)
+        ia, ib = dpnp.array(a), dpnp.array(b)
+
+        result = dpnp.logaddexp2(ia, ib)
+        expected = numpy.logaddexp2(a, b)
+        assert_almost_equal(result, expected)
+
+    @pytest.mark.parametrize("dt", get_float_dtypes())
+    def test_inf(self, dt):
+        inf = numpy.inf
+        a = numpy.array([inf, -inf, inf, -inf, inf, 1, -inf, 1], dtype=dt)
+        b = numpy.array([inf, inf, -inf, -inf, 1, inf, 1, -inf], dtype=dt)
+        ia, ib = dpnp.array(a), dpnp.array(b)
+
+        result = dpnp.logaddexp2(ia, ib)
+        expected = numpy.logaddexp2(a, b)
+        assert_equal(result, expected)
+
+    @pytest.mark.usefixtures("suppress_invalid_numpy_warnings")
+    @pytest.mark.parametrize(
+        "val1, val2",
+        [
+            pytest.param(numpy.nan, numpy.inf),
+            pytest.param(numpy.inf, numpy.nan),
+            pytest.param(numpy.nan, 0),
+            pytest.param(0, numpy.nan),
+            pytest.param(numpy.nan, numpy.nan),
+        ],
+    )
+    def test_nan(self, val1, val2):
+        a = numpy.array(val1)
+        b = numpy.array(val2)
+        ia, ib = dpnp.array(a), dpnp.array(b)
+
+        result = dpnp.logaddexp2(ia, ib)
+        expected = numpy.logaddexp2(a, b)
+        assert_equal(result, expected)
 
 
 class TestRadians:

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -655,6 +655,7 @@ def test_1in_1out(func, data, usm_type):
         pytest.param("inner", [1.0, 2.0, 3.0], [4.0, 5.0, 6.0]),
         pytest.param("kron", [3.0, 4.0, 5.0], [1.0, 2.0]),
         pytest.param("logaddexp", [[-1, 2, 5, 9]], [[4, -3, 2, -8]]),
+        pytest.param("logaddexp2", [[-1, 2, 5, 9]], [[4, -3, 2, -8]]),
         pytest.param("maximum", [0.0, 1.0, 2.0], [3.0, 4.0, 5.0]),
         pytest.param("minimum", [0.0, 1.0, 2.0], [3.0, 4.0, 5.0]),
         pytest.param("nextafter", [1, 2], [2, 1]),

--- a/tests/third_party/cupy/math_tests/test_explog.py
+++ b/tests/third_party/cupy/math_tests/test_explog.py
@@ -61,14 +61,6 @@ class TestExplog:
         a = xp.full((2, 3), val, dtype=dtype)
         return xp.logaddexp(a, a)
 
-    @testing.for_float_dtypes()
-    @testing.numpy_cupy_allclose()
-    def test_logaddexp_nan(self, xp, dtype):
-        a = xp.full((2, 3), xp.nan, dtype=dtype)
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=RuntimeWarning)
-            return xp.logaddexp(a, a)
-
     def test_logaddexp2(self):
         self.check_binary("logaddexp2", no_complex=True)
 
@@ -78,11 +70,3 @@ class TestExplog:
     def test_logaddexp2_infinities(self, xp, dtype, val):
         a = xp.full((2, 3), val, dtype=dtype)
         return xp.logaddexp2(a, a)
-
-    @testing.for_float_dtypes()
-    @testing.numpy_cupy_allclose()
-    def test_logaddexp2_nan(self, xp, dtype):
-        a = xp.full((2, 3), xp.nan, dtype=dtype)
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=RuntimeWarning)
-            return xp.logaddexp2(a, a)

--- a/tests/third_party/cupy/math_tests/test_explog.py
+++ b/tests/third_party/cupy/math_tests/test_explog.py
@@ -1,4 +1,3 @@
-import unittest
 import warnings
 
 import numpy
@@ -8,7 +7,7 @@ from tests.helper import has_support_aspect64
 from tests.third_party.cupy import testing
 
 
-class TestExplog(unittest.TestCase):
+class TestExplog:
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-5, type_check=has_support_aspect64())
     def check_unary(self, name, xp, dtype, no_complex=False):
@@ -55,30 +54,35 @@ class TestExplog(unittest.TestCase):
     def test_logaddexp(self):
         self.check_binary("logaddexp", no_complex=True)
 
+    @pytest.mark.parametrize("val", [numpy.inf, -numpy.inf])
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_logaddexp_infinities(self, xp, dtype, val):
+        a = xp.full((2, 3), val, dtype=dtype)
+        return xp.logaddexp(a, a)
+
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_logaddexp_nan(self, xp, dtype):
+        a = xp.full((2, 3), xp.nan, dtype=dtype)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=RuntimeWarning)
+            return xp.logaddexp(a, a)
+
     def test_logaddexp2(self):
         self.check_binary("logaddexp2", no_complex=True)
 
     @pytest.mark.parametrize("val", [numpy.inf, -numpy.inf])
     @testing.for_float_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(type_check=has_support_aspect64())
     def test_logaddexp2_infinities(self, xp, dtype, val):
         a = xp.full((2, 3), val, dtype=dtype)
         return xp.logaddexp2(a, a)
 
-
-@pytest.mark.parametrize("val", [numpy.inf, -numpy.inf])
-@testing.for_float_dtypes()
-@testing.numpy_cupy_allclose()
-def test_logaddexp_infinities(xp, dtype, val):
-    a = xp.full((2, 3), val, dtype=dtype)
-    return xp.logaddexp(a, a)
-
-
-@testing.for_float_dtypes()
-@testing.numpy_cupy_allclose()
-def test_logaddexp_nan(xp, dtype):
-    a = xp.full((2, 3), xp.nan, dtype=dtype)
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=RuntimeWarning)
-        result = xp.logaddexp(a, a)
-    return result
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_logaddexp2_nan(self, xp, dtype):
+        a = xp.full((2, 3), xp.nan, dtype=dtype)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=RuntimeWarning)
+            return xp.logaddexp2(a, a)


### PR DESCRIPTION
The PR adds implementation of `dpnp.logaddexp2` function.
New binary universal function `_logaddexp2` as added to `_ufunc_impl` pybind11 extension.

The all affected tests are updated to cover different use cases.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
