### PR TITLE
Update `dpnp.ediff1d` function

### DIFF
--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -316,7 +316,7 @@ def _process_ediff1d_args(arg, arg_name, ary_dtype, ary_sycl_queue, usm_type):
         usm_type = dpu.get_coerced_usm_type([usm_type, arg.usm_type])
         # check that arrays have the same allocation queue
         if dpu.get_execution_queue([ary_sycl_queue, arg.sycl_queue]) is None:
-            raise ValueError(
+            raise dpu.ExecutionPlacementError(
                 f"ary and {arg_name} must be allocated on the same SYCL queue"
             )
 

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -2151,6 +2151,14 @@ class TestEdiff1d:
         to_end = dpnp.array([5], dtype="f4")
         assert_raises(TypeError, dpnp.ediff1d, a_dp, to_end=to_end)
 
+        # another `to_begin` sycl queue
+        to_begin = dpnp.array([-20, -15], sycl_queue=dpctl.SyclQueue())
+        assert_raises(ValueError, dpnp.ediff1d, a_dp, to_begin=to_begin)
+
+        # another `to_end` sycl queue
+        to_end = dpnp.array([15, 20], sycl_queue=dpctl.SyclQueue())
+        assert_raises(ValueError, dpnp.ediff1d, a_dp, to_end=to_end)
+
 
 @pytest.mark.usefixtures("allow_fall_back_on_numpy")
 class TestTrapz:

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -2153,11 +2153,15 @@ class TestEdiff1d:
 
         # another `to_begin` sycl queue
         to_begin = dpnp.array([-20, -15], sycl_queue=dpctl.SyclQueue())
-        assert_raises(ValueError, dpnp.ediff1d, a_dp, to_begin=to_begin)
+        assert_raises(
+            ExecutionPlacementError, dpnp.ediff1d, a_dp, to_begin=to_begin
+        )
 
         # another `to_end` sycl queue
         to_end = dpnp.array([15, 20], sycl_queue=dpctl.SyclQueue())
-        assert_raises(ValueError, dpnp.ediff1d, a_dp, to_end=to_end)
+        assert_raises(
+            ExecutionPlacementError, dpnp.ediff1d, a_dp, to_end=to_end
+        )
 
 
 @pytest.mark.usefixtures("allow_fall_back_on_numpy")

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -2407,12 +2407,7 @@ def test_nan_to_num(copy, device):
 
 
 @pytest.mark.parametrize(
-    "device_x",
-    valid_devices,
-    ids=[device.filter_string for device in valid_devices],
-)
-@pytest.mark.parametrize(
-    "device_args",
+    "device",
     valid_devices,
     ids=[device.filter_string for device in valid_devices],
 )
@@ -2424,15 +2419,15 @@ def test_nan_to_num(copy, device):
         (10, -10),
     ],
 )
-def test_ediff1d(device_x, device_args, to_end, to_begin):
+def test_ediff1d(device, to_end, to_begin):
     data = [1, 3, 5, 7]
 
-    x = dpnp.array(data, device=device_x)
+    x = dpnp.array(data, device=device)
     if to_end:
-        to_end = dpnp.array(to_end, device=device_args)
+        to_end = dpnp.array(to_end, device=device)
 
     if to_begin:
-        to_begin = dpnp.array(to_begin, device=device_args)
+        to_begin = dpnp.array(to_begin, device=device)
 
     res = dpnp.ediff1d(x, to_end=to_end, to_begin=to_begin)
 

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -1431,4 +1431,4 @@ def test_ediff1d(usm_type_x, usm_type_args, to_end, to_begin):
 
     res = dp.ediff1d(x, to_end=to_end, to_begin=to_begin)
 
-    assert res.usm_type == x.usm_type
+    assert res.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_args])


### PR DESCRIPTION
This PR suggests updating the` dpnp.ediff1d()` implementation to make it more readable and adding a new `_process_ediff1d_args` helper function to reduce duplicate code

Additionally it updates tests to unlock the internal CI cover the new helper function.


- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
