### PR TITLE
update tests for `dpnp.fft.irfft` and `dpnp.fft.hfft`

### DIFF
--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -660,7 +660,7 @@ class TestRfft:
         x = dpt.linspace(-1, 1, 11)
         a_usm = dpt.asarray(dpt.sin(x))
         a_np = dpt.asnumpy(a_usm)
-        out_shape = a_usm.shape[0] // 2 + 1 if n is None else n // 2
+        out_shape = a_usm.shape[0] // 2 + 1 if n is None else n // 2 + 1
         out_dtype = map_dtype_to_device(dpnp.complex128, a_usm.sycl_device)
         out = dpt.empty(out_shape, dtype=out_dtype)
 
@@ -678,7 +678,7 @@ class TestRfft:
         a = dpnp.asarray(a, dtype=dtype)
         a_np = dpnp.asnumpy(a)
 
-        out_shape = a.shape[0] // 2 + 1 if n is None else n // 2
+        out_shape = a.shape[0] // 2 + 1 if n is None else n // 2 + 1
         out_dtype = dpnp.complex64 if dtype == dpnp.float32 else dpnp.complex128
         out = dpnp.empty(out_shape, dtype=out_dtype)
 
@@ -697,7 +697,7 @@ class TestRfft:
         a = dpnp.asarray(a_np)
 
         out_shape = list(a.shape)
-        out_shape[axis] = a.shape[axis] // 2 + 1 if n is None else n // 2
+        out_shape[axis] = a.shape[axis] // 2 + 1 if n is None else n // 2 + 1
         out_shape = tuple(out_shape)
         out_dtype = dpnp.complex64 if dtype == dpnp.float32 else dpnp.complex128
         out = dpnp.empty(out_shape, dtype=out_dtype)

--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -16,6 +16,24 @@ from .helper import (
 )
 
 
+def _make_array_Hermitian(a, n):
+    """
+    This function makes necessary changes of the input array of
+    `dpnp.fft.irfft` and `dpnp.fft.hfft` functions to make sure the
+    given array is Hermitian.
+
+    """
+
+    a[0].imag = 0
+    if n in [None, 18]:
+        # f_ny is Nyquist mode (n//2+1 mode) which is n//2 element
+        f_ny = -1 if n is None else n // 2
+        a[f_ny].imag = 0
+        a[f_ny:] = 0  # no data needed after Nyquist mode
+
+    return a
+
+
 # TODO: `assert_dtype_allclose` calls in this file have `check_only_type_kind=True`
 # since stock NumPy is currently used in public CI for code coverege which
 # always returns complex128/float64 for FFT functions, but Intel® NumPy and
@@ -390,12 +408,7 @@ class TestHfft:
     def test_hfft_1D_complex(self, dtype, n, norm):
         x = dpnp.linspace(-1, 1, 11)
         a = dpnp.sin(x) + 1j * dpnp.cos(x)
-        # input should be Hermitian
-        a[0].imag = 0
-        if n in [None, 18]:
-            f_ny = -1 if n is None else n // 2  # Nyquist mode
-            a[f_ny].imag = 0
-            a[f_ny:] = 0  # no data needed after Nyquist mode
+        a = _make_array_Hermitian(a, n)
         a = dpnp.asarray(a, dtype=dtype)
         a_np = dpnp.asnumpy(a)
 
@@ -452,12 +465,7 @@ class TestIrfft:
     def test_fft_1D_complex(self, dtype, n, norm):
         x = dpnp.linspace(-1, 1, 11)
         a = dpnp.sin(x) + 1j * dpnp.cos(x)
-        # input should be Hermitian
-        a[0].imag = 0
-        if n in [None, 18]:
-            f_ny = -1 if n is None else n // 2  # Nyquist mode
-            a[f_ny].imag = 0
-            a[f_ny:] = 0  # no data needed after Nyquist mode
+        a = _make_array_Hermitian(a, n)
         a = dpnp.asarray(a, dtype=dtype)
         a_np = dpnp.asnumpy(a)
 
@@ -519,14 +527,9 @@ class TestIrfft:
 
     @pytest.mark.parametrize("n", [None, 5, 18])
     def test_fft_usm_ndarray(self, n):
-        x = dpt.linspace(-1, 1, 11)
-        a = dpt.sin(x) + 1j * dpt.cos(x)
-        # input should be Hermitian
-        a[0] = dpt.sin(x[0])
-        if n in [None, 18]:
-            f_ny = -1 if n is None else n // 2  # Nyquist mode
-            a[f_ny] = dpt.sin(x[f_ny])
-            a[f_ny:] = 0  # no data needed after Nyquist mode
+        x = dpnp.linspace(-1, 1, 11)
+        a = dpnp.sin(x) + 1j * dpnp.cos(x)
+        a = _make_array_Hermitian(a, n)
         a_usm = dpt.asarray(a, dtype=dpt.complex64)
         a_np = dpt.asnumpy(a_usm)
         out_shape = n if n is not None else 2 * (a_usm.shape[0] - 1)
@@ -543,12 +546,7 @@ class TestIrfft:
     def test_fft_1D_out(self, dtype, n, norm):
         x = dpnp.linspace(-1, 1, 11)
         a = dpnp.sin(x) + 1j * dpnp.cos(x)
-        # input should be Hermitian
-        a[0].imag = 0
-        if n in [None, 18]:
-            f_ny = -1 if n is None else n // 2  # Nyquist mode
-            a[f_ny].imag = 0
-            a[f_ny:] = 0  # no data needed after Nyquist mode
+        a = _make_array_Hermitian(a, n)
         a = dpnp.asarray(a, dtype=dtype)
         a_np = dpnp.asnumpy(a)
 

--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -13,13 +13,7 @@ from .helper import (
     get_all_dtypes,
     get_complex_dtypes,
     get_float_dtypes,
-    is_cpu_device,
 )
-
-# aspects of default device:
-_def_device = dpctl.SyclQueue().sycl_device
-_def_dev_has_fp64 = _def_device.has_aspect_fp64
-is_gpu_with_fp64 = not is_cpu_device() and _def_dev_has_fp64
 
 
 # TODO: `assert_dtype_allclose` calls in this file have `check_only_type_kind=True`
@@ -391,11 +385,17 @@ class TestHfft:
         assert_dtype_allclose(result, expected, check_only_type_kind=True)
 
     @pytest.mark.parametrize("dtype", get_complex_dtypes())
-    @pytest.mark.parametrize("n", [None, 5, 20])
+    @pytest.mark.parametrize("n", [None, 5, 18])
     @pytest.mark.parametrize("norm", ["forward", "backward", "ortho"])
     def test_hfft_1D_complex(self, dtype, n, norm):
         x = dpnp.linspace(-1, 1, 11)
         a = dpnp.sin(x) + 1j * dpnp.cos(x)
+        # input should be Hermitian
+        a[0].imag = 0
+        if n in [None, 18]:
+            f_ny = -1 if n is None else n // 2  # Nyquist mode
+            a[f_ny].imag = 0
+            a[f_ny:] = 0  # no data needed after Nyquist mode
         a = dpnp.asarray(a, dtype=dtype)
         a_np = dpnp.asnumpy(a)
 
@@ -446,13 +446,18 @@ class TestIrfft:
         # but dpnp return float32 if input is float32
         assert_dtype_allclose(result, expected, check_only_type_kind=True)
 
-    @pytest.mark.skipif(is_gpu_with_fp64, reason="MKLD17702")
     @pytest.mark.parametrize("dtype", get_complex_dtypes())
-    @pytest.mark.parametrize("n", [None, 5, 20])
+    @pytest.mark.parametrize("n", [None, 5, 18])
     @pytest.mark.parametrize("norm", ["forward", "backward", "ortho"])
     def test_fft_1D_complex(self, dtype, n, norm):
         x = dpnp.linspace(-1, 1, 11)
         a = dpnp.sin(x) + 1j * dpnp.cos(x)
+        # input should be Hermitian
+        a[0].imag = 0
+        if n in [None, 18]:
+            f_ny = -1 if n is None else n // 2  # Nyquist mode
+            a[f_ny].imag = 0
+            a[f_ny:] = 0  # no data needed after Nyquist mode
         a = dpnp.asarray(a, dtype=dtype)
         a_np = dpnp.asnumpy(a)
 
@@ -473,29 +478,55 @@ class TestIrfft:
         expected = numpy.fft.irfft(a_np, n=n, axis=axis, norm=norm)
         assert_dtype_allclose(result, expected, check_only_type_kind=True)
 
-    @pytest.mark.skipif(is_gpu_with_fp64, reason="MKLD17702")
     @pytest.mark.parametrize("dtype", get_complex_dtypes())
     @pytest.mark.parametrize("n", [None, 5, 8])
     @pytest.mark.parametrize("axis", [0, 1, 2])
     @pytest.mark.parametrize("norm", ["forward", "backward", "ortho"])
     @pytest.mark.parametrize("order", ["C", "F"])
     def test_fft_1D_on_3D_array(self, dtype, n, axis, norm, order):
-        x1 = numpy.random.uniform(-10, 10, 24)
-        x2 = numpy.random.uniform(-10, 10, 24)
+        x1 = numpy.random.uniform(-10, 10, 120)
+        x2 = numpy.random.uniform(-10, 10, 120)
         a_np = numpy.array(x1 + 1j * x2, dtype=dtype).reshape(
-            2, 3, 4, order=order
+            4, 5, 6, order=order
         )
+        # each 1-D array of input should be Hermitian
+        if axis == 0:
+            a_np[0].imag = 0
+            if n is None:
+                # for axis=0 and n=8, Nyquist mode is not present
+                f_ny = -1  # Nyquist mode
+                a_np[-1].imag = 0
+        elif axis == 1:
+            a_np[:, 0, :].imag = 0
+            if n in [None, 8]:
+                f_ny = -1  # Nyquist mode
+                a_np[:, f_ny, :].imag = 0
+                a_np[:, f_ny:, :] = 0  # no data needed after Nyquist mode
+        elif axis == 2:
+            a_np[..., 0].imag = 0
+            if n in [None, 8]:
+                f_ny = -1 if n is None else n // 2  # Nyquist mode
+                a_np[..., f_ny].imag = 0
+                a_np[..., f_ny:] = 0  # no data needed after Nyquist mode
+
         a = dpnp.asarray(a_np)
 
         result = dpnp.fft.irfft(a, n=n, axis=axis, norm=norm)
         expected = numpy.fft.irfft(a_np, n=n, axis=axis, norm=norm)
-        assert_dtype_allclose(result, expected, check_only_type_kind=True)
+        assert_dtype_allclose(
+            result, expected, check_only_type_kind=True, factor=16
+        )
 
-    @pytest.mark.skipif(is_gpu_with_fp64, reason="MKLD17702")
-    @pytest.mark.parametrize("n", [None, 5, 20])
+    @pytest.mark.parametrize("n", [None, 5, 18])
     def test_fft_usm_ndarray(self, n):
         x = dpt.linspace(-1, 1, 11)
         a = dpt.sin(x) + 1j * dpt.cos(x)
+        # input should be Hermitian
+        a[0] = dpt.sin(x[0])
+        if n in [None, 18]:
+            f_ny = -1 if n is None else n // 2  # Nyquist mode
+            a[f_ny] = dpt.sin(x[f_ny])
+            a[f_ny:] = 0  # no data needed after Nyquist mode
         a_usm = dpt.asarray(a, dtype=dpt.complex64)
         a_np = dpt.asnumpy(a_usm)
         out_shape = n if n is not None else 2 * (a_usm.shape[0] - 1)
@@ -506,13 +537,18 @@ class TestIrfft:
         expected = numpy.fft.irfft(a_np, n=n)
         assert_dtype_allclose(result, expected, check_only_type_kind=True)
 
-    @pytest.mark.skipif(is_gpu_with_fp64, reason="MKLD17702")
     @pytest.mark.parametrize("dtype", get_complex_dtypes())
-    @pytest.mark.parametrize("n", [None, 5, 20])
+    @pytest.mark.parametrize("n", [None, 5, 18])
     @pytest.mark.parametrize("norm", ["forward", "backward", "ortho"])
     def test_fft_1D_out(self, dtype, n, norm):
         x = dpnp.linspace(-1, 1, 11)
         a = dpnp.sin(x) + 1j * dpnp.cos(x)
+        # input should be Hermitian
+        a[0].imag = 0
+        if n in [None, 18]:
+            f_ny = -1 if n is None else n // 2  # Nyquist mode
+            a[f_ny].imag = 0
+            a[f_ny:] = 0  # no data needed after Nyquist mode
         a = dpnp.asarray(a, dtype=dtype)
         a_np = dpnp.asnumpy(a)
 
@@ -624,7 +660,7 @@ class TestRfft:
         x = dpt.linspace(-1, 1, 11)
         a_usm = dpt.asarray(dpt.sin(x))
         a_np = dpt.asnumpy(a_usm)
-        out_shape = a_usm.shape[0] // 2 + 1 if n is None else n // 2 + 1
+        out_shape = a_usm.shape[0] // 2 + 1 if n is None else n // 2
         out_dtype = map_dtype_to_device(dpnp.complex128, a_usm.sycl_device)
         out = dpt.empty(out_shape, dtype=out_dtype)
 
@@ -642,7 +678,7 @@ class TestRfft:
         a = dpnp.asarray(a, dtype=dtype)
         a_np = dpnp.asnumpy(a)
 
-        out_shape = a.shape[0] // 2 + 1 if n is None else n // 2 + 1
+        out_shape = a.shape[0] // 2 + 1 if n is None else n // 2
         out_dtype = dpnp.complex64 if dtype == dpnp.float32 else dpnp.complex128
         out = dpnp.empty(out_shape, dtype=out_dtype)
 
@@ -661,7 +697,7 @@ class TestRfft:
         a = dpnp.asarray(a_np)
 
         out_shape = list(a.shape)
-        out_shape[axis] = a.shape[axis] // 2 + 1 if n is None else n // 2 + 1
+        out_shape[axis] = a.shape[axis] // 2 + 1 if n is None else n // 2
         out_shape = tuple(out_shape)
         out_dtype = dpnp.complex64 if dtype == dpnp.float32 else dpnp.complex128
         out = dpnp.empty(out_shape, dtype=out_dtype)

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -1239,7 +1239,7 @@ def test_fft(func, device):
 
     expected = getattr(numpy.fft, func)(data)
     result = getattr(dpnp.fft, func)(dpnp_data)
-    assert_dtype_allclose(result, expected)
+    assert_dtype_allclose(result, expected, factor=16)
 
     expected_queue = dpnp_data.get_array().sycl_queue
     result_queue = result.get_array().sycl_queue

--- a/tests/test_umath.py
+++ b/tests/test_umath.py
@@ -313,7 +313,7 @@ class TestDegrees:
         assert_dtype_allclose(result, expected)
 
 
-class TestLogaddexp:
+class TestLogAddExp:
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True))
     def test_logaddexp(self, dtype):
         np_array1, np_array2, expected = _get_numpy_arrays_2in_1out(


### PR DESCRIPTION
In this PR, tests for `dpnp.fft.irfft` and `dpnp.fft.hfft` (which calls back `dpnp.fft.irfft`) are updated to make sure input array is Hermitian. This means that for 1-D array 0th element of the array has zero imaginary part. In addition, if output array size is N and N is even, the N/2-th element (N/2+1 frequency point) of input (Nyquist mode) also has zero imaginary part.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
