### PR TITLE
Leverage on dpctl.tensor implementation in `dpnp.put_along_axis`

### DIFF
--- a/dpnp/dpnp_iface_indexing.py
+++ b/dpnp/dpnp_iface_indexing.py
@@ -1350,6 +1350,7 @@ def put_along_axis(a, ind, values, axis, mode="wrap"):
     mode : {"wrap", "clip"}, optional
         Specifies how out-of-bounds indices will be handled. Possible values
         are:
+        
         - ``"wrap"``: clamps indices to (``-n <= i < n``), then wraps
           negative indices.
         - ``"clip"``: clips indices to (``0 <= i < n``).

--- a/dpnp/dpnp_iface_indexing.py
+++ b/dpnp/dpnp_iface_indexing.py
@@ -1350,10 +1350,11 @@ def put_along_axis(a, ind, values, axis, mode="wrap"):
     mode : {"wrap", "clip"}, optional
         Specifies how out-of-bounds indices will be handled. Possible values
         are:
-        
+
         - ``"wrap"``: clamps indices to (``-n <= i < n``), then wraps
           negative indices.
         - ``"clip"``: clips indices to (``0 <= i < n``).
+
         Default: ``"wrap"``.
 
     See Also

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -640,6 +640,12 @@ class TestPutAlongAxis:
         dpnp.put_along_axis(a, ind, 4, axis=0, mode="clip")
         assert (a == dpnp.array([4, -1, 4, 1, 4])).all()
 
+    @pytest.mark.parametrize("xp", [numpy, dpnp])
+    def test_indices_ndim_axis_none(self, xp):
+        a = xp.ones((10, 10))
+        ind = xp.ones((10, 2), dtype=xp.intp)
+        assert_raises(ValueError, xp.put_along_axis, a, ind, -1, axis=None)
+
 
 class TestTake:
     @pytest.mark.parametrize("a_dt", get_all_dtypes(no_none=True))


### PR DESCRIPTION
The PR proposes to leverage on dpctl.tensor implementation in `dpnp.put_along_axis` function.
Additionally, the function signature is extended with new keyword `mode` to provide a control how out-of-bounds indices will be handled.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
