### PR TITLE
Remove TODO from the code as no plan to support negative values in shape setter

### DIFF
--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -224,8 +224,7 @@ def _gradient_num_diff_2nd_order_interior(
         # fix the shape for broadcasting
         shape = [1] * ndim
         shape[axis] = -1
-        # TODO: use shape.setter once dpctl#1699 is resolved
-        # a.shape = b.shape = c.shape = shape
+
         a = a.reshape(shape)
         b = b.reshape(shape)
         c = c.reshape(shape)

--- a/tests/third_party/cupy/core_tests/test_ndarray.py
+++ b/tests/third_party/cupy/core_tests/test_ndarray.py
@@ -265,7 +265,8 @@ class TestNdarrayShape(unittest.TestCase):
         return xp.array(arr.shape)
 
     @pytest.mark.skip(
-        "dpctl-1699: shape setter does not work with negative shape"
+        "dpctl-1699: shape setter does not work with negative shape "
+        "(no plan to support that)"
     )
     @testing.numpy_cupy_array_equal()
     def test_shape_set_infer(self, xp):


### PR DESCRIPTION
The PR proposes to clean the code and to remove the TODO which is no plan to be implemented.

The `shape.setter` documentation in both `dpnp.ndarray` and `usm_ndarray` clearly states that only non-negative new shape value is supported. And it is suggested to use `dpnp.reshape` instead (numpy recommends the same).

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
