### PR TITLE
Post a comments with link to built docs for PR from forked repo

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -12,7 +12,7 @@ env:
   GH_BOT_NAME: 'github-actions[bot]'
   GH_BOT_EMAIL: 'github-actions[bot]@users.noreply.github.com'
   GH_EVENT_OPEN_PR_UPSTREAM: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' &&
-                                 github.event.pull_request && !github.event.pull_request.head.repo.fork }}
+                                 github.event.pull_request && !github.event.pull_request.base.repo.fork }}
   GH_EVENT_PUSH_UPSTREAM: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' &&
                               github.event.ref == 'refs/heads/master' && github.event.repository && !github.event.repository.fork }}
   PUBLISH_DIR: doc/_build/html/
@@ -224,7 +224,7 @@ jobs:
   clean:
     if: |
       github.event_name == 'pull_request' && github.event.action == 'closed' &&
-      github.event.pull_request && !github.event.pull_request.head.repo.fork
+      github.event.pull_request && !github.event.pull_request.base.repo.fork
 
     needs: build-and-deploy
 


### PR DESCRIPTION
The PR enables posting a comment with link to rendered documentation for a PR from forked repository.

Previously the check was based on repo data of a pull request entry (i.e. `github.event.pull_request.head.repo`). It means the step with comment will be disable for a PR created in forked repo. But it can merged either into fork repo itself or into original repo (i.e. the repo it was forked from). And the second option is valid, i.e. it has to be allowed posting a comment with docs for a PR coming from the fork but into the origin repo.
To do that it is proposed to check `fork` property of `github.event.pull_request.base.repo` entry, i.e. info about repo where the PR is going to be merged.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
