### PR TITLE
Add implementation of `dpnp.i0`

### DIFF
--- a/dpnp/backend/extensions/ufunc/CMakeLists.txt
+++ b/dpnp/backend/extensions/ufunc/CMakeLists.txt
@@ -34,6 +34,7 @@ set(_elementwise_sources
     ${CMAKE_CURRENT_SOURCE_DIR}/elementwise_functions/fmod.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/elementwise_functions/gcd.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/elementwise_functions/heaviside.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/elementwise_functions/i0.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/elementwise_functions/lcm.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/elementwise_functions/ldexp.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/elementwise_functions/logaddexp2.cpp

--- a/dpnp/backend/extensions/ufunc/elementwise_functions/i0.cpp
+++ b/dpnp/backend/extensions/ufunc/elementwise_functions/i0.cpp
@@ -1,0 +1,124 @@
+//*****************************************************************************
+// Copyright (c) 2024, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//*****************************************************************************
+
+#include <sycl/sycl.hpp>
+
+#include "dpctl4pybind11.hpp"
+
+#include "i0.hpp"
+#include "kernels/elementwise_functions/i0.hpp"
+#include "populate.hpp"
+
+// include a local copy of elementwise common header from dpctl tensor:
+// dpctl/tensor/libtensor/source/elementwise_functions/elementwise_functions.hpp
+// TODO: replace by including dpctl header once available
+#include "../../elementwise_functions/elementwise_functions.hpp"
+
+// dpctl tensor headers
+#include "kernels/elementwise_functions/common.hpp"
+#include "utils/type_dispatch.hpp"
+
+namespace dpnp::extensions::ufunc
+{
+namespace py = pybind11;
+namespace py_int = dpnp::extensions::py_internal;
+
+namespace impl
+{
+namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+namespace td_ns = dpctl::tensor::type_dispatch;
+
+/**
+ * @brief A factory to define pairs of supported types for which
+ * sycl::i0<T> function is available.
+ *
+ * @tparam T Type of input vector `a` and of result vector `y`.
+ */
+template <typename T>
+struct OutputType
+{
+    using value_type =
+        typename std::disjunction<td_ns::TypeMapResultEntry<T, float>,
+                                  td_ns::TypeMapResultEntry<T, double>,
+                                  td_ns::DefaultResultEntry<void>>::result_type;
+};
+
+using dpnp::kernels::i0::I0Functor;
+
+template <typename argT,
+          typename resT = argT,
+          unsigned int vec_sz = 4,
+          unsigned int n_vecs = 2,
+          bool enable_sg_loadstore = true>
+using ContigFunctor = ew_cmn_ns::UnaryContigFunctor<argT,
+                                                    resT,
+                                                    I0Functor<argT, resT>,
+                                                    vec_sz,
+                                                    n_vecs,
+                                                    enable_sg_loadstore>;
+
+template <typename argTy, typename resTy, typename IndexerT>
+using StridedFunctor = ew_cmn_ns::
+    UnaryStridedFunctor<argTy, resTy, IndexerT, I0Functor<argTy, resTy>>;
+
+using ew_cmn_ns::unary_contig_impl_fn_ptr_t;
+using ew_cmn_ns::unary_strided_impl_fn_ptr_t;
+
+static unary_contig_impl_fn_ptr_t i0_contig_dispatch_vector[td_ns::num_types];
+static int i0_output_typeid_vector[td_ns::num_types];
+static unary_strided_impl_fn_ptr_t
+    i0_strided_dispatch_vector[td_ns::num_types];
+
+MACRO_POPULATE_DISPATCH_VECTORS(i0);
+} // namespace impl
+
+void init_i0(py::module_ m)
+{
+    using arrayT = dpctl::tensor::usm_ndarray;
+    using event_vecT = std::vector<sycl::event>;
+    {
+        impl::populate_i0_dispatch_vectors();
+        using impl::i0_contig_dispatch_vector;
+        using impl::i0_output_typeid_vector;
+        using impl::i0_strided_dispatch_vector;
+
+        auto i0_pyapi = [&](const arrayT &src, const arrayT &dst,
+                              sycl::queue &exec_q,
+                              const event_vecT &depends = {}) {
+            return py_int::py_unary_ufunc(
+                src, dst, exec_q, depends, i0_output_typeid_vector,
+                i0_contig_dispatch_vector, i0_strided_dispatch_vector);
+        };
+        m.def("_i0", i0_pyapi, "", py::arg("src"), py::arg("dst"),
+              py::arg("sycl_queue"), py::arg("depends") = py::list());
+
+        auto i0_result_type_pyapi = [&](const py::dtype &dtype) {
+            return py_int::py_unary_ufunc_result_type(
+                dtype, i0_output_typeid_vector);
+        };
+        m.def("_i0_result_type", i0_result_type_pyapi);
+    }
+}
+} // namespace dpnp::extensions::ufunc

--- a/dpnp/backend/extensions/ufunc/elementwise_functions/i0.cpp
+++ b/dpnp/backend/extensions/ufunc/elementwise_functions/i0.cpp
@@ -60,7 +60,8 @@ template <typename T>
 struct OutputType
 {
     using value_type =
-        typename std::disjunction<td_ns::TypeMapResultEntry<T, float>,
+        typename std::disjunction<td_ns::TypeMapResultEntry<T, sycl::half>,
+                                  td_ns::TypeMapResultEntry<T, float>,
                                   td_ns::TypeMapResultEntry<T, double>,
                                   td_ns::DefaultResultEntry<void>>::result_type;
 };
@@ -88,8 +89,7 @@ using ew_cmn_ns::unary_strided_impl_fn_ptr_t;
 
 static unary_contig_impl_fn_ptr_t i0_contig_dispatch_vector[td_ns::num_types];
 static int i0_output_typeid_vector[td_ns::num_types];
-static unary_strided_impl_fn_ptr_t
-    i0_strided_dispatch_vector[td_ns::num_types];
+static unary_strided_impl_fn_ptr_t i0_strided_dispatch_vector[td_ns::num_types];
 
 MACRO_POPULATE_DISPATCH_VECTORS(i0);
 } // namespace impl
@@ -105,8 +105,8 @@ void init_i0(py::module_ m)
         using impl::i0_strided_dispatch_vector;
 
         auto i0_pyapi = [&](const arrayT &src, const arrayT &dst,
-                              sycl::queue &exec_q,
-                              const event_vecT &depends = {}) {
+                            sycl::queue &exec_q,
+                            const event_vecT &depends = {}) {
             return py_int::py_unary_ufunc(
                 src, dst, exec_q, depends, i0_output_typeid_vector,
                 i0_contig_dispatch_vector, i0_strided_dispatch_vector);
@@ -115,8 +115,8 @@ void init_i0(py::module_ m)
               py::arg("sycl_queue"), py::arg("depends") = py::list());
 
         auto i0_result_type_pyapi = [&](const py::dtype &dtype) {
-            return py_int::py_unary_ufunc_result_type(
-                dtype, i0_output_typeid_vector);
+            return py_int::py_unary_ufunc_result_type(dtype,
+                                                      i0_output_typeid_vector);
         };
         m.def("_i0_result_type", i0_result_type_pyapi);
     }

--- a/dpnp/backend/extensions/ufunc/elementwise_functions/i0.hpp
+++ b/dpnp/backend/extensions/ufunc/elementwise_functions/i0.hpp
@@ -23,45 +23,13 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //*****************************************************************************
 
-#include <pybind11/pybind11.h>
+#pragma once
 
-#include "degrees.hpp"
-#include "fabs.hpp"
-#include "fix.hpp"
-#include "float_power.hpp"
-#include "fmax.hpp"
-#include "fmin.hpp"
-#include "fmod.hpp"
-#include "gcd.hpp"
-#include "heaviside.hpp"
-#include "i0.hpp"
-#include "lcm.hpp"
-#include "ldexp.hpp"
-#include "logaddexp2.hpp"
-#include "radians.hpp"
+#include <pybind11/pybind11.h>
 
 namespace py = pybind11;
 
 namespace dpnp::extensions::ufunc
 {
-/**
- * @brief Add elementwise functions to Python module
- */
-void init_elementwise_functions(py::module_ m)
-{
-    init_degrees(m);
-    init_fabs(m);
-    init_fix(m);
-    init_float_power(m);
-    init_fmax(m);
-    init_fmin(m);
-    init_fmod(m);
-    init_gcd(m);
-    init_heaviside(m);
-    init_i0(m);
-    init_lcm(m);
-    init_ldexp(m);
-    init_logaddexp2(m);
-    init_radians(m);
-}
+void init_i0(py::module_ m);
 } // namespace dpnp::extensions::ufunc

--- a/dpnp/backend/kernels/elementwise_functions/i0.hpp
+++ b/dpnp/backend/kernels/elementwise_functions/i0.hpp
@@ -1,0 +1,384 @@
+//*****************************************************************************
+// Copyright (c) 2024, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//*****************************************************************************
+
+#pragma once
+
+#include <sycl/ext/intel/math.hpp>
+#include <sycl/sycl.hpp>
+
+/**
+ * Version of SYCL DPC++ 2025.1 compiler where an issue with
+ * sycl::ext::intel::math::cyl_bessel_i0(x) is fully resolved.
+ */
+#ifndef __SYCL_COMPILER_BESSEL_I0_SUPPORT
+// TODO: update with proper version
+#define __SYCL_COMPILER_BESSEL_I0_SUPPORT 20241030L
+#endif
+
+namespace dpnp::kernels::i0
+{
+/**
+ * The below implementation of Bessel function of order 0
+ * is based on the source code from https://github.com/gcc-mirror/gcc
+ */
+namespace impl
+{
+/**
+ * @brief This routine returns the cylindrical Bessel functions
+ *        of order 0: \f$ J_0 \f$ or \f$ I_0 \f$
+ *        by series expansion.
+ *
+ * The modified cylindrical Bessel function is:
+ * @f[
+ *  Z_0(x) = \sum_{k=0}^{\infty}
+ *           \frac{\sigma^k (x/2)^{2k}}{k!\Gamma(k+1)}
+ * @f]
+ * where \f$ \sigma = +1 \f$ or\f$  -1 \f$ for
+ * \f$ Z = I \f$ or \f$ J \f$ respectively.
+ *
+ * See Abramowitz & Stegun, 9.1.10
+ *     Abramowitz & Stegun, 9.6.7
+ * (1) Handbook of Mathematical Functions,
+ *     ed. Milton Abramowitz and Irene A. Stegun,
+ *     Dover Publications,
+ *     Equation 9.1.10 p. 360 and Equation 9.6.10 p. 375
+ *
+ * @param x   The argument of the Bessel function.
+ * @param sgn The sign of the alternate terms
+ *              -1 for the Bessel function of the first kind.
+ *              +1 for the modified Bessel function of the first kind.
+ * @return The output Bessel function.
+ */
+template <typename Tp>
+inline Tp cyl_bessel_ij_0_series(Tp x, Tp sgn, unsigned int max_iter)
+{
+    if (x == Tp(0)) {
+        return Tp(1);
+    }
+
+    const Tp x2 = x / Tp(2);
+    Tp fact = -sycl::lgamma(Tp(1));
+    fact = std::exp(fact);
+
+    const Tp xx4 = sgn * x2 * x2;
+    Tp Jn = Tp(1);
+    Tp term = Tp(1);
+
+    for (unsigned int i = 1; i < max_iter; ++i) {
+        term *= xx4 / (Tp(i) * Tp(i));
+        Jn += term;
+        if (sycl::fabs(term / Jn) < std::numeric_limits<Tp>::epsilon()) {
+            break;
+        }
+    }
+    return fact * Jn;
+}
+
+/**
+ * @brief  Compute the modified Bessel functions @f$ I_0(0) @f$ and
+ *         @f$ K_0(0) @f$ and their first derivatives
+ *         @f$ I'_0(0) @f$ and @f$ K'_0(0) @f$ respectively.
+ *
+ * @param  Inu  The output regular modified Bessel function.
+ * @param  Knu  The output irregular modified Bessel function.
+ * @param  Ipnu The output derivative of the regular
+ *                modified Bessel function.
+ * @param  Kpnu The output derivative of the irregular
+ *                modified Bessel function.
+ */
+template <typename Tp>
+inline void bessel_ik_0_x_0(Tp &Inu, Tp &Knu, Tp &Ipnu, Tp &Kpnu)
+{
+    Inu = Tp(1);
+    Ipnu = Tp(0);
+    Knu = std::numeric_limits<Tp>::infinity();
+    Kpnu = -std::numeric_limits<Tp>::infinity();
+}
+
+/**
+ * @brief Compute the gamma functions required by the Temme series
+ *        expansions of @f$ N_\nu(x) @f$ and @f$ K_\nu(x) @f$.
+ * @f[
+ *   \Gamma_1 = \frac{1}{2\mu}
+ *              [\frac{1}{\Gamma(1 - \mu)} - \frac{1}{\Gamma(1 + \mu)}]
+ * @f]
+ * and
+ * @f[
+ *   \Gamma_2 = \frac{1}{2}
+ *              [\frac{1}{\Gamma(1 - \mu)} + \frac{1}{\Gamma(1 + \mu)}]
+ * @f]
+ * where @f$ -1/2 <= \mu <= 1/2 @f$ is @f$ \mu = \nu - N @f$ and @f$ N @f$.
+ * is the nearest integer to @f$ \nu @f$.
+ * The values of \f$ \Gamma(1 + \mu) \f$ and \f$ \Gamma(1 - \mu) \f$
+ * are returned as well.
+ *
+ * The accuracy requirements on this are exquisite.
+ *
+ * @param mu     The input parameter of the gamma functions.
+ * @param gam1   The output function \f$ \Gamma_1(\mu) \f$
+ * @param gam2   The output function \f$ \Gamma_2(\mu) \f$
+ * @param gampl  The output function \f$ \Gamma(1 + \mu) \f$
+ * @param gammi  The output function \f$ \Gamma(1 - \mu) \f$
+ */
+template <typename Tp>
+inline void gamma_temme(Tp mu, Tp &gam1, Tp &gam2, Tp &gampl, Tp &gammi)
+{
+    gampl = Tp(1) / sycl::tgamma(Tp(1) + mu);
+    gammi = Tp(1) / sycl::tgamma(Tp(1) - mu);
+
+    if (sycl::fabs(mu) < std::numeric_limits<Tp>::epsilon())
+        // constant Euler's constant @f$ \gamma_E @f$.
+        gam1 = -static_cast<Tp>(0.5772156649015328606065120900824024L);
+    else
+        gam1 = (gammi - gampl) / (Tp(2) * mu);
+
+    gam2 = (gammi + gampl) / (Tp(2));
+}
+
+/**
+ * @brief  Compute the modified Bessel functions @f$ I_0(x) @f$ and
+ *         @f$ K_0(x) @f$ and their first derivatives
+ *         @f$ I'_0(x) @f$ and @f$ K'_0(x) @f$ respectively.
+ *         These four functions are computed together for numerical
+ *         stability.
+ *
+ * @param  x    The argument of the Bessel functions.
+ * @param  Inu  The output regular modified Bessel function.
+ * @param  Knu  The output irregular modified Bessel function.
+ * @param  Ipnu The output derivative of the regular
+ *                modified Bessel function.
+ * @param  Kpnu The output derivative of the irregular
+ *                modified Bessel function.
+ */
+template <typename Tp>
+inline void bessel_ik_0(Tp x, Tp &Inu, Tp &Knu, Tp &Ipnu, Tp &Kpnu)
+{
+    if (x == Tp(0)) {
+        bessel_ik_0_x_0(Inu, Knu, Ipnu, Kpnu);
+        return;
+    }
+
+    constexpr Tp __nu = Tp(0);
+
+    constexpr Tp eps = std::numeric_limits<Tp>::epsilon();
+    constexpr Tp fp_min = Tp(10) * eps;
+    constexpr int max_iter = 15000;
+    constexpr Tp x_min = Tp(2);
+
+    constexpr int nl = int(0.5L);
+
+    const Tp mu = -nl;
+    const Tp mu2 = mu * mu;
+    const Tp xi = Tp(1) / x;
+    const Tp xi2 = Tp(2) * xi;
+    Tp h = fp_min;
+
+    Tp b = Tp(0);
+    Tp d = Tp(0);
+    Tp c = h;
+    int i;
+    for (i = 1; i <= max_iter; ++i) {
+        b += xi2;
+        d = Tp(1) / (b + d);
+        c = b + Tp(1) / c;
+
+        const Tp del = c * d;
+        h *= del;
+        if (sycl::fabs(del - Tp(1)) < eps) {
+            break;
+        }
+    }
+    if (i > max_iter) {
+        // argument `x` is too large
+        bessel_ik_0_x_0(Inu, Knu, Ipnu, Kpnu);
+        return;
+    }
+
+    Tp Inul = fp_min;
+    Tp Ipnul = h * Inul;
+    Tp Inul1 = Inul;
+    Tp Ipnu1 = Ipnul;
+    Tp fact = Tp(0);
+    for (int l = nl; l >= 1; --l) {
+        const Tp Inutemp = fact * Inul + Ipnul;
+        fact -= xi;
+        Ipnul = fact * Inutemp + Inul;
+        Inul = Inutemp;
+    }
+
+    constexpr Tp pi = static_cast<Tp>(3.1415926535897932384626433832795029L);
+    Tp f = Ipnul / Inul;
+    Tp Kmu, Knu1;
+    if (x < x_min) {
+        const Tp x2 = x / Tp(2);
+        const Tp pimu = pi * mu;
+        const Tp fact =
+            (sycl::fabs(pimu) < eps ? Tp(1) : pimu / sycl::sin(pimu));
+
+        Tp d = -sycl::log(x2);
+        Tp e = mu * d;
+        const Tp fact2 = (sycl::fabs(e) < eps ? Tp(1) : sycl::sinh(e) / e);
+
+        Tp gam1, gam2, gampl, gammi;
+        gamma_temme(mu, gam1, gam2, gampl, gammi);
+
+        Tp ff = fact * (gam1 * sycl::cosh(e) + gam2 * fact2 * d);
+        Tp sum = ff;
+        e = sycl::exp(e);
+
+        Tp p = e / (Tp(2) * gampl);
+        Tp q = Tp(1) / (Tp(2) * e * gammi);
+        Tp c = Tp(1);
+        d = x2 * x2;
+        Tp sum1 = p;
+        int i;
+        for (i = 1; i <= max_iter; ++i) {
+            ff = (i * ff + p + q) / (i * i - mu2);
+            c *= d / i;
+            p /= i - mu;
+            q /= i + mu;
+            const Tp del = c * ff;
+            sum += del;
+            const Tp __del1 = c * (p - i * ff);
+            sum1 += __del1;
+            if (sycl::fabs(del) < eps * sycl::fabs(sum)) {
+                break;
+            }
+        }
+        if (i > max_iter) {
+            // Bessel k series failed to converge
+            bessel_ik_0_x_0(Inu, Knu, Ipnu, Kpnu);
+            return;
+        }
+        Kmu = sum;
+        Knu1 = sum1 * xi2;
+    }
+    else {
+        Tp b = Tp(2) * (Tp(1) + x);
+        Tp d = Tp(1) / b;
+        Tp delh = d;
+        Tp h = delh;
+        Tp q1 = Tp(0);
+        Tp q2 = Tp(1);
+        Tp a1 = Tp(0.25L) - mu2;
+        Tp q = c = a1;
+        Tp a = -a1;
+        Tp s = Tp(1) + q * delh;
+        int i;
+        for (i = 2; i <= max_iter; ++i) {
+            a -= 2 * (i - 1);
+            c = -a * c / i;
+            const Tp qnew = (q1 - b * q2) / a;
+            q1 = q2;
+            q2 = qnew;
+            q += c * qnew;
+            b += Tp(2);
+            d = Tp(1) / (b + a * d);
+            delh = (b * d - Tp(1)) * delh;
+            h += delh;
+            const Tp dels = q * delh;
+            s += dels;
+            if (sycl::fabs(dels / s) < eps) {
+                break;
+            }
+        }
+        if (i > max_iter) {
+            // Steed's method failed
+            bessel_ik_0_x_0(Inu, Knu, Ipnu, Kpnu);
+            return;
+        }
+        h = a1 * h;
+        Kmu = std::sqrt(pi / (Tp(2) * x)) * std::exp(-x) / s;
+        Knu1 = Kmu * (mu + x + Tp(0.5L) - h) * xi;
+    }
+
+    Tp Kpmu = mu * xi * Kmu - Knu1;
+    Tp Inumu = xi / (f * Kmu - Kpmu);
+    Inu = Inumu * Inul1 / Inul;
+    Ipnu = Inumu * Ipnu1 / Inul;
+    for (i = 1; i <= nl; ++i) {
+        const Tp Knutemp = (mu + i) * xi2 * Knu1 + Kmu;
+        Kmu = Knu1;
+        Knu1 = Knutemp;
+    }
+    Knu = Kmu;
+    Kpnu = -Knu1;
+}
+
+/**
+ * @brief Return the regular modified Bessel function of order 0:
+ *        \f$ I_0(x) \f$.
+ *
+ *  The regular modified cylindrical Bessel function is:
+ *  @f[
+ *    I_0(x) = \sum_{k=0}^{\infty}
+ *                 \frac{(x/2)^{2k}}{k!\Gamma(k+1)}
+ *  @f]
+ *
+ * @param x The argument of the regular modified Bessel function.
+ * @return The output regular modified Bessel function.
+ */
+template <typename Tp>
+inline Tp cyl_bessel_0(Tp x)
+{
+    if (sycl::isnan(x)) {
+        return std::numeric_limits<Tp>::quiet_NaN();
+    }
+
+    x = sycl::fabs(x);
+
+    if (x * x < Tp(10)) {
+        return cyl_bessel_ij_0_series(x, +Tp(1), 200);
+    }
+    else {
+        Tp I_nu, K_nu, Ip_nu, Kp_nu;
+        bessel_ik_0(x, I_nu, K_nu, Ip_nu, Kp_nu);
+        return I_nu;
+    }
+}
+} // namespace impl
+
+template <typename argT, typename resT>
+struct I0Functor
+{
+    // is function constant for given argT
+    using is_constant = typename std::false_type;
+    // constant value, if constant
+    // constexpr resT constant_value = resT{};
+    // is function defined for sycl::vec
+    using supports_vec = typename std::false_type;
+    // do both argT and resT support subgroup store/load operation
+    using supports_sg_loadstore = typename std::true_type;
+
+    resT operator()(const argT &x) const
+    {
+#if __SYCL_COMPILER_VERSION >= __SYCL_COMPILER_BESSEL_I0_SUPPORT
+        return sycl::ext::intel::math::cyl_bessel_i0(x);
+#else
+        return impl::cyl_bessel_0(x);
+#endif
+    }
+};
+} // namespace dpnp::kernels::i0

--- a/dpnp/backend/kernels/elementwise_functions/i0.hpp
+++ b/dpnp/backend/kernels/elementwise_functions/i0.hpp
@@ -32,8 +32,7 @@
  * sycl::ext::intel::math::cyl_bessel_i0(x) is fully resolved.
  */
 #ifndef __SYCL_COMPILER_BESSEL_I0_SUPPORT
-// TODO: update with proper version
-#define __SYCL_COMPILER_BESSEL_I0_SUPPORT 20241030L
+#define __SYCL_COMPILER_BESSEL_I0_SUPPORT 20241111L
 #endif
 
 #if __SYCL_COMPILER_VERSION >= __SYCL_COMPILER_BESSEL_I0_SUPPORT

--- a/dpnp/backend/kernels/elementwise_functions/i0.hpp
+++ b/dpnp/backend/kernels/elementwise_functions/i0.hpp
@@ -180,8 +180,6 @@ inline void bessel_ik_0(Tp x, Tp &Inu, Tp &Knu, Tp &Ipnu, Tp &Kpnu)
         return;
     }
 
-    constexpr Tp __nu = Tp(0);
-
     constexpr Tp eps = std::numeric_limits<Tp>::epsilon();
     constexpr Tp fp_min = Tp(10) * eps;
     constexpr int max_iter = 15000;
@@ -350,11 +348,11 @@ inline Tp cyl_bessel_0(Tp x)
     x = sycl::fabs(x);
 
     if (x * x < Tp(10)) {
-        return cyl_bessel_ij_0_series(x, +Tp(1), 200);
+        return cyl_bessel_ij_0_series<Tp>(x, +Tp(1), 200);
     }
     else {
         Tp I_nu, K_nu, Ip_nu, Kp_nu;
-        bessel_ik_0(x, I_nu, K_nu, Ip_nu, Kp_nu);
+        bessel_ik_0<Tp>(x, I_nu, K_nu, Ip_nu, Kp_nu);
         return I_nu;
     }
 }
@@ -377,6 +375,9 @@ struct I0Functor
 #if __SYCL_COMPILER_VERSION >= __SYCL_COMPILER_BESSEL_I0_SUPPORT
         return sycl::ext::intel::math::cyl_bessel_i0(x);
 #else
+        if constexpr (std::is_same_v<resT, sycl::half>) {
+            return static_cast<resT>(impl::cyl_bessel_0<float>(float(x)));
+        }
         return impl::cyl_bessel_0(x);
 #endif
     }

--- a/dpnp/dpnp_algo/dpnp_elementwise_common.py
+++ b/dpnp/dpnp_algo/dpnp_elementwise_common.py
@@ -38,17 +38,18 @@ import dpnp.backend.extensions.vm._vm_impl as vmi
 from dpnp.dpnp_array import dpnp_array
 
 __all__ = [
-    "acceptance_fn_gcd_lcm",
-    "acceptance_fn_negative",
-    "acceptance_fn_positive",
-    "acceptance_fn_sign",
-    "acceptance_fn_subtract",
+    "DPNPI0",
     "DPNPAngle",
     "DPNPBinaryFunc",
     "DPNPImag",
     "DPNPReal",
     "DPNPRound",
     "DPNPUnaryFunc",
+    "acceptance_fn_gcd_lcm",
+    "acceptance_fn_negative",
+    "acceptance_fn_positive",
+    "acceptance_fn_sign",
+    "acceptance_fn_subtract",
     "resolve_weak_types_2nd_arg_int",
 ]
 
@@ -497,6 +498,27 @@ class DPNPAngle(DPNPUnaryFunc):
         if deg is True:
             res *= 180 / dpnp.pi
         return res
+
+
+class DPNPI0(DPNPUnaryFunc):
+    """Class that implements dpnp.i0 unary element-wise functions."""
+
+    def __init__(
+        self,
+        name,
+        result_type_resolver_fn,
+        unary_dp_impl_fn,
+        docs,
+    ):
+        super().__init__(
+            name,
+            result_type_resolver_fn,
+            unary_dp_impl_fn,
+            docs,
+        )
+
+    def __call__(self, x, out=None, order="K"):
+        return super().__call__(x, out=out, order=order)
 
 
 class DPNPImag(DPNPUnaryFunc):

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -2364,7 +2364,7 @@ out : dpnp.ndarray
 
 Examples
 --------
->>> import numpy as np
+>>> import dpnp as np
 >>> np.i0(np.array(0.0))
 array(1.)
 >>> np.i0(np.array([0, 1, 2, 3]))

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -60,6 +60,7 @@ import dpnp.backend.extensions.ufunc._ufunc_impl as ufi
 
 from .dpnp_algo import dpnp_modf
 from .dpnp_algo.dpnp_elementwise_common import (
+    DPNPI0,
     DPNPAngle,
     DPNPBinaryFunc,
     DPNPImag,
@@ -108,6 +109,7 @@ __all__ = [
     "gradient",
     "heaviside",
     "imag",
+    "i0",
     "lcm",
     "ldexp",
     "maximum",
@@ -2330,6 +2332,50 @@ heaviside = DPNPBinaryFunc(
     ufi._heaviside_result_type,
     ufi._heaviside,
     _HEAVISIDE_DOCSTRING,
+)
+
+
+_I0_DOCSTRING = """
+Modified Bessel function of the first kind, order 0.
+
+Usually denoted :math:`I_0`.
+
+For full documentation refer to :obj:`numpy.i0`.
+
+Parameters
+----------
+x : {dpnp.ndarray, usm_ndarray}
+    Argument of the Bessel function, expected to have floating-point data type.
+out : {None, dpnp.ndarray, usm_ndarray}, optional
+    Output array to populate.
+    Array must have the correct shape and the expected data type.
+    Default: ``None``.
+order : {"C", "F", "A", "K"}, optional
+    Memory layout of the newly output array, if parameter `out` is ``None``.
+    Default: ``"K"``.
+
+Returns
+-------
+out : dpnp.ndarray
+    The modified Bessel function evaluated at each of the elements of `x`.
+    If the input is of either boolean or integer data type, the returned array
+    will have the default floating point data type of a device where `x` has
+    been allocated. Otherwise the returned array has the same data type.
+
+Examples
+--------
+>>> import numpy as np
+>>> np.i0(np.array(0.0))
+array(1.)
+>>> np.i0(np.array([0, 1, 2, 3]))
+array([1.        , 1.26606588, 2.2795853 , 4.88079259])
+"""
+
+i0 = DPNPI0(
+    "i0",
+    ufi._i0_result_type,
+    ufi._i0,
+    _I0_DOCSTRING,
 )
 
 

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -1326,6 +1326,21 @@ class TestI0:
         expected = numpy.i0(a)
         assert_dtype_allclose(result, expected)
 
+    @pytest.mark.filterwarnings("ignore::RuntimeWarning")
+    def test_nan(self):
+        a = numpy.array(numpy.nan)
+        ia = dpnp.array(a)
+
+        result = dpnp.i0(ia)
+        expected = numpy.i0(a)
+        assert_equal(result, expected)
+
+    # numpy.i0(numpy.inf) returns NaN, but expected Inf
+    @pytest.mark.parametrize("dt", get_float_dtypes())
+    def test_infs(self, dt):
+        a = dpnp.array([dpnp.inf, -dpnp.inf], dtype=dt)
+        assert (dpnp.i0(a) == dpnp.inf).all()
+
     # dpnp.i0 returns float16, but numpy.i0 returns float64
     def test_bool(self):
         a = numpy.array([False, True, False])

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -1289,6 +1289,58 @@ def test_op_multiple_dtypes(dtype1, func, dtype2, data):
         assert_allclose(result, expected)
 
 
+class TestI0:
+    def test_0d(self):
+        a = dpnp.array(0.5)
+        na = a.asnumpy()
+        assert_dtype_allclose(dpnp.i0(a), numpy.i0(na))
+
+    @pytest.mark.parametrize(
+        "dt", get_all_dtypes(no_bool=True, no_none=True, no_complex=True)
+    )
+    def test_1d(self, dt):
+        a = numpy.array(
+            [0.49842636, 0.6969809, 0.22011976, 0.0155549, 10.0], dtype=dt
+        )
+        ia = dpnp.array(a)
+
+        result = dpnp.i0(ia)
+        expected = numpy.i0(a)
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("dt", get_float_dtypes())
+    def test_2d(self, dt):
+        a = numpy.array(
+            [
+                [0.827002, 0.99959078],
+                [0.89694769, 0.39298162],
+                [0.37954418, 0.05206293],
+                [0.36465447, 0.72446427],
+                [0.48164949, 0.50324519],
+            ],
+            dtype=dt,
+        )
+        ia = dpnp.array(a)
+
+        result = dpnp.i0(ia)
+        expected = numpy.i0(a)
+        assert_dtype_allclose(result, expected)
+
+    # dpnp.i0 returns float16, but numpy.i0 returns float64
+    def test_bool(self):
+        a = numpy.array([False, True, False])
+        ia = dpnp.array(a)
+
+        result = dpnp.i0(ia)
+        expected = numpy.i0(a)
+        assert_dtype_allclose(result, expected, check_only_type_kind=True)
+
+    @pytest.mark.parametrize("xp", [dpnp, numpy])
+    def test_complex(self, xp):
+        a = xp.array([0, 1 + 2j])
+        assert_raises((ValueError, TypeError), xp.i0, a)
+
+
 class TestLdexp:
     @pytest.mark.parametrize("mant_dt", get_float_dtypes())
     @pytest.mark.parametrize("exp_dt", get_integer_dtypes())

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -462,6 +462,7 @@ def test_meshgrid(device):
         pytest.param("floor", [-1.7, -1.5, -0.2, 0.2, 1.5, 1.7, 2.0]),
         pytest.param("gradient", [1.0, 2.0, 4.0, 7.0, 11.0, 16.0]),
         pytest.param("histogram_bin_edges", [0, 0, 0, 1, 2, 3, 3, 4, 5]),
+        pytest.param("i0", [0, 1, 2, 3]),
         pytest.param(
             "imag", [complex(1.0, 2.0), complex(3.0, 4.0), complex(5.0, 6.0)]
         ),

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -586,6 +586,7 @@ def test_norm(usm_type, ord, axis):
         pytest.param("floor", [-1.7, -1.5, -0.2, 0.2, 1.5, 1.7, 2.0]),
         pytest.param("gradient", [1, 2, 4, 7, 11, 16]),
         pytest.param("histogram_bin_edges", [0, 0, 0, 1, 2, 3, 3, 4, 5]),
+        pytest.param("i0", [0, 1, 2, 3]),
         pytest.param(
             "imag", [complex(1.0, 2.0), complex(3.0, 4.0), complex(5.0, 6.0)]
         ),

--- a/tests/third_party/cupy/math_tests/test_special.py
+++ b/tests/third_party/cupy/math_tests/test_special.py
@@ -1,0 +1,34 @@
+import unittest
+
+import pytest
+
+import dpnp as cupy
+from tests.third_party.cupy import testing
+
+
+class TestSpecial(unittest.TestCase):
+    @testing.for_dtypes(["e", "f", "d"])
+    @testing.numpy_cupy_allclose(rtol=1e-3)
+    def test_i0(self, xp, dtype):
+        a = testing.shaped_random((2, 3), xp, dtype)
+        return xp.i0(a)
+
+    @pytest.mark.skip("sinc is not implemented")
+    @testing.for_dtypes(["e", "f", "d", "F", "D"])
+    @testing.numpy_cupy_allclose(atol=1e-3)
+    def test_sinc(self, xp, dtype):
+
+        if dtype in [cupy.float16, cupy.float32, cupy.complex64]:
+            pytest.xfail(
+                reason="XXX: np2.0: numpy 1.26 uses a wrong "
+                "promotion; numpy 2.0 is OK"
+            )
+
+        a = testing.shaped_random((2, 3), xp, dtype, scale=1)
+        return xp.sinc(a)
+
+    @pytest.mark.skip("sinc is not implemented")
+    @testing.for_dtypes(["e", "f", "d", "F", "D"])
+    def test_sinc_zero(self, dtype):
+        a = cupy.sinc(cupy.zeros(1, dtype=dtype))
+        testing.assert_array_equal(a, cupy.ones(1, dtype=dtype))


### PR DESCRIPTION
The PR proposes to add implementation of `dpnp.i0` function.

The new dedicated `_i0` function are added to `_ufunc_impl` pybind11 extension.
All the required tests are implemented to cover the new functions.

Note that SYCL kernel for the elementwise function assumes to call `sycl::ext::intel::math::cyl_bessel_i0` where possible or to rely on own implementation based on source from gcc repo.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
