### PR TITLE
Pin compiler at build time to 2025.0 for 0.16.x release

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set required_compiler_and_mkl_version = "2024.2" %}
+{% set required_compiler_and_mkl_version = "2025.0.0" %}
 {% set required_dpctl_version = "0.18.0*" %}
 
 package:


### PR DESCRIPTION
This change pins compile-time version of the compiler to 2025.0.0 and host MKL version to 2025.0.0, and restricts the range of compiler runtime and MKL libraries accordingly for dpnp=0.16.0.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
