### PR TITLE
Add workaround to prevent crash on Windows in internal CI/CD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ In addition, this release completes implementation of `dpnp.fft` module and adds
 * Resolved a possible race condition in `dpnp.inv` [#1940](https://github.com/IntelPython/dpnp/pull/1940)
 * Resolved an issue with failing tests for `dpnp.append` when running on a device without fp64 support [#2034](https://github.com/IntelPython/dpnp/pull/2034)
 * Resolved an issue with input array of `usm_ndarray` passed into `dpnp.ix_` [#2047](https://github.com/IntelPython/dpnp/pull/2047)
+* Added a workaround to prevent crash in tests on Windows in internal CI/CD (when running on either Lunar Lake or Arrow Lake) [#2062](https://github.com/IntelPython/dpnp/pull/2062)
 
 
 ## [0.15.0] - 05/25/2024

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -1075,7 +1075,10 @@ def test_random_state(func, args, kwargs, device, usm_type):
     assert device == res_array.sycl_device
     assert usm_type == res_array.usm_type
 
-    sycl_queue = dpctl.SyclQueue(device, property="in_order")
+    # SAT-7414: w/a to avoid crash on Windows (observing on LNL and ARL)
+    # sycl_queue = dpctl.SyclQueue(device, property="in_order")
+    # TODO: remove the w/a once resolved
+    sycl_queue = dpctl.SyclQueue(device, property="enable_profiling")
 
     # test with in-order SYCL queue per a device and passed as argument
     seed = (147, 56, 896) if device.is_cpu else 987654

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -1032,7 +1032,10 @@ def test_random(func, kwargs, device, usm_type):
     assert device == res_array.sycl_device
     assert usm_type == res_array.usm_type
 
-    sycl_queue = dpctl.SyclQueue(device, property="in_order")
+    # SAT-7414: w/a to avoid crash on Windows (observing on LNL and ARL)
+    # sycl_queue = dpctl.SyclQueue(device, property="in_order")
+    # TODO: remove the w/a once resolved
+    sycl_queue = dpctl.SyclQueue(device, property="enable_profiling")
     kwargs["device"] = None
     kwargs["sycl_queue"] = sycl_queue
 


### PR DESCRIPTION
The PR implements a temporary workaround to prevent crash in dpnp tests on Windows in internal CI/CD jobs (when running on either Lunar Lake or Arrow Lake machine).
The w/a has to be removed once the issue is resolved.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
