### PR TITLE
Add test_flags scope to third party tests of dpnp

### DIFF
--- a/tests/third_party/cupy/core_tests/test_flags.py
+++ b/tests/third_party/cupy/core_tests/test_flags.py
@@ -1,0 +1,91 @@
+import unittest
+
+import numpy
+import pytest
+
+import dpnp as cupy
+from tests.third_party.cupy import testing
+
+
+@pytest.mark.skip("class Flags is not exposed")
+class TestFlags(unittest.TestCase):
+    def setUp(self):
+        self.flags = flags.Flags(1, 2, 3)
+
+    def test_c_contiguous(self):
+        assert 1 == self.flags["C_CONTIGUOUS"]
+
+    def test_f_contiguous(self):
+        assert 2 == self.flags["F_CONTIGUOUS"]
+
+    def test_owndata(self):
+        assert 3 == self.flags["OWNDATA"]
+
+    def test_key_error(self):
+        with self.assertRaises(KeyError):
+            self.flags["unknown key"]
+
+    def test_repr(self):
+        assert """  C_CONTIGUOUS : 1
+  F_CONTIGUOUS : 2
+  OWNDATA : 3""" == repr(
+            self.flags
+        )
+
+
+@testing.parameterize(
+    *testing.product(
+        {
+            "order": ["C", "F", "non-contiguous"],
+            "shape": [(8,), (4, 8)],
+        }
+    )
+)
+class TestContiguityFlags(unittest.TestCase):
+    def setUp(self):
+        self.flags = None
+
+    def init_flags(self, xp):
+        if self.order == "non-contiguous":
+            a = xp.empty(self.shape)[::2]
+        else:
+            a = xp.empty(self.shape, order=self.order)
+        self.flags = a.flags
+
+    @testing.numpy_cupy_equal()
+    def test_fnc(self, xp):
+        self.init_flags(xp)
+        return self.flags.fnc
+
+    @testing.numpy_cupy_equal()
+    def test_forc(self, xp):
+        self.init_flags(xp)
+        return self.flags.forc
+
+    @testing.numpy_cupy_equal()
+    def test_f_contiguous(self, xp):
+        self.init_flags(xp)
+        return self.flags.f_contiguous
+
+    @testing.numpy_cupy_equal()
+    def test_c_contiguous(self, xp):
+        self.init_flags(xp)
+        return self.flags.c_contiguous
+
+    def test_c_contiguous_setter(self):
+        for xp in (numpy, cupy):
+            self.init_flags(xp)
+            with pytest.raises(AttributeError):
+                self.flags.c_contiguous = True
+
+    def test_f_contiguous_setter(self):
+        for xp in (numpy, cupy):
+            self.init_flags(xp)
+            with pytest.raises(AttributeError):
+                self.flags.f_contiguous = True
+
+    def test_owndata_setter(self):
+        for xp in (numpy, cupy):
+            self.init_flags(xp)
+            with pytest.raises(AttributeError):
+                self.flags.owndata = True


### PR DESCRIPTION
The PR is about to add `test_flags` scope to third party tests of dpnp for proper verification of flags behavior.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
