### PR TITLE
Backport gh-2066

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # CMake build and local install directory
 _skbuild
 build_cython
+cython_debug
 dpnp.egg-info
 
 # Byte-compiled / optimized / DLL files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ In addition, this release completes implementation of `dpnp.fft` module and adds
 * Resolved an issue with failing tests for `dpnp.append` when running on a device without fp64 support [#2034](https://github.com/IntelPython/dpnp/pull/2034)
 * Resolved an issue with input array of `usm_ndarray` passed into `dpnp.ix_` [#2047](https://github.com/IntelPython/dpnp/pull/2047)
 * Added a workaround to prevent crash in tests on Windows in internal CI/CD (when running on either Lunar Lake or Arrow Lake) [#2062](https://github.com/IntelPython/dpnp/pull/2062)
+* Resolve compilation warning and error while building in debug mode [#2066](https://github.com/IntelPython/dpnp/pull/2066)
 
 
 ## [0.15.0] - 05/25/2024

--- a/dpnp/backend/kernels/dpnp_krnl_random.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_random.cpp
@@ -2553,7 +2553,8 @@ DPCTLSyclEventRef
 
     const _DataType d_zero = 0.0, d_one = 1.0;
 
-    assert(0. < kappa <= 1.0);
+    assert(0. < kappa);
+    assert(kappa <= 1.0);
 
     r = 1 + sqrt(1 + 4 * kappa * kappa);
     rho_over_kappa = (2) / (r + sqrt(2 * r));

--- a/dpnp/backend/src/queue_sycl.cpp
+++ b/dpnp/backend/src/queue_sycl.cpp
@@ -56,6 +56,29 @@
 }
 
 #if (not defined(NDEBUG))
+[[maybe_unused]] static std::string
+    device_type_to_str(sycl::info::device_type devTy)
+{
+    std::stringstream ss;
+    switch (devTy) {
+    case sycl::info::device_type::cpu:
+        ss << "cpu";
+        break;
+    case sycl::info::device_type::gpu:
+        ss << "gpu";
+        break;
+    case sycl::info::device_type::accelerator:
+        ss << "accelerator";
+        break;
+    case sycl::info::device_type::custom:
+        ss << "custom";
+        break;
+    default:
+        ss << "unknown";
+    }
+    return ss.str();
+}
+
 [[maybe_unused]] static void show_available_sycl_devices()
 {
     const std::vector<sycl::device> devices = sycl::device::get_devices();
@@ -69,7 +92,7 @@
             // it->has(sycl::aspect::usm_shared_allocations)  << " "
             << " - id=" << it->get_info<sycl::info::device::vendor_id>()
             << ", type="
-            << static_cast<pi_uint64>(
+            << device_type_to_str(
                    it->get_info<sycl::info::device::device_type>())
             << ", gws="
             << it->get_info<sycl::info::device::max_work_group_size>()


### PR DESCRIPTION
This PR backports of https://github.com/IntelPython/dpnp/pull/2066 from development branch to `maintenance/0.16.x`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
