### PR TITLE
Use `group_load_store` compiler extension

### DIFF
--- a/dpnp/dpnp_iface_histograms.py
+++ b/dpnp/dpnp_iface_histograms.py
@@ -325,7 +325,7 @@ def bincount(x, weights=None, minlength=None):
     -------
     out : dpnp.ndarray of ints
         The result of binning the input array.
-        The length of `out` is equal to ``np.amax(x) + 1``.
+        The length of `out` is equal to ``dpnp.max(x) + 1``.
 
     See Also
     --------
@@ -353,7 +353,7 @@ def bincount(x, weights=None, minlength=None):
       ...
     TypeError: x must be an integer array
 
-    A possible use of ``bincount`` is to perform sums over
+    A possible use of :obj:`dpnp.bincount` is to perform sums over
     variable-size chunks of an array, using the `weights` keyword.
 
     >>> w = np.array([0.3, 0.5, 0.2, 0.7, 1., -0.6], dtype=np.float32) # weights


### PR DESCRIPTION
The PR switches to `group_load_store` experimental extension per deprecation warning for 2025.1 DPC++ compiler.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
