### PR TITLE
Update lapack extensions

### DIFF
--- a/dpnp/backend/extensions/lapack/evd_batch_common.hpp
+++ b/dpnp/backend/extensions/lapack/evd_batch_common.hpp
@@ -55,8 +55,8 @@ std::pair<sycl::event, sycl::event>
     evd_batch_func(sycl::queue &exec_q,
                    const std::int8_t jobz,
                    const std::int8_t upper_lower,
-                   dpctl::tensor::usm_ndarray &eig_vecs,
-                   dpctl::tensor::usm_ndarray &eig_vals,
+                   const dpctl::tensor::usm_ndarray &eig_vecs,
+                   const dpctl::tensor::usm_ndarray &eig_vals,
                    const std::vector<sycl::event> &depends,
                    const dispatchT &evd_batch_dispatch_table)
 {

--- a/dpnp/backend/extensions/lapack/evd_common.hpp
+++ b/dpnp/backend/extensions/lapack/evd_common.hpp
@@ -55,8 +55,8 @@ std::pair<sycl::event, sycl::event>
     evd_func(sycl::queue &exec_q,
              const std::int8_t jobz,
              const std::int8_t upper_lower,
-             dpctl::tensor::usm_ndarray &eig_vecs,
-             dpctl::tensor::usm_ndarray &eig_vals,
+             const dpctl::tensor::usm_ndarray &eig_vecs,
+             const dpctl::tensor::usm_ndarray &eig_vals,
              const std::vector<sycl::event> &depends,
              const dispatchT &evd_dispatch_table)
 {

--- a/dpnp/backend/extensions/lapack/evd_common_utils.hpp
+++ b/dpnp/backend/extensions/lapack/evd_common_utils.hpp
@@ -50,8 +50,8 @@ void init_evd_dispatch_table(
 }
 
 inline void common_evd_checks(sycl::queue &exec_q,
-                              dpctl::tensor::usm_ndarray &eig_vecs,
-                              dpctl::tensor::usm_ndarray &eig_vals,
+                              const dpctl::tensor::usm_ndarray &eig_vecs,
+                              const dpctl::tensor::usm_ndarray &eig_vals,
                               const py::ssize_t *eig_vecs_shape,
                               const int expected_eig_vecs_nd,
                               const int expected_eig_vals_nd)

--- a/dpnp/backend/extensions/lapack/geqrf.cpp
+++ b/dpnp/backend/extensions/lapack/geqrf.cpp
@@ -134,8 +134,8 @@ static sycl::event geqrf_impl(sycl::queue &exec_q,
 
 std::pair<sycl::event, sycl::event>
     geqrf(sycl::queue &exec_q,
-          dpctl::tensor::usm_ndarray a_array,
-          dpctl::tensor::usm_ndarray tau_array,
+          const dpctl::tensor::usm_ndarray &a_array,
+          const dpctl::tensor::usm_ndarray &tau_array,
           const std::vector<sycl::event> &depends)
 {
     const int a_array_nd = a_array.get_ndim();

--- a/dpnp/backend/extensions/lapack/geqrf.hpp
+++ b/dpnp/backend/extensions/lapack/geqrf.hpp
@@ -33,13 +33,13 @@
 namespace dpnp::extensions::lapack
 {
 extern std::pair<sycl::event, sycl::event>
-    geqrf(sycl::queue exec_q,
+    geqrf(sycl::queue &exec_q,
           dpctl::tensor::usm_ndarray a_array,
           dpctl::tensor::usm_ndarray tau_array,
           const std::vector<sycl::event> &depends = {});
 
 extern std::pair<sycl::event, sycl::event>
-    geqrf_batch(sycl::queue exec_q,
+    geqrf_batch(sycl::queue &exec_q,
                 dpctl::tensor::usm_ndarray a_array,
                 dpctl::tensor::usm_ndarray tau_array,
                 std::int64_t m,

--- a/dpnp/backend/extensions/lapack/geqrf.hpp
+++ b/dpnp/backend/extensions/lapack/geqrf.hpp
@@ -34,14 +34,14 @@ namespace dpnp::extensions::lapack
 {
 extern std::pair<sycl::event, sycl::event>
     geqrf(sycl::queue &exec_q,
-          dpctl::tensor::usm_ndarray a_array,
-          dpctl::tensor::usm_ndarray tau_array,
+          const dpctl::tensor::usm_ndarray &a_array,
+          const dpctl::tensor::usm_ndarray &tau_array,
           const std::vector<sycl::event> &depends = {});
 
 extern std::pair<sycl::event, sycl::event>
     geqrf_batch(sycl::queue &exec_q,
-                dpctl::tensor::usm_ndarray a_array,
-                dpctl::tensor::usm_ndarray tau_array,
+                const dpctl::tensor::usm_ndarray &a_array,
+                const dpctl::tensor::usm_ndarray &tau_array,
                 std::int64_t m,
                 std::int64_t n,
                 std::int64_t stride_a,

--- a/dpnp/backend/extensions/lapack/geqrf_batch.cpp
+++ b/dpnp/backend/extensions/lapack/geqrf_batch.cpp
@@ -41,7 +41,7 @@ namespace py = pybind11;
 namespace type_utils = dpctl::tensor::type_utils;
 
 typedef sycl::event (*geqrf_batch_impl_fn_ptr_t)(
-    sycl::queue,
+    sycl::queue &,
     std::int64_t,
     std::int64_t,
     char *,
@@ -57,7 +57,7 @@ static geqrf_batch_impl_fn_ptr_t
     geqrf_batch_dispatch_vector[dpctl_td_ns::num_types];
 
 template <typename T>
-static sycl::event geqrf_batch_impl(sycl::queue exec_q,
+static sycl::event geqrf_batch_impl(sycl::queue &exec_q,
                                     std::int64_t m,
                                     std::int64_t n,
                                     char *in_a,
@@ -154,7 +154,7 @@ static sycl::event geqrf_batch_impl(sycl::queue exec_q,
 }
 
 std::pair<sycl::event, sycl::event>
-    geqrf_batch(sycl::queue q,
+    geqrf_batch(sycl::queue &exec_q,
                 dpctl::tensor::usm_ndarray a_array,
                 dpctl::tensor::usm_ndarray tau_array,
                 std::int64_t m,
@@ -180,7 +180,7 @@ std::pair<sycl::event, sycl::event>
     }
 
     // check compatibility of execution queue and allocation queue
-    if (!dpctl::utils::queues_are_compatible(q, {a_array, tau_array})) {
+    if (!dpctl::utils::queues_are_compatible(exec_q, {a_array, tau_array})) {
         throw py::value_error(
             "Execution queue is not compatible with allocation queues");
     }
@@ -229,12 +229,12 @@ std::pair<sycl::event, sycl::event>
     const std::int64_t lda = std::max<size_t>(1UL, m);
 
     std::vector<sycl::event> host_task_events;
-    sycl::event geqrf_batch_ev =
-        geqrf_batch_fn(q, m, n, a_array_data, lda, stride_a, tau_array_data,
-                       stride_tau, batch_size, host_task_events, depends);
+    sycl::event geqrf_batch_ev = geqrf_batch_fn(
+        exec_q, m, n, a_array_data, lda, stride_a, tau_array_data, stride_tau,
+        batch_size, host_task_events, depends);
 
-    sycl::event args_ev = dpctl::utils::keep_args_alive(q, {a_array, tau_array},
-                                                        host_task_events);
+    sycl::event args_ev = dpctl::utils::keep_args_alive(
+        exec_q, {a_array, tau_array}, host_task_events);
 
     return std::make_pair(args_ev, geqrf_batch_ev);
 }

--- a/dpnp/backend/extensions/lapack/geqrf_batch.cpp
+++ b/dpnp/backend/extensions/lapack/geqrf_batch.cpp
@@ -155,8 +155,8 @@ static sycl::event geqrf_batch_impl(sycl::queue &exec_q,
 
 std::pair<sycl::event, sycl::event>
     geqrf_batch(sycl::queue &exec_q,
-                dpctl::tensor::usm_ndarray a_array,
-                dpctl::tensor::usm_ndarray tau_array,
+                const dpctl::tensor::usm_ndarray &a_array,
+                const dpctl::tensor::usm_ndarray &tau_array,
                 std::int64_t m,
                 std::int64_t n,
                 std::int64_t stride_a,

--- a/dpnp/backend/extensions/lapack/gesv.cpp
+++ b/dpnp/backend/extensions/lapack/gesv.cpp
@@ -198,8 +198,8 @@ static sycl::event gesv_impl(sycl::queue &exec_q,
 
 std::pair<sycl::event, sycl::event>
     gesv(sycl::queue &exec_q,
-         dpctl::tensor::usm_ndarray coeff_matrix,
-         dpctl::tensor::usm_ndarray dependent_vals,
+         const dpctl::tensor::usm_ndarray &coeff_matrix,
+         const dpctl::tensor::usm_ndarray &dependent_vals,
          const std::vector<sycl::event> &depends)
 {
     const int coeff_matrix_nd = coeff_matrix.get_ndim();

--- a/dpnp/backend/extensions/lapack/gesv.hpp
+++ b/dpnp/backend/extensions/lapack/gesv.hpp
@@ -34,19 +34,19 @@ namespace dpnp::extensions::lapack
 {
 extern std::pair<sycl::event, sycl::event>
     gesv(sycl::queue &exec_q,
-         dpctl::tensor::usm_ndarray coeff_matrix,
-         dpctl::tensor::usm_ndarray dependent_vals,
+         const dpctl::tensor::usm_ndarray &coeff_matrix,
+         const dpctl::tensor::usm_ndarray &dependent_vals,
          const std::vector<sycl::event> &depends);
 
 extern std::pair<sycl::event, sycl::event>
     gesv_batch(sycl::queue &exec_q,
-               dpctl::tensor::usm_ndarray coeff_matrix,
-               dpctl::tensor::usm_ndarray dependent_vals,
+               const dpctl::tensor::usm_ndarray &coeff_matrix,
+               const dpctl::tensor::usm_ndarray &dependent_vals,
                const std::vector<sycl::event> &depends);
 
 extern void common_gesv_checks(sycl::queue &exec_q,
-                               dpctl::tensor::usm_ndarray coeff_matrix,
-                               dpctl::tensor::usm_ndarray dependent_vals,
+                               const dpctl::tensor::usm_ndarray &coeff_matrix,
+                               const dpctl::tensor::usm_ndarray &dependent_vals,
                                const py::ssize_t *coeff_matrix_shape,
                                const py::ssize_t *dependent_vals_shape,
                                const int expected_coeff_matrix_ndim,

--- a/dpnp/backend/extensions/lapack/gesv_batch.cpp
+++ b/dpnp/backend/extensions/lapack/gesv_batch.cpp
@@ -307,8 +307,8 @@ static sycl::event gesv_batch_impl(sycl::queue &exec_q,
 
 std::pair<sycl::event, sycl::event>
     gesv_batch(sycl::queue &exec_q,
-               dpctl::tensor::usm_ndarray coeff_matrix,
-               dpctl::tensor::usm_ndarray dependent_vals,
+               const dpctl::tensor::usm_ndarray &coeff_matrix,
+               const dpctl::tensor::usm_ndarray &dependent_vals,
                const std::vector<sycl::event> &depends)
 {
     const int coeff_matrix_nd = coeff_matrix.get_ndim();

--- a/dpnp/backend/extensions/lapack/gesv_common_utils.hpp
+++ b/dpnp/backend/extensions/lapack/gesv_common_utils.hpp
@@ -41,8 +41,8 @@ namespace dpctl_td_ns = dpctl::tensor::type_dispatch;
 namespace py = pybind11;
 
 inline void common_gesv_checks(sycl::queue &exec_q,
-                               dpctl::tensor::usm_ndarray coeff_matrix,
-                               dpctl::tensor::usm_ndarray dependent_vals,
+                               const dpctl::tensor::usm_ndarray &coeff_matrix,
+                               const dpctl::tensor::usm_ndarray &dependent_vals,
                                const py::ssize_t *coeff_matrix_shape,
                                const py::ssize_t *dependent_vals_shape,
                                const int expected_coeff_matrix_ndim,

--- a/dpnp/backend/extensions/lapack/getrf.cpp
+++ b/dpnp/backend/extensions/lapack/getrf.cpp
@@ -143,8 +143,8 @@ static sycl::event getrf_impl(sycl::queue &exec_q,
 
 std::pair<sycl::event, sycl::event>
     getrf(sycl::queue &exec_q,
-          dpctl::tensor::usm_ndarray a_array,
-          dpctl::tensor::usm_ndarray ipiv_array,
+          const dpctl::tensor::usm_ndarray &a_array,
+          const dpctl::tensor::usm_ndarray &ipiv_array,
           py::list dev_info,
           const std::vector<sycl::event> &depends)
 {

--- a/dpnp/backend/extensions/lapack/getrf.cpp
+++ b/dpnp/backend/extensions/lapack/getrf.cpp
@@ -40,7 +40,7 @@ namespace mkl_lapack = oneapi::mkl::lapack;
 namespace py = pybind11;
 namespace type_utils = dpctl::tensor::type_utils;
 
-typedef sycl::event (*getrf_impl_fn_ptr_t)(sycl::queue,
+typedef sycl::event (*getrf_impl_fn_ptr_t)(sycl::queue &,
                                            const std::int64_t,
                                            char *,
                                            std::int64_t,
@@ -52,7 +52,7 @@ typedef sycl::event (*getrf_impl_fn_ptr_t)(sycl::queue,
 static getrf_impl_fn_ptr_t getrf_dispatch_vector[dpctl_td_ns::num_types];
 
 template <typename T>
-static sycl::event getrf_impl(sycl::queue exec_q,
+static sycl::event getrf_impl(sycl::queue &exec_q,
                               const std::int64_t n,
                               char *in_a,
                               std::int64_t lda,
@@ -142,7 +142,7 @@ static sycl::event getrf_impl(sycl::queue exec_q,
 }
 
 std::pair<sycl::event, sycl::event>
-    getrf(sycl::queue exec_q,
+    getrf(sycl::queue &exec_q,
           dpctl::tensor::usm_ndarray a_array,
           dpctl::tensor::usm_ndarray ipiv_array,
           py::list dev_info,

--- a/dpnp/backend/extensions/lapack/getrf.hpp
+++ b/dpnp/backend/extensions/lapack/getrf.hpp
@@ -34,15 +34,15 @@ namespace dpnp::extensions::lapack
 {
 extern std::pair<sycl::event, sycl::event>
     getrf(sycl::queue &exec_q,
-          dpctl::tensor::usm_ndarray a_array,
-          dpctl::tensor::usm_ndarray ipiv_array,
+          const dpctl::tensor::usm_ndarray &a_array,
+          const dpctl::tensor::usm_ndarray &ipiv_array,
           py::list dev_info,
           const std::vector<sycl::event> &depends = {});
 
 extern std::pair<sycl::event, sycl::event>
     getrf_batch(sycl::queue &exec_q,
-                dpctl::tensor::usm_ndarray a_array,
-                dpctl::tensor::usm_ndarray ipiv_array,
+                const dpctl::tensor::usm_ndarray &a_array,
+                const dpctl::tensor::usm_ndarray &ipiv_array,
                 py::list dev_info,
                 std::int64_t n,
                 std::int64_t stride_a,

--- a/dpnp/backend/extensions/lapack/getrf.hpp
+++ b/dpnp/backend/extensions/lapack/getrf.hpp
@@ -33,14 +33,14 @@
 namespace dpnp::extensions::lapack
 {
 extern std::pair<sycl::event, sycl::event>
-    getrf(sycl::queue exec_q,
+    getrf(sycl::queue &exec_q,
           dpctl::tensor::usm_ndarray a_array,
           dpctl::tensor::usm_ndarray ipiv_array,
           py::list dev_info,
           const std::vector<sycl::event> &depends = {});
 
 extern std::pair<sycl::event, sycl::event>
-    getrf_batch(sycl::queue exec_q,
+    getrf_batch(sycl::queue &exec_q,
                 dpctl::tensor::usm_ndarray a_array,
                 dpctl::tensor::usm_ndarray ipiv_array,
                 py::list dev_info,

--- a/dpnp/backend/extensions/lapack/getrf_batch.cpp
+++ b/dpnp/backend/extensions/lapack/getrf_batch.cpp
@@ -41,7 +41,7 @@ namespace py = pybind11;
 namespace type_utils = dpctl::tensor::type_utils;
 
 typedef sycl::event (*getrf_batch_impl_fn_ptr_t)(
-    sycl::queue,
+    sycl::queue &,
     std::int64_t,
     char *,
     std::int64_t,
@@ -57,7 +57,7 @@ static getrf_batch_impl_fn_ptr_t
     getrf_batch_dispatch_vector[dpctl_td_ns::num_types];
 
 template <typename T>
-static sycl::event getrf_batch_impl(sycl::queue exec_q,
+static sycl::event getrf_batch_impl(sycl::queue &exec_q,
                                     std::int64_t n,
                                     char *in_a,
                                     std::int64_t lda,
@@ -168,7 +168,7 @@ static sycl::event getrf_batch_impl(sycl::queue exec_q,
 }
 
 std::pair<sycl::event, sycl::event>
-    getrf_batch(sycl::queue exec_q,
+    getrf_batch(sycl::queue &exec_q,
                 dpctl::tensor::usm_ndarray a_array,
                 dpctl::tensor::usm_ndarray ipiv_array,
                 py::list dev_info,

--- a/dpnp/backend/extensions/lapack/getrf_batch.cpp
+++ b/dpnp/backend/extensions/lapack/getrf_batch.cpp
@@ -169,8 +169,8 @@ static sycl::event getrf_batch_impl(sycl::queue &exec_q,
 
 std::pair<sycl::event, sycl::event>
     getrf_batch(sycl::queue &exec_q,
-                dpctl::tensor::usm_ndarray a_array,
-                dpctl::tensor::usm_ndarray ipiv_array,
+                const dpctl::tensor::usm_ndarray &a_array,
+                const dpctl::tensor::usm_ndarray &ipiv_array,
                 py::list dev_info,
                 std::int64_t n,
                 std::int64_t stride_a,

--- a/dpnp/backend/extensions/lapack/getri.hpp
+++ b/dpnp/backend/extensions/lapack/getri.hpp
@@ -34,8 +34,8 @@ namespace dpnp::extensions::lapack
 {
 extern std::pair<sycl::event, sycl::event>
     getri_batch(sycl::queue &exec_q,
-                dpctl::tensor::usm_ndarray a_array,
-                dpctl::tensor::usm_ndarray ipiv_array,
+                const dpctl::tensor::usm_ndarray &a_array,
+                const dpctl::tensor::usm_ndarray &ipiv_array,
                 py::list dev_info,
                 std::int64_t n,
                 std::int64_t stride_a,

--- a/dpnp/backend/extensions/lapack/getri.hpp
+++ b/dpnp/backend/extensions/lapack/getri.hpp
@@ -33,7 +33,7 @@
 namespace dpnp::extensions::lapack
 {
 extern std::pair<sycl::event, sycl::event>
-    getri_batch(sycl::queue exec_q,
+    getri_batch(sycl::queue &exec_q,
                 dpctl::tensor::usm_ndarray a_array,
                 dpctl::tensor::usm_ndarray ipiv_array,
                 py::list dev_info,

--- a/dpnp/backend/extensions/lapack/getri_batch.cpp
+++ b/dpnp/backend/extensions/lapack/getri_batch.cpp
@@ -41,7 +41,7 @@ namespace py = pybind11;
 namespace type_utils = dpctl::tensor::type_utils;
 
 typedef sycl::event (*getri_batch_impl_fn_ptr_t)(
-    sycl::queue,
+    sycl::queue &,
     std::int64_t,
     char *,
     std::int64_t,
@@ -57,7 +57,7 @@ static getri_batch_impl_fn_ptr_t
     getri_batch_dispatch_vector[dpctl_td_ns::num_types];
 
 template <typename T>
-static sycl::event getri_batch_impl(sycl::queue exec_q,
+static sycl::event getri_batch_impl(sycl::queue &exec_q,
                                     std::int64_t n,
                                     char *in_a,
                                     std::int64_t lda,
@@ -166,7 +166,7 @@ static sycl::event getri_batch_impl(sycl::queue exec_q,
 }
 
 std::pair<sycl::event, sycl::event>
-    getri_batch(sycl::queue exec_q,
+    getri_batch(sycl::queue &exec_q,
                 dpctl::tensor::usm_ndarray a_array,
                 dpctl::tensor::usm_ndarray ipiv_array,
                 py::list dev_info,

--- a/dpnp/backend/extensions/lapack/getri_batch.cpp
+++ b/dpnp/backend/extensions/lapack/getri_batch.cpp
@@ -167,8 +167,8 @@ static sycl::event getri_batch_impl(sycl::queue &exec_q,
 
 std::pair<sycl::event, sycl::event>
     getri_batch(sycl::queue &exec_q,
-                dpctl::tensor::usm_ndarray a_array,
-                dpctl::tensor::usm_ndarray ipiv_array,
+                const dpctl::tensor::usm_ndarray &a_array,
+                const dpctl::tensor::usm_ndarray &ipiv_array,
                 py::list dev_info,
                 std::int64_t n,
                 std::int64_t stride_a,

--- a/dpnp/backend/extensions/lapack/getrs.cpp
+++ b/dpnp/backend/extensions/lapack/getrs.cpp
@@ -157,9 +157,9 @@ static sycl::event getrs_impl(sycl::queue &exec_q,
 
 std::pair<sycl::event, sycl::event>
     getrs(sycl::queue &exec_q,
-          dpctl::tensor::usm_ndarray a_array,
-          dpctl::tensor::usm_ndarray ipiv_array,
-          dpctl::tensor::usm_ndarray b_array,
+          const dpctl::tensor::usm_ndarray &a_array,
+          const dpctl::tensor::usm_ndarray &ipiv_array,
+          const dpctl::tensor::usm_ndarray &b_array,
           const std::vector<sycl::event> &depends)
 {
     const int a_array_nd = a_array.get_ndim();

--- a/dpnp/backend/extensions/lapack/getrs.hpp
+++ b/dpnp/backend/extensions/lapack/getrs.hpp
@@ -34,9 +34,9 @@ namespace dpnp::extensions::lapack
 {
 extern std::pair<sycl::event, sycl::event>
     getrs(sycl::queue &exec_q,
-          dpctl::tensor::usm_ndarray a_array,
-          dpctl::tensor::usm_ndarray ipiv_array,
-          dpctl::tensor::usm_ndarray b_array,
+          const dpctl::tensor::usm_ndarray &a_array,
+          const dpctl::tensor::usm_ndarray &ipiv_array,
+          const dpctl::tensor::usm_ndarray &b_array,
           const std::vector<sycl::event> &depends = {});
 
 extern void init_getrs_dispatch_vector(void);

--- a/dpnp/backend/extensions/lapack/heevd.cpp
+++ b/dpnp/backend/extensions/lapack/heevd.cpp
@@ -137,8 +137,8 @@ void init_heevd(py::module_ m)
             heevd_dispatch_table);
 
         auto heevd_pyapi = [&](sycl::queue &exec_q, const std::int8_t jobz,
-                               const std::int8_t upper_lower, arrayT &eig_vecs,
-                               arrayT &eig_vals,
+                               const std::int8_t upper_lower,
+                               const arrayT &eig_vecs, const arrayT &eig_vals,
                                const event_vecT &depends = {}) {
             return evd::evd_func(exec_q, jobz, upper_lower, eig_vecs, eig_vals,
                                  depends, heevd_dispatch_table);

--- a/dpnp/backend/extensions/lapack/heevd_batch.cpp
+++ b/dpnp/backend/extensions/lapack/heevd_batch.cpp
@@ -177,8 +177,8 @@ void init_heevd_batch(py::module_ m)
 
         auto heevd_batch_pyapi =
             [&](sycl::queue &exec_q, const std::int8_t jobz,
-                const std::int8_t upper_lower, arrayT &eig_vecs,
-                arrayT &eig_vals, const event_vecT &depends = {}) {
+                const std::int8_t upper_lower, const arrayT &eig_vecs,
+                const arrayT &eig_vals, const event_vecT &depends = {}) {
                 return evd::evd_batch_func(exec_q, jobz, upper_lower, eig_vecs,
                                            eig_vals, depends,
                                            heevd_batch_dispatch_table);

--- a/dpnp/backend/extensions/lapack/orgqr.cpp
+++ b/dpnp/backend/extensions/lapack/orgqr.cpp
@@ -141,8 +141,8 @@ std::pair<sycl::event, sycl::event>
           const std::int64_t m,
           const std::int64_t n,
           const std::int64_t k,
-          dpctl::tensor::usm_ndarray a_array,
-          dpctl::tensor::usm_ndarray tau_array,
+          const dpctl::tensor::usm_ndarray &a_array,
+          const dpctl::tensor::usm_ndarray &tau_array,
           const std::vector<sycl::event> &depends)
 {
     const int a_array_nd = a_array.get_ndim();

--- a/dpnp/backend/extensions/lapack/orgqr.cpp
+++ b/dpnp/backend/extensions/lapack/orgqr.cpp
@@ -40,7 +40,7 @@ namespace mkl_lapack = oneapi::mkl::lapack;
 namespace py = pybind11;
 namespace type_utils = dpctl::tensor::type_utils;
 
-typedef sycl::event (*orgqr_impl_fn_ptr_t)(sycl::queue,
+typedef sycl::event (*orgqr_impl_fn_ptr_t)(sycl::queue &,
                                            const std::int64_t,
                                            const std::int64_t,
                                            const std::int64_t,
@@ -53,7 +53,7 @@ typedef sycl::event (*orgqr_impl_fn_ptr_t)(sycl::queue,
 static orgqr_impl_fn_ptr_t orgqr_dispatch_vector[dpctl_td_ns::num_types];
 
 template <typename T>
-static sycl::event orgqr_impl(sycl::queue exec_q,
+static sycl::event orgqr_impl(sycl::queue &exec_q,
                               const std::int64_t m,
                               const std::int64_t n,
                               const std::int64_t k,
@@ -137,7 +137,7 @@ static sycl::event orgqr_impl(sycl::queue exec_q,
 }
 
 std::pair<sycl::event, sycl::event>
-    orgqr(sycl::queue q,
+    orgqr(sycl::queue &exec_q,
           const std::int64_t m,
           const std::int64_t n,
           const std::int64_t k,
@@ -161,7 +161,7 @@ std::pair<sycl::event, sycl::event>
     }
 
     // check compatibility of execution queue and allocation queue
-    if (!dpctl::utils::queues_are_compatible(q, {a_array, tau_array})) {
+    if (!dpctl::utils::queues_are_compatible(exec_q, {a_array, tau_array})) {
         throw py::value_error(
             "Execution queue is not compatible with allocation queues");
     }
@@ -221,11 +221,11 @@ std::pair<sycl::event, sycl::event>
     char *tau_array_data = tau_array.get_data();
 
     std::vector<sycl::event> host_task_events;
-    sycl::event orgqr_ev = orgqr_fn(q, m, n, k, a_array_data, lda,
+    sycl::event orgqr_ev = orgqr_fn(exec_q, m, n, k, a_array_data, lda,
                                     tau_array_data, host_task_events, depends);
 
-    sycl::event args_ev = dpctl::utils::keep_args_alive(q, {a_array, tau_array},
-                                                        host_task_events);
+    sycl::event args_ev = dpctl::utils::keep_args_alive(
+        exec_q, {a_array, tau_array}, host_task_events);
 
     return std::make_pair(args_ev, orgqr_ev);
 }

--- a/dpnp/backend/extensions/lapack/orgqr.hpp
+++ b/dpnp/backend/extensions/lapack/orgqr.hpp
@@ -33,7 +33,7 @@
 namespace dpnp::extensions::lapack
 {
 extern std::pair<sycl::event, sycl::event>
-    orgqr(sycl::queue exec_q,
+    orgqr(sycl::queue &exec_q,
           const std::int64_t m,
           const std::int64_t n,
           const std::int64_t k,
@@ -42,7 +42,7 @@ extern std::pair<sycl::event, sycl::event>
           const std::vector<sycl::event> &depends = {});
 
 extern std::pair<sycl::event, sycl::event>
-    orgqr_batch(sycl::queue exec_q,
+    orgqr_batch(sycl::queue &exec_q,
                 dpctl::tensor::usm_ndarray a_array,
                 dpctl::tensor::usm_ndarray tau_array,
                 std::int64_t m,

--- a/dpnp/backend/extensions/lapack/orgqr.hpp
+++ b/dpnp/backend/extensions/lapack/orgqr.hpp
@@ -37,14 +37,14 @@ extern std::pair<sycl::event, sycl::event>
           const std::int64_t m,
           const std::int64_t n,
           const std::int64_t k,
-          dpctl::tensor::usm_ndarray a_array,
-          dpctl::tensor::usm_ndarray tau_array,
+          const dpctl::tensor::usm_ndarray &a_array,
+          const dpctl::tensor::usm_ndarray &tau_array,
           const std::vector<sycl::event> &depends = {});
 
 extern std::pair<sycl::event, sycl::event>
     orgqr_batch(sycl::queue &exec_q,
-                dpctl::tensor::usm_ndarray a_array,
-                dpctl::tensor::usm_ndarray tau_array,
+                const dpctl::tensor::usm_ndarray &a_array,
+                const dpctl::tensor::usm_ndarray &tau_array,
                 std::int64_t m,
                 std::int64_t n,
                 std::int64_t k,

--- a/dpnp/backend/extensions/lapack/orgqr_batch.cpp
+++ b/dpnp/backend/extensions/lapack/orgqr_batch.cpp
@@ -159,8 +159,8 @@ static sycl::event orgqr_batch_impl(sycl::queue &exec_q,
 
 std::pair<sycl::event, sycl::event>
     orgqr_batch(sycl::queue &exec_q,
-                dpctl::tensor::usm_ndarray a_array,
-                dpctl::tensor::usm_ndarray tau_array,
+                const dpctl::tensor::usm_ndarray &a_array,
+                const dpctl::tensor::usm_ndarray &tau_array,
                 std::int64_t m,
                 std::int64_t n,
                 std::int64_t k,

--- a/dpnp/backend/extensions/lapack/orgqr_batch.cpp
+++ b/dpnp/backend/extensions/lapack/orgqr_batch.cpp
@@ -41,7 +41,7 @@ namespace py = pybind11;
 namespace type_utils = dpctl::tensor::type_utils;
 
 typedef sycl::event (*orgqr_batch_impl_fn_ptr_t)(
-    sycl::queue,
+    sycl::queue &,
     std::int64_t,
     std::int64_t,
     std::int64_t,
@@ -58,7 +58,7 @@ static orgqr_batch_impl_fn_ptr_t
     orgqr_batch_dispatch_vector[dpctl_td_ns::num_types];
 
 template <typename T>
-static sycl::event orgqr_batch_impl(sycl::queue exec_q,
+static sycl::event orgqr_batch_impl(sycl::queue &exec_q,
                                     std::int64_t m,
                                     std::int64_t n,
                                     std::int64_t k,
@@ -158,7 +158,7 @@ static sycl::event orgqr_batch_impl(sycl::queue exec_q,
 }
 
 std::pair<sycl::event, sycl::event>
-    orgqr_batch(sycl::queue q,
+    orgqr_batch(sycl::queue &exec_q,
                 dpctl::tensor::usm_ndarray a_array,
                 dpctl::tensor::usm_ndarray tau_array,
                 std::int64_t m,
@@ -185,7 +185,7 @@ std::pair<sycl::event, sycl::event>
     }
 
     // check compatibility of execution queue and allocation queue
-    if (!dpctl::utils::queues_are_compatible(q, {a_array, tau_array})) {
+    if (!dpctl::utils::queues_are_compatible(exec_q, {a_array, tau_array})) {
         throw py::value_error(
             "Execution queue is not compatible with allocation queues");
     }
@@ -234,12 +234,12 @@ std::pair<sycl::event, sycl::event>
     const std::int64_t lda = std::max<size_t>(1UL, m);
 
     std::vector<sycl::event> host_task_events;
-    sycl::event orgqr_batch_ev =
-        orgqr_batch_fn(q, m, n, k, a_array_data, lda, stride_a, tau_array_data,
-                       stride_tau, batch_size, host_task_events, depends);
+    sycl::event orgqr_batch_ev = orgqr_batch_fn(
+        exec_q, m, n, k, a_array_data, lda, stride_a, tau_array_data,
+        stride_tau, batch_size, host_task_events, depends);
 
-    sycl::event args_ev = dpctl::utils::keep_args_alive(q, {a_array, tau_array},
-                                                        host_task_events);
+    sycl::event args_ev = dpctl::utils::keep_args_alive(
+        exec_q, {a_array, tau_array}, host_task_events);
 
     return std::make_pair(args_ev, orgqr_batch_ev);
 }

--- a/dpnp/backend/extensions/lapack/potrf.cpp
+++ b/dpnp/backend/extensions/lapack/potrf.cpp
@@ -134,7 +134,7 @@ static sycl::event potrf_impl(sycl::queue &exec_q,
 
 std::pair<sycl::event, sycl::event>
     potrf(sycl::queue &exec_q,
-          dpctl::tensor::usm_ndarray a_array,
+          const dpctl::tensor::usm_ndarray &a_array,
           const std::int8_t upper_lower,
           const std::vector<sycl::event> &depends)
 {

--- a/dpnp/backend/extensions/lapack/potrf.hpp
+++ b/dpnp/backend/extensions/lapack/potrf.hpp
@@ -33,13 +33,13 @@
 namespace dpnp::extensions::lapack
 {
 extern std::pair<sycl::event, sycl::event>
-    potrf(sycl::queue exec_q,
+    potrf(sycl::queue &exec_q,
           dpctl::tensor::usm_ndarray a_array,
           const std::int8_t upper_lower,
           const std::vector<sycl::event> &depends = {});
 
 extern std::pair<sycl::event, sycl::event>
-    potrf_batch(sycl::queue exec_q,
+    potrf_batch(sycl::queue &exec_q,
                 dpctl::tensor::usm_ndarray a_array,
                 const std::int8_t upper_lower,
                 const std::int64_t n,

--- a/dpnp/backend/extensions/lapack/potrf.hpp
+++ b/dpnp/backend/extensions/lapack/potrf.hpp
@@ -34,13 +34,13 @@ namespace dpnp::extensions::lapack
 {
 extern std::pair<sycl::event, sycl::event>
     potrf(sycl::queue &exec_q,
-          dpctl::tensor::usm_ndarray a_array,
+          const dpctl::tensor::usm_ndarray &a_array,
           const std::int8_t upper_lower,
           const std::vector<sycl::event> &depends = {});
 
 extern std::pair<sycl::event, sycl::event>
     potrf_batch(sycl::queue &exec_q,
-                dpctl::tensor::usm_ndarray a_array,
+                const dpctl::tensor::usm_ndarray &a_array,
                 const std::int8_t upper_lower,
                 const std::int64_t n,
                 const std::int64_t stride_a,

--- a/dpnp/backend/extensions/lapack/potrf_batch.cpp
+++ b/dpnp/backend/extensions/lapack/potrf_batch.cpp
@@ -164,7 +164,7 @@ static sycl::event potrf_batch_impl(sycl::queue &exec_q,
 
 std::pair<sycl::event, sycl::event>
     potrf_batch(sycl::queue &exec_q,
-                dpctl::tensor::usm_ndarray a_array,
+                const dpctl::tensor::usm_ndarray &a_array,
                 const std::int8_t upper_lower,
                 const std::int64_t n,
                 const std::int64_t stride_a,

--- a/dpnp/backend/extensions/lapack/syevd.cpp
+++ b/dpnp/backend/extensions/lapack/syevd.cpp
@@ -137,8 +137,8 @@ void init_syevd(py::module_ m)
             syevd_dispatch_table);
 
         auto syevd_pyapi = [&](sycl::queue &exec_q, const std::int8_t jobz,
-                               const std::int8_t upper_lower, arrayT &eig_vecs,
-                               arrayT &eig_vals,
+                               const std::int8_t upper_lower,
+                               const arrayT &eig_vecs, const arrayT &eig_vals,
                                const event_vecT &depends = {}) {
             return evd::evd_func(exec_q, jobz, upper_lower, eig_vecs, eig_vals,
                                  depends, syevd_dispatch_table);

--- a/dpnp/backend/extensions/lapack/syevd_batch.cpp
+++ b/dpnp/backend/extensions/lapack/syevd_batch.cpp
@@ -177,8 +177,8 @@ void init_syevd_batch(py::module_ m)
 
         auto syevd_batch_pyapi =
             [&](sycl::queue &exec_q, const std::int8_t jobz,
-                const std::int8_t upper_lower, arrayT &eig_vecs,
-                arrayT &eig_vals, const event_vecT &depends = {}) {
+                const std::int8_t upper_lower, const arrayT &eig_vecs,
+                const arrayT &eig_vals, const event_vecT &depends = {}) {
                 return evd::evd_batch_func(exec_q, jobz, upper_lower, eig_vecs,
                                            eig_vals, depends,
                                            syevd_batch_dispatch_table);

--- a/dpnp/backend/extensions/lapack/ungqr.cpp
+++ b/dpnp/backend/extensions/lapack/ungqr.cpp
@@ -141,8 +141,8 @@ std::pair<sycl::event, sycl::event>
           const std::int64_t m,
           const std::int64_t n,
           const std::int64_t k,
-          dpctl::tensor::usm_ndarray a_array,
-          dpctl::tensor::usm_ndarray tau_array,
+          const dpctl::tensor::usm_ndarray &a_array,
+          const dpctl::tensor::usm_ndarray &tau_array,
           const std::vector<sycl::event> &depends)
 {
     const int a_array_nd = a_array.get_ndim();

--- a/dpnp/backend/extensions/lapack/ungqr.cpp
+++ b/dpnp/backend/extensions/lapack/ungqr.cpp
@@ -40,7 +40,7 @@ namespace mkl_lapack = oneapi::mkl::lapack;
 namespace py = pybind11;
 namespace type_utils = dpctl::tensor::type_utils;
 
-typedef sycl::event (*ungqr_impl_fn_ptr_t)(sycl::queue,
+typedef sycl::event (*ungqr_impl_fn_ptr_t)(sycl::queue &,
                                            const std::int64_t,
                                            const std::int64_t,
                                            const std::int64_t,
@@ -53,7 +53,7 @@ typedef sycl::event (*ungqr_impl_fn_ptr_t)(sycl::queue,
 static ungqr_impl_fn_ptr_t ungqr_dispatch_vector[dpctl_td_ns::num_types];
 
 template <typename T>
-static sycl::event ungqr_impl(sycl::queue exec_q,
+static sycl::event ungqr_impl(sycl::queue &exec_q,
                               const std::int64_t m,
                               const std::int64_t n,
                               const std::int64_t k,
@@ -137,7 +137,7 @@ static sycl::event ungqr_impl(sycl::queue exec_q,
 }
 
 std::pair<sycl::event, sycl::event>
-    ungqr(sycl::queue q,
+    ungqr(sycl::queue &exec_q,
           const std::int64_t m,
           const std::int64_t n,
           const std::int64_t k,
@@ -161,7 +161,7 @@ std::pair<sycl::event, sycl::event>
     }
 
     // check compatibility of execution queue and allocation queue
-    if (!dpctl::utils::queues_are_compatible(q, {a_array, tau_array})) {
+    if (!dpctl::utils::queues_are_compatible(exec_q, {a_array, tau_array})) {
         throw py::value_error(
             "Execution queue is not compatible with allocation queues");
     }
@@ -221,11 +221,11 @@ std::pair<sycl::event, sycl::event>
     char *tau_array_data = tau_array.get_data();
 
     std::vector<sycl::event> host_task_events;
-    sycl::event ungqr_ev = ungqr_fn(q, m, n, k, a_array_data, lda,
+    sycl::event ungqr_ev = ungqr_fn(exec_q, m, n, k, a_array_data, lda,
                                     tau_array_data, host_task_events, depends);
 
-    sycl::event args_ev = dpctl::utils::keep_args_alive(q, {a_array, tau_array},
-                                                        host_task_events);
+    sycl::event args_ev = dpctl::utils::keep_args_alive(
+        exec_q, {a_array, tau_array}, host_task_events);
 
     return std::make_pair(args_ev, ungqr_ev);
 }

--- a/dpnp/backend/extensions/lapack/ungqr.hpp
+++ b/dpnp/backend/extensions/lapack/ungqr.hpp
@@ -33,7 +33,7 @@
 namespace dpnp::extensions::lapack
 {
 extern std::pair<sycl::event, sycl::event>
-    ungqr(sycl::queue exec_q,
+    ungqr(sycl::queue &exec_q,
           const std::int64_t m,
           const std::int64_t n,
           const std::int64_t k,
@@ -42,7 +42,7 @@ extern std::pair<sycl::event, sycl::event>
           const std::vector<sycl::event> &depends = {});
 
 extern std::pair<sycl::event, sycl::event>
-    ungqr_batch(sycl::queue exec_q,
+    ungqr_batch(sycl::queue &exec_q,
                 dpctl::tensor::usm_ndarray a_array,
                 dpctl::tensor::usm_ndarray tau_array,
                 std::int64_t m,

--- a/dpnp/backend/extensions/lapack/ungqr.hpp
+++ b/dpnp/backend/extensions/lapack/ungqr.hpp
@@ -37,14 +37,14 @@ extern std::pair<sycl::event, sycl::event>
           const std::int64_t m,
           const std::int64_t n,
           const std::int64_t k,
-          dpctl::tensor::usm_ndarray a_array,
-          dpctl::tensor::usm_ndarray tau_array,
+          const dpctl::tensor::usm_ndarray &a_array,
+          const dpctl::tensor::usm_ndarray &tau_array,
           const std::vector<sycl::event> &depends = {});
 
 extern std::pair<sycl::event, sycl::event>
     ungqr_batch(sycl::queue &exec_q,
-                dpctl::tensor::usm_ndarray a_array,
-                dpctl::tensor::usm_ndarray tau_array,
+                const dpctl::tensor::usm_ndarray &a_array,
+                const dpctl::tensor::usm_ndarray &tau_array,
                 std::int64_t m,
                 std::int64_t n,
                 std::int64_t k,

--- a/dpnp/backend/extensions/lapack/ungqr_batch.cpp
+++ b/dpnp/backend/extensions/lapack/ungqr_batch.cpp
@@ -159,8 +159,8 @@ static sycl::event ungqr_batch_impl(sycl::queue &exec_q,
 
 std::pair<sycl::event, sycl::event>
     ungqr_batch(sycl::queue &exec_q,
-                dpctl::tensor::usm_ndarray a_array,
-                dpctl::tensor::usm_ndarray tau_array,
+                const dpctl::tensor::usm_ndarray &a_array,
+                const dpctl::tensor::usm_ndarray &tau_array,
                 std::int64_t m,
                 std::int64_t n,
                 std::int64_t k,


### PR DESCRIPTION
This PR suggests updating `dpnp lapack` extensions :

1. Pass `sycl::queue` by reference
2. Pass  `dpctl::tensor::usm_ndarray` by constant reference

It is necessary to avoid unnecessary copying

Additionally it changes the name of `q` variable to `exeq_q` in some functions to follow the common code style


- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
