### PR TITLE
updating a test for `dpnp.pad` with `mode="empty"` to avoid direct comparison

### DIFF
--- a/tests/test_arraypad.py
+++ b/tests/test_arraypad.py
@@ -432,7 +432,10 @@ class TestPad:
         a_dp = dpnp.array(a_np)
         expected = numpy.pad(a_np, [(0,), (2,), (1,)], mode)
         result = dpnp.pad(a_dp, [(0,), (2,), (1,)], mode)
-        assert_dtype_allclose(result, expected)
+        assert result.shape == expected.shape
+        if mode == "constant":
+            # In "empty" mode, arrays are uninitialized and comparing may fail
+            assert_dtype_allclose(result, expected)
 
     @pytest.mark.parametrize(
         "mode",


### PR DESCRIPTION
In this PR, a test for `dpnp.pad` with `mode="empty"` is updated to avoid direct comparison since in "empty" mode, arrays are uninitialized and comparing may fail.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
