### PR TITLE
Remove the wheels installation with anaconda from the instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ python scripts/build_locally.py
 ## Install Wheel Package via pip
 Install DPNP
 ```cmd
-python -m pip install --index-url https://pypi.anaconda.org/intel/simple dpnp
+python -m pip install dpnp
 ```
 
 Set path to Performance Libraries in case of using venv or system Python:

--- a/doc/quick_start_guide.rst
+++ b/doc/quick_start_guide.rst
@@ -44,7 +44,7 @@ You will need one of the commands below:
 
 * Conda: ``conda install dpnp -c https://software.repos.intel.com/python/conda/ -c conda-forge``
 
-* Pip: ``python -m pip install --index-url https://pypi.anaconda.org/intel/simple dpnp``
+* Pip: ``python -m pip install dpnp``
 
 These commands install dpnp package along with its dependencies, including
 ``dpctl`` package with `Data Parallel Control Library`_ and all required


### PR DESCRIPTION
This PR removes the wheels installation with Anaconda from the instruction, since we will no longer be able to upload packages to Anaconda. And so far, wheels can only be uploaded on Pypi

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
