### PR TITLE
Resolve crash identified in backend implementation of `dpnp.choose`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ In addition, this release completes implementation of `dpnp.fft` module and adds
 * Resolved an issue with input array of `usm_ndarray` passed into `dpnp.ix_` [#2047](https://github.com/IntelPython/dpnp/pull/2047)
 * Fixed a crash in `dpnp.choose` caused by missing memory copying from host to device memory [#2063](https://github.com/IntelPython/dpnp/pull/2063)
 
+
 ## [0.15.0] - 05/25/2024
 
 This release completes implementation of `dpnp.linalg` module and array creation routine, adds cumulative reductions and histogram functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,7 @@ In addition, this release completes implementation of `dpnp.fft` module and adds
 * Resolved a possible race condition in `dpnp.inv` [#1940](https://github.com/IntelPython/dpnp/pull/1940)
 * Resolved an issue with failing tests for `dpnp.append` when running on a device without fp64 support [#2034](https://github.com/IntelPython/dpnp/pull/2034)
 * Resolved an issue with input array of `usm_ndarray` passed into `dpnp.ix_` [#2047](https://github.com/IntelPython/dpnp/pull/2047)
-
+* Fixed a crash in `dpnp.choose` caused by missing memory copying from host to device memory [#2063](https://github.com/IntelPython/dpnp/pull/2063)
 
 ## [0.15.0] - 05/25/2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,7 +121,7 @@ In addition, this release completes implementation of `dpnp.fft` module and adds
 * Resolved a possible race condition in `dpnp.inv` [#1940](https://github.com/IntelPython/dpnp/pull/1940)
 * Resolved an issue with failing tests for `dpnp.append` when running on a device without fp64 support [#2034](https://github.com/IntelPython/dpnp/pull/2034)
 * Resolved an issue with input array of `usm_ndarray` passed into `dpnp.ix_` [#2047](https://github.com/IntelPython/dpnp/pull/2047)
-* Fixed a crash in `dpnp.choose` caused by missing memory copying from host to device memory [#2063](https://github.com/IntelPython/dpnp/pull/2063)
+* Fixed a crash in `dpnp.choose` caused by missing control of releasing temporary allocated device memory [#2063](https://github.com/IntelPython/dpnp/pull/2063)
 
 
 ## [0.15.0] - 05/25/2024

--- a/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
@@ -60,19 +60,19 @@ DPCTLSyclEventRef dpnp_choose_c(DPCTLSyclQueueRef q_ref,
 
     sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    DPNPC_ptr_adapter<_DataType1> input1_ptr(q_ref, array1_in, size);
+    DPNPC_ptr_adapter<_DataType1> input1_ptr(q_ref, array1_in, size, true);
     _DataType1 *array_in = input1_ptr.get_ptr();
 
-    DPNPC_ptr_adapter<_DataType2 *> choices_ptr(q_ref, choices1, choices_size);
+    DPNPC_ptr_adapter<_DataType2 *> choices_ptr(q_ref, choices1, choices_size, true);
     _DataType2 **choices = choices_ptr.get_ptr();
 
     for (size_t i = 0; i < choices_size; ++i) {
         DPNPC_ptr_adapter<_DataType2> choice_ptr(q_ref, choices[i],
-                                                 choice_size);
+                                                 choice_size, true);
         choices[i] = choice_ptr.get_ptr();
     }
 
-    DPNPC_ptr_adapter<_DataType2> result1_ptr(q_ref, result1, size, false,
+    DPNPC_ptr_adapter<_DataType2> result1_ptr(q_ref, result1, size, true,
                                               true);
     _DataType2 *result = result1_ptr.get_ptr();
 
@@ -88,6 +88,7 @@ DPCTLSyclEventRef dpnp_choose_c(DPCTLSyclQueueRef q_ref,
     };
 
     sycl::event event = q.submit(kernel_func);
+    result1_ptr.depends_on(event);
 
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
 

--- a/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
@@ -60,15 +60,15 @@ DPCTLSyclEventRef dpnp_choose_c(DPCTLSyclQueueRef q_ref,
 
     sycl::queue q = *(reinterpret_cast<sycl::queue *>(q_ref));
 
-    DPNPC_ptr_adapter<_DataType1> input1_ptr(q_ref, array1_in, size, true);
+    DPNPC_ptr_adapter<_DataType1> input1_ptr(q_ref, array1_in, size);
     _DataType1 *array_in = input1_ptr.get_ptr();
 
-    DPNPC_ptr_adapter<_DataType2 *> choices_ptr(q_ref, choices1, choices_size, true);
+    DPNPC_ptr_adapter<_DataType2 *> choices_ptr(q_ref, choices1, choices_size);
     _DataType2 **choices = choices_ptr.get_ptr();
 
     for (size_t i = 0; i < choices_size; ++i) {
         DPNPC_ptr_adapter<_DataType2> choice_ptr(q_ref, choices[i],
-                                                 choice_size, true);
+                                                 choice_size);
         choices[i] = choice_ptr.get_ptr();
     }
 

--- a/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
@@ -63,7 +63,9 @@ DPCTLSyclEventRef dpnp_choose_c(DPCTLSyclQueueRef q_ref,
     DPNPC_ptr_adapter<_DataType1> input1_ptr(q_ref, array1_in, size);
     _DataType1 *array_in = input1_ptr.get_ptr();
 
-    DPNPC_ptr_adapter<_DataType2 *> choices_ptr(q_ref, choices1, choices_size);
+    // choices1 is a list of pointers to device memory,
+    // which is allocating on the host, so memcpy to device memory is required
+    DPNPC_ptr_adapter<_DataType2 *> choices_ptr(q_ref, choices1, choices_size, true);
     _DataType2 **choices = choices_ptr.get_ptr();
 
     for (size_t i = 0; i < choices_size; ++i) {
@@ -72,7 +74,7 @@ DPCTLSyclEventRef dpnp_choose_c(DPCTLSyclQueueRef q_ref,
         choices[i] = choice_ptr.get_ptr();
     }
 
-    DPNPC_ptr_adapter<_DataType2> result1_ptr(q_ref, result1, size, true,
+    DPNPC_ptr_adapter<_DataType2> result1_ptr(q_ref, result1, size, false,
                                               true);
     _DataType2 *result = result1_ptr.get_ptr();
 
@@ -88,7 +90,7 @@ DPCTLSyclEventRef dpnp_choose_c(DPCTLSyclQueueRef q_ref,
     };
 
     sycl::event event = q.submit(kernel_func);
-    result1_ptr.depends_on(event);
+    choices_ptr.depends_on(event);
 
     event_ref = reinterpret_cast<DPCTLSyclEventRef>(&event);
 

--- a/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_indexing.cpp
@@ -65,7 +65,8 @@ DPCTLSyclEventRef dpnp_choose_c(DPCTLSyclQueueRef q_ref,
 
     // choices1 is a list of pointers to device memory,
     // which is allocating on the host, so memcpy to device memory is required
-    DPNPC_ptr_adapter<_DataType2 *> choices_ptr(q_ref, choices1, choices_size, true);
+    DPNPC_ptr_adapter<_DataType2 *> choices_ptr(q_ref, choices1, choices_size,
+                                                true);
     _DataType2 **choices = choices_ptr.get_ptr();
 
     for (size_t i = 0; i < choices_size; ++i) {


### PR DESCRIPTION
The PR resolves crash in `dpnp.choose` observing in internal CI/CD flow on PVC machine with Linux OS.

The issue was caused by missing dependency of temporary allocated device memory on a computing event. Thus the memory was released before the execution kernel completes work,
While allocation of temporary memory was implicit, because `DPNPC_ptr_adapter` constructor identified the input pointer `choices1` as of unknown USM allocation type. And it was valid classification, since the pointer was allocated in host memory for holding a list of pointers on arrays in device memory.

The change assumes to request explicit memory transfer for `choices1` pointer from host to device memory and to add a dependency from the temporary allocated device memory on the event from the submitted kernel. 

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
