### PR TITLE
Add support for `order="K"` or `"A"` for `dpnp.empty_like`, `dpnp.ones_like`, `dpnp.zeros_like` and `dpnp.full_like`

### DIFF
--- a/dpnp/dpnp_iface.py
+++ b/dpnp/dpnp_iface.py
@@ -320,14 +320,10 @@ def as_usm_ndarray(a, dtype=None, device=None, usm_type=None, sycl_queue=None):
     )
 
 
-def check_limitations(
-    order=None, subok=False, like=None, initial=None, where=True
-):
+def check_limitations(subok=False, like=None, initial=None, where=True):
     """
     Checking limitation kwargs for their supported values.
 
-    Parameter `order` is only supported with values ``"C"``, ``"F"``,
-    and ``None``.
     Parameter `subok` is only supported with default value ``False``.
     Parameter `like` is only supported with default value ``None``.
     Parameter `initial` is only supported with default value ``None``.
@@ -340,16 +336,6 @@ def check_limitations(
 
     """
 
-    if order in ("A", "a", "K", "k"):
-        raise NotImplementedError(
-            "Keyword argument `order` is supported only with "
-            f"values 'C' and 'F', but got '{order}'"
-        )
-    if order not in ("C", "c", "F", "f", None):
-        raise ValueError(
-            "Unrecognized `order` keyword value, expecting "
-            f"'C' or 'F', but got '{order}'"
-        )
     if like is not None:
         raise NotImplementedError(
             "Keyword argument `like` is supported only with "

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -127,13 +127,13 @@ def _get_empty_array(
     )
 
     if order is None:
-        order = "C"
-    elif order == "A":
+        order = "K"
+    elif order in "aA":
         if a.flags.fnc:
             order = "F"
         else:
             order = "C"
-    elif order == "K":
+    elif order in "kK":
         if len(_shape) != a.ndim:
             order = "C"
         elif a.flags.f_contiguous:
@@ -1301,6 +1301,7 @@ def empty_like(
         input array is allocated.
     order : {None, "C", "F", "A", "K"}, optional
         Memory layout of the newly output array.
+        ``order=None`` is an alias for ``order="K"``.
         Default: ``"K"``.
     shape : {None, int, sequence of ints}
         Overrides the shape of the result.
@@ -2156,6 +2157,7 @@ def full_like(
         input array is allocated.
     order : {None, "C", "F", "A", "K"}, optional
         Memory layout of the newly output array.
+        ``order=None`` is an alias for ``order="K"``.
         Default: ``"K"``.
     shape : {None, int, sequence of ints}
         Overrides the shape of the result.
@@ -3195,6 +3197,7 @@ def ones_like(
         input array is allocated.
     order : {None, "C", "F", "A", "K"}, optional
         Memory layout of the newly output array.
+        ``order=None`` is an alias for ``order="K"``.
         Default: ``"K"``.
     shape : {None, int, sequence of ints}
         Overrides the shape of the result.
@@ -3838,6 +3841,7 @@ def zeros_like(
         input array is allocated.
     order : {None, "C", "F", "A", "K"}, optional
         Memory layout of the newly output array.
+        ``order=None`` is an alias for ``order="K"``.
         Default: ``"K"``.
     shape : {None, int, sequence of ints}
         Overrides the shape of the result.

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -138,7 +138,7 @@ def _get_empty_array(
             order = "C"
         elif a.flags.f_contiguous:
             order = "F"
-        elif a.flags.f_contiguous:
+        elif a.flags.c_contiguous:
             order = "C"
         else:
             strides = _get_strides_for_order_k(a, _shape)

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -143,6 +143,10 @@ def _get_empty_array(
         else:
             strides = _get_strides_for_order_k(a, _shape)
             order = "C"
+    elif order not in "cfCF":
+        raise ValueError(
+            f"order must be None, 'C', 'F', 'A', or 'K' (got '{order}')"
+        )
 
     return dpnp_array(
         _shape,

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -128,7 +128,7 @@ def _get_empty_array(
 
     if order is None:
         order = "K"
-    elif order in "aA":
+    if order in "aA":
         if a.flags.fnc:
             order = "F"
         else:

--- a/tests/test_arraycreation.py
+++ b/tests/test_arraycreation.py
@@ -74,18 +74,6 @@ class TestTrace:
         pytest.param("full_like", [dpnp.ones(10), 7]),
         pytest.param("ones_like", [dpnp.ones(10)]),
         pytest.param("zeros_like", [dpnp.ones(10)]),
-    ],
-)
-def test_exception_order1(func, args):
-    with pytest.raises(NotImplementedError):
-        getattr(dpnp, func)(*args, order="K")
-    with pytest.raises(ValueError):
-        getattr(dpnp, func)(*args, order="S")
-
-
-@pytest.mark.parametrize(
-    "func, args",
-    [
         pytest.param("empty", [3]),
         pytest.param("eye", [3]),
         pytest.param("full", [3, 7]),
@@ -93,7 +81,7 @@ def test_exception_order1(func, args):
         pytest.param("zeros", [3]),
     ],
 )
-def test_exception_order2(func, args):
+def test_exception_order(func, args):
     with pytest.raises(ValueError):
         getattr(dpnp, func)(*args, order="S")
 
@@ -552,7 +540,9 @@ def test_full(shape, fill_value, dtype, order):
     "fill_value", [1.5, 2, 1.5 + 0.0j], ids=["1.5", "2", "1.5+0.j"]
 )
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_float16=False))
-@pytest.mark.parametrize("order", [None, "C", "F"], ids=["None", "C", "F"])
+@pytest.mark.parametrize(
+    "order", [None, "C", "F", "A", "K"], ids=["None", "C", "F", "A", "K"]
+)
 def test_full_like(array, fill_value, dtype, order):
     func = lambda xp, x: xp.full_like(x, fill_value, dtype=dtype, order=order)
 
@@ -611,7 +601,9 @@ def test_zeros(shape, dtype, order):
     ids=["[]", "0", "[1, 2, 3]", "[[1, 2], [3, 4]]"],
 )
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_float16=False))
-@pytest.mark.parametrize("order", [None, "C", "F"], ids=["None", "C", "F"])
+@pytest.mark.parametrize(
+    "order", [None, "C", "F", "A", "K"], ids=["None", "C", "F", "A", "K"]
+)
 def test_zeros_like(array, dtype, order):
     func = lambda xp, x: xp.zeros_like(x, dtype=dtype, order=order)
 
@@ -638,7 +630,9 @@ def test_empty(shape, dtype, order):
     ids=["[]", "0", "[1, 2, 3]", "[[1, 2], [3, 4]]"],
 )
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_float16=False))
-@pytest.mark.parametrize("order", [None, "C", "F"], ids=["None", "C", "F"])
+@pytest.mark.parametrize(
+    "order", [None, "C", "F", "A", "K"], ids=["None", "C", "F", "A", "K"]
+)
 def test_empty_like(array, dtype, order):
     func = lambda xp, x: xp.empty_like(x, dtype=dtype, order=order)
 
@@ -665,7 +659,9 @@ def test_ones(shape, dtype, order):
     ids=["[]", "0", "[1, 2, 3]", "[[1, 2], [3, 4]]"],
 )
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_float16=False))
-@pytest.mark.parametrize("order", [None, "C", "F"], ids=["None", "C", "F"])
+@pytest.mark.parametrize(
+    "order", [None, "C", "F", "A", "K"], ids=["None", "C", "F", "A", "K"]
+)
 def test_ones_like(array, dtype, order):
     func = lambda xp, x: xp.ones_like(x, dtype=dtype, order=order)
 

--- a/tests/test_arraycreation.py
+++ b/tests/test_arraycreation.py
@@ -540,9 +540,7 @@ def test_full(shape, fill_value, dtype, order):
     "fill_value", [1.5, 2, 1.5 + 0.0j], ids=["1.5", "2", "1.5+0.j"]
 )
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_float16=False))
-@pytest.mark.parametrize(
-    "order", [None, "C", "F", "A", "K"], ids=["None", "C", "F", "A", "K"]
-)
+@pytest.mark.parametrize("order", [None, "C", "F", "A", "K"])
 def test_full_like(array, fill_value, dtype, order):
     func = lambda xp, x: xp.full_like(x, fill_value, dtype=dtype, order=order)
 
@@ -601,9 +599,7 @@ def test_zeros(shape, dtype, order):
     ids=["[]", "0", "[1, 2, 3]", "[[1, 2], [3, 4]]"],
 )
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_float16=False))
-@pytest.mark.parametrize(
-    "order", [None, "C", "F", "A", "K"], ids=["None", "C", "F", "A", "K"]
-)
+@pytest.mark.parametrize("order", [None, "C", "F", "A", "K"])
 def test_zeros_like(array, dtype, order):
     func = lambda xp, x: xp.zeros_like(x, dtype=dtype, order=order)
 
@@ -630,9 +626,7 @@ def test_empty(shape, dtype, order):
     ids=["[]", "0", "[1, 2, 3]", "[[1, 2], [3, 4]]"],
 )
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_float16=False))
-@pytest.mark.parametrize(
-    "order", [None, "C", "F", "A", "K"], ids=["None", "C", "F", "A", "K"]
-)
+@pytest.mark.parametrize("order", [None, "C", "F", "A", "K"])
 def test_empty_like(array, dtype, order):
     func = lambda xp, x: xp.empty_like(x, dtype=dtype, order=order)
 
@@ -659,9 +653,7 @@ def test_ones(shape, dtype, order):
     ids=["[]", "0", "[1, 2, 3]", "[[1, 2], [3, 4]]"],
 )
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_float16=False))
-@pytest.mark.parametrize(
-    "order", [None, "C", "F", "A", "K"], ids=["None", "C", "F", "A", "K"]
-)
+@pytest.mark.parametrize("order", [None, "C", "F", "A", "K"])
 def test_ones_like(array, dtype, order):
     func = lambda xp, x: xp.ones_like(x, dtype=dtype, order=order)
 

--- a/tests/third_party/cupy/creation_tests/test_basic.py
+++ b/tests/third_party/cupy/creation_tests/test_basic.py
@@ -82,7 +82,7 @@ class TestBasic:
         del a
         cupy.get_default_memory_pool().free_all_blocks()
 
-    @testing.for_CF_orders()
+    @testing.for_orders("CFAK")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_empty_like(self, xp, dtype, order):
@@ -91,7 +91,7 @@ class TestBasic:
         b.fill(0)
         return b
 
-    @testing.for_CF_orders()
+    @testing.for_orders("CFAK")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_empty_like_contiguity(self, xp, dtype, order):
@@ -104,7 +104,7 @@ class TestBasic:
             assert b.flags.c_contiguous
         return b
 
-    @testing.for_orders("CF")
+    @testing.for_orders("CFAK")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_empty_like_contiguity2(self, xp, dtype, order):
@@ -118,7 +118,7 @@ class TestBasic:
             assert b.flags.f_contiguous
         return b
 
-    @testing.for_orders("CF")
+    @testing.for_orders("CFAK")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_empty_like_contiguity3(self, xp, dtype, order):
@@ -138,7 +138,6 @@ class TestBasic:
             assert not b.flags.f_contiguous
         return b
 
-    @pytest.mark.skip("order 'K' is not supported")
     @testing.for_all_dtypes()
     def test_empty_like_K_strides(self, dtype):
         # test strides that are both non-contiguous and non-descending
@@ -154,7 +153,10 @@ class TestBasic:
         bg.fill(0)
 
         # make sure NumPy and CuPy strides agree
-        assert b.strides == bg.strides
+        scaled_numpy_strides = b.strides
+        scale = b.itemsize
+        numpy_strides = tuple(i / scale for i in scaled_numpy_strides)
+        assert numpy_strides == bg.strides
         return
 
     @testing.with_requires("numpy>=1.19")
@@ -165,10 +167,9 @@ class TestBasic:
             with pytest.raises(ValueError):
                 xp.empty_like(a, order="Q")
 
-    @pytest.mark.skip("subok keyword is not supported")
     def test_empty_like_subok(self):
         a = testing.shaped_arange((2, 3, 4), cupy)
-        with pytest.raises(TypeError):
+        with pytest.raises(NotImplementedError):
             cupy.empty_like(a, subok=True)
 
     @pytest.mark.skip("strides for zero sized array is different")
@@ -225,17 +226,16 @@ class TestBasic:
         b_strides = tuple(x * b.itemsize for x in b.strides)
         assert b_strides == a.strides
 
-    @testing.for_CF_orders()
+    @testing.for_orders("CFAK")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_zeros_like(self, xp, dtype, order):
         a = xp.ndarray((2, 3, 4), dtype=dtype)
         return xp.zeros_like(a, order=order)
 
-    @pytest.mark.skip("subok keyword is not supported")
     def test_zeros_like_subok(self):
         a = cupy.ndarray((2, 3, 4))
-        with pytest.raises(TypeError):
+        with pytest.raises(NotImplementedError):
             cupy.zeros_like(a, subok=True)
 
     @testing.for_CF_orders()
@@ -244,17 +244,16 @@ class TestBasic:
     def test_ones(self, xp, dtype, order):
         return xp.ones((2, 3, 4), dtype=dtype, order=order)
 
-    @testing.for_CF_orders()
+    @testing.for_orders("CFAK")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_ones_like(self, xp, dtype, order):
         a = xp.ndarray((2, 3, 4), dtype=dtype)
         return xp.ones_like(a, order=order)
 
-    @pytest.mark.skip("subok keyword is not supported")
     def test_ones_like_subok(self):
         a = cupy.ndarray((2, 3, 4))
-        with pytest.raises(TypeError):
+        with pytest.raises(NotImplementedError):
             cupy.ones_like(a, subok=True)
 
     @testing.for_CF_orders()
@@ -278,7 +277,7 @@ class TestBasic:
                 (2, 3, 4), numpy.array(1, dtype=dtype1), dtype=dtype2
             )
 
-    @testing.for_CF_orders()
+    @testing.for_orders("CFAK")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_full_like(self, xp, dtype, order):
@@ -293,10 +292,9 @@ class TestBasic:
             warnings.simplefilter("ignore", ComplexWarning)
             return xp.full_like(a, numpy.array(1, dtype=dtype1))
 
-    @pytest.mark.skip("subok keyword is not supported")
     def test_full_like_subok(self):
         a = cupy.ndarray((2, 3, 4))
-        with pytest.raises(TypeError):
+        with pytest.raises(NotImplementedError):
             cupy.full_like(a, 1, subok=True)
 
 
@@ -309,7 +307,7 @@ class TestBasic:
 )
 class TestBasicReshape:
     @testing.with_requires("numpy>=1.17.0")
-    @testing.for_CF_orders()
+    @testing.for_orders("CFAK")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_empty_like_reshape(self, xp, dtype, order):
@@ -330,7 +328,7 @@ class TestBasicReshape:
         testing.assert_array_equal(b, c)
 
     @testing.with_requires("numpy>=1.17.0")
-    @testing.for_CF_orders()
+    @testing.for_orders("CFAK")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_empty_like_reshape_contiguity(self, xp, dtype, order):
@@ -343,7 +341,7 @@ class TestBasicReshape:
             assert b.flags.c_contiguous
         return b
 
-    @testing.for_CF_orders()
+    @testing.for_orders("CFAK")
     @testing.for_all_dtypes()
     def test_empty_like_reshape_contiguity_cupy_only(self, dtype, order):
         a = testing.shaped_arange((2, 3, 4), cupy, dtype)
@@ -358,7 +356,7 @@ class TestBasicReshape:
         testing.assert_array_equal(b, c)
 
     @testing.with_requires("numpy>=1.17.0")
-    @testing.for_orders("CF")
+    @testing.for_orders("CFAK")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_empty_like_reshape_contiguity2(self, xp, dtype, order):
@@ -375,7 +373,7 @@ class TestBasicReshape:
             assert b.flags.f_contiguous
         return b
 
-    @testing.for_orders("CF")
+    @testing.for_orders("CFAK")
     @testing.for_all_dtypes()
     def test_empty_like_reshape_contiguity2_cupy_only(self, dtype, order):
         a = testing.shaped_arange((2, 3, 4), cupy, dtype)
@@ -394,7 +392,7 @@ class TestBasicReshape:
         testing.assert_array_equal(b, c)
 
     @testing.with_requires("numpy>=1.17.0")
-    @testing.for_orders("CF")
+    @testing.for_orders("CFAK")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_empty_like_reshape_contiguity3(self, xp, dtype, order):
@@ -418,7 +416,7 @@ class TestBasicReshape:
             assert not b.flags.f_contiguous
         return b
 
-    @testing.for_orders("CF")
+    @testing.for_orders("CFAK")
     @testing.for_all_dtypes()
     def test_empty_like_reshape_contiguity3_cupy_only(self, dtype, order):
         a = testing.shaped_arange((2, 3, 4), cupy, dtype)
@@ -444,7 +442,6 @@ class TestBasicReshape:
         c.fill(0)
         testing.assert_array_equal(b, c)
 
-    @pytest.mark.skip("order 'K' is not supported")
     @testing.with_requires("numpy>=1.17.0")
     @testing.for_all_dtypes()
     def test_empty_like_K_strides_reshape(self, dtype):
@@ -461,11 +458,14 @@ class TestBasicReshape:
         bg.fill(0)
 
         # make sure NumPy and CuPy strides agree
-        assert b.strides == bg.strides
+        scaled_numpy_strides = b.strides
+        scale = b.itemsize
+        numpy_strides = tuple(i / scale for i in scaled_numpy_strides)
+        assert numpy_strides == bg.strides
         return
 
     @testing.with_requires("numpy>=1.17.0")
-    @testing.for_CF_orders()
+    @testing.for_orders("CFAK")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_zeros_like_reshape(self, xp, dtype, order):
@@ -482,7 +482,7 @@ class TestBasicReshape:
         testing.assert_array_equal(b, c)
 
     @testing.with_requires("numpy>=1.17.0")
-    @testing.for_CF_orders()
+    @testing.for_orders("CFAK")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_ones_like_reshape(self, xp, dtype, order):
@@ -498,7 +498,7 @@ class TestBasicReshape:
         testing.assert_array_equal(b, c)
 
     @testing.with_requires("numpy>=1.17.0")
-    @testing.for_CF_orders()
+    @testing.for_orders("CFAK")
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_full_like_reshape(self, xp, dtype, order):


### PR DESCRIPTION
In this PR, support for `order="K"` and `order="A"` is added to for `dpnp.empty_like`, `dpnp.ones_like`, `dpnp.zeros_like` and `dpnp.full_like`.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
