### PR TITLE
add support for kwarg `ndmin` for `dpnp.array`

### DIFF
--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -643,7 +643,7 @@ def ascontiguousarray(
     a, dtype=None, *, like=None, device=None, usm_type=None, sycl_queue=None
 ):
     """
-    Return a contiguous array in memory (C order).
+    Return a contiguous array ``(ndim >= 1)`` in memory (C order).
 
     For full documentation refer to :obj:`numpy.ascontiguousarray`.
 
@@ -739,14 +739,12 @@ def ascontiguousarray(
 
     dpnp.check_limitations(like=like)
 
-    # at least 1-d array has to be returned
-    if dpnp.isscalar(a) or hasattr(a, "ndim") and a.ndim == 0:
-        a = [a]
-
-    return asarray(
+    return dpnp.array(
         a,
         dtype=dtype,
+        copy=None,
         order="C",
+        ndmin=1,
         device=device,
         usm_type=usm_type,
         sycl_queue=sycl_queue,
@@ -857,14 +855,12 @@ def asfortranarray(
 
     dpnp.check_limitations(like=like)
 
-    # at least 1-d array has to be returned
-    if dpnp.isscalar(a) or hasattr(a, "ndim") and a.ndim == 0:
-        a = [a]
-
-    return asarray(
+    return dpnp.array(
         a,
         dtype=dtype,
+        copy=None,
         order="F",
+        ndmin=1,
         device=device,
         usm_type=usm_type,
         sycl_queue=sycl_queue,

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -421,7 +421,8 @@ def array(
         return result
 
     num_axes = ndmin - res_ndim
-    return result[(dpnp.newaxis,) * num_axes + (slice(None),)]
+    new_shape = (1,) * num_axes + result.shape
+    return result.reshape(new_shape)
 
 
 def asanyarray(

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -377,6 +377,11 @@ def array(
     >>> x
     array([1, 2, 3])
 
+    Upcasting:
+
+    >>> np.array([1, 2, 3.0])
+    array([ 1.,  2.,  3.])
+
     More than one dimension:
 
     >>> x2 = np.array([[1, 2], [3, 4]])
@@ -385,6 +390,16 @@ def array(
     >>> x2
     array([[1, 2],
            [3, 4]])
+
+    Minimum dimensions 2:
+
+    >>> np.array([1, 2, 3], ndmin=2)
+    array([[1, 2, 3]])
+
+    Type provided:
+
+    >>> np.array([1, 2, 3], dtype=complex)
+    array([ 1.+0.j,  2.+0.j,  3.+0.j])
 
     Creating an array on a different device or with a specified usm_type
 

--- a/tests/test_arraycreation.py
+++ b/tests/test_arraycreation.py
@@ -24,7 +24,8 @@ from .helper import (
 
 class TestArray:
     @pytest.mark.parametrize(
-        "x", [numpy.ones((3, 4)), numpy.ones((0, 4)), [1, 2, 3], []]
+        "x",
+        [numpy.ones(5), numpy.ones((3, 4)), numpy.ones((0, 4)), [1, 2, 3], []],
     )
     @pytest.mark.parametrize("ndmin", [-5, -1, 0, 1, 2, 3, 4, 9, 21])
     def test_ndmin(self, x, ndmin):

--- a/tests/test_arraycreation.py
+++ b/tests/test_arraycreation.py
@@ -860,10 +860,8 @@ def test_geomspace(sign, dtype, num, endpoint):
         assert_allclose(dpnp_res, np_res, rtol=1e-04)
 
 
-@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("start", [1j, 1 + 1j])
 @pytest.mark.parametrize("stop", [10j, 10 + 10j])
-# dpnp.sign raise numpy fall back for complex dtype
 def test_geomspace_complex(start, stop):
     func = lambda xp: xp.geomspace(start, stop, num=10)
     np_res = func(numpy)
@@ -922,7 +920,7 @@ def test_logspace_axis(axis):
 @pytest.mark.parametrize(
     "data", [(), 1, (2, 3), [4], numpy.array(5), numpy.array([6, 7])]
 )
-def test_ascontiguousarray(data):
+def test_ascontiguousarray1(data):
     result = dpnp.ascontiguousarray(data)
     expected = numpy.ascontiguousarray(data)
     assert_dtype_allclose(result, expected)
@@ -930,7 +928,7 @@ def test_ascontiguousarray(data):
 
 
 @pytest.mark.parametrize("data", [(), 1, (2, 3), [4]])
-def test_ascontiguousarray1(data):
+def test_ascontiguousarray2(data):
     result = dpnp.ascontiguousarray(dpnp.array(data))
     expected = numpy.ascontiguousarray(numpy.array(data))
     assert_dtype_allclose(result, expected)
@@ -940,7 +938,7 @@ def test_ascontiguousarray1(data):
 @pytest.mark.parametrize(
     "data", [(), 1, (2, 3), [4], numpy.array(5), numpy.array([6, 7])]
 )
-def test_asfortranarray(data):
+def test_asfortranarray1(data):
     result = dpnp.asfortranarray(data)
     expected = numpy.asfortranarray(data)
     assert_dtype_allclose(result, expected)
@@ -948,7 +946,7 @@ def test_asfortranarray(data):
 
 
 @pytest.mark.parametrize("data", [(), 1, (2, 3), [4]])
-def test_asfortranarray1(data):
+def test_asfortranarray2(data):
     result = dpnp.asfortranarray(dpnp.array(data))
     expected = numpy.asfortranarray(numpy.array(data))
     assert_dtype_allclose(result, expected)

--- a/tests/test_arraycreation.py
+++ b/tests/test_arraycreation.py
@@ -9,6 +9,7 @@ from numpy.testing import (
     assert_allclose,
     assert_array_equal,
     assert_equal,
+    assert_raises,
 )
 
 import dpnp
@@ -19,6 +20,40 @@ from .helper import (
     get_all_dtypes,
     has_support_aspect64,
 )
+
+
+class TestArray:
+    @pytest.mark.parametrize(
+        "x", [numpy.ones((3, 4)), numpy.ones((0, 4)), [1, 2, 3], []]
+    )
+    @pytest.mark.parametrize("ndmin", [-5, -1, 0, 1, 2, 3, 4, 9, 21])
+    def test_ndmin(self, x, ndmin):
+        a = numpy.array(x, ndmin=ndmin)
+        ia = dpnp.array(x, ndmin=ndmin)
+        assert_array_equal(ia, a)
+
+    @pytest.mark.parametrize(
+        "x",
+        [
+            numpy.ones((2, 3, 4, 5)),
+            numpy.ones((3, 4)),
+            numpy.ones((0, 4)),
+            [1, 2, 3],
+            [],
+        ],
+    )
+    @pytest.mark.parametrize("order", ["C", "F", "K", "A"])
+    @pytest.mark.parametrize("ndmin", [1, 2, 3, 4, 9, 21])
+    def test_ndmin_order(self, x, order, ndmin):
+        a = numpy.array(x, order=order, ndmin=ndmin)
+        ia = dpnp.array(x, order=order, ndmin=ndmin)
+        assert a.flags.c_contiguous == ia.flags.c_contiguous
+        assert a.flags.f_contiguous == ia.flags.f_contiguous
+        assert_array_equal(ia, a)
+
+    def test_error(self):
+        x = numpy.ones((3, 4))
+        assert_raises(TypeError, dpnp.array, x, ndmin=3.0)
 
 
 class TestTrace:
@@ -140,17 +175,9 @@ def test_exception_subok(func, args):
         getattr(dpnp, func)(x, *args, subok=True)
 
 
-@pytest.mark.parametrize(
-    "start", [0, -5, 10, -2.5, 9.7], ids=["0", "-5", "10", "-2.5", "9.7"]
-)
-@pytest.mark.parametrize(
-    "stop",
-    [None, 10, -2, 20.5, 1000],
-    ids=["None", "10", "-2", "20.5", "10**5"],
-)
-@pytest.mark.parametrize(
-    "step", [None, 1, 2.7, -1.6, 100], ids=["None", "1", "2.7", "-1.6", "100"]
-)
+@pytest.mark.parametrize("start", [0, -5, 10, -2.5, 9.7])
+@pytest.mark.parametrize("stop", [None, 10, -2, 20.5, 1000])
+@pytest.mark.parametrize("step", [None, 1, 2.7, -1.6, 100])
 @pytest.mark.parametrize(
     "dtype", get_all_dtypes(no_bool=True, no_float16=False)
 )
@@ -188,11 +215,7 @@ def test_arange(start, stop, step, dtype):
 
 
 @pytest.mark.parametrize("func", ["diag", "diagflat"])
-@pytest.mark.parametrize(
-    "k",
-    [-6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6],
-    ids=["-6", "-5", "-4", "-3", "-2", "-1", "0", "1", "2", "3", "4", "5", "6"],
-)
+@pytest.mark.parametrize("k", [-6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6])
 @pytest.mark.parametrize(
     "v",
     [
@@ -251,17 +274,11 @@ def test_diag_diagflat_seq(func, seq):
     assert_array_equal(expected, result)
 
 
-@pytest.mark.parametrize("N", [0, 1, 2, 3], ids=["0", "1", "2", "3"])
-@pytest.mark.parametrize(
-    "M", [None, 0, 1, 2, 3], ids=["None", "0", "1", "2", "3"]
-)
-@pytest.mark.parametrize(
-    "k",
-    [-4, -3, -2, -1, 0, 1, 2, 3, 4],
-    ids=["-4", "-3", "-2", "-1", "0", "1", "2", "3", "4"],
-)
+@pytest.mark.parametrize("N", [0, 1, 2, 3])
+@pytest.mark.parametrize("M", [None, 0, 1, 2, 3])
+@pytest.mark.parametrize("k", [-4, -3, -2, -1, 0, 1, 2, 3, 4])
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_float16=False))
-@pytest.mark.parametrize("order", [None, "C", "F"], ids=["None", "C", "F"])
+@pytest.mark.parametrize("order", [None, "C", "F"])
 def test_eye(N, M, k, dtype, order):
     func = lambda xp: xp.eye(N, M, k=k, dtype=dtype, order=order)
     assert_array_equal(func(numpy), func(dpnp))
@@ -317,7 +334,7 @@ def test_fromstring(dtype):
     assert_array_equal(func(dpnp), func(numpy))
 
 
-@pytest.mark.parametrize("n", [0, 1, 4], ids=["0", "1", "4"])
+@pytest.mark.parametrize("n", [0, 1, 4])
 @pytest.mark.parametrize("dtype", get_all_dtypes())
 def test_identity(n, dtype):
     func = lambda xp: xp.identity(n, dtype=dtype)
@@ -340,15 +357,9 @@ def test_loadtxt(dtype):
     assert_array_equal(dpnp_res, np_res)
 
 
-@pytest.mark.parametrize("N", [0, 1, 2, 3, 4], ids=["0", "1", "2", "3", "4"])
-@pytest.mark.parametrize(
-    "M", [None, 0, 1, 2, 3, 4], ids=["None", "0", "1", "2", "3", "4"]
-)
-@pytest.mark.parametrize(
-    "k",
-    [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5],
-    ids=["-5", "-4", "-3", "-2", "-1", "0", "1", "2", "3", "4", "5"],
-)
+@pytest.mark.parametrize("N", [0, 1, 2, 3, 4])
+@pytest.mark.parametrize("M", [None, 0, 1, 2, 3, 4])
+@pytest.mark.parametrize("k", [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5])
 @pytest.mark.parametrize("dtype", get_all_dtypes())
 def test_tri(N, M, k, dtype):
     func = lambda xp: xp.tri(N, M, k, dtype=dtype)
@@ -409,7 +420,6 @@ def test_tri_default_dtype():
         "[[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]",
     ],
 )
-@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_float16=False))
 def test_tril(m, k, dtype):
     a = numpy.array(m, dtype=dtype)
@@ -463,7 +473,6 @@ def test_tril(m, k, dtype):
         "[[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]",
     ],
 )
-@pytest.mark.usefixtures("allow_fall_back_on_numpy")
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_float16=False))
 def test_triu(m, k, dtype):
     a = numpy.array(m, dtype=dtype)
@@ -473,11 +482,7 @@ def test_triu(m, k, dtype):
     assert_array_equal(expected, result)
 
 
-@pytest.mark.parametrize(
-    "k",
-    [-4, -3, -2, -1, 0, 1, 2, 3, 4],
-    ids=["-4", "-3", "-2", "-1", "0", "1", "2", "3", "4"],
-)
+@pytest.mark.parametrize("k", [-4, -3, -2, -1, 0, 1, 2, 3, 4])
 def test_triu_size_null(k):
     a = numpy.ones(shape=(1, 2, 0))
     ia = dpnp.array(a)
@@ -492,8 +497,8 @@ def test_triu_size_null(k):
     ids=["[1, 2, 3, 4]", "[]", "[0, 3, 5]"],
 )
 @pytest.mark.parametrize("dtype", get_all_dtypes())
-@pytest.mark.parametrize("n", [0, 1, 4, None], ids=["0", "1", "4", "None"])
-@pytest.mark.parametrize("increase", [True, False], ids=["True", "False"])
+@pytest.mark.parametrize("n", [0, 1, 4, None])
+@pytest.mark.parametrize("increase", [True, False])
 def test_vander(array, dtype, n, increase):
     if dtype in [dpnp.complex64, dpnp.complex128] and array == [0, 3, 5]:
         pytest.skip(
@@ -537,7 +542,7 @@ def test_vander_seq(sequence):
     "fill_value", [1.5, 2, 1.5 + 0.0j], ids=["1.5", "2", "1.5+0.j"]
 )
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_float16=False))
-@pytest.mark.parametrize("order", [None, "C", "F"], ids=["None", "C", "F"])
+@pytest.mark.parametrize("order", [None, "C", "F"])
 def test_full(shape, fill_value, dtype, order):
     func = lambda xp: xp.full(shape, fill_value, dtype=dtype, order=order)
     assert_array_equal(func(numpy), func(dpnp))
@@ -562,8 +567,8 @@ def test_full_like(array, fill_value, dtype, order):
     assert_array_equal(func(numpy, a), func(dpnp, ia))
 
 
-@pytest.mark.parametrize("order1", ["F", "C"], ids=["F", "C"])
-@pytest.mark.parametrize("order2", ["F", "C"], ids=["F", "C"])
+@pytest.mark.parametrize("order1", ["F", "C"])
+@pytest.mark.parametrize("order2", ["F", "C"])
 def test_full_order(order1, order2):
     array = numpy.array([1, 2, 3], order=order1)
     a = numpy.full((3, 3), array, order=order2)
@@ -600,7 +605,7 @@ def test_full_invalid_fill_value(fill_value):
     ids=["()", "0", "(0,)", "(2, 0, 3)", "(3, 2)"],
 )
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_float16=False))
-@pytest.mark.parametrize("order", [None, "C", "F"], ids=["None", "C", "F"])
+@pytest.mark.parametrize("order", [None, "C", "F"])
 def test_zeros(shape, dtype, order):
     func = lambda xp: xp.zeros(shape, dtype=dtype, order=order)
     assert_array_equal(func(numpy), func(dpnp))
@@ -627,7 +632,7 @@ def test_zeros_like(array, dtype, order):
     ids=["()", "0", "(0,)", "(2, 0, 3)", "(3, 2)"],
 )
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_float16=False))
-@pytest.mark.parametrize("order", [None, "C", "F"], ids=["None", "C", "F"])
+@pytest.mark.parametrize("order", [None, "C", "F"])
 def test_empty(shape, dtype, order):
     func = lambda xp: xp.empty(shape, dtype=dtype, order=order)
     assert func(numpy).shape == func(dpnp).shape
@@ -654,7 +659,7 @@ def test_empty_like(array, dtype, order):
     ids=["()", "0", "(0,)", "(2, 0, 3)", "(3, 2)"],
 )
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_float16=False))
-@pytest.mark.parametrize("order", [None, "C", "F"], ids=["None", "C", "F"])
+@pytest.mark.parametrize("order", [None, "C", "F"])
 def test_ones(shape, dtype, order):
     func = lambda xp: xp.ones(shape, dtype=dtype, order=order)
     assert_array_equal(func(numpy), func(dpnp))
@@ -695,12 +700,8 @@ def test_dpctl_tensor_input(func, args):
         assert_array_equal(X, Y)
 
 
-@pytest.mark.parametrize(
-    "start", [0, -5, 10, -2.5, 9.7], ids=["0", "-5", "10", "-2.5", "9.7"]
-)
-@pytest.mark.parametrize(
-    "stop", [0, 10, -2, 20.5, 1000], ids=["0", "10", "-2", "20.5", "1000"]
-)
+@pytest.mark.parametrize("start", [0, -5, 10, -2.5, 9.7])
+@pytest.mark.parametrize("stop", [0, 10, -2, 20.5, 1000])
 @pytest.mark.parametrize(
     "num",
     [1, 5, numpy.array(10), dpnp.array(17), dpt.asarray(100)],
@@ -709,7 +710,7 @@ def test_dpctl_tensor_input(func, args):
 @pytest.mark.parametrize(
     "dtype", get_all_dtypes(no_bool=True, no_float16=False)
 )
-@pytest.mark.parametrize("retstep", [True, False], ids=["True", "False"])
+@pytest.mark.parametrize("retstep", [True, False])
 def test_linspace(start, stop, num, dtype, retstep):
     res_np = numpy.linspace(start, stop, num, dtype=dtype, retstep=retstep)
     res_dp = dpnp.linspace(start, stop, num, dtype=dtype, retstep=retstep)
@@ -803,7 +804,7 @@ def test_linspace_retstep(start, stop):
     ids=["[]", "[[1]]", "[[1, 2, 3], [4, 5, 6]]", "[[1, 2], [3, 4], [5, 6]]"],
 )
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_float16=False))
-@pytest.mark.parametrize("indexing", ["ij", "xy"], ids=["ij", "xy"])
+@pytest.mark.parametrize("indexing", ["ij", "xy"])
 def test_meshgrid(arrays, dtype, indexing):
     func = lambda xp, xi: xp.meshgrid(*xi, indexing=indexing)
     a = tuple(numpy.array(array, dtype=dtype) for array in arrays)

--- a/tests/test_manipulation.py
+++ b/tests/test_manipulation.py
@@ -686,62 +686,6 @@ class TestRequire:
         assert_array_equal(expected, result)
 
 
-class TestResize:
-    @pytest.mark.parametrize(
-        "data, shape",
-        [
-            pytest.param([[1, 2], [3, 4]], (2, 4)),
-            pytest.param([[1, 2], [3, 4], [1, 2], [3, 4]], (4, 2)),
-            pytest.param([[1, 2, 3], [4, 1, 2], [3, 4, 1], [2, 3, 4]], (4, 3)),
-        ],
-    )
-    def test_copies(self, data, shape):
-        a = numpy.array(data)
-        ia = dpnp.array(a)
-        assert_equal(dpnp.resize(ia, shape), numpy.resize(a, shape))
-
-    @pytest.mark.parametrize("newshape", [(2, 4), [2, 4], (10,), 10])
-    def test_newshape_type(self, newshape):
-        a = numpy.array([[1, 2], [3, 4]])
-        ia = dpnp.array(a)
-        assert_equal(dpnp.resize(ia, newshape), numpy.resize(a, newshape))
-
-    @pytest.mark.parametrize(
-        "data, shape",
-        [
-            pytest.param([1, 2, 3], (2, 4)),
-            pytest.param([[1, 2], [3, 1], [2, 3], [1, 2]], (4, 2)),
-            pytest.param([[1, 2, 3], [1, 2, 3], [1, 2, 3], [1, 2, 3]], (4, 3)),
-        ],
-    )
-    def test_repeats(self, data, shape):
-        a = numpy.array(data)
-        ia = dpnp.array(a)
-        assert_equal(dpnp.resize(ia, shape), numpy.resize(a, shape))
-
-    def test_zeroresize(self):
-        a = numpy.array([[1, 2], [3, 4]])
-        ia = dpnp.array(a)
-        assert_array_equal(dpnp.resize(ia, (0,)), numpy.resize(a, (0,)))
-        assert_equal(a.dtype, ia.dtype)
-
-        assert_equal(dpnp.resize(ia, (0, 2)), numpy.resize(a, (0, 2)))
-        assert_equal(dpnp.resize(ia, (2, 0)), numpy.resize(a, (2, 0)))
-
-    def test_reshape_from_zero(self):
-        a = numpy.zeros(0, dtype=numpy.float32)
-        ia = dpnp.array(a)
-        assert_array_equal(dpnp.resize(ia, (2, 1)), numpy.resize(a, (2, 1)))
-        assert_equal(a.dtype, ia.dtype)
-
-    @pytest.mark.parametrize("xp", [numpy, dpnp])
-    def test_negative_resize(self, xp):
-        a = xp.arange(0, 10, dtype=xp.float32)
-        new_shape = (-10, -1)
-        with pytest.raises(ValueError, match=r"negative"):
-            xp.resize(a, new_shape=new_shape)
-
-
 class TestReshape:
     def test_error(self):
         ia = dpnp.arange(10)
@@ -815,6 +759,62 @@ class TestReshape:
         assert_raises(
             ValueError, dpnp.reshape, ia, (5, 2), order="F", copy=False
         )
+
+
+class TestResize:
+    @pytest.mark.parametrize(
+        "data, shape",
+        [
+            pytest.param([[1, 2], [3, 4]], (2, 4)),
+            pytest.param([[1, 2], [3, 4], [1, 2], [3, 4]], (4, 2)),
+            pytest.param([[1, 2, 3], [4, 1, 2], [3, 4, 1], [2, 3, 4]], (4, 3)),
+        ],
+    )
+    def test_copies(self, data, shape):
+        a = numpy.array(data)
+        ia = dpnp.array(a)
+        assert_equal(dpnp.resize(ia, shape), numpy.resize(a, shape))
+
+    @pytest.mark.parametrize("newshape", [(2, 4), [2, 4], (10,), 10])
+    def test_newshape_type(self, newshape):
+        a = numpy.array([[1, 2], [3, 4]])
+        ia = dpnp.array(a)
+        assert_equal(dpnp.resize(ia, newshape), numpy.resize(a, newshape))
+
+    @pytest.mark.parametrize(
+        "data, shape",
+        [
+            pytest.param([1, 2, 3], (2, 4)),
+            pytest.param([[1, 2], [3, 1], [2, 3], [1, 2]], (4, 2)),
+            pytest.param([[1, 2, 3], [1, 2, 3], [1, 2, 3], [1, 2, 3]], (4, 3)),
+        ],
+    )
+    def test_repeats(self, data, shape):
+        a = numpy.array(data)
+        ia = dpnp.array(a)
+        assert_equal(dpnp.resize(ia, shape), numpy.resize(a, shape))
+
+    def test_zeroresize(self):
+        a = numpy.array([[1, 2], [3, 4]])
+        ia = dpnp.array(a)
+        assert_array_equal(dpnp.resize(ia, (0,)), numpy.resize(a, (0,)))
+        assert_equal(a.dtype, ia.dtype)
+
+        assert_equal(dpnp.resize(ia, (0, 2)), numpy.resize(a, (0, 2)))
+        assert_equal(dpnp.resize(ia, (2, 0)), numpy.resize(a, (2, 0)))
+
+    def test_reshape_from_zero(self):
+        a = numpy.zeros(0, dtype=numpy.float32)
+        ia = dpnp.array(a)
+        assert_array_equal(dpnp.resize(ia, (2, 1)), numpy.resize(a, (2, 1)))
+        assert_equal(a.dtype, ia.dtype)
+
+    @pytest.mark.parametrize("xp", [numpy, dpnp])
+    def test_negative_resize(self, xp):
+        a = xp.arange(0, 10, dtype=xp.float32)
+        new_shape = (-10, -1)
+        with pytest.raises(ValueError, match=r"negative"):
+            xp.resize(a, new_shape=new_shape)
 
 
 class TestRot90:

--- a/tests/test_manipulation.py
+++ b/tests/test_manipulation.py
@@ -299,122 +299,6 @@ class TestArraySplit:
         _compare_results(result, expected)
 
 
-class TestSplit:
-    # The split function is essentially the same as array_split,
-    # except that it test if splitting will result in an
-    # equal split. Only test for this case.
-    def test_equal_split(self):
-        a = numpy.arange(10)
-        a_dp = dpnp.array(a)
-
-        expected = numpy.split(a, 2)
-        result = dpnp.split(a_dp, 2)
-        _compare_results(result, expected)
-
-    @pytest.mark.parametrize("xp", [numpy, dpnp])
-    def test_unequal_split(self, xp):
-        a = xp.arange(10)
-        assert_raises(ValueError, xp.split, a, 3)
-
-    @pytest.mark.parametrize("xp", [numpy, dpnp])
-    def test_error(self, xp):
-        # axis out of range
-        a = xp.arange(9)
-        assert_raises(IndexError, xp.split, a, 3, axis=1)
-
-    @pytest.mark.parametrize(
-        "indices",
-        [
-            2,
-            3.0,
-            dpnp.int64(5),
-            dpnp.int32(5),
-            dpnp.array(6),
-            numpy.array(7),
-            numpy.int32(5),
-        ],
-    )
-    def test_integer_split(self, indices):
-        a = numpy.arange(10)
-        a_dp = dpnp.array(a)
-
-        expected = numpy.array_split(a, indices)
-        result = dpnp.array_split(a_dp, indices)
-        _compare_results(result, expected)
-
-
-# array_split has more comprehensive test of splitting.
-# only do simple test on hsplit, vsplit, and dsplit
-class TestHsplit:
-    @pytest.mark.parametrize("xp", [numpy, dpnp])
-    def test_error(self, xp):
-        # 0D array
-        a = xp.array(1)
-        assert_raises(ValueError, xp.hsplit, a, 2)
-
-    def test_1D_array(self):
-        a = numpy.array([1, 2, 3, 4])
-        a_dp = dpnp.array(a)
-
-        expected = numpy.hsplit(a, 2)
-        result = dpnp.hsplit(a_dp, 2)
-        _compare_results(result, expected)
-
-    def test_2D_array(self):
-        a = numpy.array([[1, 2, 3, 4], [1, 2, 3, 4]])
-        a_dp = dpnp.array(a)
-
-        expected = numpy.hsplit(a, 2)
-        result = dpnp.hsplit(a_dp, 2)
-        _compare_results(result, expected)
-
-
-class TestVsplit:
-    @pytest.mark.parametrize("xp", [numpy, dpnp])
-    def test_error(self, xp):
-        # 0D array
-        a = xp.array(1)
-        assert_raises(ValueError, xp.vsplit, a, 2)
-
-        # 1D array
-        a = xp.array([1, 2, 3, 4])
-        assert_raises(ValueError, xp.vsplit, a, 2)
-
-    def test_2D_array(self):
-        a = numpy.array([[1, 2, 3, 4], [1, 2, 3, 4]])
-        a_dp = dpnp.array(a)
-
-        expected = numpy.vsplit(a, 2)
-        result = dpnp.vsplit(a_dp, 2)
-        _compare_results(result, expected)
-
-
-class TestDsplit:
-    @pytest.mark.parametrize("xp", [numpy, dpnp])
-    def test_error(self, xp):
-        # 0D array
-        a = xp.array(1)
-        assert_raises(ValueError, xp.dsplit, a, 2)
-
-        # 1D array
-        a = xp.array([1, 2, 3, 4])
-        assert_raises(ValueError, xp.dsplit, a, 2)
-
-        # 2D array
-        a = xp.array([[1, 2, 3, 4], [1, 2, 3, 4]])
-        assert_raises(ValueError, xp.dsplit, a, 2)
-
-    def test_3D_array(self):
-        a = numpy.array(
-            [[[1, 2, 3, 4], [1, 2, 3, 4]], [[1, 2, 3, 4], [1, 2, 3, 4]]]
-        )
-        a_dp = dpnp.array(a)
-
-        expected = numpy.dsplit(a, 2)
-        result = dpnp.dsplit(a_dp, 2)
-        _compare_results(result, expected)
-
-
 class TestAsarrayCheckFinite:
     @pytest.mark.parametrize("dtype", get_all_dtypes())
     def test_basic(self, dtype):
@@ -446,6 +330,58 @@ class TestAsarrayCheckFinite:
         # b is a view of a, changing b, modifies a
         b[0::2] = 0
         assert_array_equal(b, a)
+
+
+class TestDsplit:
+    @pytest.mark.parametrize("xp", [numpy, dpnp])
+    def test_error(self, xp):
+        # 0D array
+        a = xp.array(1)
+        assert_raises(ValueError, xp.dsplit, a, 2)
+
+        # 1D array
+        a = xp.array([1, 2, 3, 4])
+        assert_raises(ValueError, xp.dsplit, a, 2)
+
+        # 2D array
+        a = xp.array([[1, 2, 3, 4], [1, 2, 3, 4]])
+        assert_raises(ValueError, xp.dsplit, a, 2)
+
+    def test_3D_array(self):
+        a = numpy.array(
+            [[[1, 2, 3, 4], [1, 2, 3, 4]], [[1, 2, 3, 4], [1, 2, 3, 4]]]
+        )
+        a_dp = dpnp.array(a)
+
+        expected = numpy.dsplit(a, 2)
+        result = dpnp.dsplit(a_dp, 2)
+        _compare_results(result, expected)
+
+
+# array_split has more comprehensive test of splitting.
+# only do simple test on hsplit, vsplit, and dsplit
+class TestHsplit:
+    @pytest.mark.parametrize("xp", [numpy, dpnp])
+    def test_error(self, xp):
+        # 0D array
+        a = xp.array(1)
+        assert_raises(ValueError, xp.hsplit, a, 2)
+
+    def test_1D_array(self):
+        a = numpy.array([1, 2, 3, 4])
+        a_dp = dpnp.array(a)
+
+        expected = numpy.hsplit(a, 2)
+        result = dpnp.hsplit(a_dp, 2)
+        _compare_results(result, expected)
+
+    def test_2D_array(self):
+        a = numpy.array([[1, 2, 3, 4], [1, 2, 3, 4]])
+        a_dp = dpnp.array(a)
+
+        expected = numpy.hsplit(a, 2)
+        result = dpnp.hsplit(a_dp, 2)
+        _compare_results(result, expected)
 
 
 class TestRavel:
@@ -939,6 +875,50 @@ class TestRot90:
                 dpnp.rot90(ia, k=k, axes=(2, 0)),
                 numpy.rot90(a, k=k, axes=(2, 0)),
             )
+
+
+class TestSplit:
+    # The split function is essentially the same as array_split,
+    # except that it test if splitting will result in an
+    # equal split. Only test for this case.
+    def test_equal_split(self):
+        a = numpy.arange(10)
+        a_dp = dpnp.array(a)
+
+        expected = numpy.split(a, 2)
+        result = dpnp.split(a_dp, 2)
+        _compare_results(result, expected)
+
+    @pytest.mark.parametrize("xp", [numpy, dpnp])
+    def test_unequal_split(self, xp):
+        a = xp.arange(10)
+        assert_raises(ValueError, xp.split, a, 3)
+
+    @pytest.mark.parametrize("xp", [numpy, dpnp])
+    def test_error(self, xp):
+        # axis out of range
+        a = xp.arange(9)
+        assert_raises(IndexError, xp.split, a, 3, axis=1)
+
+    @pytest.mark.parametrize(
+        "indices",
+        [
+            2,
+            3.0,
+            dpnp.int64(5),
+            dpnp.int32(5),
+            dpnp.array(6),
+            numpy.array(7),
+            numpy.int32(5),
+        ],
+    )
+    def test_integer_split(self, indices):
+        a = numpy.arange(10)
+        a_dp = dpnp.array(a)
+
+        expected = numpy.array_split(a, indices)
+        result = dpnp.array_split(a_dp, indices)
+        _compare_results(result, expected)
 
 
 class TestTranspose:
@@ -1446,3 +1426,23 @@ class TestUnique:
                 )
             for iv, v in zip(result, expected):
                 assert_array_equal(iv, v)
+
+
+class TestVsplit:
+    @pytest.mark.parametrize("xp", [numpy, dpnp])
+    def test_error(self, xp):
+        # 0D array
+        a = xp.array(1)
+        assert_raises(ValueError, xp.vsplit, a, 2)
+
+        # 1D array
+        a = xp.array([1, 2, 3, 4])
+        assert_raises(ValueError, xp.vsplit, a, 2)
+
+    def test_2D_array(self):
+        a = numpy.array([[1, 2, 3, 4], [1, 2, 3, 4]])
+        a_dp = dpnp.array(a)
+
+        expected = numpy.vsplit(a, 2)
+        result = dpnp.vsplit(a_dp, 2)
+        _compare_results(result, expected)

--- a/tests/test_sycl_queue.py
+++ b/tests/test_sycl_queue.py
@@ -688,7 +688,8 @@ def test_reduce_hypot(device):
         pytest.param(
             "allclose", [1.0, dpnp.inf, -dpnp.inf], [1.0, dpnp.inf, -dpnp.inf]
         ),
-        pytest.param("arctan2", [[-1, +1, +1, -1]], [[-1, -1, +1, +1]]),
+        pytest.param("append", [1, 2, 3], [4, 5, 6]),
+        pytest.param("arctan2", [-1, +1, +1, -1], [-1, -1, +1, +1]),
         pytest.param("copysign", [0.0, 1.0, 2.0], [-1.0, 0.0, 1.0]),
         pytest.param("cross", [1.0, 2.0, 3.0], [4.0, 5.0, 6.0]),
         pytest.param("digitize", [0.2, 6.4, 3.0], [0.0, 1.0, 2.5, 4.0]),
@@ -1482,11 +1483,7 @@ def test_cholesky(data, is_empty, device):
     valid_devices,
     ids=[device.filter_string for device in valid_devices],
 )
-@pytest.mark.parametrize(
-    "p",
-    [None, -dpnp.inf, -2, -1, 1, 2, dpnp.inf, "fro"],
-    ids=["None", "-dpnp.inf", "-2", "-1", "1", "2", "dpnp.inf", "fro"],
-)
+@pytest.mark.parametrize("p", [None, -dpnp.inf, -2, -1, 1, 2, dpnp.inf, "fro"])
 def test_cond(device, p):
     numpy.random.seed(42)
     a = numpy.array(numpy.random.uniform(-5, 5, 16)).reshape(4, 4)
@@ -1645,11 +1642,7 @@ def test_inv(shape, is_empty, device):
     assert_sycl_queue_equal(result_queue, expected_queue)
 
 
-@pytest.mark.parametrize(
-    "n",
-    [-1, 0, 1, 2, 3],
-    ids=["-1", "0", "1", "2", "3"],
-)
+@pytest.mark.parametrize("n", [-1, 0, 1, 2, 3])
 @pytest.mark.parametrize(
     "device",
     valid_devices,
@@ -1707,20 +1700,7 @@ def test_matrix_rank(data, tol, device):
     ids=[device.filter_string for device in valid_devices],
 )
 @pytest.mark.parametrize(
-    "ord",
-    [None, -dpnp.inf, -2, -1, 1, 2, 3, dpnp.inf, "fro", "nuc"],
-    ids=[
-        "None",
-        "-dpnp.inf",
-        "-2",
-        "-1",
-        "1",
-        "2",
-        "3",
-        "dpnp.inf",
-        '"fro"',
-        '"nuc"',
-    ],
+    "ord", [None, -dpnp.inf, -2, -1, 1, 2, 3, dpnp.inf, "fro", "nuc"]
 )
 @pytest.mark.parametrize(
     "axis",
@@ -1916,9 +1896,7 @@ def test_array_copy(device, func, device_param, queue_param):
     assert_sycl_queue_equal(result.sycl_queue, dpnp_data.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "copy", [True, False, None], ids=["True", "False", "None"]
-)
+@pytest.mark.parametrize("copy", [True, False, None])
 @pytest.mark.parametrize(
     "device",
     valid_devices,
@@ -2006,25 +1984,6 @@ def test_concat_stack(func, data1, data2, device):
     x1 = dpnp.array(data1, device=device)
     x2 = dpnp.array(data2, device=device)
     result = getattr(dpnp, func)((x1, x2))
-
-    assert_allclose(result, expected)
-    assert_sycl_queue_equal(result.sycl_queue, x1.sycl_queue)
-    assert_sycl_queue_equal(result.sycl_queue, x2.sycl_queue)
-
-
-@pytest.mark.parametrize(
-    "device",
-    valid_devices,
-    ids=[device.filter_string for device in valid_devices],
-)
-def test_append(device):
-    x1_orig = numpy.array([1, 2, 3])
-    x2_orig = numpy.array([4, 5, 6])
-    expected = numpy.append(x1_orig, x2_orig)
-
-    x1 = dpnp.array(x1_orig, device=device)
-    x2 = dpnp.array(x2_orig, device=device)
-    result = dpnp.append(x1, x2)
 
     assert_allclose(result, expected)
     assert_sycl_queue_equal(result.sycl_queue, x1.sycl_queue)

--- a/tests/test_usm_type.py
+++ b/tests/test_usm_type.py
@@ -344,9 +344,7 @@ def test_array_copy(func, usm_type_x, usm_type_y):
     assert y.usm_type == usm_type_y
 
 
-@pytest.mark.parametrize(
-    "copy", [True, False, None], ids=["True", "False", "None"]
-)
+@pytest.mark.parametrize("copy", [True, False, None])
 @pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
 def test_array_creation_from_dpctl(copy, usm_type_x):
     x = dpt.ones((3, 3), usm_type=usm_type_x)
@@ -510,20 +508,7 @@ def test_meshgrid(usm_type_x, usm_type_y):
 
 @pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
 @pytest.mark.parametrize(
-    "ord",
-    [None, -dp.inf, -2, -1, 1, 2, 3, dp.inf, "fro", "nuc"],
-    ids=[
-        "None",
-        "-dpnp.inf",
-        "-2",
-        "-1",
-        "1",
-        "2",
-        "3",
-        "dpnp.inf",
-        '"fro"',
-        '"nuc"',
-    ],
+    "ord", [None, -dp.inf, -2, -1, 1, 2, 3, dp.inf, "fro", "nuc"]
 )
 @pytest.mark.parametrize(
     "axis",
@@ -667,7 +652,8 @@ def test_1in_1out(func, data, usm_type):
             [[1.2, -0.0], [-7, 2.34567]],
             [[1.2, 0.0], [-7, 2.34567]],
         ),
-        pytest.param("arctan2", [[-1, +1, +1, -1]], [[-1, -1, +1, +1]]),
+        pytest.param("append", [1, 2, 3], [4, 5, 6]),
+        pytest.param("arctan2", [-1, +1, +1, -1], [-1, -1, +1, +1]),
         pytest.param("copysign", [0.0, 1.0, 2.0], [-1.0, 0.0, 1.0]),
         pytest.param("cross", [1.0, 2.0, 3.0], [4.0, 5.0, 6.0]),
         pytest.param("digitize", [0.2, 6.4, 3.0], [0.0, 1.0, 2.5, 4.0]),
@@ -676,8 +662,7 @@ def test_1in_1out(func, data, usm_type):
         pytest.param("dot", [3.0, 4.0, 5.0], [1.0, 2.0, 3.0]),
         pytest.param("dot", [3, 4, 5], [1, 2, 3]),
         pytest.param("dot", [3 + 2j, 4 + 1j, 5], [1, 2 + 3j, 3]),
-        # TODO: uncomment once resolved in gh-1723 by dpctl
-        # pytest.param("extract", [False, True, True, False], [0, 1, 2, 3]),
+        pytest.param("extract", [False, True, True, False], [0, 1, 2, 3]),
         pytest.param(
             "float_power",
             [0, 1, 2, 3, 4, 5],
@@ -808,24 +793,8 @@ def test_split(func, data1, usm_type):
     assert y[1].usm_type == usm_type
 
 
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
-def test_append(usm_type_x, usm_type_y):
-    x = dp.array([1, 2, 3], usm_type=usm_type_x)
-    y = dp.array([4, 5, 6], usm_type=usm_type_y)
-    z = dp.append(x, y)
-
-    assert x.usm_type == usm_type_x
-    assert y.usm_type == usm_type_y
-    assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
-
-
 @pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize(
-    "p",
-    [None, -dp.inf, -2, -1, 1, 2, dp.inf, "fro"],
-    ids=["None", "-dpnp.inf", "-2", "-1", "1", "2", "dpnp.inf", "fro"],
-)
+@pytest.mark.parametrize("p", [None, -dp.inf, -2, -1, 1, 2, dp.inf, "fro"])
 def test_cond(usm_type, p):
     ia = dp.arange(32, usm_type=usm_type).reshape(2, 4, 4)
 
@@ -1296,11 +1265,7 @@ def test_svd(usm_type, shape, full_matrices_param, compute_uv_param):
     assert x.usm_type == s.usm_type
 
 
-@pytest.mark.parametrize(
-    "n",
-    [-1, 0, 1, 2, 3],
-    ids=["-1", "0", "1", "2", "3"],
-)
+@pytest.mark.parametrize("n", [-1, 0, 1, 2, 3])
 @pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
 def test_matrix_power(n, usm_type):
     a = dp.array([[1, 2], [3, 5]], usm_type=usm_type)


### PR DESCRIPTION
In this PR, support for `ndmin` kwarg is added for `dpnp.array` , new tests are added and cupy tests are updated to include relevant test cases.
In addition, test classes in `test_manipulation` are re-ordered to follow alphabetic order:

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
