### PR TITLE
Add implementation of `dpnp.isfortran()`

### DIFF
--- a/dpnp/dpnp_iface_logic.py
+++ b/dpnp/dpnp_iface_logic.py
@@ -1014,9 +1014,9 @@ def isfortran(a):
 
     Examples
     --------
-    dpnp.array allows to specify whether the array is written in C-contiguous
-    order (last index varies the fastest), or FORTRAN-contiguous order in
-    memory (first index varies the fastest).
+    :obj:`dpnp.array` allows to specify whether the array is written in
+    C-contiguous order (last index varies the fastest), or FORTRAN-contiguous
+    order in memory (first index varies the fastest).
 
     >>> import dpnp as np
     >>> a = np.array([[1, 2, 3], [4, 5, 6]], order='C')

--- a/dpnp/dpnp_iface_logic.py
+++ b/dpnp/dpnp_iface_logic.py
@@ -64,6 +64,7 @@ __all__ = [
     "iscomplex",
     "iscomplexobj",
     "isfinite",
+    "isfortran",
     "isinf",
     "isnan",
     "isneginf",
@@ -989,6 +990,76 @@ isfinite = DPNPUnaryFunc(
     tei._isfinite,
     _ISFINITE_DOCSTRING,
 )
+
+
+def isfortran(a):
+    """
+    Check if the array is Fortran contiguous but *not* C contiguous.
+
+    This function is obsolete. If you only want to check if an array is Fortran
+    contiguous use ``a.flags.f_contiguous`` instead.
+
+    For full documentation refer to :obj:`numpy.isfortran`.
+
+    Parameters
+    ----------
+    a : {dpnp.ndarray, usm_ndarray}
+        Input array.
+
+    Returns
+    -------
+    isfortran : bool
+        Returns ``True`` if the array is Fortran contiguous
+        but *not* C contiguous.
+
+    Examples
+    --------
+    dpnp.array allows to specify whether the array is written in C-contiguous
+    order (last index varies the fastest), or FORTRAN-contiguous order in
+    memory (first index varies the fastest).
+
+    >>> import dpnp as np
+    >>> a = np.array([[1, 2, 3], [4, 5, 6]], order='C')
+    >>> a
+    array([[1, 2, 3],
+           [4, 5, 6]])
+    >>> np.isfortran(a)
+    False
+
+    >>> b = np.array([[1, 2, 3], [4, 5, 6]], order='F')
+    >>> b
+    array([[1, 2, 3],
+           [4, 5, 6]])
+    >>> np.isfortran(b)
+    True
+
+    The transpose of a C-ordered array is a FORTRAN-ordered array.
+
+    >>> a = np.array([[1, 2, 3], [4, 5, 6]], order='C')
+    >>> a
+    array([[1, 2, 3],
+           [4, 5, 6]])
+    >>> np.isfortran(a)
+    False
+    >>> b = a.T
+    >>> b
+    array([[1, 4],
+           [2, 5],
+           [3, 6]])
+    >>> np.isfortran(b)
+    True
+
+    C-ordered arrays evaluate as ``False`` even if they are also
+    FORTRAN-ordered.
+
+    >>> np.isfortran(np.array([1, 2], order='F'))
+    False
+
+    """
+
+    dpnp.check_supported_arrays_type(a)
+
+    return a.flags.fnc
 
 
 _ISINF_DOCSTRING = """

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -431,6 +431,34 @@ def test_finite(op, data, dtype):
     assert_equal(dpnp_res, np_res)
 
 
+class TestIsFortran:
+    @pytest.mark.parametrize(
+        "array, expected",
+        [
+            (dpnp.ones((2, 4), order="C"), True),
+            (dpnp.ones((2, 4), order="F"), False),
+        ],
+    )
+    def test_isfortran_transpose(self, array, expected):
+        assert dpnp.isfortran(array.T) == expected
+
+    @pytest.mark.parametrize(
+        "array, expected",
+        [
+            (dpnp.ones((2, 4), order="C"), False),
+            (dpnp.ones((2, 4), order="F"), True),
+        ],
+    )
+    def test_isfortran_usm_ndarray(self, array, expected):
+        assert dpnp.isfortran(array.get_array()) == expected
+
+    def test_isfortran_errors(self):
+        # unsupported type
+        a_np = numpy.ones((2, 3))
+        assert_raises(TypeError, dpnp.isfortran, a_np)
+        assert_raises(TypeError, dpnp.isfortran, [1, 2, 3])
+
+
 @pytest.mark.parametrize("func", ["isneginf", "isposinf"])
 @pytest.mark.parametrize(
     "data",

--- a/tests/third_party/cupy/logic_tests/test_type_test.py
+++ b/tests/third_party/cupy/logic_tests/test_type_test.py
@@ -72,7 +72,6 @@ class TestIsScalarValues2(testing.NumpyAliasValuesTestBase):
 )
 class TestIsFortran(unittest.TestCase):
 
-    @pytest.mark.skip("isfortran not implemented")
     @testing.numpy_cupy_equal()
     def test(self, xp):
         return xp.isfortran(xp.asarray(self.value))


### PR DESCRIPTION
This PR suggests adding an implementation of `dpnp.isfortran()` to check if the array is Fortran-contiguous using a call to `dpnp.ndarray.flags.fnc` attribute.



- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
