### PR TITLE
Implement a temporary workaround to avoid usage of `2025.0` components in GutHub actions

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -76,11 +76,11 @@ jobs:
 
       - name: Install Intel OneAPI
         run: |
-          sudo apt-get install intel-oneapi-mkl                \
-                               intel-oneapi-mkl-devel          \
-                               intel-oneapi-tbb-devel          \
-                               intel-oneapi-libdpstd-devel     \
-                               intel-oneapi-compiler-dpcpp-cpp
+          sudo apt-get install intel-oneapi-mkl-2024.2*                \
+                               intel-oneapi-mkl-devel-2024.2*          \
+                               intel-oneapi-tbb-devel-2021.13*         \
+                               intel-oneapi-libdpstd-devel-2022.6*     \
+                               intel-oneapi-compiler-dpcpp-cpp-2024.2*
 
       # required by sphinxcontrib-spelling extension
       - name: Install enchant package

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -144,6 +144,8 @@ jobs:
 
       - name: Build conda package
         run: conda build --no-test --python ${{ matrix.python }} --numpy 2.0 ${{ env.CHANNELS }} conda-recipe
+        env:
+          MAX_BUILD_CMPL_MKL_VERSION: '2024.3'
 
       - name: Upload artifact
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Build conda package
         run: conda build --no-test --python ${{ matrix.python }} --numpy 2.0 ${{ env.CHANNELS }} conda-recipe
         env:
-          MAX_BUILD_CMPL_MKL_VERSION: '2024.3'
+          MAX_BUILD_CMPL_MKL_VERSION: '2024.3a0'
 
       - name: Upload artifact
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -49,11 +49,11 @@ jobs:
       - name: Install latest Intel OneAPI
         if: env.INSTALL_ONE_API == 'yes'
         run: |
-          sudo apt-get install intel-oneapi-mkl                \
-                               intel-oneapi-mkl-devel          \
-                               intel-oneapi-tbb-devel          \
-                               intel-oneapi-libdpstd-devel     \
-                               intel-oneapi-compiler-dpcpp-cpp
+          sudo apt-get install intel-oneapi-mkl-2024.2*                \
+                               intel-oneapi-mkl-devel-2024.2*          \
+                               intel-oneapi-tbb-devel-2021.13*         \
+                               intel-oneapi-libdpstd-devel-2022.6*     \
+                               intel-oneapi-compiler-dpcpp-cpp-2024.2*
 
       - name: Install Lcov
         run: |

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set max_compiler_and_mkl_version = environ.get("MAX_BUILD_CMPL_MKL_VERSION", "2026.0") %}
+{% set max_compiler_and_mkl_version = environ.get("MAX_BUILD_CMPL_MKL_VERSION", "2026.0a0") %}
 {% set required_compiler_and_mkl_version = "2024.2" %}
-{% set required_dpctl_version = "0.18.0*" %}
+{% set required_dpctl_version = "0.18.1" %}
 
 package:
     name: dpnp

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,14 +17,14 @@ requirements:
       - ninja
       - git
       - dpctl >={{ required_dpctl_version }}
-      - mkl-devel-dpcpp >={{ required_compiler_and_mkl_version }}
+      - mkl-devel-dpcpp ={{ required_compiler_and_mkl_version }}
       - onedpl-devel
       - tbb-devel
       - wheel
       - scikit-build
     build:
       - {{ compiler('cxx') }}
-      - {{ compiler('dpcpp') }} >={{ required_compiler_and_mkl_version }}
+      - {{ compiler('dpcpp') }} ={{ required_compiler_and_mkl_version }}
       - sysroot_linux-64 >=2.28 # [linux]
     run:
       - python

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,3 +1,4 @@
+{% set max_compiler_and_mkl_version = environ.get("MAX_BUILD_CMPL_MKL_VERSION", "2026.0") %}
 {% set required_compiler_and_mkl_version = "2024.2" %}
 {% set required_dpctl_version = "0.18.0*" %}
 
@@ -17,14 +18,14 @@ requirements:
       - ninja
       - git
       - dpctl >={{ required_dpctl_version }}
-      - mkl-devel-dpcpp ={{ required_compiler_and_mkl_version }}
+      - mkl-devel-dpcpp >={{ required_compiler_and_mkl_version }},<{{ max_compiler_and_mkl_version }}
       - onedpl-devel
       - tbb-devel
       - wheel
       - scikit-build
     build:
       - {{ compiler('cxx') }}
-      - {{ compiler('dpcpp') }} ={{ required_compiler_and_mkl_version }}
+      - {{ compiler('dpcpp') }} >={{ required_compiler_and_mkl_version }},<{{ max_compiler_and_mkl_version }}
       - sysroot_linux-64 >=2.28 # [linux]
     run:
       - python


### PR DESCRIPTION
The PR is about to unblock GitHub actions until all components from `2025.0` release will be published (currently it's done only for part of components which breaks the workflows).

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
