### PR TITLE
Mute deprecation warning in tests for dpnp.cross

### DIFF
--- a/tests/third_party/cupy/linalg_tests/test_product.py
+++ b/tests/third_party/cupy/linalg_tests/test_product.py
@@ -102,6 +102,7 @@ class TestDot(unittest.TestCase):
     )
 )
 class TestCrossProduct(unittest.TestCase):
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     @testing.for_all_dtypes_combination(["dtype_a", "dtype_b"])
     @testing.numpy_cupy_allclose(type_check=has_support_aspect64())
     def test_cross(self, xp, dtype_a, dtype_b):


### PR DESCRIPTION
The PR proposes to mute warnings while running tests for `dpnp.cross`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
