### PR TITLE
Update cupy tests for dpnp.linalg.solve()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ In addition, this release completes implementation of `dpnp.fft` module and adds
 * Use `dpctl::tensor::alloc_utils::sycl_free_noexcept` instead of `sycl::free` in `host_task` tasks associated with life-time management of temporary USM allocations [#2058](https://github.com/IntelPython/dpnp/pull/2058)
 * Improved implementation of `dpnp.kron` to avoid unnecessary copy for non-contiguous arrays [#2059](https://github.com/IntelPython/dpnp/pull/2059)
 * Updated the test suit for `dpnp.fft` module [#2071](https://github.com/IntelPython/dpnp/pull/2071)
+* Skipped outdated tests for `dpnp.linalg.solve` due to compatibility issues with NumPy 2.0 [#2074](https://github.com/IntelPython/dpnp/pull/2074)
 
 ### Fixed
 

--- a/tests/third_party/cupy/linalg_tests/test_solve.py
+++ b/tests/third_party/cupy/linalg_tests/test_solve.py
@@ -50,14 +50,20 @@ class TestSolve(unittest.TestCase):
     def test_solve(self):
         self.check_x((4, 4), (4,))
         self.check_x((5, 5), (5, 2))
-        self.check_x((2, 4, 4), (2, 4))
         self.check_x((2, 5, 5), (2, 5, 2))
-        self.check_x((2, 3, 2, 2), (2, 3, 2))
         self.check_x((2, 3, 3, 3), (2, 3, 3, 2))
         self.check_x((0, 0), (0,))
         self.check_x((0, 0), (0, 2))
-        self.check_x((0, 2, 2), (0, 2))
         self.check_x((0, 2, 2), (0, 2, 3))
+        # In numpy 2.0 the broadcast ambiguity has been removed and now
+        # b is treaded as a single vector if and only if it is 1-dimensional;
+        # for other cases this signature must be followed
+        # (..., m, m), (..., m, n) -> (..., m, n)
+        # https://github.com/numpy/numpy/pull/25914
+        if numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0":
+            self.check_x((2, 4, 4), (2, 4))
+            self.check_x((2, 3, 2, 2), (2, 3, 2))
+            self.check_x((0, 2, 2), (0, 2))
 
     def check_shape(self, a_shape, b_shape, error_types):
         for xp, error_type in error_types.items():
@@ -90,7 +96,9 @@ class TestSolve(unittest.TestCase):
         self.check_shape((3, 3), (2,), value_errors)
         self.check_shape((3, 3), (2, 2), value_errors)
         self.check_shape((3, 3, 4), (3,), linalg_errors)
-        self.check_shape((2, 3, 3), (3,), value_errors)
+        # Since numpy >= 2.0, this case does not raise an error
+        if numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0":
+            self.check_shape((2, 3, 3), (3,), value_errors)
         self.check_shape((3, 3), (0,), value_errors)
         self.check_shape((0, 3, 4), (3,), linalg_errors)
 


### PR DESCRIPTION
This PR suggests skipping some cupy tests for `dpnp.linalg.solve()` until `dpnp.linalg.solve()` is updated to support numpy>=2.0

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
