### PR TITLE
Remove TODO comments with `itemset` and `newbyteorder` methods of dpnp.ndarray

### DIFF
--- a/doc/reference/ndarray.rst
+++ b/doc/reference/ndarray.rst
@@ -134,7 +134,6 @@ Array conversion
 
    dpnp.ndarray.item
    dpnp.ndarray.tolist
-   dpnp.ndarray.itemset
    dpnp.ndarray.tostring
    dpnp.ndarray.tobytes
    dpnp.ndarray.tofile

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -1087,8 +1087,6 @@ class dpnp_array:
 
         return self.flat[id]
 
-    # 'itemset',
-
     @property
     def itemsize(self):
         """Size of one array element in bytes."""
@@ -1192,8 +1190,6 @@ class dpnp_array:
         """
 
         return self._array_obj.ndim
-
-    # 'newbyteorder',
 
     def nonzero(self):
         """


### PR DESCRIPTION
Currently `itemset` and `newbyteorder` methods are not implemented for `dpnp.ndarray`, but TODO comment was left in the code where it was expected to have the implementation.
Since NumPy 2.0 removes these methods from `numpy.ndarray` it looks as not needed to implement them in dpnp.

So the PR proposes to clean up the code and to remove comments per `itemset` and `newbyteorder` methods, since they are not going to be implemented for `dpnp.ndarray` anymore.
The link of the methods are also removed from generated dpnp documentation.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
