### PR TITLE
Enable third party tests for dpnp.size

### DIFF
--- a/tests/third_party/cupy/core_tests/test_core.py
+++ b/tests/third_party/cupy/core_tests/test_core.py
@@ -1,5 +1,5 @@
-import unittest
 import sys
+import unittest
 
 import numpy
 import pytest
@@ -35,15 +35,15 @@ class TestSize(unittest.TestCase):
     @testing.numpy_cupy_equal()
     @testing.slow
     def test_size_huge(self, xp):
-        a = xp.ndarray(2 ** 32, 'b')  # 4 GiB
+        a = xp.ndarray(2**32, "b")  # 4 GiB
         return xp.size(a)
 
 
 _orders = {
     order_arg: order_expect
     for order_expect, order_args in [
-        ('C', ['C', 'c', 'CONTIGUOUS', '', None]),
-        ('F', ['F', 'f', 'FORTRAN']),
+        ("C", ["C", "c", "CONTIGUOUS", "", None]),
+        ("F", ["F", "f", "FORTRAN"]),
     ]
     for order_arg in order_args
 }
@@ -55,8 +55,8 @@ class TestOrder(unittest.TestCase):
     def test_ndarray(self, order):
         order_expect = _orders[order]
         a = core.ndarray((2, 3), order=order)
-        expect_c = order_expect == 'C'
-        expect_f = order_expect == 'F'
+        expect_c = order_expect == "C"
+        expect_f = order_expect == "F"
         assert a.flags.c_contiguous == expect_c
         assert a.flags.f_contiguous == expect_f
 
@@ -92,27 +92,33 @@ class TestMinScalarType:
             assert cupy.min_scalar_type(v) is arr.dtype
 
 
-@testing.parameterize(*testing.product({
-    'cxx': (None, '--std=c++11'),
-}))
+@testing.parameterize(
+    *testing.product(
+        {
+            "cxx": (None, "--std=c++11"),
+        }
+    )
+)
 @pytest.mark.skip("compiling cupy headers are not supported")
 class TestCuPyHeaders(unittest.TestCase):
     def setUp(self):
         self.temporary_cache_dir_context = test_raw.use_temporary_cache_dir()
         self.cache_dir = self.temporary_cache_dir_context.__enter__()
-        self.header = '\n'.join(['#include <' + h + '>'
-                                 for h in core._cupy_header_list])
+        self.header = "\n".join(
+            ["#include <" + h + ">" for h in core._cupy_header_list]
+        )
 
     def tearDown(self):
         self.temporary_cache_dir_context.__exit__(*sys.exc_info())
 
     def test_compiling_core_header(self):
-        code = r'''
+        code = r"""
         extern "C" __global__ void _test_ker_() { }
-        '''
+        """
         code = self.header + code
         options = () if self.cxx is None else (self.cxx,)
-        ker = cupy.RawKernel(code, '_test_ker_',
-                             options=options, backend='nvrtc')
+        ker = cupy.RawKernel(
+            code, "_test_ker_", options=options, backend="nvrtc"
+        )
         ker((1,), (1,), ())
         cupy.cuda.Device().synchronize()

--- a/tests/third_party/cupy/core_tests/test_core.py
+++ b/tests/third_party/cupy/core_tests/test_core.py
@@ -1,0 +1,118 @@
+import unittest
+import sys
+
+import numpy
+import pytest
+
+import dpnp as cupy
+from tests.third_party.cupy import testing
+
+
+class TestSize(unittest.TestCase):
+    # def tearDown(self):
+    #     # Free huge memory for slow test
+    #     cupy.get_default_memory_pool().free_all_blocks()
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_equal()
+    def test_size(self, xp, dtype):
+        a = xp.ndarray((2, 3), dtype=dtype)
+        return xp.size(a)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_equal()
+    def test_size_axis(self, xp, dtype):
+        a = xp.ndarray((2, 3), dtype=dtype)
+        return xp.size(a, axis=1)
+
+    @testing.for_all_dtypes()
+    def test_size_axis_error(self, dtype):
+        for xp in (numpy, cupy):
+            a = xp.ndarray((2, 3), dtype=dtype)
+            with pytest.raises(IndexError):
+                return xp.size(a, axis=3)
+
+    @testing.numpy_cupy_equal()
+    @testing.slow
+    def test_size_huge(self, xp):
+        a = xp.ndarray(2 ** 32, 'b')  # 4 GiB
+        return xp.size(a)
+
+
+_orders = {
+    order_arg: order_expect
+    for order_expect, order_args in [
+        ('C', ['C', 'c', 'CONTIGUOUS', '', None]),
+        ('F', ['F', 'f', 'FORTRAN']),
+    ]
+    for order_arg in order_args
+}
+
+
+@pytest.mark.skip("no cupy._core submodule")
+class TestOrder(unittest.TestCase):
+    @testing.for_orders(_orders.keys())
+    def test_ndarray(self, order):
+        order_expect = _orders[order]
+        a = core.ndarray((2, 3), order=order)
+        expect_c = order_expect == 'C'
+        expect_f = order_expect == 'F'
+        assert a.flags.c_contiguous == expect_c
+        assert a.flags.f_contiguous == expect_f
+
+
+@pytest.mark.skip("min_scalar_type() is not supported")
+class TestMinScalarType:
+    def test_scalar(self):
+        for v in (-129, -128, 0, 1.2, numpy.inf):
+            assert cupy.min_scalar_type(v) is numpy.min_scalar_type(v)
+
+    @testing.for_all_dtypes()
+    def test_numpy_scalar(self, dtype):
+        sc = dtype(1)
+        for v in (sc, [sc, sc]):
+            assert cupy.min_scalar_type(v) is numpy.min_scalar_type(v)
+
+    @testing.for_all_dtypes()
+    def test_cupy_scalar(self, dtype):
+        sc = cupy.array(-1).astype(dtype)
+        for v in (sc, [sc, sc]):
+            assert cupy.min_scalar_type(v) is sc.dtype
+
+    @testing.for_all_dtypes()
+    def test_numpy_ndarray(self, dtype):
+        arr = numpy.array([[-1, 1]]).astype(dtype)
+        for v in (arr, (arr, arr)):
+            assert cupy.min_scalar_type(v) is numpy.min_scalar_type(v)
+
+    @testing.for_all_dtypes()
+    def test_cupy_ndarray(self, dtype):
+        arr = cupy.array([[-1, 1]]).astype(dtype)
+        for v in (arr, (arr, arr)):
+            assert cupy.min_scalar_type(v) is arr.dtype
+
+
+@testing.parameterize(*testing.product({
+    'cxx': (None, '--std=c++11'),
+}))
+@pytest.mark.skip("compiling cupy headers are not supported")
+class TestCuPyHeaders(unittest.TestCase):
+    def setUp(self):
+        self.temporary_cache_dir_context = test_raw.use_temporary_cache_dir()
+        self.cache_dir = self.temporary_cache_dir_context.__enter__()
+        self.header = '\n'.join(['#include <' + h + '>'
+                                 for h in core._cupy_header_list])
+
+    def tearDown(self):
+        self.temporary_cache_dir_context.__exit__(*sys.exc_info())
+
+    def test_compiling_core_header(self):
+        code = r'''
+        extern "C" __global__ void _test_ker_() { }
+        '''
+        code = self.header + code
+        options = () if self.cxx is None else (self.cxx,)
+        ker = cupy.RawKernel(code, '_test_ker_',
+                             options=options, backend='nvrtc')
+        ker((1,), (1,), ())
+        cupy.cuda.Device().synchronize()

--- a/tests/third_party/cupy/core_tests/test_ndarray.py
+++ b/tests/third_party/cupy/core_tests/test_ndarray.py
@@ -155,10 +155,17 @@ class TestNdarrayInitRaise(unittest.TestCase):
             cupy.array(arr)
 
     @pytest.mark.skip("no ndim limit")
+    @testing.with_requires("numpy>=2.0")
+    @testing.numpy_cupy_array_equal()
+    def test_upper_limit_ndim(self, xp):
+        shape = [1 for i in range(64)]
+        return xp.zeros(shape, dtype=xp.int8)
+
+    @pytest.mark.skip("no ndim limit")
     def test_excessive_ndim(self):
         for xp in (numpy, cupy):
             with pytest.raises(ValueError):
-                xp.ndarray(shape=[1 for i in range(33)], dtype=xp.int8)
+                xp.ndarray(shape=[1 for i in range(65)], dtype=xp.int8)
 
 
 @testing.parameterize(
@@ -588,7 +595,6 @@ class TestZeroSizedNdarrayTakeIndexError(unittest.TestCase):
                 wrap_take(a, i)
 
 
-@pytest.mark.skip("size() is not supported")
 class TestSize(unittest.TestCase):
     @testing.numpy_cupy_equal()
     def test_size_without_axis(self, xp):


### PR DESCRIPTION
The PR extends test coverage of `dpnp.size` implemented in #2014 by enabling third party tests for the function.

The affected tests are unmuted in `test_ndarray.py` scope and the new `test_core.py` with more third party tests of core functionality.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
