### PR TITLE
Fix strides tests

### DIFF
--- a/tests/test_strides.py
+++ b/tests/test_strides.py
@@ -246,7 +246,7 @@ def test_strides_2args(func_name, dtype, shape):
     numpy_func = _getattr(numpy, func_name)
     expected = numpy_func(a, b)
 
-    assert_allclose(result, expected)
+    assert_dtype_allclose(result, expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Apply `rtol` and `atol` for assert_allclose for current dtype.

Before this test `test_strides_2args[(3, 3)-float32-hypot]` failed:
Max absolute difference: 9.536743e-07
Max relative difference: 1.1086239e-07

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
