### PR TITLE
update tests for `dpnp.fft` module to avoid failures and warning with NumPy 2.0

### DIFF
--- a/dpnp/fft/dpnp_utils_fft.py
+++ b/dpnp/fft/dpnp_utils_fft.py
@@ -268,7 +268,7 @@ def _copy_array(x, complex_input):
     elif complex_input and not dpnp.issubdtype(dtype, dpnp.complexfloating):
         # c2c/c2r FFT, if input is not complex, convert to complex
         copy_flag = True
-        if dtype == dpnp.float32:
+        if dtype in [dpnp.float16, dpnp.float32]:
             dtype = dpnp.complex64
         else:
             dtype = map_dtype_to_device(dpnp.complex128, x.sycl_device)

--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -69,15 +69,33 @@ class TestFft:
     @pytest.mark.parametrize("norm", [None, "forward", "ortho"])
     def test_fft_1D(self, dtype, n, norm):
         x = dpnp.linspace(-1, 1, 11, dtype=dtype)
-        a = dpnp.sin(x)
+        a = dpnp.sin(x)  # a.dtype is float16 if a.dtype is bool
         a_np = dpnp.asnumpy(a)
 
+        factor = 140 if dtype == dpnp.bool else 8
         result = dpnp.fft.fft(a, n=n, norm=norm)
         expected = numpy.fft.fft(a_np, n=n, norm=norm)
-        assert_dtype_allclose(result, expected, check_only_type_kind=True)
+        assert_dtype_allclose(
+            result, expected, factor=factor, check_only_type_kind=True
+        )
 
         iresult = dpnp.fft.ifft(result, n=n, norm=norm)
         iexpected = numpy.fft.ifft(expected, n=n, norm=norm)
+        assert_dtype_allclose(
+            iresult, iexpected, factor=factor, check_only_type_kind=True
+        )
+
+    @pytest.mark.parametrize("norm", [None, "forward", "ortho"])
+    def test_fft_1D_bool(self, norm):
+        a = dpnp.linspace(-1, 1, 11, dtype=dpnp.bool)
+        a_np = dpnp.asnumpy(a)
+
+        result = dpnp.fft.fft(a, norm=norm)
+        expected = numpy.fft.fft(a_np, norm=norm)
+        assert_dtype_allclose(result, expected, check_only_type_kind=True)
+
+        iresult = dpnp.fft.ifft(result, norm=norm)
+        iexpected = numpy.fft.ifft(expected, norm=norm)
         assert_dtype_allclose(iresult, iexpected, check_only_type_kind=True)
 
     @pytest.mark.parametrize("dtype", get_complex_dtypes())

--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -69,7 +69,7 @@ class TestFft:
     @pytest.mark.parametrize("norm", [None, "forward", "ortho"])
     def test_fft_1D(self, dtype, n, norm):
         x = dpnp.linspace(-1, 1, 11, dtype=dtype)
-        a = dpnp.sin(x)  # a.dtype is float16 if a.dtype is bool
+        a = dpnp.sin(x)  # a.dtype is float16 if x.dtype is bool
         a_np = dpnp.asnumpy(a)
 
         factor = 140 if dtype == dpnp.bool else 8

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -541,8 +541,8 @@ def test_1in_1out(func, data, device):
     expected = getattr(numpy, func)(x_orig)
     assert_dtype_allclose(result, expected)
 
-    expected_queue = x.get_array().sycl_queue
-    result_queue = result.get_array().sycl_queue
+    expected_queue = x.sycl_queue
+    result_queue = result.sycl_queue
 
     assert_sycl_queue_equal(result_queue, expected_queue)
 
@@ -575,8 +575,8 @@ def test_logic_op_1in(op, device):
     expected = getattr(numpy, op)(x_orig)
     assert_dtype_allclose(result, expected)
 
-    expected_queue = x.get_array().sycl_queue
-    result_queue = result.get_array().sycl_queue
+    expected_queue = x.sycl_queue
+    result_queue = result.sycl_queue
 
     assert_sycl_queue_equal(result_queue, expected_queue)
 
@@ -605,8 +605,8 @@ def test_proj(device):
     expected = dpnp.array(Y)
     assert_allclose(result, expected)
 
-    expected_queue = x.get_array().sycl_queue
-    result_queue = result.get_array().sycl_queue
+    expected_queue = x.sycl_queue
+    result_queue = result.sycl_queue
     assert_sycl_queue_equal(result_queue, expected_queue)
 
 
@@ -622,8 +622,8 @@ def test_rsqrt(device):
     expected = 1 / numpy.sqrt(x.asnumpy())
     assert_allclose(result, expected)
 
-    expected_queue = x.get_array().sycl_queue
-    result_queue = result.get_array().sycl_queue
+    expected_queue = x.sycl_queue
+    result_queue = result.sycl_queue
     assert_sycl_queue_equal(result_queue, expected_queue)
 
 
@@ -638,8 +638,8 @@ def test_logsumexp(device):
     expected = numpy.logaddexp.reduce(x.asnumpy())
     assert_dtype_allclose(result, expected)
 
-    expected_queue = x.get_array().sycl_queue
-    result_queue = result.get_array().sycl_queue
+    expected_queue = x.sycl_queue
+    result_queue = result.sycl_queue
     assert_sycl_queue_equal(result_queue, expected_queue)
 
 
@@ -654,8 +654,8 @@ def test_cumlogsumexp(device):
     expected = numpy.logaddexp.accumulate(x.asnumpy())
     assert_dtype_allclose(result, expected)
 
-    expected_queue = x.get_array().sycl_queue
-    result_queue = result.get_array().sycl_queue
+    expected_queue = x.sycl_queue
+    result_queue = result.sycl_queue
     assert_sycl_queue_equal(result_queue, expected_queue)
 
 
@@ -670,8 +670,8 @@ def test_reduce_hypot(device):
     expected = numpy.hypot.reduce(x.asnumpy())
     assert_dtype_allclose(result, expected)
 
-    expected_queue = x.get_array().sycl_queue
-    result_queue = result.get_array().sycl_queue
+    expected_queue = x.sycl_queue
+    result_queue = result.sycl_queue
     assert_sycl_queue_equal(result_queue, expected_queue)
 
 
@@ -913,8 +913,8 @@ def test_broadcasting(func, data1, data2, device):
 
     assert_array_equal(result, expected)
 
-    expected_queue = x1.get_array().sycl_queue
-    result_queue = result.get_array().sycl_queue
+    expected_queue = x1.sycl_queue
+    result_queue = result.sycl_queue
 
     assert_sycl_queue_equal(result_queue, expected_queue)
 
@@ -1202,9 +1202,9 @@ def test_modf(device):
     assert_array_equal(result1, expected1)
     assert_array_equal(result2, expected2)
 
-    expected_queue = x.get_array().sycl_queue
-    result1_queue = result1.get_array().sycl_queue
-    result2_queue = result2.get_array().sycl_queue
+    expected_queue = x.sycl_queue
+    result1_queue = result1.sycl_queue
+    result2_queue = result2.sycl_queue
 
     assert_sycl_queue_equal(result1_queue, expected_queue)
     assert_sycl_queue_equal(result2_queue, expected_queue)
@@ -1301,8 +1301,8 @@ class TestFft:
         result = getattr(dpnp.fft, func)(dpnp_data)
         assert_dtype_allclose(result, expected, factor=24)
 
-        expected_queue = dpnp_data.get_array().sycl_queue
-        result_queue = result.get_array().sycl_queue
+        expected_queue = dpnp_data.sycl_queue
+        result_queue = result.sycl_queue
         assert_sycl_queue_equal(result_queue, expected_queue)
 
     @pytest.mark.parametrize(
@@ -1381,8 +1381,8 @@ class TestFft:
 
         assert_dtype_allclose(result, expected)
 
-        expected_queue = dpnp_data.get_array().sycl_queue
-        result_queue = result.get_array().sycl_queue
+        expected_queue = dpnp_data.sycl_queue
+        result_queue = result.sycl_queue
 
         assert_sycl_queue_equal(result_queue, expected_queue)
 
@@ -1413,8 +1413,8 @@ def test_cholesky(data, is_empty, device):
     expected = numpy.linalg.cholesky(numpy_data)
     assert_dtype_allclose(result, expected)
 
-    expected_queue = dpnp_data.get_array().sycl_queue
-    result_queue = result.get_array().sycl_queue
+    expected_queue = dpnp_data.sycl_queue
+    result_queue = result.sycl_queue
 
     assert_sycl_queue_equal(result_queue, expected_queue)
 
@@ -1438,8 +1438,8 @@ def test_cond(device, p):
     expected = numpy.linalg.cond(a, p=p)
     assert_dtype_allclose(result, expected)
 
-    expected_queue = ia.get_array().sycl_queue
-    result_queue = result.get_array().sycl_queue
+    expected_queue = ia.sycl_queue
+    result_queue = result.sycl_queue
     assert_sycl_queue_equal(result_queue, expected_queue)
 
 
@@ -1457,8 +1457,8 @@ def test_det(device):
     expected = numpy.linalg.det(numpy_data)
     assert_allclose(expected, result)
 
-    expected_queue = dpnp_data.get_array().sycl_queue
-    result_queue = result.get_array().sycl_queue
+    expected_queue = dpnp_data.sycl_queue
+    result_queue = result.sycl_queue
 
     assert_sycl_queue_equal(result_queue, expected_queue)
 
@@ -1507,7 +1507,7 @@ def test_eigenvalue(func, shape, device):
     )
     dp_a = dpnp.array(a, device=device)
 
-    expected_queue = dp_a.get_array().sycl_queue
+    expected_queue = dp_a.sycl_queue
 
     if func in ("eig", "eigh"):
         dp_val, dp_vec = getattr(dpnp.linalg, func)(dp_a)
@@ -1529,7 +1529,7 @@ def test_eigenvalue(func, shape, device):
         assert dp_vec.shape == np_vec.shape
         assert dp_vec.dtype == np_vec.dtype
 
-        dpnp_vec_queue = dp_vec.get_array().sycl_queue
+        dpnp_vec_queue = dp_vec.sycl_queue
         # compare queue and device
         assert_sycl_queue_equal(dpnp_vec_queue, expected_queue)
 
@@ -1541,7 +1541,7 @@ def test_eigenvalue(func, shape, device):
     assert dp_val.shape == np_val.shape
     assert dp_val.dtype == np_val.dtype
 
-    dpnp_val_queue = dp_val.get_array().sycl_queue
+    dpnp_val_queue = dp_val.sycl_queue
     # compare queue and device
     assert_sycl_queue_equal(dpnp_val_queue, expected_queue)
 
@@ -1581,8 +1581,8 @@ def test_inv(shape, is_empty, device):
     expected = numpy.linalg.inv(numpy_x)
     assert_dtype_allclose(result, expected)
 
-    expected_queue = dpnp_x.get_array().sycl_queue
-    result_queue = result.get_array().sycl_queue
+    expected_queue = dpnp_x.sycl_queue
+    result_queue = result.sycl_queue
 
     assert_sycl_queue_equal(result_queue, expected_queue)
 
@@ -1605,8 +1605,8 @@ def test_matrix_power(n, device):
     expected = numpy.linalg.matrix_power(data, n)
     assert_dtype_allclose(result, expected)
 
-    expected_queue = dp_data.get_array().sycl_queue
-    result_queue = result.get_array().sycl_queue
+    expected_queue = dp_data.sycl_queue
+    result_queue = result.sycl_queue
 
     assert_sycl_queue_equal(result_queue, expected_queue)
 
@@ -1636,8 +1636,8 @@ def test_matrix_rank(data, tol, device):
     expected = numpy.linalg.matrix_rank(data, tol=tol)
     assert_array_equal(expected, result)
 
-    expected_queue = dp_data.get_array().sycl_queue
-    result_queue = result.get_array().sycl_queue
+    expected_queue = dp_data.sycl_queue
+    result_queue = result.sycl_queue
 
     assert_sycl_queue_equal(result_queue, expected_queue)
 
@@ -1683,8 +1683,8 @@ def test_norm(device, ord, axis):
         expected = numpy.linalg.norm(a, ord=ord, axis=axis)
         assert_dtype_allclose(result, expected)
 
-        expected_queue = ia.get_array().sycl_queue
-        result_queue = result.get_array().sycl_queue
+        expected_queue = ia.sycl_queue
+        result_queue = result.sycl_queue
         assert_sycl_queue_equal(result_queue, expected_queue)
 
 
@@ -1720,17 +1720,17 @@ def test_qr(shape, mode, device):
     count_elems = numpy.prod(shape)
     a = dpnp.arange(count_elems, dtype=dtype, device=device).reshape(shape)
 
-    expected_queue = a.get_array().sycl_queue
+    expected_queue = a.sycl_queue
 
     if mode == "r":
         dp_r = dpnp.linalg.qr(a, mode=mode)
-        dp_r_queue = dp_r.get_array().sycl_queue
+        dp_r_queue = dp_r.sycl_queue
         assert_sycl_queue_equal(dp_r_queue, expected_queue)
     else:
         dp_q, dp_r = dpnp.linalg.qr(a, mode=mode)
 
-        dp_q_queue = dp_q.get_array().sycl_queue
-        dp_r_queue = dp_r.get_array().sycl_queue
+        dp_q_queue = dp_q.sycl_queue
+        dp_r_queue = dp_r.sycl_queue
 
         assert_sycl_queue_equal(dp_q_queue, expected_queue)
         assert_sycl_queue_equal(dp_r_queue, expected_queue)
@@ -1775,16 +1775,16 @@ def test_svd(shape, full_matrices, compute_uv, device):
     dpnp_data = dpnp.arange(count_elems, dtype=dtype, device=device).reshape(
         shape
     )
-    expected_queue = dpnp_data.get_array().sycl_queue
+    expected_queue = dpnp_data.sycl_queue
 
     if compute_uv:
         dpnp_u, dpnp_s, dpnp_vt = dpnp.linalg.svd(
             dpnp_data, full_matrices=full_matrices, compute_uv=compute_uv
         )
 
-        dpnp_u_queue = dpnp_u.get_array().sycl_queue
-        dpnp_vt_queue = dpnp_vt.get_array().sycl_queue
-        dpnp_s_queue = dpnp_s.get_array().sycl_queue
+        dpnp_u_queue = dpnp_u.sycl_queue
+        dpnp_vt_queue = dpnp_vt.sycl_queue
+        dpnp_s_queue = dpnp_s.sycl_queue
 
         assert_sycl_queue_equal(dpnp_u_queue, expected_queue)
         assert_sycl_queue_equal(dpnp_vt_queue, expected_queue)
@@ -1794,7 +1794,7 @@ def test_svd(shape, full_matrices, compute_uv, device):
         dpnp_s = dpnp.linalg.svd(
             dpnp_data, full_matrices=full_matrices, compute_uv=compute_uv
         )
-        dpnp_s_queue = dpnp_s.get_array().sycl_queue
+        dpnp_s_queue = dpnp_s.sycl_queue
 
         assert_sycl_queue_equal(dpnp_s_queue, expected_queue)
 
@@ -1815,7 +1815,7 @@ def test_to_device(device_from, device_to):
     x = dpnp.array(data, dtype=dpnp.float32, device=device_from)
     y = x.to_device(device_to)
 
-    assert y.get_array().sycl_device == device_to
+    assert y.sycl_device == device_to
 
 
 @pytest.mark.parametrize(
@@ -1991,8 +1991,8 @@ def test_diff_scalar_append(device, kwargs):
     result = dpnp.diff(dpnp_data, **kwargs)
     assert_allclose(expected, result)
 
-    expected_queue = dpnp_data.get_array().sycl_queue
-    result_queue = result.get_array().sycl_queue
+    expected_queue = dpnp_data.sycl_queue
+    result_queue = result.sycl_queue
     assert_sycl_queue_equal(result_queue, expected_queue)
 
 
@@ -2023,8 +2023,8 @@ def test_take(device):
     expected = numpy.take(numpy_data, np_ind, axis=None)
     assert_allclose(expected, result)
 
-    expected_queue = dpnp_data.get_array().sycl_queue
-    result_queue = result.get_array().sycl_queue
+    expected_queue = dpnp_data.sycl_queue
+    result_queue = result.sycl_queue
     assert_sycl_queue_equal(result_queue, expected_queue)
 
 
@@ -2052,8 +2052,8 @@ def test_take_along_axis(data, ind, axis, device):
     expected = numpy.take_along_axis(data, ind, axis=axis)
     assert_allclose(expected, result)
 
-    expected_queue = dp_data.get_array().sycl_queue
-    result_queue = result.get_array().sycl_queue
+    expected_queue = dp_data.sycl_queue
+    result_queue = result.sycl_queue
     assert_sycl_queue_equal(result_queue, expected_queue)
 
 
@@ -2107,8 +2107,8 @@ def test_where(device):
     expected = numpy.where(a < 4, a, -1)
     assert_allclose(expected, result)
 
-    expected_queue = ia.get_array().sycl_queue
-    result_queue = result.get_array().sycl_queue
+    expected_queue = ia.sycl_queue
+    result_queue = result.sycl_queue
     assert_sycl_queue_equal(result_queue, expected_queue)
 
 

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -975,65 +975,70 @@ def test_eigenvalue(func, shape, usm_type):
     assert a.usm_type == dp_val.usm_type
 
 
-@pytest.mark.parametrize(
-    "func", ["fft", "ifft", "rfft", "irfft", "hfft", "ihfft"]
-)
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
-def test_fft(func, usm_type):
-    dtype = dp.float32 if func in ["rfft", "ihfft"] else dp.complex64
-    dpnp_data = dp.arange(100, usm_type=usm_type, dtype=dtype)
-    result = getattr(dp.fft, func)(dpnp_data)
+class TestFft:
+    @pytest.mark.parametrize(
+        "func", ["fft", "ifft", "rfft", "irfft", "hfft", "ihfft"]
+    )
+    @pytest.mark.parametrize(
+        "usm_type", list_of_usm_types, ids=list_of_usm_types
+    )
+    def test_fft(self, func, usm_type):
+        dtype = dp.float32 if func in ["rfft", "ihfft"] else dp.complex64
+        dpnp_data = dp.arange(100, usm_type=usm_type, dtype=dtype)
+        result = getattr(dp.fft, func)(dpnp_data)
 
-    assert dpnp_data.usm_type == usm_type
-    assert result.usm_type == usm_type
+        assert dpnp_data.usm_type == usm_type
+        assert result.usm_type == usm_type
 
+    @pytest.mark.parametrize(
+        "usm_type", list_of_usm_types, ids=list_of_usm_types
+    )
+    def test_fftn(self, usm_type):
+        dpnp_data = dp.arange(24, usm_type=usm_type).reshape(2, 3, 4)
+        assert dpnp_data.usm_type == usm_type
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
-def test_fftn(usm_type):
-    dpnp_data = dp.arange(24, usm_type=usm_type).reshape(2, 3, 4)
-    assert dpnp_data.usm_type == usm_type
+        result = dp.fft.fftn(dpnp_data)
+        assert result.usm_type == usm_type
 
-    result = dp.fft.fftn(dpnp_data)
-    assert result.usm_type == usm_type
+        result = dp.fft.ifftn(result)
+        assert result.usm_type == usm_type
 
-    result = dp.fft.ifftn(result)
-    assert result.usm_type == usm_type
+    @pytest.mark.parametrize(
+        "usm_type", list_of_usm_types, ids=list_of_usm_types
+    )
+    def test_rfftn(self, usm_type):
+        dpnp_data = dp.arange(24, usm_type=usm_type).reshape(2, 3, 4)
+        assert dpnp_data.usm_type == usm_type
 
+        result = dp.fft.rfftn(dpnp_data)
+        assert result.usm_type == usm_type
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
-def test_rfftn(usm_type):
-    dpnp_data = dp.arange(24, usm_type=usm_type).reshape(2, 3, 4)
-    assert dpnp_data.usm_type == usm_type
+        result = dp.fft.irfftn(result)
+        assert result.usm_type == usm_type
 
-    result = dp.fft.rfftn(dpnp_data)
-    assert result.usm_type == usm_type
+    @pytest.mark.parametrize("func", ["fftfreq", "rfftfreq"])
+    @pytest.mark.parametrize("usm_type", list_of_usm_types + [None])
+    def test_fftfreq(self, func, usm_type):
+        result = getattr(dp.fft, func)(10, 0.5, usm_type=usm_type)
+        expected = getattr(numpy.fft, func)(10, 0.5)
 
-    result = dp.fft.irfftn(result)
-    assert result.usm_type == usm_type
+        if usm_type is None:
+            # assert against default USM type
+            usm_type = "device"
 
+        assert_dtype_allclose(result, expected)
+        assert result.usm_type == usm_type
 
-@pytest.mark.parametrize("func", ["fftfreq", "rfftfreq"])
-@pytest.mark.parametrize("usm_type", list_of_usm_types + [None])
-def test_fftfreq(func, usm_type):
-    result = getattr(dp.fft, func)(10, 0.5, usm_type=usm_type)
-    expected = getattr(numpy.fft, func)(10, 0.5)
+    @pytest.mark.parametrize("func", ["fftshift", "ifftshift"])
+    @pytest.mark.parametrize(
+        "usm_type", list_of_usm_types, ids=list_of_usm_types
+    )
+    def test_fftshift(self, func, usm_type):
+        dpnp_data = dp.fft.fftfreq(10, 0.5, usm_type=usm_type)
+        result = getattr(dp.fft, func)(dpnp_data)
 
-    if usm_type is None:
-        # assert against default USM type
-        usm_type = "device"
-
-    assert_dtype_allclose(result, expected)
-    assert result.usm_type == usm_type
-
-
-@pytest.mark.parametrize("func", ["fftshift", "ifftshift"])
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
-def test_fftshift(func, usm_type):
-    dpnp_data = dp.fft.fftfreq(10, 0.5, usm_type=usm_type)
-    result = getattr(dp.fft, func)(dpnp_data)
-
-    assert dpnp_data.usm_type == usm_type
-    assert result.usm_type == usm_type
+        assert dpnp_data.usm_type == usm_type
+        assert result.usm_type == usm_type
 
 
 @pytest.mark.parametrize(

--- a/tests/third_party/cupy/fft_tests/test_fft.py
+++ b/tests/third_party/cupy/fft_tests/test_fft.py
@@ -122,7 +122,7 @@ class TestFftOrder:
             [
                 # some of the following cases are modified, since in NumPy 2.0.0
                 # `s` must contain only integer `s`, not None values, and
-                # If `s` is not None, `axes`` must not be None either.
+                # If `s` is not None, `axes` must not be None either.
                 {"shape": (3, 4), "s": None, "axes": None},
                 {"shape": (3, 4), "s": (1, 4), "axes": (0, 1)},
                 {"shape": (3, 4), "s": (1, 5), "axes": (0, 1)},
@@ -208,7 +208,7 @@ class TestFft2:
             [
                 # some of the following cases are modified, since in NumPy 2.0.0
                 # `s` must contain only integer `s`, not None values, and
-                # If `s` is not None, `axes`` must not be None either.
+                # If `s` is not None, `axes` must not be None either.
                 {"shape": (3, 4), "s": None, "axes": None},
                 {"shape": (3, 4), "s": (1, 4), "axes": (0, 1)},
                 {"shape": (3, 4), "s": (1, 5), "axes": (0, 1)},
@@ -341,7 +341,7 @@ class TestRfft:
             [
                 # some of the following cases are modified, since in NumPy 2.0.0
                 # `s` must contain only integer `s`, not None values, and
-                # If `s` is not None, `axes`` must not be None either.
+                # If `s` is not None, `axes` must not be None either.
                 {"shape": (3, 4), "s": None, "axes": None},
                 {"shape": (3, 4), "s": (1, 4), "axes": (0, 1)},
                 {"shape": (3, 4), "s": (1, 5), "axes": (0, 1)},
@@ -434,7 +434,7 @@ class TestRfft2EmptyAxes:
             [
                 # some of the following cases are modified, since in NumPy 2.0.0
                 # `s` must contain only integer `s`, not None values, and
-                # If `s` is not None, `axes`` must not be None either.
+                # If `s` is not None, `axes` must not be None either.
                 {"shape": (3, 4), "s": None, "axes": None},
                 {"shape": (3, 4), "s": (1, 4), "axes": (0, 1)},
                 {"shape": (3, 4), "s": (1, 5), "axes": (0, 1)},

--- a/tests/third_party/cupy/fft_tests/test_fft.py
+++ b/tests/third_party/cupy/fft_tests/test_fft.py
@@ -142,8 +142,8 @@ class TestFftOrder:
                 # {"shape": (0, 5), "s": None, "axes": None}, # mkl_fft gh-110
                 # {"shape": (2, 0, 5), "s": None, "axes": None}, # mkl_fft gh-110
                 # {"shape": (0, 0, 5), "s": None, "axes": None}, # mkl_fft gh-110
-                {"shape": (3, 4), "s": (0, 5), "axes": None},
-                {"shape": (3, 4), "s": (1, 0), "axes": None},
+                {"shape": (3, 4), "s": (0, 5), "axes": (0, 1)},
+                {"shape": (3, 4), "s": (1, 0), "axes": (0, 1)},
             ],
             testing.product(
                 {"norm": [None, "backward", "ortho", "forward", ""]}


### PR DESCRIPTION
In this PR, a few tests are updated to avoid failure in comparison with NumPy 2.0. Also, third party tests are updated to avoid deprecated warning from NumPy 2.0 for "if `s` is given, `axes` cannot be `None`".

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
