### PR TITLE
Limit a test run for `roll` function by NumPy version

### DIFF
--- a/tests/third_party/cupy/manipulation_tests/test_rearrange.py
+++ b/tests/third_party/cupy/manipulation_tests/test_rearrange.py
@@ -41,6 +41,8 @@ class TestRoll(unittest.TestCase):
 
 
 class TestRollTypeError(unittest.TestCase):
+    # TODO: update, once dpctl#1857 is resolved
+    @testing.with_requires("numpy<2.1.2") # done in numpy#27437
     def test_roll_invalid_shift(self):
         for xp in (numpy, cupy):
             x = testing.shaped_arange((5, 2), xp)

--- a/tests/third_party/cupy/manipulation_tests/test_rearrange.py
+++ b/tests/third_party/cupy/manipulation_tests/test_rearrange.py
@@ -42,7 +42,7 @@ class TestRoll(unittest.TestCase):
 
 class TestRollTypeError(unittest.TestCase):
     # TODO: update, once dpctl#1857 is resolved
-    @testing.with_requires("numpy<2.1.2") # done in numpy#27437
+    @testing.with_requires("numpy<2.1.2")  # done in numpy#27437
     def test_roll_invalid_shift(self):
         for xp in (numpy, cupy):
             x = testing.shaped_arange((5, 2), xp)


### PR DESCRIPTION
There was issue#27431 resolved since NumPy 2.1.2 which allows unsigned shift argument value for `numpy.roll`.
Thus `test_roll_invalid_shift` test from `tests/third_party/cupy/manipulation_tests/test_rearrange.py::TestRollTypeError` scope will no raise `TypeError` in that case.

[dpctl#1857](https://github.com/IntelPython/dpctl/issues/1857) is filed to address the same issue in dpctl.

Meanwhile that PR proposes to limit the test run by `numpy<2.1.2` condition and to update the test again once the issue is resolved by dpctl.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
