### PR TITLE
Add `copy` keyword to `dpnp.asarray` and align `dpnp.array(..., copy=None)` with NumPy 2.0

### DIFF
--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -233,10 +233,16 @@ def array(
         The desired dtype for the array. If not given, a default dtype will be
         used that can represent the values (by considering Promotion Type Rule
         and device capabilities when necessary).
-    copy : bool, optional
-        If ``True`` (default), then the object is copied.
+        Default: ``None``.
+    copy : {None, bool}, optional
+        If ``True``, then the array data is copied. If ``None``, a copy will
+        only be made if a copy is needed to satisfy any of the requirements
+        (``dtype``, ``order``, etc.). For ``False`` it raises a ``ValueError``
+        exception if a copy can not be avoided.
+        Default: ``True``.
     order : {"C", "F", "A", "K"}, optional
-        Memory layout of the newly output array. Default: "K".
+        Memory layout of the newly output array.
+        Default: "K".
     device : {None, string, SyclDevice, SyclQueue}, optional
         An array API concept of device where the output array is created.
         The `device` can be ``None`` (the default), an OneAPI filter selector
@@ -244,6 +250,7 @@ def array(
         a non-partitioned SYCL device, an instance of :class:`dpctl.SyclQueue`,
         or a `Device` object returned by
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
+        Default: ``None``.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
         Default: ``None``.
@@ -321,11 +328,6 @@ def array(
             "Keyword argument `ndmin` is supported only with "
             f"default value ``0``, but got {ndmin}"
         )
-
-    # `False`` in numpy means exactly the same like `None` in python array API:
-    # that is to reuse existing memory buffer if possible or to copy otherwise.
-    if copy is False:
-        copy = None
 
     return dpnp_container.asarray(
         a,
@@ -443,10 +445,12 @@ def asarray(
     a,
     dtype=None,
     order=None,
-    like=None,
+    *,
     device=None,
     usm_type=None,
     sycl_queue=None,
+    copy=None,
+    like=None,
 ):
     """
     Converts an input object into array.
@@ -463,8 +467,10 @@ def asarray(
         The desired dtype for the array. If not given, a default dtype will be
         used that can represent the values (by considering Promotion Type Rule
         and device capabilities when necessary).
+        Default: ``None``.
     order : {None, "C", "F", "A", "K"}, optional
-        Memory layout of the newly output array. Default: "K".
+        Memory layout of the newly output array.
+        Default: "K".
     device : {None, string, SyclDevice, SyclQueue}, optional
         An array API concept of device where the output array is created.
         The `device` can be ``None`` (the default), an OneAPI filter selector
@@ -472,6 +478,7 @@ def asarray(
         a non-partitioned SYCL device, an instance of :class:`dpctl.SyclQueue`,
         or a `Device` object returned by
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
+        Default: ``None``.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
         Default: ``None``.
@@ -481,6 +488,12 @@ def asarray(
         to get the SYCL queue from `device` keyword if present or to use
         a default queue.
         Default: ``None``.
+    copy : {None, bool}, optional
+        If ``True``, then the array data is copied. If ``None``, a copy will
+        only be made if a copy is needed to satisfy any of the requirements
+        (``dtype``, ``order``, etc.). For ``False`` it raises a ``ValueError``
+        exception if a copy can not be avoided.
+        Default: ``True``.
 
     Returns
     -------
@@ -533,6 +546,7 @@ def asarray(
     return dpnp_container.asarray(
         a,
         dtype=dtype,
+        copy=copy,
         order=order,
         device=device,
         usm_type=usm_type,

--- a/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
+++ b/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
@@ -925,7 +925,7 @@ def dpnp_matmul(
         # If `order` was not passed as default
         # we need to update it to match the passed `order`.
         if order not in ["k", "K"]:
-            return dpnp.array(result, copy=None, order=order)
+            return dpnp.asarray(result, order=order)
         # dpnp.ascontiguousarray changes 0-D array to 1-D array
         if result.ndim == 0:
             return result

--- a/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
+++ b/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
@@ -925,7 +925,7 @@ def dpnp_matmul(
         # If `order` was not passed as default
         # we need to update it to match the passed `order`.
         if order not in ["k", "K"]:
-            return dpnp.array(result, copy=False, order=order)
+            return dpnp.array(result, copy=None, order=order)
         # dpnp.ascontiguousarray changes 0-D array to 1-D array
         if result.ndim == 0:
             return result

--- a/tests/third_party/cupy/creation_tests/test_from_data.py
+++ b/tests/third_party/cupy/creation_tests/test_from_data.py
@@ -304,7 +304,12 @@ class TestFromData(unittest.TestCase):
     @testing.numpy_cupy_array_equal()
     def test_array_no_copy(self, xp, dtype, order):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
-        b = xp.array(a, copy=False, order=order)
+        if xp is numpy and numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0":
+            # copy keyword behavior changes in asarray, array since numpy 2.0
+            copy_flag = False
+        else:
+            copy_flag = None
+        b = xp.array(a, copy=copy_flag, order=order)
         a.fill(0)
         return b
 
@@ -313,14 +318,24 @@ class TestFromData(unittest.TestCase):
     @testing.numpy_cupy_array_equal()
     def test_array_f_contiguous_input(self, xp, dtype, order):
         a = testing.shaped_arange((2, 3, 4), xp, dtype, order="F")
-        b = xp.array(a, copy=False, order=order)
+        if xp is numpy and numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0":
+            # copy keyword behavior changes in asarray, array since numpy 2.0
+            copy_flag = False
+        else:
+            copy_flag = None
+        b = xp.array(a, copy=copy_flag, order=order)
         return b
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_array_f_contiguous_output(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
-        b = xp.array(a, copy=False, order="F")
+        if xp is numpy and numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0":
+            # copy keyword behavior changes in asarray, array since numpy 2.0
+            copy_flag = False
+        else:
+            copy_flag = None
+        b = xp.array(a, copy=copy_flag, order="F")
         assert b.flags.f_contiguous
         return b
 


### PR DESCRIPTION
The `copy` keyword behavior changes in `numpy.asarray` and `numpy.array` during migration to NumPy 2.0 (see [link](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword) for details).

The PR propose to align `dpnp.array` behavior with the changes done for `numpy.asarray`.
And also to add `copy` keyword to `dpnp.asarray`, which has been already present in `dpctl.tensor` interface for a time.

All the impacted tests are updated to cover any numpy version between 1.23 and 2.0.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
