### PR TITLE
Add python 3.12 to public CI

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -72,7 +72,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11']
+        python: ['3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-22.04, windows-2019]
 
     permissions:
@@ -168,7 +168,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11']
+        python: ['3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-22.04, ubuntu-latest]
 
     continue-on-error: true
@@ -290,7 +290,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11']
+        python: ['3.9', '3.10', '3.11', '3.12']
 
     continue-on-error: true
 
@@ -439,7 +439,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11']
+        python: ['3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-22.04, windows-2019]
 
     runs-on: ${{ matrix.os }}
@@ -509,7 +509,7 @@ jobs:
           use-mamba: true
           channels: conda-forge
           run-post: false
-          python-version: '3.11'
+          python-version: '3.12'
           activate-environment: 'cleanup'
 
       - name: Remove defaults channel

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -20,7 +20,7 @@ jobs:
         shell: bash -l {0}
 
     env:
-      python-ver: '3.11'
+      python-ver: '3.12'
       CHANNELS: '-c dppy/label/dev -c intel -c conda-forge --override-channels'
       NO_INTEL_CHANNELS: '-c dppy/label/dev -c conda-forge --override-channels'
       # Install the latest oneAPI compiler to work around an issue

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Run pre-commit checks
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3.10
 Programming Language :: Python :: 3.11
+Programming Language :: Python :: 3.12
 Programming Language :: Python :: Implementation :: CPython
 Topic :: Software Development
 Topic :: Scientific/Engineering


### PR DESCRIPTION
The PR proposes to extend build and test matrix of DPNP with python 3.12.
The default python version for other actions is moved to 3.12 also.
The metadata of DPNP package is properly updated to reflect support of python 3.12.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
