### PR TITLE
Use `INTEL_MKL_VERSION` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,9 +105,10 @@ In addition, this release completes implementation of `dpnp.fft` module and adds
 * Added `copy` keyword to `dpnp.array` to align with NumPy 2.0  [#2006](https://github.com/IntelPython/dpnp/pull/2006)
 * Extended `dpnp.heaviside` to support `order` and `out` keyword arguments by writing dedicated kernel for it [#2008](https://github.com/IntelPython/dpnp/pull/2008)
 * `dpnp` uses pybind11 2.13.5 [#2010](https://github.com/IntelPython/dpnp/pull/2010)
-* Add `COMPILER_VERSION_2025_OR_LATER` flag to be able to run `dpnp.fft` module with both 2024.2 and 2025.0 versions of the compiler [#2025](https://github.com/IntelPython/dpnp/pull/2025)
+* Added `COMPILER_VERSION_2025_OR_LATER` flag to be able to run `dpnp.fft` module with both 2024.2 and 2025.0 versions of the compiler [#2025](https://github.com/IntelPython/dpnp/pull/2025)
 * Cleaned up an implementation of `dpnp.gradient` by removing obsolete TODO which is not going to be done [#2032](https://github.com/IntelPython/dpnp/pull/2032)
 * Updated `Array Manipulation Routines` page in documentation to add missing functions and to remove duplicate entries [#2033](https://github.com/IntelPython/dpnp/pull/2033)
+* Updated `dpnp.fft` backend to depend on `INTEL_MKL_VERSION` flag to ensures that the appropriate code segment is executed based on the version of OneMKL [#2035](https://github.com/IntelPython/dpnp/pull/2035)
 
 ### Fixed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,12 +46,6 @@ else()
     find_package(oneDPL REQUIRED PATHS ${CMAKE_SOURCE_DIR}/dpnp/backend/cmake/Modules NO_DEFAULT_PATH)
 endif()
 
-if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "2025.0.0")
-    add_definitions(-DCOMPILER_VERSION_2025_OR_LATER=1)
-else()
-    add_definitions(-DCOMPILER_VERSION_2025_OR_LATER=0)
-endif()
-
 include(GNUInstallDirs)
 
 # Fetch pybind11

--- a/dpnp/backend/extensions/fft/common.hpp
+++ b/dpnp/backend/extensions/fft/common.hpp
@@ -111,12 +111,12 @@ public:
         const typename valT::value_type dim = get_dim();
 
         valT fwd_strides(dim + 1);
-#if COMPILER_VERSION_2025_OR_LATER
+#if INTEL_MKL_VERSION >= 20250000
         descr_.get_value(mkl_dft::config_param::FWD_STRIDES, &fwd_strides);
 #else
         descr_.get_value(mkl_dft::config_param::FWD_STRIDES,
                          fwd_strides.data());
-#endif // COMPILER_VERSION_2025_OR_LATER
+#endif // INTEL_MKL_VERSION
         return fwd_strides;
     }
 
@@ -129,11 +129,11 @@ public:
             throw py::value_error(
                 "Strides length does not match descriptor's dimension");
         }
-#if COMPILER_VERSION_2025_OR_LATER
+#if INTEL_MKL_VERSION >= 20250000
         descr_.set_value(mkl_dft::config_param::FWD_STRIDES, strides);
 #else
         descr_.set_value(mkl_dft::config_param::FWD_STRIDES, strides.data());
-#endif // COMPILER_VERSION_2025_OR_LATER
+#endif // INTEL_MKL_VERSION
     }
 
     // config_param::BWD_STRIDES
@@ -143,12 +143,12 @@ public:
         const typename valT::value_type dim = get_dim();
 
         valT bwd_strides(dim + 1);
-#if COMPILER_COMPILER_VERSION_2025_OR_LATER
+#if INTEL_MKL_VERSION >= 20250000
         descr_.get_value(mkl_dft::config_param::BWD_STRIDES, &bwd_strides);
 #else
         descr_.get_value(mkl_dft::config_param::BWD_STRIDES,
                          bwd_strides.data());
-#endif // COMPILER_VERSION_2025_OR_LATER
+#endif // INTEL_MKL_VERSION
         return bwd_strides;
     }
 
@@ -161,11 +161,11 @@ public:
             throw py::value_error(
                 "Strides length does not match descriptor's dimension");
         }
-#if COMPILER_VERSION_2025_OR_LATER
+#if INTEL_MKL_VERSION >= 20250000
         descr_.set_value(mkl_dft::config_param::BWD_STRIDES, strides);
 #else
         descr_.set_value(mkl_dft::config_param::BWD_STRIDES, strides.data());
-#endif // COMPILER_VERSION_2025_OR_LATER
+#endif // INTEL_MKL_VERSION
     }
 
     // config_param::FWD_DISTANCE
@@ -203,7 +203,7 @@ public:
     // config_param::PLACEMENT
     bool get_in_place()
     {
-#if defined(USE_ONEMKL_INTERFACES) || COMPILER_VERSION_2025_OR_LATER
+#if defined(USE_ONEMKL_INTERFACES) || INTEL_MKL_VERSION >= 20250000
         mkl_dft::config_value placement;
         descr_.get_value(mkl_dft::config_param::PLACEMENT, &placement);
         return (placement == mkl_dft::config_value::INPLACE);
@@ -212,12 +212,12 @@ public:
         DFTI_CONFIG_VALUE placement;
         descr_.get_value(mkl_dft::config_param::PLACEMENT, &placement);
         return (placement == DFTI_CONFIG_VALUE::DFTI_INPLACE);
-#endif // USE_ONEMKL_INTERFACES or COMPILER_VERSION_2025_OR_LATER
+#endif // USE_ONEMKL_INTERFACES or INTEL_MKL_VERSION
     }
 
     void set_in_place(const bool &in_place_request)
     {
-#if defined(USE_ONEMKL_INTERFACES) || COMPILER_VERSION_2025_OR_LATER
+#if defined(USE_ONEMKL_INTERFACES) || INTEL_MKL_VERSION >= 20250000
         descr_.set_value(mkl_dft::config_param::PLACEMENT,
                          (in_place_request)
                              ? mkl_dft::config_value::INPLACE
@@ -228,7 +228,7 @@ public:
                          (in_place_request)
                              ? DFTI_CONFIG_VALUE::DFTI_INPLACE
                              : DFTI_CONFIG_VALUE::DFTI_NOT_INPLACE);
-#endif // USE_ONEMKL_INTERFACES or COMPILER_VERSION_2025_OR_LATER
+#endif // USE_ONEMKL_INTERFACES or INTEL_MKL_VERSION
     }
 
     // config_param::PRECISION
@@ -243,7 +243,7 @@ public:
     // config_param::COMMIT_STATUS
     bool is_committed()
     {
-#if defined(USE_ONEMKL_INTERFACES) || COMPILER_VERSION_2025_OR_LATER
+#if defined(USE_ONEMKL_INTERFACES) || INTEL_MKL_VERSION >= 20250000
         mkl_dft::config_value committed;
         descr_.get_value(mkl_dft::config_param::COMMIT_STATUS, &committed);
         return (committed == mkl_dft::config_value::COMMITTED);
@@ -252,7 +252,7 @@ public:
         DFTI_CONFIG_VALUE committed;
         descr_.get_value(mkl_dft::config_param::COMMIT_STATUS, &committed);
         return (committed == DFTI_CONFIG_VALUE::DFTI_COMMITTED);
-#endif // USE_ONEMKL_INTERFACES or COMPILER_VERSION_2025_OR_LATER
+#endif // USE_ONEMKL_INTERFACES or INTEL_MKL_VERSION
     }
 
 private:


### PR DESCRIPTION
In continuation of #2025, the code is modified to use `INTEL_MKL_VERSION` flag to determine which version of MKL is installed and being used and accordingly run the proper part of the code.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
