### PR TITLE
Replace sycl::free with `sycl_free_noexcept`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ In addition, this release completes implementation of `dpnp.fft` module and adds
 * Updated `Array Manipulation Routines` page in documentation to add missing functions and to remove duplicate entries [#2033](https://github.com/IntelPython/dpnp/pull/2033)
 * `dpnp` uses pybind11 2.13.6 [#2041](https://github.com/IntelPython/dpnp/pull/2041)
 * Updated `dpnp.fft` backend to depend on `INTEL_MKL_VERSION` flag to ensures that the appropriate code segment is executed based on the version of OneMKL [#2035](https://github.com/IntelPython/dpnp/pull/2035)
+* Use `dpctl::tensor::alloc_utils::sycl_free_noexcept` instead of `sycl::free` in `host_task` tasks associated with life-time management of temporary USM allocations [#2058](https://github.com/IntelPython/dpnp/pull/2058)
 
 ### Fixed
 

--- a/dpnp/backend/extensions/elementwise_functions/elementwise_functions.hpp
+++ b/dpnp/backend/extensions/elementwise_functions/elementwise_functions.hpp
@@ -41,6 +41,7 @@
 #include "utils/memory_overlap.hpp"
 #include "utils/offset_utils.hpp"
 #include "utils/output_validation.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_dispatch.hpp"
 
 namespace py = pybind11;
@@ -232,8 +233,9 @@ std::pair<sycl::event, sycl::event>
     auto ctx = q.get_context();
     sycl::event tmp_cleanup_ev = q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(strided_fn_ev);
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
         cgh.host_task(
-            [ctx, shape_strides]() { sycl::free(shape_strides, ctx); });
+            [ctx, shape_strides]() { sycl_free_noexcept(shape_strides, ctx); });
     });
     host_tasks.push_back(tmp_cleanup_ev);
 
@@ -558,8 +560,9 @@ std::pair<sycl::event, sycl::event> py_binary_ufunc(
 
     sycl::event tmp_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(strided_fn_ev);
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
         cgh.host_task(
-            [ctx, shape_strides]() { sycl::free(shape_strides, ctx); });
+            [ctx, shape_strides]() { sycl_free_noexcept(shape_strides, ctx); });
     });
 
     host_tasks.push_back(tmp_cleanup_ev);
@@ -810,8 +813,9 @@ std::pair<sycl::event, sycl::event>
 
     sycl::event tmp_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(strided_fn_ev);
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
         cgh.host_task(
-            [ctx, shape_strides]() { sycl::free(shape_strides, ctx); });
+            [ctx, shape_strides]() { sycl_free_noexcept(shape_strides, ctx); });
     });
 
     host_tasks.push_back(tmp_cleanup_ev);

--- a/dpnp/backend/extensions/lapack/common_helpers.hpp
+++ b/dpnp/backend/extensions/lapack/common_helpers.hpp
@@ -31,6 +31,9 @@
 #include <cstring>
 #include <stdexcept>
 
+// dpctl tensor headers
+#include "utils/sycl_alloc_utils.hpp"
+
 namespace dpnp::extensions::lapack::helper
 {
 namespace py = pybind11;
@@ -78,7 +81,7 @@ inline std::int64_t *alloc_ipiv(const std::int64_t n, sycl::queue &exec_q)
         }
     } catch (sycl::exception const &e) {
         if (ipiv != nullptr)
-            sycl::free(ipiv, exec_q);
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(ipiv, exec_q);
         throw std::runtime_error(
             std::string(
                 "Unexpected SYCL exception caught during ipiv allocation: ") +
@@ -122,7 +125,7 @@ inline T *alloc_scratchpad(std::int64_t scratchpad_size, sycl::queue &exec_q)
         }
     } catch (sycl::exception const &e) {
         if (scratchpad != nullptr) {
-            sycl::free(scratchpad, exec_q);
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, exec_q);
         }
         throw std::runtime_error(std::string("Unexpected SYCL exception caught "
                                              "during scratchpad allocation: ") +

--- a/dpnp/backend/extensions/lapack/geqrf.cpp
+++ b/dpnp/backend/extensions/lapack/geqrf.cpp
@@ -27,6 +27,7 @@
 
 // dpctl tensor headers
 #include "utils/memory_overlap.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_utils.hpp"
 
 #include "geqrf.hpp"
@@ -117,7 +118,7 @@ static sycl::event geqrf_impl(sycl::queue &exec_q,
     if (is_exception_caught) // an unexpected error occurs
     {
         if (scratchpad != nullptr) {
-            sycl::free(scratchpad, exec_q);
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, exec_q);
         }
         throw std::runtime_error(error_msg.str());
     }
@@ -125,7 +126,9 @@ static sycl::event geqrf_impl(sycl::queue &exec_q,
     sycl::event clean_up_event = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(geqrf_event);
         auto ctx = exec_q.get_context();
-        cgh.host_task([ctx, scratchpad]() { sycl::free(scratchpad, ctx); });
+        cgh.host_task([ctx, scratchpad]() {
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, ctx);
+        });
     });
     host_task_events.push_back(clean_up_event);
 

--- a/dpnp/backend/extensions/lapack/geqrf_batch.cpp
+++ b/dpnp/backend/extensions/lapack/geqrf_batch.cpp
@@ -27,6 +27,7 @@
 
 // dpctl tensor headers
 #include "utils/memory_overlap.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_utils.hpp"
 
 #include "geqrf.hpp"
@@ -138,7 +139,7 @@ static sycl::event geqrf_batch_impl(sycl::queue &exec_q,
     if (is_exception_caught) // an unexpected error occurs
     {
         if (scratchpad != nullptr) {
-            sycl::free(scratchpad, exec_q);
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, exec_q);
         }
 
         throw std::runtime_error(error_msg.str());
@@ -147,7 +148,9 @@ static sycl::event geqrf_batch_impl(sycl::queue &exec_q,
     sycl::event clean_up_event = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(geqrf_batch_event);
         auto ctx = exec_q.get_context();
-        cgh.host_task([ctx, scratchpad]() { sycl::free(scratchpad, ctx); });
+        cgh.host_task([ctx, scratchpad]() {
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, ctx);
+        });
     });
     host_task_events.push_back(clean_up_event);
     return geqrf_batch_event;

--- a/dpnp/backend/extensions/lapack/gesv_common_utils.hpp
+++ b/dpnp/backend/extensions/lapack/gesv_common_utils.hpp
@@ -30,6 +30,7 @@
 // dpctl tensor headers
 #include "utils/memory_overlap.hpp"
 #include "utils/output_validation.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_dispatch.hpp"
 
 #include "common_helpers.hpp"
@@ -159,10 +160,12 @@ inline void handle_lapack_exc(sycl::queue &exec_q,
         const auto threshold =
             std::numeric_limits<ThresholdType>::epsilon() * 100;
         if (std::abs(host_U) < threshold) {
+            using dpctl::tensor::alloc_utils::sycl_free_noexcept;
+
             if (scratchpad != nullptr)
-                sycl::free(scratchpad, exec_q);
+                sycl_free_noexcept(scratchpad, exec_q);
             if (ipiv != nullptr)
-                sycl::free(ipiv, exec_q);
+                sycl_free_noexcept(ipiv, exec_q);
             throw LinAlgError("The input coefficient matrix is singular.");
         }
         else {

--- a/dpnp/backend/extensions/lapack/gesvd.cpp
+++ b/dpnp/backend/extensions/lapack/gesvd.cpp
@@ -125,7 +125,7 @@ static sycl::event gesvd_impl(sycl::queue &exec_q,
     if (is_exception_caught) // an unexpected error occurs
     {
         if (scratchpad != nullptr) {
-            sycl::free(scratchpad, exec_q);
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, exec_q);
         }
         throw std::runtime_error(error_msg.str());
     }
@@ -133,7 +133,9 @@ static sycl::event gesvd_impl(sycl::queue &exec_q,
     sycl::event ht_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(gesvd_event);
         auto ctx = exec_q.get_context();
-        cgh.host_task([ctx, scratchpad]() { sycl::free(scratchpad, ctx); });
+        cgh.host_task([ctx, scratchpad]() {
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, ctx);
+        });
     });
 
     return ht_ev;

--- a/dpnp/backend/extensions/lapack/gesvd_batch.cpp
+++ b/dpnp/backend/extensions/lapack/gesvd_batch.cpp
@@ -189,7 +189,7 @@ static sycl::event gesvd_batch_impl(sycl::queue &exec_q,
     if (is_exception_caught) // an unexpected error occurs
     {
         if (scratchpad != nullptr) {
-            sycl::free(scratchpad, exec_q);
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, exec_q);
         }
         throw std::runtime_error(error_msg.str());
     }
@@ -199,7 +199,9 @@ static sycl::event gesvd_batch_impl(sycl::queue &exec_q,
             cgh.depends_on(ev);
         }
         auto ctx = exec_q.get_context();
-        cgh.host_task([ctx, scratchpad]() { sycl::free(scratchpad, ctx); });
+        cgh.host_task([ctx, scratchpad]() {
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, ctx);
+        });
     });
 
     return ht_ev;

--- a/dpnp/backend/extensions/lapack/getrf.cpp
+++ b/dpnp/backend/extensions/lapack/getrf.cpp
@@ -27,6 +27,7 @@
 
 // dpctl tensor headers
 #include "utils/memory_overlap.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_utils.hpp"
 
 #include "getrf.hpp"
@@ -126,7 +127,7 @@ static sycl::event getrf_impl(sycl::queue &exec_q,
     if (is_exception_caught) // an unexpected error occurs
     {
         if (scratchpad != nullptr) {
-            sycl::free(scratchpad, exec_q);
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, exec_q);
         }
 
         throw std::runtime_error(error_msg.str());
@@ -135,7 +136,9 @@ static sycl::event getrf_impl(sycl::queue &exec_q,
     sycl::event clean_up_event = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(getrf_event);
         auto ctx = exec_q.get_context();
-        cgh.host_task([ctx, scratchpad]() { sycl::free(scratchpad, ctx); });
+        cgh.host_task([ctx, scratchpad]() {
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, ctx);
+        });
     });
     host_task_events.push_back(clean_up_event);
     return getrf_event;

--- a/dpnp/backend/extensions/lapack/getrf_batch.cpp
+++ b/dpnp/backend/extensions/lapack/getrf_batch.cpp
@@ -27,6 +27,7 @@
 
 // dpctl tensor headers
 #include "utils/memory_overlap.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_utils.hpp"
 
 #include "getrf.hpp"
@@ -152,7 +153,7 @@ static sycl::event getrf_batch_impl(sycl::queue &exec_q,
     if (is_exception_caught) // an unexpected error occurs
     {
         if (scratchpad != nullptr) {
-            sycl::free(scratchpad, exec_q);
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, exec_q);
         }
 
         throw std::runtime_error(error_msg.str());
@@ -161,7 +162,9 @@ static sycl::event getrf_batch_impl(sycl::queue &exec_q,
     sycl::event clean_up_event = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(getrf_batch_event);
         auto ctx = exec_q.get_context();
-        cgh.host_task([ctx, scratchpad]() { sycl::free(scratchpad, ctx); });
+        cgh.host_task([ctx, scratchpad]() {
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, ctx);
+        });
     });
     host_task_events.push_back(clean_up_event);
     return getrf_batch_event;

--- a/dpnp/backend/extensions/lapack/getri_batch.cpp
+++ b/dpnp/backend/extensions/lapack/getri_batch.cpp
@@ -27,6 +27,7 @@
 
 // dpctl tensor headers
 #include "utils/memory_overlap.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_utils.hpp"
 
 #include "getri.hpp"
@@ -150,7 +151,7 @@ static sycl::event getri_batch_impl(sycl::queue &exec_q,
     if (is_exception_caught) // an unexpected error occurs
     {
         if (scratchpad != nullptr) {
-            sycl::free(scratchpad, exec_q);
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, exec_q);
         }
 
         throw std::runtime_error(error_msg.str());
@@ -159,7 +160,9 @@ static sycl::event getri_batch_impl(sycl::queue &exec_q,
     sycl::event clean_up_event = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(getri_batch_event);
         auto ctx = exec_q.get_context();
-        cgh.host_task([ctx, scratchpad]() { sycl::free(scratchpad, ctx); });
+        cgh.host_task([ctx, scratchpad]() {
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, ctx);
+        });
     });
     host_task_events.push_back(clean_up_event);
     return getri_batch_event;

--- a/dpnp/backend/extensions/lapack/getrs.cpp
+++ b/dpnp/backend/extensions/lapack/getrs.cpp
@@ -27,6 +27,7 @@
 
 // dpctl tensor headers
 #include "utils/memory_overlap.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_utils.hpp"
 
 #include "getrs.hpp"
@@ -122,7 +123,8 @@ static sycl::event getrs_impl(sycl::queue &exec_q,
         else if (info > 0) {
             is_exception_caught = false;
             if (scratchpad != nullptr) {
-                sycl::free(scratchpad, exec_q);
+                dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad,
+                                                               exec_q);
             }
             throw LinAlgError("The solve could not be completed.");
         }
@@ -140,7 +142,7 @@ static sycl::event getrs_impl(sycl::queue &exec_q,
     if (is_exception_caught) // an unexpected error occurs
     {
         if (scratchpad != nullptr) {
-            sycl::free(scratchpad, exec_q);
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, exec_q);
         }
 
         throw std::runtime_error(error_msg.str());
@@ -149,7 +151,9 @@ static sycl::event getrs_impl(sycl::queue &exec_q,
     sycl::event clean_up_event = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(getrs_event);
         auto ctx = exec_q.get_context();
-        cgh.host_task([ctx, scratchpad]() { sycl::free(scratchpad, ctx); });
+        cgh.host_task([ctx, scratchpad]() {
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, ctx);
+        });
     });
     host_task_events.push_back(clean_up_event);
     return getrs_event;

--- a/dpnp/backend/extensions/lapack/heevd.cpp
+++ b/dpnp/backend/extensions/lapack/heevd.cpp
@@ -93,7 +93,7 @@ static sycl::event heevd_impl(sycl::queue &exec_q,
     if (info != 0) // an unexpected error occurs
     {
         if (scratchpad != nullptr) {
-            sycl::free(scratchpad, exec_q);
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, exec_q);
         }
         throw std::runtime_error(error_msg.str());
     }
@@ -101,7 +101,9 @@ static sycl::event heevd_impl(sycl::queue &exec_q,
     sycl::event ht_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(heevd_event);
         auto ctx = exec_q.get_context();
-        cgh.host_task([ctx, scratchpad]() { sycl::free(scratchpad, ctx); });
+        cgh.host_task([ctx, scratchpad]() {
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, ctx);
+        });
     });
 
     return ht_ev;

--- a/dpnp/backend/extensions/lapack/heevd_batch.cpp
+++ b/dpnp/backend/extensions/lapack/heevd_batch.cpp
@@ -128,7 +128,7 @@ static sycl::event heevd_batch_impl(sycl::queue &exec_q,
     if (info != 0) // an unexpected error occurs
     {
         if (scratchpad != nullptr) {
-            sycl::free(scratchpad, exec_q);
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, exec_q);
         }
         throw std::runtime_error(error_msg.str());
     }
@@ -138,7 +138,9 @@ static sycl::event heevd_batch_impl(sycl::queue &exec_q,
             cgh.depends_on(ev);
         }
         auto ctx = exec_q.get_context();
-        cgh.host_task([ctx, scratchpad]() { sycl::free(scratchpad, ctx); });
+        cgh.host_task([ctx, scratchpad]() {
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, ctx);
+        });
     });
 
     return ht_ev;

--- a/dpnp/backend/extensions/lapack/orgqr.cpp
+++ b/dpnp/backend/extensions/lapack/orgqr.cpp
@@ -27,6 +27,7 @@
 
 // dpctl tensor headers
 #include "utils/memory_overlap.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_utils.hpp"
 
 #include "orgqr.hpp"
@@ -121,7 +122,7 @@ static sycl::event orgqr_impl(sycl::queue &exec_q,
     if (is_exception_caught) // an unexpected error occurs
     {
         if (scratchpad != nullptr) {
-            sycl::free(scratchpad, exec_q);
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, exec_q);
         }
         throw std::runtime_error(error_msg.str());
     }
@@ -129,7 +130,9 @@ static sycl::event orgqr_impl(sycl::queue &exec_q,
     sycl::event clean_up_event = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(orgqr_event);
         auto ctx = exec_q.get_context();
-        cgh.host_task([ctx, scratchpad]() { sycl::free(scratchpad, ctx); });
+        cgh.host_task([ctx, scratchpad]() {
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, ctx);
+        });
     });
     host_task_events.push_back(clean_up_event);
 

--- a/dpnp/backend/extensions/lapack/orgqr_batch.cpp
+++ b/dpnp/backend/extensions/lapack/orgqr_batch.cpp
@@ -27,6 +27,7 @@
 
 // dpctl tensor headers
 #include "utils/memory_overlap.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_utils.hpp"
 
 #include "orgqr.hpp"
@@ -142,7 +143,7 @@ static sycl::event orgqr_batch_impl(sycl::queue &exec_q,
     if (is_exception_caught) // an unexpected error occurs
     {
         if (scratchpad != nullptr) {
-            sycl::free(scratchpad, exec_q);
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, exec_q);
         }
 
         throw std::runtime_error(error_msg.str());
@@ -151,7 +152,9 @@ static sycl::event orgqr_batch_impl(sycl::queue &exec_q,
     sycl::event clean_up_event = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(orgqr_batch_event);
         auto ctx = exec_q.get_context();
-        cgh.host_task([ctx, scratchpad]() { sycl::free(scratchpad, ctx); });
+        cgh.host_task([ctx, scratchpad]() {
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, ctx);
+        });
     });
     host_task_events.push_back(clean_up_event);
     return orgqr_batch_event;

--- a/dpnp/backend/extensions/lapack/syevd.cpp
+++ b/dpnp/backend/extensions/lapack/syevd.cpp
@@ -93,7 +93,7 @@ static sycl::event syevd_impl(sycl::queue &exec_q,
     if (info != 0) // an unexpected error occurs
     {
         if (scratchpad != nullptr) {
-            sycl::free(scratchpad, exec_q);
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, exec_q);
         }
         throw std::runtime_error(error_msg.str());
     }
@@ -101,7 +101,9 @@ static sycl::event syevd_impl(sycl::queue &exec_q,
     sycl::event ht_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(syevd_event);
         auto ctx = exec_q.get_context();
-        cgh.host_task([ctx, scratchpad]() { sycl::free(scratchpad, ctx); });
+        cgh.host_task([ctx, scratchpad]() {
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, ctx);
+        });
     });
 
     return ht_ev;

--- a/dpnp/backend/extensions/lapack/syevd_batch.cpp
+++ b/dpnp/backend/extensions/lapack/syevd_batch.cpp
@@ -128,7 +128,7 @@ static sycl::event syevd_batch_impl(sycl::queue &exec_q,
     if (info != 0) // an unexpected error occurs
     {
         if (scratchpad != nullptr) {
-            sycl::free(scratchpad, exec_q);
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, exec_q);
         }
         throw std::runtime_error(error_msg.str());
     }
@@ -138,7 +138,9 @@ static sycl::event syevd_batch_impl(sycl::queue &exec_q,
             cgh.depends_on(ev);
         }
         auto ctx = exec_q.get_context();
-        cgh.host_task([ctx, scratchpad]() { sycl::free(scratchpad, ctx); });
+        cgh.host_task([ctx, scratchpad]() {
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, ctx);
+        });
     });
 
     return ht_ev;

--- a/dpnp/backend/extensions/lapack/ungqr.cpp
+++ b/dpnp/backend/extensions/lapack/ungqr.cpp
@@ -27,6 +27,7 @@
 
 // dpctl tensor headers
 #include "utils/memory_overlap.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_utils.hpp"
 
 #include "types_matrix.hpp"
@@ -121,7 +122,7 @@ static sycl::event ungqr_impl(sycl::queue &exec_q,
     if (is_exception_caught) // an unexpected error occurs
     {
         if (scratchpad != nullptr) {
-            sycl::free(scratchpad, exec_q);
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, exec_q);
         }
         throw std::runtime_error(error_msg.str());
     }
@@ -129,7 +130,9 @@ static sycl::event ungqr_impl(sycl::queue &exec_q,
     sycl::event clean_up_event = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(ungqr_event);
         auto ctx = exec_q.get_context();
-        cgh.host_task([ctx, scratchpad]() { sycl::free(scratchpad, ctx); });
+        cgh.host_task([ctx, scratchpad]() {
+            dpctl::tensor::alloc_utils::sycl_free_noexcept(scratchpad, ctx);
+        });
     });
     host_task_events.push_back(clean_up_event);
 


### PR DESCRIPTION
The PR replaces `sycl::free` with `dpctl::tensor::alloc_utils::sycl_free_noexcept` from dpctl tensor headers.
Replaced calls to `sycl::free` in `host_task` with use of `sycl_free_noexcept`.

This change should improve stability of test suite run executed on CPU device due to a known issue.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
