### PR TITLE
Remove `pytest.mark.skip`, since slow mark is supported

### DIFF
--- a/tests/third_party/cupy/sorting_tests/test_search.py
+++ b/tests/third_party/cupy/sorting_tests/test_search.py
@@ -82,7 +82,6 @@ class TestSearch:
         return a.argmax(axis=1)
 
     @testing.slow
-    @pytest.mark.skip("slow mark is not implemented")
     def test_argmax_int32_overflow(self):
         a = testing.shaped_arange((2**32 + 1,), cupy, numpy.float64)
         assert a.argmax().item() == 2**32
@@ -162,7 +161,6 @@ class TestSearch:
         return a.argmin(axis=1)
 
     @testing.slow
-    @pytest.mark.skip("slow mark is not implemented")
     def test_argmin_int32_overflow(self):
         a = testing.shaped_arange((2**32 + 1,), cupy, numpy.float64)
         cupy.negative(a, out=a)


### PR DESCRIPTION
The slow mark was implemented in scope of #1831.
So the PR is about to remove `pytest.mark.skip` around slow tests, because tests deselecting is now done through `slow` mark.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
