### PR TITLE
Fix an issue with asynchronous execution in `dpnp.fft` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,8 +123,8 @@ In addition, this release completes implementation of `dpnp.fft` module and adds
 * Resolved an issue with input array of `usm_ndarray` passed into `dpnp.ix_` [#2047](https://github.com/IntelPython/dpnp/pull/2047)
 * Added a workaround to prevent crash in tests on Windows in internal CI/CD (when running on either Lunar Lake or Arrow Lake) [#2062](https://github.com/IntelPython/dpnp/pull/2062)
 * Fixed a crash in `dpnp.choose` caused by missing control of releasing temporary allocated device memory [#2063](https://github.com/IntelPython/dpnp/pull/2063)
-* Resolve compilation warning and error while building in debug mode [#2066](https://github.com/IntelPython/dpnp/pull/2066)
-
+* Resolved compilation warning and error while building in debug mode [#2066](https://github.com/IntelPython/dpnp/pull/2066)
+* Fixed an issue with asynchronous execution in `dpnp.fft` module [#2067](https://github.com/IntelPython/dpnp/pull/2067)
 
 ## [0.15.0] - 05/25/2024
 


### PR DESCRIPTION
In this PR, an issue regarding asynchronous execution of  `dpnp.fft` module is resolved. In the process of padding the input arrays, dependent event list (`dep_evs`) was obtained before creating the new zero array which by itself add a new dependent event to `dep_evs` list. So, we need to get `dep_evs` after calling `dpnp.zeros`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
