### PR TITLE
Skip test_solve with 3D matrix for numpy 2.0

### DIFF
--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -2251,8 +2251,13 @@ def test_solve(matrix, vector, device):
     a_dp = dpnp.array(a_np, device=device)
     b_dp = dpnp.array(b_np, device=device)
 
-    if a_dp.ndim > 2 and a_dp.device.sycl_device.is_cpu:
-        pytest.skip("SAT-6842: reported hanging in public CI")
+    # In numpy 2.0 the broadcast ambiguity has been removed and now
+    # b is treaded as a single vector if and only if it is 1-dimensional;
+    # for other cases this signature must be followed
+    # (..., m, m), (..., m, n) -> (..., m, n)
+    # https://github.com/numpy/numpy/pull/25914
+    if a_dp.ndim > 2 and numpy.lib.NumpyVersion(numpy.__version__) >= "2.0.0":
+        pytest.skip("SAT-6928")
 
     result = dpnp.linalg.solve(a_dp, b_dp)
     expected = numpy.linalg.solve(a_np, b_np)


### PR DESCRIPTION
This PR suggests skipping `test_solve` with `3D_Matrix_and_Vectors` in `test_sycl_queue.py` until dpnp.linalg.solve() is updated to support numpy>=2.0

Also removes skip for SAT-6842 due to irrelevance (Issue has been fixed)

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
