### PR TITLE
Update `dpnp.einsum` to align with NEP-50

### DIFF
--- a/dpnp/dpnp_iface_statistics.py
+++ b/dpnp/dpnp_iface_statistics.py
@@ -370,7 +370,7 @@ def correlate(x1, x2, mode="valid"):
     -----------
     Input arrays are supported as :obj:`dpnp.ndarray`.
     Size and shape of input arrays are supported to be equal.
-    Parameter `mode` is supported only with default value ``"valid``.
+    Parameter `mode` is supported only with default value ``"valid"``.
     Otherwise the function will be executed sequentially on CPU.
     Input array data types are limited by supported DPNP :ref:`Data types`.
 

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -1139,14 +1139,12 @@ class TestEinsum:
         result = inp.einsum(*args, dtype="?", casting="unsafe", optimize=do_opt)
         assert_dtype_allclose(result, expected)
 
-        # with an scalar, NumPy < 2.0.0 uses the other input arrays to
-        # determine the output type while for NumPy > 2.0.0 the scalar
-        # with default machine dtype is used to determine the output
-        # data type
+        # NumPy >= 2.0 follows NEP-50 to determine the output dtype when one of
+        # the inputs is a scalar while NumPy < 2.0 does not
         if numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0":
-            check_type = True
-        else:
             check_type = False
+        else:
+            check_type = True
         a = numpy.arange(9, dtype=dtype)
         a_dp = inp.array(a)
         expected = numpy.einsum(",i->", 3, a)
@@ -1712,7 +1710,7 @@ class TestEinsum:
 
     def test_output_order(self):
         # Ensure output order is respected for optimize cases, the below
-        # conraction should yield a reshaped tensor view
+        # contraction should yield a reshaped tensor view
         a = inp.ones((2, 3, 5), order="F")
         b = inp.ones((4, 3), order="F")
 

--- a/tests/third_party/cupy/linalg_tests/test_einsum.py
+++ b/tests/third_party/cupy/linalg_tests/test_einsum.py
@@ -475,13 +475,12 @@ class TestEinSumBinaryOperation:
 
 
 class TestEinSumBinaryOperationWithScalar:
-    # with an scalar, NumPy < 2.0.0 uses the other input arrays to determine
-    # the output type while for NumPy > 2.0.0 the scalar with default machine
-    # dtype is used to determine the output type
+    # NumPy >= 2.0 follows NEP-50 to determine the output dtype when one of
+    # the inputs is a scalar while NumPy < 2.0 does not
     if numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0":
-        type_check = has_support_aspect64()
-    else:
         type_check = False
+    else:
+        type_check = has_support_aspect64()
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False, type_check=type_check)


### PR DESCRIPTION
In NumPy 2.0 and above, `numpy.einsum` function follows [NEP-50](https://numpy.org/neps/nep-0050-scalar-promotion.htm) while in previous version it was not followed.

`dpnp.einsum` is updated to behave similarly.

New behavior in `NumPy` and update `dpnp` on this branch:
```python
import numpy as np
np.__version__
# 2.1.1
a=np.ones(2, dtype=np.float32)
np.einsum(",i->", 3., a)
# np.float64(6.0)

import dpnp
a_dp=dpnp.ones(2, dtype=dpnp.float32)
dpnp.einsum(",i->", 3., a_dp).dtype # on a device with support for double precision
# dtype('float64')
```
Old behavior in `NumPy` and `dpnp`:
```python
import numpy as np
np.__version__
# 1.26.4
a=np.ones(2, dtype=np.float32)
np.einsum(",i->", 3., a).dtype
# dtype('float32')

import dpnp
a_dp=dpnp.ones(2, dtype=dpnp.float32)
dpnp.einsum(",i->", 3., a_dp).dtype
# dtype('float32')
```

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
