### PR TITLE
Add build documentation for custom SYCL targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ if(_use_onemkl_interfaces)
             GIT_TAG f2d2dcb4213a435bb60fbb88320c5f24892423ce
     )
     FetchContent_MakeAvailable(onemkl_interfaces_library)
+    set(CMAKE_INSTALL_RPATH "${CMAKE_BINARY_DIR}/lib")
 endif()
 
 if(WIN32)

--- a/doc/quick_start_guide.rst
+++ b/doc/quick_start_guide.rst
@@ -116,6 +116,27 @@ Alternatively, to develop on Linux OS, you can use the driver script:
 
     python scripts/build_locally.py
 
+Building for custom SYCL targets
+--------------------------------
+Project ``dpnp`` is written using generic SYCL and supports building for multiple SYCL targets,
+subject to limitations of `CodePlay <https://codeplay.com/>`_ plugins implementing SYCL
+programming model for classes of devices.
+
+Building ``dpnp`` for these targets requires that these CodePlay plugins be installed into DPC++
+installation layout of compatible version. The following plugins from CodePlay are supported:
+
+    - `oneAPI for NVIDIA(R) GPUs <codeplay_nv_plugin_>`_
+
+.. _codeplay_nv_plugin: https://developer.codeplay.com/products/oneapi/nvidia/
+
+Build ``dpnp`` requires `build Data Parallel Control Library for custom SYCL targets
+<https://intelpython.github.io/dpctl/latest/beginners_guides/installation.html#building-for-custom-sycl-targets>`_
+
+Build ``dpnp`` as follows:
+
+.. code-block:: bash
+
+    python scripts/build_locally.py --target=cuda
 
 Testing
 =======


### PR DESCRIPTION
Added build documentation for custom SYCL targets.

Added RPATH for build with oneMKL Interfaces for simplify user experience.
Now there is no need to specify LD_LIBRARY_PATH.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
