### PR TITLE
Add implementation of `dpnp.trapezoid`

### DIFF
--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -121,7 +121,7 @@ __all__ = [
     "signbit",
     "subtract",
     "sum",
-    "trapz",
+    "trapezoid",
     "true_divide",
     "trunc",
 ]
@@ -1106,6 +1106,8 @@ def cumsum(a, axis=None, dtype=None, out=None):
     See Also
     --------
     :obj:`dpnp.sum` : Sum array elements.
+    :obj:`dpnp.trapezoid` : Integration of array values using composite
+                            trapezoidal rule.
     :obj:`dpnp.diff` : Calculate the n-th discrete difference along given axis.
 
     Examples
@@ -3507,8 +3509,8 @@ def sum(
     --------
     :obj:`dpnp.ndarray.sum` : Equivalent method.
     :obj:`dpnp.cumsum` : Cumulative sum of array elements.
-    :obj:`dpnp.trapz` : Integration of array values using the composite
-                        trapezoidal rule.
+    :obj:`dpnp.trapezoid` : Integration of array values using the composite
+                            trapezoidal rule.
     :obj:`dpnp.mean` : Compute the arithmetic mean.
     :obj:`dpnp.average` : Compute the weighted average.
 
@@ -3544,34 +3546,126 @@ def sum(
     )
 
 
-def trapz(y1, x1=None, dx=1.0, axis=-1):
-    """
+def trapezoid(y, x=None, dx=1.0, axis=-1):
+    r"""
     Integrate along the given axis using the composite trapezoidal rule.
 
-    For full documentation refer to :obj:`numpy.trapz`.
+    If `x` is provided, the integration happens in sequence along its elements -
+    they are not sorted.
 
-    Limitations
-    -----------
-    Parameters `y` and `x` are supported as :class:`dpnp.ndarray`.
-    Keyword argument `kwargs` is currently unsupported.
-    Otherwise the function will be executed sequentially on CPU.
-    Input array data types are limited by supported DPNP :ref:`Data types`.
+    Integrate `y` (`x`) along each 1d slice on the given axis, compute
+    :math:`\int y(x) dx`.
+    When `x` is specified, this integrates along the parametric curve,
+    computing :math:`\int_t y(t) dt =
+    \int_t y(t) \left.\frac{dx}{dt}\right|_{x=x(t)} dt`.
+
+    For full documentation refer to :obj:`numpy.trapezoid`.
+
+    Parameters
+    ----------
+    y : {dpnp.ndarray, usm_ndarray}
+        Input array to integrate.
+    x : {dpnp.ndarray, usm_ndarray, None}, optional
+        The sample points corresponding to the `y` values. If `x` is ``None``,
+        the sample points are assumed to be evenly spaced `dx` apart.
+        Default: ``None``.
+    dx : scalar, optional
+        The spacing between sample points when `x` is ``None``.
+        Default: ``1``.
+    axis : int, optional
+        The axis along which to integrate.
+        Default: ``-1``.
+
+    Returns
+    -------
+    out : dpnp.ndarray
+        Definite integral of `y` = n-dimensional array as approximated along
+        a single axis by the trapezoidal rule. The result is an `n`-1
+        dimensional array.
+
+    See Also
+    --------
+    :obj:`dpnp.sum` : Sum of array elements over a given axis.
+    :obj:`dpnp.cumsum` : Cumulative sum of the elements along a given axis.
 
     Examples
     --------
     >>> import dpnp as np
-    >>> a = np.array([1, 2, 3])
-    >>> b = np.array([4, 6, 8])
-    >>> np.trapz(a)
-    4.0
-    >>> np.trapz(a, x=b)
-    8.0
-    >>> np.trapz(a, dx=2)
-    8.0
+
+    Use the trapezoidal rule on evenly spaced points:
+
+    >>> y = np.array([1, 2, 3])
+    >>> np.trapezoid(y)
+    array(4.)
+
+    The spacing between sample points can be selected by either the `x` or `dx`
+    arguments:
+
+    >>> y = np.array([1, 2, 3])
+    >>> x = np.array([4, 6, 8])
+    >>> np.trapezoid(y, x=x)
+    array(8.)
+    >>> np.trapezoid(y, dx=2)
+    array(8.)
+
+    Using a decreasing `x` corresponds to integrating in reverse:
+
+    >>> y = np.array([1, 2, 3])
+    >>> x = np.array([8, 6, 4])
+    >>> np.trapezoid(y, x=x)
+    array(-8.)
+
+    More generally `x` is used to integrate along a parametric curve. We can
+    estimate the integral :math:`\int_0^1 x^2 = 1/3` using:
+
+    >>> x = np.linspace(0, 1, num=50)
+    >>> y = x**2
+    >>> np.trapezoid(y, x)
+    array(0.33340275)
+
+    Or estimate the area of a circle, noting we repeat the sample which closes
+    the curve:
+
+    >>> theta = np.linspace(0, 2 * np.pi, num=1000, endpoint=True)
+    >>> np.trapezoid(np.cos(theta), x=np.sin(theta))
+    array(3.14157194)
+
+    :obj:`dpnp.trapezoid` can be applied along a specified axis to do multiple
+    computations in one call:
+
+    >>> a = np.arange(6).reshape(2, 3)
+    >>> a
+    array([[0, 1, 2],
+           [3, 4, 5]])
+    >>> np.trapezoid(a, axis=0)
+    array([1.5, 2.5, 3.5])
+    >>> np.trapezoid(a, axis=1)
+    array([2., 8.])
 
     """
 
-    return call_origin(numpy.trapz, y1, x1, dx, axis)
+    dpnp.check_supported_arrays_type(y)
+    nd = y.ndim
+
+    if x is None:
+        d = dx
+    else:
+        dpnp.check_supported_arrays_type(x)
+        if x.ndim == 1:
+            d = dpnp.diff(x)
+
+            # reshape to correct shape
+            shape = [1] * nd
+            shape[axis] = d.shape[0]
+            d = d.reshape(shape)
+        else:
+            d = dpnp.diff(x, axis=axis)
+
+    slice1 = [slice(None)] * nd
+    slice2 = [slice(None)] * nd
+    slice1[axis] = slice(1, None)
+    slice2[axis] = slice(None, -1)
+    return (d * (y[tuple(slice1)] + y[tuple(slice2)]) / 2.0).sum(axis)
 
 
 true_divide = divide

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -513,7 +513,7 @@ def test_meshgrid(device):
         pytest.param(
             "trace", [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
         ),
-        pytest.param("trapz", [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]),
+        pytest.param("trapezoid", [1, 2, 3]),
         pytest.param("trim_zeros", [0, 0, 0, 1, 2, 3, 0, 2, 1, 0]),
         pytest.param("trunc", [-1.7, -1.5, -0.2, 0.2, 1.5, 1.7, 2.0]),
         pytest.param("unwrap", [[0, 1, 2, -1, 0]]),
@@ -528,6 +528,13 @@ def test_meshgrid(device):
 def test_1in_1out(func, data, device):
     x = dpnp.array(data, device=device)
     result = getattr(dpnp, func)(x)
+
+    if (
+        func == "trapezoid"
+        and numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0"
+    ):
+        # `trapezoid` is available from NumPy 2.0
+        func = "trapz"
 
     x_orig = dpnp.asnumpy(x)
     expected = getattr(numpy, func)(x_orig)
@@ -758,6 +765,7 @@ def test_reduce_hypot(device):
             [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]],
             [[4.0, 4.0, 4.0], [4.0, 4.0, 4.0]],
         ),
+        pytest.param("trapezoid", [1, 2, 3], [4, 6, 8]),
         # dpnp.vdot has 3 different implementations based on input arrays dtype
         # checking all of them
         pytest.param("vdot", [3.0, 4.0, 5.0], [1.0, 2.0, 3.0]),
@@ -771,13 +779,20 @@ def test_reduce_hypot(device):
     ids=[device.filter_string for device in valid_devices],
 )
 def test_2in_1out(func, data1, data2, device):
-    x1_orig = numpy.array(data1)
-    x2_orig = numpy.array(data2)
-    expected = getattr(numpy, func)(x1_orig, x2_orig)
-
     x1 = dpnp.array(data1, device=device)
     x2 = dpnp.array(data2, device=device)
     result = getattr(dpnp, func)(x1, x2)
+
+    if (
+        func == "trapezoid"
+        and numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0"
+    ):
+        # `trapezoid` is available from NumPy 2.0
+        func = "trapz"
+
+    x1_orig = numpy.array(data1)
+    x2_orig = numpy.array(data2)
+    expected = getattr(numpy, func)(x1_orig, x2_orig)
 
     assert_dtype_allclose(result, expected)
 

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -640,6 +640,7 @@ def test_norm(usm_type, ord, axis):
         pytest.param(
             "trace", [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
         ),
+        pytest.param("trapezoid", [1, 2, 3]),
         pytest.param("trim_zeros", [0, 0, 0, 1, 2, 3, 0, 2, 1, 0]),
         pytest.param("trunc", [-1.7, -1.5, -0.2, 0.2, 1.5, 1.7, 2.0]),
         pytest.param("unwrap", [[0, 1, 2, -1, 0]]),
@@ -700,6 +701,7 @@ def test_1in_1out(func, data, usm_type):
             [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]],
             [[4.0, 4.0, 4.0], [4.0, 4.0, 4.0]],
         ),
+        pytest.param("trapezoid", [1, 2, 3], [4, 6, 8]),
         # dpnp.vdot has 3 different implementations based on input arrays dtype
         # checking all of them
         pytest.param("vdot", [3.0, 4.0, 5.0], [1.0, 2.0, 3.0]),

--- a/tests/third_party/cupy/math_tests/test_sumprod.py
+++ b/tests/third_party/cupy/math_tests/test_sumprod.py
@@ -930,55 +930,60 @@ class TestEdiff1d:
         )
 
 
-@pytest.mark.skip("trapz() is not implemented yet")
 class TestTrapz:
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(rtol={numpy.float16: 1e-1, "default": 1e-7})
-    def test_trapz_1dim(self, xp, dtype):
-        a = testing.shaped_arange((5,), xp, dtype)
-        return xp.trapz(a)
+    def get_func(self, xp):
+        if xp is numpy and numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0":
+            # `trapz` is deprecated in NumPy 2.0
+            return xp.trapz
+        return xp.trapezoid
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(rtol={numpy.float16: 1e-1, "default": 1e-7})
+    @testing.numpy_cupy_allclose(type_check=has_support_aspect64())
+    def test_trapz_1dim(self, xp, dtype):
+        a = testing.shaped_arange((5,), xp, dtype)
+        return self.get_func(xp)(a)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(type_check=has_support_aspect64())
     def test_trapz_1dim_with_x(self, xp, dtype):
         a = testing.shaped_arange((5,), xp, dtype)
         x = testing.shaped_arange((5,), xp, dtype)
-        return xp.trapz(a, x=x)
+        return self.get_func(xp)(a, x=x)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(rtol={numpy.float16: 1e-1, "default": 1e-7})
+    @testing.numpy_cupy_allclose(type_check=has_support_aspect64())
     def test_trapz_1dim_with_dx(self, xp, dtype):
         a = testing.shaped_arange((5,), xp, dtype)
-        return xp.trapz(a, dx=0.1)
+        return self.get_func(xp)(a, dx=0.1)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(rtol={numpy.float16: 1e-1, "default": 1e-7})
+    @testing.numpy_cupy_allclose(type_check=has_support_aspect64())
     def test_trapz_2dim_without_axis(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
-        return xp.trapz(a)
+        return self.get_func(xp)(a)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(rtol={numpy.float16: 1e-1, "default": 1e-7})
+    @testing.numpy_cupy_allclose(type_check=has_support_aspect64())
     def test_trapz_2dim_with_axis(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
-        return xp.trapz(a, axis=-2)
+        return self.get_func(xp)(a, axis=-2)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(rtol={numpy.float16: 1e-1, "default": 1e-7})
+    @testing.numpy_cupy_allclose(type_check=has_support_aspect64())
     def test_trapz_2dim_with_x_and_axis(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
         x = testing.shaped_arange((5,), xp, dtype)
-        return xp.trapz(a, x=x, axis=1)
+        return self.get_func(xp)(a, x=x, axis=1)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(rtol={numpy.float16: 1e-1, "default": 1e-7})
+    @testing.numpy_cupy_allclose(type_check=has_support_aspect64())
     def test_trapz_2dim_with_dx_and_axis(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
-        return xp.trapz(a, dx=0.1, axis=1)
+        return self.get_func(xp)(a, dx=0.1, axis=1)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(rtol={numpy.float16: 1e-1, "default": 1e-7})
+    @testing.numpy_cupy_allclose(type_check=has_support_aspect64())
     def test_trapz_1dim_with_x_and_dx(self, xp, dtype):
         a = testing.shaped_arange((5,), xp, dtype)
         x = testing.shaped_arange((5,), xp, dtype)
-        return xp.trapz(a, x=x, dx=0.1)
+        return self.get_func(xp)(a, x=x, dx=0.1)


### PR DESCRIPTION
The PR proposes to implement `dpnp.trapezoid` function.

The implementation is done through existing python calls.
Existing third party tests are unmuted. And new tests are added to cover different use cases.

Note that in numpy prior 2.0 version there is `numpy.trapz` function which was deprecated and new function `numpy.trapezoid` was added since 2.0. Thus the PR proposes to implement `dpnp.trapezoid` function from the beginning, rather than `dpnp.trapz` one which is going to be removed in future numpy versions.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
