### PR TITLE
update the test suit for `dpnp.fft` module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,6 +99,7 @@ repos:
             "--disable=c-extension-no-member",
             "--disable=import-error",
             "--disable=redefined-builtin",
-            "--disable=unused-wildcard-import"
+            "--disable=unused-wildcard-import",
+            "--disable=too-many-arguments"
             ]
         files: '^dpnp/(dpnp_iface.*|fft|linalg)'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,6 +100,6 @@ repos:
             "--disable=import-error",
             "--disable=redefined-builtin",
             "--disable=unused-wildcard-import",
-            "--disable=too-many-arguments"
+            "--disable=too-many-positional-arguments"
             ]
         files: '^dpnp/(dpnp_iface.*|fft|linalg)'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,7 +99,6 @@ repos:
             "--disable=c-extension-no-member",
             "--disable=import-error",
             "--disable=redefined-builtin",
-            "--disable=unused-wildcard-import",
-            "--disable=too-many-positional-arguments"
+            "--disable=unused-wildcard-import"
             ]
         files: '^dpnp/(dpnp_iface.*|fft|linalg)'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-### Change
+### Changed
 
 ### Fixed
 
@@ -50,7 +50,7 @@ In addition, this release completes implementation of `dpnp.fft` module and adds
 * Added implementation of `dpnp.resize` and `dpnp.rot90` functions [#2030](https://github.com/IntelPython/dpnp/pull/2030)
 * Added implementation of `dpnp.require` function [#2036](https://github.com/IntelPython/dpnp/pull/2036)
 
-### Change
+### Changed
 
 * Extended pre-commit pylint check to `dpnp.fft` module [#1860](https://github.com/IntelPython/dpnp/pull/1860)
 * Reworked `vm` vector math backend to reuse `dpctl.tensor` functions around unary and binary functions [#1868](https://github.com/IntelPython/dpnp/pull/1868)
@@ -114,6 +114,7 @@ In addition, this release completes implementation of `dpnp.fft` module and adds
 * Updated `dpnp.fft` backend to depend on `INTEL_MKL_VERSION` flag to ensures that the appropriate code segment is executed based on the version of OneMKL [#2035](https://github.com/IntelPython/dpnp/pull/2035)
 * Use `dpctl::tensor::alloc_utils::sycl_free_noexcept` instead of `sycl::free` in `host_task` tasks associated with life-time management of temporary USM allocations [#2058](https://github.com/IntelPython/dpnp/pull/2058)
 * Improved implementation of `dpnp.kron` to avoid unnecessary copy for non-contiguous arrays [#2059](https://github.com/IntelPython/dpnp/pull/2059)
+* Updated the test suit for `dpnp.fft` module [#2071](https://github.com/IntelPython/dpnp/pull/2071)
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ exclude-protected = ["_create_from_usm_ndarray"]
 
 [tool.pylint.design]
 max-args = 11
+max-positional-arguments = 9
 max-locals = 30
 max-branches = 15
 max-returns = 8

--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -564,10 +564,13 @@ class TestFftn:
         assert_dtype_allclose(iresult, iexpected, check_only_type_kind=True)
 
     def test_negative_s(self):
-        # stock NumPy 2.0, if s is -1, the whole input is used (no padding/trimming).
-        a_np = numpy.empty((3, 4, 5), dtype=numpy.complex64)
+        x1 = numpy.random.uniform(-10, 10, 60)
+        x2 = numpy.random.uniform(-10, 10, 60)
+        a_np = numpy.array(x1 + 1j * x2, dtype=numpy.complex64).reshape(3, 4, 5)
         a = dpnp.array(a_np)
 
+        # For dpnp and stock NumPy 2.0, if s is -1, the whole input is used
+        # (no padding or trimming).
         result = dpnp.fft.fftn(a, s=(-1, -1), axes=(0, 2))
         expected = numpy.fft.fftn(a_np, s=(3, 5), axes=(0, 2))
         assert_dtype_allclose(result, expected, check_only_type_kind=True)


### PR DESCRIPTION
In this PR, FFT test suite is updated to avoid initializing input arrays with `dpnp.empty` which might produce invalid data.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
