### PR TITLE
Add a `COMPILER_VERSION_2025_OR_LATER` to be able to run `dpnp` with both 2024.2 and 2025.0 versions of the compiler/MKL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,11 @@ else()
     find_package(oneDPL REQUIRED PATHS ${CMAKE_SOURCE_DIR}/dpnp/backend/cmake/Modules NO_DEFAULT_PATH)
 endif()
 
+if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "2025.0.0")
+    add_definitions(-DCOMPILER_VERSION_FLAG=1)
+else()
+    add_definitions(-DCOMPILER_VERSION_FLAG=0)
+endif()
 
 include(GNUInstallDirs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,9 +47,9 @@ else()
 endif()
 
 if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "2025.0.0")
-    add_definitions(-DCOMPILER_VERSION_FLAG=1)
+    add_definitions(-DCOMPILER_VERSION_2025_OR_LATER=1)
 else()
-    add_definitions(-DCOMPILER_VERSION_FLAG=0)
+    add_definitions(-DCOMPILER_VERSION_2025_OR_LATER=0)
 endif()
 
 include(GNUInstallDirs)

--- a/dpnp/backend/extensions/fft/common.hpp
+++ b/dpnp/backend/extensions/fft/common.hpp
@@ -111,12 +111,12 @@ public:
         const typename valT::value_type dim = get_dim();
 
         valT fwd_strides(dim + 1);
-#if COMPILER_VERSION_FLAG
+#if COMPILER_VERSION_2025_OR_LATER
         descr_.get_value(mkl_dft::config_param::FWD_STRIDES, &fwd_strides);
 #else
         descr_.get_value(mkl_dft::config_param::FWD_STRIDES,
                          fwd_strides.data());
-#endif
+#endif // COMPILER_VERSION_2025_OR_LATER
         return fwd_strides;
     }
 
@@ -130,11 +130,11 @@ public:
                 "Strides length does not match descriptor's dimension");
         }
         descr_.set_value(mkl_dft::config_param::FWD_STRIDES, strides.data());
-#if COMPILER_VERSION_FLAG
+#if COMPILER_VERSION_2025_OR_LATER
         descr_.set_value(mkl_dft::config_param::FWD_STRIDES, strides);
 #else
         descr_.set_value(mkl_dft::config_param::FWD_STRIDES, strides.data());
-#endif
+#endif // COMPILER_VERSION_2025_OR_LATER
     }
 
     // config_param::BWD_STRIDES
@@ -144,12 +144,12 @@ public:
         const typename valT::value_type dim = get_dim();
 
         valT bwd_strides(dim + 1);
-#if COMPILER_COMPILER_VERSION_FLAG
+#if COMPILER_COMPILER_VERSION_2025_OR_LATER
         descr_.get_value(mkl_dft::config_param::BWD_STRIDES, &bwd_strides);
 #else
         descr_.get_value(mkl_dft::config_param::BWD_STRIDES,
                          bwd_strides.data());
-#endif
+#endif // COMPILER_VERSION_2025_OR_LATER
         return bwd_strides;
     }
 
@@ -162,11 +162,11 @@ public:
             throw py::value_error(
                 "Strides length does not match descriptor's dimension");
         }
-#if COMPILER_VERSION_FLAG
+#if COMPILER_VERSION_2025_OR_LATER
         descr_.set_value(mkl_dft::config_param::BWD_STRIDES, strides);
 #else
         descr_.set_value(mkl_dft::config_param::BWD_STRIDES, strides.data());
-#endif
+#endif // COMPILER_VERSION_2025_OR_LATER
     }
 
     // config_param::FWD_DISTANCE
@@ -204,7 +204,7 @@ public:
     // config_param::PLACEMENT
     bool get_in_place()
     {
-#if defined(USE_ONEMKL_INTERFACES) || COMPILER_VERSION_FLAG
+#if defined(USE_ONEMKL_INTERFACES) || COMPILER_VERSION_2025_OR_LATER
         mkl_dft::config_value placement;
         descr_.get_value(mkl_dft::config_param::PLACEMENT, &placement);
         return (placement == mkl_dft::config_value::INPLACE);
@@ -213,12 +213,12 @@ public:
         DFTI_CONFIG_VALUE placement;
         descr_.get_value(mkl_dft::config_param::PLACEMENT, &placement);
         return (placement == DFTI_CONFIG_VALUE::DFTI_INPLACE);
-#endif // USE_ONEMKL_INTERFACES
+#endif // USE_ONEMKL_INTERFACES or COMPILER_VERSION_2025_OR_LATER
     }
 
     void set_in_place(const bool &in_place_request)
     {
-#if defined(USE_ONEMKL_INTERFACES) || COMPILER_VERSION_FLAG
+#if defined(USE_ONEMKL_INTERFACES) || COMPILER_VERSION_2025_OR_LATER
         descr_.set_value(mkl_dft::config_param::PLACEMENT,
                          (in_place_request)
                              ? mkl_dft::config_value::INPLACE
@@ -229,7 +229,7 @@ public:
                          (in_place_request)
                              ? DFTI_CONFIG_VALUE::DFTI_INPLACE
                              : DFTI_CONFIG_VALUE::DFTI_NOT_INPLACE);
-#endif // USE_ONEMKL_INTERFACES
+#endif // USE_ONEMKL_INTERFACES or COMPILER_VERSION_2025_OR_LATER
     }
 
     // config_param::PRECISION
@@ -244,7 +244,7 @@ public:
     // config_param::COMMIT_STATUS
     bool is_committed()
     {
-#if defined(USE_ONEMKL_INTERFACES) || COMPILER_VERSION_FLAG
+#if defined(USE_ONEMKL_INTERFACES) || COMPILER_VERSION_2025_OR_LATER
         mkl_dft::config_value committed;
         descr_.get_value(mkl_dft::config_param::COMMIT_STATUS, &committed);
         return (committed == mkl_dft::config_value::COMMITTED);
@@ -253,7 +253,7 @@ public:
         DFTI_CONFIG_VALUE committed;
         descr_.get_value(mkl_dft::config_param::COMMIT_STATUS, &committed);
         return (committed == DFTI_CONFIG_VALUE::DFTI_COMMITTED);
-#endif // USE_ONEMKL_INTERFACES
+#endif // USE_ONEMKL_INTERFACES or COMPILER_VERSION_2025_OR_LATER
     }
 
 private:

--- a/dpnp/backend/extensions/fft/common.hpp
+++ b/dpnp/backend/extensions/fft/common.hpp
@@ -129,7 +129,6 @@ public:
             throw py::value_error(
                 "Strides length does not match descriptor's dimension");
         }
-        descr_.set_value(mkl_dft::config_param::FWD_STRIDES, strides.data());
 #if COMPILER_VERSION_2025_OR_LATER
         descr_.set_value(mkl_dft::config_param::FWD_STRIDES, strides);
 #else

--- a/dpnp/backend/extensions/fft/common.hpp
+++ b/dpnp/backend/extensions/fft/common.hpp
@@ -111,8 +111,12 @@ public:
         const typename valT::value_type dim = get_dim();
 
         valT fwd_strides(dim + 1);
+#if COMPILER_VERSION_FLAG
+        descr_.get_value(mkl_dft::config_param::FWD_STRIDES, &fwd_strides);
+#else
         descr_.get_value(mkl_dft::config_param::FWD_STRIDES,
                          fwd_strides.data());
+#endif
         return fwd_strides;
     }
 
@@ -126,6 +130,11 @@ public:
                 "Strides length does not match descriptor's dimension");
         }
         descr_.set_value(mkl_dft::config_param::FWD_STRIDES, strides.data());
+#if COMPILER_VERSION_FLAG
+        descr_.set_value(mkl_dft::config_param::FWD_STRIDES, strides);
+#else
+        descr_.set_value(mkl_dft::config_param::FWD_STRIDES, strides.data());
+#endif
     }
 
     // config_param::BWD_STRIDES
@@ -135,8 +144,12 @@ public:
         const typename valT::value_type dim = get_dim();
 
         valT bwd_strides(dim + 1);
+#if COMPILER_COMPILER_VERSION_FLAG
+        descr_.get_value(mkl_dft::config_param::BWD_STRIDES, &bwd_strides);
+#else
         descr_.get_value(mkl_dft::config_param::BWD_STRIDES,
                          bwd_strides.data());
+#endif
         return bwd_strides;
     }
 
@@ -149,7 +162,11 @@ public:
             throw py::value_error(
                 "Strides length does not match descriptor's dimension");
         }
+#if COMPILER_VERSION_FLAG
+        descr_.set_value(mkl_dft::config_param::BWD_STRIDES, strides);
+#else
         descr_.set_value(mkl_dft::config_param::BWD_STRIDES, strides.data());
+#endif
     }
 
     // config_param::FWD_DISTANCE
@@ -187,7 +204,7 @@ public:
     // config_param::PLACEMENT
     bool get_in_place()
     {
-#if defined(USE_ONEMKL_INTERFACES)
+#if defined(USE_ONEMKL_INTERFACES) || COMPILER_VERSION_FLAG
         mkl_dft::config_value placement;
         descr_.get_value(mkl_dft::config_param::PLACEMENT, &placement);
         return (placement == mkl_dft::config_value::INPLACE);
@@ -201,7 +218,7 @@ public:
 
     void set_in_place(const bool &in_place_request)
     {
-#if defined(USE_ONEMKL_INTERFACES)
+#if defined(USE_ONEMKL_INTERFACES) || COMPILER_VERSION_FLAG
         descr_.set_value(mkl_dft::config_param::PLACEMENT,
                          (in_place_request)
                              ? mkl_dft::config_value::INPLACE
@@ -227,7 +244,7 @@ public:
     // config_param::COMMIT_STATUS
     bool is_committed()
     {
-#if defined(USE_ONEMKL_INTERFACES)
+#if defined(USE_ONEMKL_INTERFACES) || COMPILER_VERSION_FLAG
         mkl_dft::config_value committed;
         descr_.get_value(mkl_dft::config_param::COMMIT_STATUS, &committed);
         return (committed == mkl_dft::config_value::COMMITTED);


### PR DESCRIPTION
OneMKL FFT 2025.0.0 includes some backward incompatible changes. However, code can not be updated with these changes yet since public CI is still using older version of OneMKL.  To keep `dpnp` working with both new compiler/MKL pakcge and the old one, a compile flag is defined to compile the proper part of the code based on the compiler version.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
