### PR TITLE
Enable the whole scope of indexing tests in public CI

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -53,8 +53,7 @@ env:
       third_party/cupy/core_tests
       third_party/cupy/fft_tests
       third_party/cupy/creation_tests
-      third_party/cupy/indexing_tests/test_indexing.py
-      third_party/cupy/indexing_tests/test_generate.py
+      third_party/cupy/indexing_tests
       third_party/cupy/lib_tests
       third_party/cupy/linalg_tests
       third_party/cupy/logic_tests

--- a/tests/skipped_tests.tbl
+++ b/tests/skipped_tests.tbl
@@ -55,21 +55,6 @@ tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestCubReduction_pa
 tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestCubReduction_param_7_{order='F', shape=(10, 20, 30, 40)}::test_cub_max
 tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestCubReduction_param_7_{order='F', shape=(10, 20, 30, 40)}::test_cub_min
 
-tests/third_party/cupy/indexing_tests/test_generate.py::TestAxisConcatenator::test_AxisConcatenator_init1
-tests/third_party/cupy/indexing_tests/test_generate.py::TestAxisConcatenator::test_len
-tests/third_party/cupy/indexing_tests/test_generate.py::TestC_::test_c_1
-tests/third_party/cupy/indexing_tests/test_generate.py::TestC_::test_c_2
-tests/third_party/cupy/indexing_tests/test_generate.py::TestC_::test_c_3
-tests/third_party/cupy/indexing_tests/test_generate.py::TestR_::test_r_1
-tests/third_party/cupy/indexing_tests/test_generate.py::TestR_::test_r_2
-tests/third_party/cupy/indexing_tests/test_generate.py::TestR_::test_r_3
-tests/third_party/cupy/indexing_tests/test_generate.py::TestR_::test_r_4
-tests/third_party/cupy/indexing_tests/test_generate.py::TestR_::test_r_5
-tests/third_party/cupy/indexing_tests/test_generate.py::TestR_::test_r_6
-tests/third_party/cupy/indexing_tests/test_generate.py::TestR_::test_r_7
-tests/third_party/cupy/indexing_tests/test_generate.py::TestR_::test_r_8
-tests/third_party/cupy/indexing_tests/test_generate.py::TestR_::test_r_9
-
 tests/third_party/cupy/indexing_tests/test_insert.py::TestPutmaskDifferentDtypes::test_putmask_differnt_dtypes_raises
 tests/third_party/cupy/indexing_tests/test_insert.py::TestPutmask::test_putmask_non_equal_shape_raises
 

--- a/tests/skipped_tests_gpu.tbl
+++ b/tests/skipped_tests_gpu.tbl
@@ -108,21 +108,6 @@ tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestCubReduction_pa
 tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestCubReduction_param_7_{order='F', shape=(10, 20, 30, 40)}::test_cub_max
 tests/third_party/cupy/core_tests/test_ndarray_reduction.py::TestCubReduction_param_7_{order='F', shape=(10, 20, 30, 40)}::test_cub_min
 
-tests/third_party/cupy/indexing_tests/test_generate.py::TestAxisConcatenator::test_AxisConcatenator_init1
-tests/third_party/cupy/indexing_tests/test_generate.py::TestAxisConcatenator::test_len
-tests/third_party/cupy/indexing_tests/test_generate.py::TestC_::test_c_1
-tests/third_party/cupy/indexing_tests/test_generate.py::TestC_::test_c_2
-tests/third_party/cupy/indexing_tests/test_generate.py::TestC_::test_c_3
-tests/third_party/cupy/indexing_tests/test_generate.py::TestR_::test_r_1
-tests/third_party/cupy/indexing_tests/test_generate.py::TestR_::test_r_2
-tests/third_party/cupy/indexing_tests/test_generate.py::TestR_::test_r_3
-tests/third_party/cupy/indexing_tests/test_generate.py::TestR_::test_r_4
-tests/third_party/cupy/indexing_tests/test_generate.py::TestR_::test_r_5
-tests/third_party/cupy/indexing_tests/test_generate.py::TestR_::test_r_6
-tests/third_party/cupy/indexing_tests/test_generate.py::TestR_::test_r_7
-tests/third_party/cupy/indexing_tests/test_generate.py::TestR_::test_r_8
-tests/third_party/cupy/indexing_tests/test_generate.py::TestR_::test_r_9
-
 tests/third_party/cupy/indexing_tests/test_insert.py::TestPutmaskDifferentDtypes::test_putmask_differnt_dtypes_raises
 tests/third_party/cupy/indexing_tests/test_insert.py::TestPutmask::test_putmask_non_equal_shape_raises
 

--- a/tests/third_party/cupy/indexing_tests/test_generate.py
+++ b/tests/third_party/cupy/indexing_tests/test_generate.py
@@ -23,6 +23,7 @@ class TestIndices(unittest.TestCase):
     def test_indices_list2(self, xp, dtype):
         return xp.indices((1, 2, 3, 4), dtype)
 
+    @testing.with_requires("numpy>=1.24")
     def test_indices_list3(self):
         for xp in (numpy, cupy):
             with pytest.raises((ValueError, TypeError)):
@@ -49,6 +50,7 @@ class TestIX_(unittest.TestCase):
         return xp.ix_(xp.array([True, False] * 2))
 
 
+@pytest.mark.skip("r_[] is not supported yet")
 class TestR_(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
@@ -66,7 +68,9 @@ class TestR_(unittest.TestCase):
         return xp.r_[a, b, c]
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_equal()
+    @testing.numpy_cupy_array_equal(
+        type_check=(numpy.lib.NumpyVersion(numpy.__version__) >= "1.25.0")
+    )
     def test_r_2(self, xp, dtype):
         a = xp.array([1, 2, 3], dtype)
         return xp.r_[a, 0, 0, a]
@@ -100,7 +104,14 @@ class TestR_(unittest.TestCase):
         with self.assertRaises(ValueError):
             cupy.r_[a, b]
 
+    @testing.numpy_cupy_array_equal(
+        type_check=(numpy.lib.NumpyVersion(numpy.__version__) >= "1.25.0")
+    )
+    def test_r_scalars(self, xp):
+        return xp.r_[0, 0.5, -1, 0.3]
 
+
+@pytest.mark.skip("c_[] is not supported yet")
 class TestC_(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
@@ -125,6 +136,7 @@ class TestC_(unittest.TestCase):
             cupy.c_[a, b]
 
 
+@pytest.mark.skip("no AxisConcatenator is provided")
 class TestAxisConcatenator(unittest.TestCase):
     def test_AxisConcatenator_init1(self):
         with self.assertRaises(TypeError):
@@ -132,7 +144,7 @@ class TestAxisConcatenator(unittest.TestCase):
 
     def test_len(self):
         a = generate.AxisConcatenator()
-        self.assertEqual(len(a), 0)
+        assert len(a) == 0
 
 
 class TestUnravelIndex(unittest.TestCase):
@@ -339,11 +351,7 @@ class TestTrilIndicesForm:
     @testing.for_all_dtypes()
     def test_tril_indices_from_4(self, dtype):
         for xp in (numpy, cupy):
-            if xp is numpy:
-                error = AttributeError
-            else:
-                error = TypeError
-            with pytest.raises(error):
+            with pytest.raises((AttributeError, TypeError)):
                 xp.tril_indices_from(4, k=1)
 
 
@@ -394,9 +402,5 @@ class TestTriuIndicesFrom:
     @testing.for_all_dtypes()
     def test_triu_indices_from_4(self, dtype):
         for xp in (numpy, cupy):
-            if xp is numpy:
-                error = AttributeError
-            else:
-                error = TypeError
-            with pytest.raises(error):
+            with pytest.raises((AttributeError, TypeError)):
                 xp.triu_indices_from(4, k=1)


### PR DESCRIPTION
The PR proposes to enable all tests scopes from `indexing_tests` folder in public CI.
While `tests/third_party/cupy/indexing_tests/test_generate.py` is updated with the recent latest changes in third party tests.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
