### PR TITLE
update `dpnp.reshape` to use `shape` keyword argument instead of `newshape`

### DIFF
--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -1286,7 +1286,7 @@ class dpnp_array:
 
         return dpnp.repeat(self, repeats, axis=axis)
 
-    def reshape(self, *sh, **kwargs):
+    def reshape(self, *shape, order="C", copy=None):
         """
         Returns an array containing the same data with a new shape.
 
@@ -1311,9 +1311,9 @@ class dpnp_array:
 
         """
 
-        if len(sh) == 1:
-            sh = sh[0]
-        return dpnp.reshape(self, sh, **kwargs)
+        if len(shape) == 1:
+            shape = shape[0]
+        return dpnp.reshape(self, shape, order=order, copy=copy)
 
     # 'resize',
 

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -2225,7 +2225,9 @@ def reshape(a, /, shape=None, order="C", *, newshape=None, copy=None):
     elif order in "aA":
         order = "F" if a.flags.fnc else "C"
     elif order not in "cfCF":
-        raise ValueError(f"order must be None, 'C', 'F', or 'A' (got {order})")
+        raise ValueError(
+            f"order must be None, 'C', 'F', or 'A' (got '{order}')"
+        )
 
     usm_a = dpnp.get_usm_ndarray(a)
     usm_res = dpt.reshape(usm_a, shape=shape, order=order, copy=copy)

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -2055,7 +2055,7 @@ def require(a, dtype=None, requirements=None, *, like=None):
     return arr
 
 
-def reshape(a, /, newshape, order="C", copy=None):
+def reshape(a, /, shape=None, *, newshape=None, order="C", copy=None):
     """
     Gives a new shape to an array without changing its data.
 
@@ -2065,12 +2065,14 @@ def reshape(a, /, newshape, order="C", copy=None):
     ----------
     a : {dpnp.ndarray, usm_ndarray}
         Array to be reshaped.
-    newshape : int or tuple of ints
+    shape : int or tuple of ints
         The new shape should be compatible with the original shape. If
         an integer, then the result will be a 1-D array of that length.
         One shape dimension can be -1. In this case, the value is
         inferred from the length of the array and remaining dimensions.
-    order : {"C", "F"}, optional
+    newshape : int or tuple of ints
+        Replaced by shape argument. Retained for backward compatibility.
+    order : {None, "C", "F"}, optional
         Read the elements of `a` using this index order, and place the
         elements into the reshaped array using this index order. ``"C"``
         means to read / write the elements using C-like index order,
@@ -2080,6 +2082,8 @@ def reshape(a, /, newshape, order="C", copy=None):
         changing fastest, and the last index changing slowest. Note that
         the ``"C"`` and ``"F"`` options take no account of the memory layout of
         the underlying array, and only refer to the order of indexing.
+        ``order=None`` is an alias for ``order="C"``.
+        Default: ``"C"``.
     copy : {None, bool}, optional
         Boolean indicating whether or not to copy the input array.
         If ``True``, the result array will always be a copy of input `a`.
@@ -2093,7 +2097,7 @@ def reshape(a, /, newshape, order="C", copy=None):
     -------
     out : dpnp.ndarray
         This will be a new view object if possible; otherwise, it will
-        be a copy.  Note there is no guarantee of the *memory layout* (C- or
+        be a copy. Note there is no guarantee of the *memory layout* (C- or
         Fortran- contiguous) of the returned array.
 
     Limitations
@@ -2120,8 +2124,18 @@ def reshape(a, /, newshape, order="C", copy=None):
 
     """
 
-    if newshape is None:
-        newshape = a.shape
+    if newshape is None and shape is None:
+        raise TypeError(
+            "reshape() missing 1 required positional argument: 'shape'"
+        )
+
+    if newshape is not None:
+        if shape is not None:
+            raise TypeError(
+                "You cannot specify 'newshape' and 'shape' arguments "
+                "at the same time."
+            )
+        shape = newshape
 
     if order is None:
         order = "C"
@@ -2129,7 +2143,7 @@ def reshape(a, /, newshape, order="C", copy=None):
         raise ValueError(f"order must be one of 'C' or 'F' (got {order})")
 
     usm_a = dpnp.get_usm_ndarray(a)
-    usm_res = dpt.reshape(usm_a, shape=newshape, order=order, copy=copy)
+    usm_res = dpt.reshape(usm_a, shape=shape, order=order, copy=copy)
     return dpnp_array._create_from_usm_ndarray(usm_res)
 
 

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -2071,7 +2071,7 @@ def reshape(a, /, shape=None, *, newshape=None, order="C", copy=None):
         One shape dimension can be -1. In this case, the value is
         inferred from the length of the array and remaining dimensions.
     newshape : int or tuple of ints
-        Replaced by shape argument. Retained for backward compatibility.
+        Replaced by `shape` argument. Retained for backward compatibility.
     order : {None, "C", "F"}, optional
         Read the elements of `a` using this index order, and place the
         elements into the reshaped array using this index order. ``"C"``

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -1885,7 +1885,7 @@ def ravel(a, order="C"):
     Notes
     -----
     In row-major, C-style order, in two dimensions, the row index
-    varies the slowest, and the column index the quickest.  This can
+    varies the slowest, and the column index the quickest. This can
     be generalized to multiple dimensions, where row-major order
     implies that the index along the first axis varies slowest, and
     the index along the last quickest. The opposite holds for
@@ -1907,7 +1907,8 @@ def ravel(a, order="C"):
     >>> np.ravel(x, order='F')
     array([1, 4, 2, 5, 3, 6])
 
-    When ``order`` is 'A', it will preserve the array's 'C' or 'F' ordering:
+    When `order` is ``"A"``, it will preserve the array's
+    ``"C"`` or ``"F"`` ordering:
 
     >>> np.ravel(x.T)
     array([1, 4, 2, 5, 3, 6])

--- a/tests/test_manipulation.py
+++ b/tests/test_manipulation.py
@@ -448,6 +448,22 @@ class TestAsarrayCheckFinite:
         assert_array_equal(b, a)
 
 
+class TestRavel:
+    def test_error(self):
+        ia = dpnp.arange(10).reshape(2, 5)
+        assert_raises(NotImplementedError, dpnp.ravel, ia, order="K")
+
+    @pytest.mark.parametrize("order", ["C", "F", "A"])
+    def test_non_contiguous(self, order):
+        a = numpy.arange(10)[::2]
+        ia = dpnp.arange(10)[::2]
+        expected = numpy.ravel(a, order=order)
+        result = dpnp.ravel(ia, order=order)
+        assert result.flags.c_contiguous == expected.flags.c_contiguous
+        assert result.flags.f_contiguous == expected.flags.f_contiguous
+        assert_array_equal(result, expected)
+
+
 class TestRepeat:
     @pytest.mark.parametrize(
         "data",

--- a/tests/test_manipulation.py
+++ b/tests/test_manipulation.py
@@ -790,6 +790,32 @@ class TestResize:
             xp.resize(a, new_shape=new_shape)
 
 
+class TestReshape:
+    def test_error(self):
+        ia = dpnp.arange(10)
+        assert_raises(TypeError, dpnp.reshape, ia)
+        assert_raises(
+            TypeError, dpnp.reshape, ia, shape=(2, 5), newshape=(2, 5)
+        )
+
+    def test_newshape(self):
+        a = numpy.arange(10)
+        ia = dpnp.array(a)
+        expected = numpy.reshape(a, (2, 5))
+        result = dpnp.reshape(ia, newshape=(2, 5))
+        assert_array_equal(result, expected)
+
+    @pytest.mark.parametrize("order", [None, "C", "F"])
+    def test_order(self, order):
+        a = numpy.arange(10)
+        ia = dpnp.array(a)
+        expected = numpy.reshape(a, (2, 5), order=order)
+        result = dpnp.reshape(ia, newshape=(2, 5), order=order)
+        assert result.flags["C_CONTIGUOUS"] == expected.flags["C_CONTIGUOUS"]
+        assert result.flags["F_CONTIGUOUS"] == expected.flags["F_CONTIGUOUS"]
+        assert_array_equal(result, expected)
+
+
 class TestRot90:
     @pytest.mark.parametrize("xp", [numpy, dpnp])
     def test_error(self, xp):

--- a/tests/third_party/cupy/manipulation_tests/test_shape.py
+++ b/tests/third_party/cupy/manipulation_tests/test_shape.py
@@ -2,6 +2,7 @@ import numpy
 import pytest
 
 import dpnp as cupy
+from tests.helper import has_support_aspect64
 from tests.third_party.cupy import testing
 
 
@@ -93,21 +94,19 @@ class TestReshape:
             with pytest.raises(ValueError):
                 a.reshape((-1, 0))
 
-    @pytest.mark.skip("array.base is not implemented")
-    @testing.numpy_cupy_array_equal()
+    @testing.numpy_cupy_array_equal(type_check=has_support_aspect64())
     def test_reshape_zerosize(self, xp):
         a = xp.zeros((0,))
         b = a.reshape((0,))
-        assert b.base is a
+        # assert b.base is a
         return b
 
-    @pytest.mark.skip("array.base is not implemented")
     @testing.for_orders("CFA")
-    @testing.numpy_cupy_array_equal(strides_check=True)
+    @testing.numpy_cupy_array_equal(type_check=has_support_aspect64())
     def test_reshape_zerosize2(self, xp, order):
         a = xp.zeros((2, 0, 3))
         b = a.reshape((5, 0, 4), order=order)
-        assert b.base is a
+        # assert b.base is a
         return b
 
     @testing.for_orders("CFA")

--- a/tests/third_party/cupy/manipulation_tests/test_shape.py
+++ b/tests/third_party/cupy/manipulation_tests/test_shape.py
@@ -1,5 +1,3 @@
-import unittest
-
 import numpy
 import pytest
 
@@ -7,31 +5,20 @@ import dpnp as cupy
 from tests.third_party.cupy import testing
 
 
-@testing.parameterize(
-    *testing.product(
-        {
-            "shape": [(2, 3), (), (4,)],
-        }
-    )
-)
-class TestShape(unittest.TestCase):
-    def test_shape(self):
-        shape = self.shape
+@pytest.mark.parametrize("shape", [(2, 3), (), (4,)])
+class TestShape:
+    def test_shape(self, shape):
         for xp in (numpy, cupy):
             a = testing.shaped_arange(shape, xp)
             assert cupy.shape(a) == shape
 
-    def test_shape_list(self):
-        shape = self.shape
+    def test_shape_list(self, shape):
         a = testing.shaped_arange(shape, numpy)
         a = a.tolist()
         assert cupy.shape(a) == shape
 
 
-class TestReshape(unittest.TestCase):
-    # order = 'A' is out of support currently
-    _supported_orders = "CF"
-
+class TestReshape:
     def test_reshape_shapes(self):
         def func(xp):
             a = testing.shaped_arange((1, 1, 1, 2, 2), xp)
@@ -46,7 +33,7 @@ class TestReshape(unittest.TestCase):
 
         assert func(numpy) == func(cupy)
 
-    @testing.for_orders(_supported_orders)
+    @testing.for_orders("CFA")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_nocopy_reshape(self, xp, dtype, order):
@@ -55,7 +42,7 @@ class TestReshape(unittest.TestCase):
         b[1] = 1
         return a
 
-    @testing.for_orders(_supported_orders)
+    @testing.for_orders("CFA")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_nocopy_reshape_with_order(self, xp, dtype, order):
@@ -64,13 +51,13 @@ class TestReshape(unittest.TestCase):
         b[1] = 1
         return a
 
-    @testing.for_orders(_supported_orders)
+    @testing.for_orders("CFA")
     @testing.numpy_cupy_array_equal()
     def test_transposed_reshape2(self, xp, order):
         a = testing.shaped_arange((2, 3, 4), xp).transpose(2, 0, 1)
         return a.reshape(2, 3, 4, order=order)
 
-    @testing.for_orders(_supported_orders)
+    @testing.for_orders("CFA")
     @testing.numpy_cupy_array_equal()
     def test_reshape_with_unknown_dimension(self, xp, order):
         a = testing.shaped_arange((2, 3, 4), xp)
@@ -115,7 +102,7 @@ class TestReshape(unittest.TestCase):
         return b
 
     @pytest.mark.skip("array.base is not implemented")
-    @testing.for_orders(_supported_orders)
+    @testing.for_orders("CFA")
     @testing.numpy_cupy_array_equal(strides_check=True)
     def test_reshape_zerosize2(self, xp, order):
         a = xp.zeros((2, 0, 3))
@@ -123,7 +110,7 @@ class TestReshape(unittest.TestCase):
         assert b.base is a
         return b
 
-    @testing.for_orders(_supported_orders)
+    @testing.for_orders("CFA")
     @testing.numpy_cupy_array_equal()
     def test_external_reshape(self, xp, order):
         a = xp.zeros((8,), dtype=xp.float32)
@@ -137,25 +124,24 @@ class TestReshape(unittest.TestCase):
         assert a.ndim == ndim
         return a
 
-    @testing.for_orders(_supported_orders)
+    @testing.with_requires("numpy>=2.0")
+    @testing.for_orders("CFA")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_ndim_limit1(self, xp, dtype, order):
-        # from cupy/cupy#4193
-        a = self._test_ndim_limit(xp, 32, dtype, order)
+        a = self._test_ndim_limit(xp, 64, dtype, order)
         return a
 
     @pytest.mark.skip("no max ndim limit for reshape in dpctl")
-    @testing.for_orders(_supported_orders)
+    @testing.for_orders("CFA")
     @testing.for_all_dtypes()
     def test_ndim_limit2(self, dtype, order):
-        # from cupy/cupy#4193
         for xp in (numpy, cupy):
             with pytest.raises(ValueError):
-                self._test_ndim_limit(xp, 33, dtype, order)
+                self._test_ndim_limit(xp, 65, dtype, order)
 
 
-class TestRavel(unittest.TestCase):
+class TestRavel:
     @testing.for_orders("CF")
     # order = 'A' is out of support currently
     @testing.numpy_cupy_array_equal()
@@ -186,32 +172,27 @@ class TestRavel(unittest.TestCase):
         return xp.ravel(a)
 
 
-@testing.parameterize(
-    *testing.product(
-        {
-            "order_init": ["C", "F"],
-            # order = 'A' is out of support currently
-            # 'order_reshape': ['C', 'F', 'A', 'c', 'f', 'a'],
-            "order_reshape": ["C", "F", "c", "f"],
-            "shape_in_out": [
-                ((2, 3), (1, 6, 1)),  # (shape_init, shape_final)
-                ((6,), (2, 3)),
-                ((3, 3, 3), (9, 3)),
-            ],
-        }
-    )
+@pytest.mark.parametrize("order_init", ["C", "F"])
+@pytest.mark.parametrize("order_reshape", ["C", "F", "A", "c", "f", "a"])
+@pytest.mark.parametrize(
+    "shape_in_out",
+    [
+        ((2, 3), (1, 6, 1)),  # (shape_init, shape_final)
+        ((6,), (2, 3)),
+        ((3, 3, 3), (9, 3)),
+    ],
 )
-class TestReshapeOrder(unittest.TestCase):
-    def test_reshape_contiguity(self):
-        shape_init, shape_final = self.shape_in_out
+class TestReshapeOrder:
+    def test_reshape_contiguity(self, order_init, order_reshape, shape_in_out):
+        shape_init, shape_final = shape_in_out
 
         a_cupy = testing.shaped_arange(shape_init, xp=cupy)
-        a_cupy = cupy.asarray(a_cupy, order=self.order_init)
-        b_cupy = a_cupy.reshape(shape_final, order=self.order_reshape)
+        a_cupy = cupy.asarray(a_cupy, order=order_init)
+        b_cupy = a_cupy.reshape(shape_final, order=order_reshape)
 
         a_numpy = testing.shaped_arange(shape_init, xp=numpy)
-        a_numpy = numpy.asarray(a_numpy, order=self.order_init)
-        b_numpy = a_numpy.reshape(shape_final, order=self.order_reshape)
+        a_numpy = numpy.asarray(a_numpy, order=order_init)
+        b_numpy = a_numpy.reshape(shape_final, order=order_reshape)
 
         assert b_cupy.flags.f_contiguous == b_numpy.flags.f_contiguous
         assert b_cupy.flags.c_contiguous == b_numpy.flags.c_contiguous

--- a/tests/third_party/cupy/manipulation_tests/test_shape.py
+++ b/tests/third_party/cupy/manipulation_tests/test_shape.py
@@ -142,28 +142,79 @@ class TestReshape:
 
 
 class TestRavel:
-    @testing.for_orders("CF")
-    # order = 'A' is out of support currently
+    @testing.for_orders("CFA")
+    # order = 'K' is not supported currently
     @testing.numpy_cupy_array_equal()
     def test_ravel(self, xp, order):
         a = testing.shaped_arange((2, 3, 4), xp)
         a = a.transpose(2, 0, 1)
         return a.ravel(order)
 
-    @testing.for_orders("CF")
-    # order = 'A' is out of support currently
+    @testing.for_orders("CFA")
+    # order = 'K' is not supported currently
     @testing.numpy_cupy_array_equal()
     def test_ravel2(self, xp, order):
         a = testing.shaped_arange((2, 3, 4), xp)
         return a.ravel(order)
 
-    @testing.for_orders("CF")
-    # order = 'A' is out of support currently
+    @testing.for_orders("CFA")
+    # order = 'K' is not supported currently
     @testing.numpy_cupy_array_equal()
     def test_ravel3(self, xp, order):
         a = testing.shaped_arange((2, 3, 4), xp)
         a = xp.asfortranarray(a)
         return a.ravel(order)
+
+    @testing.for_orders("CFA")
+    # order = 'K' is not supported currently
+    @testing.numpy_cupy_array_equal()
+    def test_ravel4(self, xp, order):
+        a = testing.shaped_arange((2, 3, 4), xp)
+        a = a.transpose(0, 2, 1)[:, ::-2]
+        return a.ravel(order)
+
+    @testing.for_orders("CFA")
+    # order = 'K' is not supported currently
+    @testing.numpy_cupy_array_equal()
+    def test_ravel_non_contiguous(self, xp, order):
+        a = xp.arange(10)[::2]
+        assert not a.flags.c_contiguous and not a.flags.f_contiguous
+        b = a.ravel(order)
+        assert b.flags.c_contiguous
+        return b
+
+    @testing.for_orders("CFA")
+    # order = 'K' is not supported currently
+    @testing.numpy_cupy_array_equal()
+    def test_ravel_broadcasted(self, xp, order):
+        a = xp.array([1])
+        b = xp.broadcast_to(a, (10,))
+        assert not b.flags.c_contiguous and not b.flags.f_contiguous
+        b = b.ravel(order)
+        assert b.flags.c_contiguous
+        return b
+
+    @testing.for_orders("CFA")
+    # order = 'K' is not supported currently
+    @testing.numpy_cupy_array_equal()
+    def test_ravel_broadcasted2(self, xp, order):
+        a = testing.shaped_arange((2, 1), xp)
+        b = xp.broadcast_to(a, (3, 2, 4))
+        assert not b.flags.c_contiguous and not b.flags.f_contiguous
+        b = b.ravel(order)
+        assert b.flags.c_contiguous
+        return b
+
+    @testing.for_orders("CFA")
+    # order = 'K' is not supported currently
+    @testing.for_orders("CF", name="a_order")
+    @testing.numpy_cupy_array_equal()
+    def test_ravel_broadcasted3(self, xp, order, a_order):
+        a = testing.shaped_arange((2, 1, 3), xp, order=a_order)
+        b = xp.broadcast_to(a, (2, 4, 3))
+        b = b.ravel(order)
+        assert b.flags.c_contiguous
+        return b
 
     @testing.numpy_cupy_array_equal()
     def test_external_ravel(self, xp):


### PR DESCRIPTION
In this PR, `dpnp.reshape` and `dpnp.ndarray.reshape` are updated to align with changes in `NumPy 2.1` and support for `order="A"` is added.
Accordingly, `dpnp.ravel` is also updated.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
