### PR TITLE
Pin dpctl to `0.18.0` version

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set required_compiler_and_mkl_version = "2025.0.0" %}
-{% set required_dpctl_version = "0.18.0*" %}
+{% set required_dpctl_version = "0.18.0" %}
 
 package:
     name: dpnp


### PR DESCRIPTION
The PR pins a dependency on dpctl using final tag `0.18.0`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
