### PR TITLE
Add inplace matrix multiplication

### DIFF
--- a/doc/reference/ndarray.rst
+++ b/doc/reference/ndarray.rst
@@ -361,7 +361,7 @@ For standard library functions:
 
    dpnp.ndarray.__copy__
    dpnp.ndarray.__deepcopy__
-   dpnp.ndarray.__reduce__
+   .. dpnp.ndarray.__reduce__
    dpnp.ndarray.__setstate__
 
 Basic customization:

--- a/doc/reference/ndarray.rst
+++ b/doc/reference/ndarray.rst
@@ -249,7 +249,7 @@ Comparison operators:
    dpnp.ndarray.__eq__
    dpnp.ndarray.__ne__
 
-Truth value of an array (:func:`bool()`):
+Truth value of an array (:class:`bool() <bool>`):
 
 .. autosummary::
    :toctree: generated/
@@ -260,11 +260,11 @@ Truth value of an array (:func:`bool()`):
 
    Truth-value testing of an array invokes
    :meth:`dpnp.ndarray.__bool__`, which raises an error if the number of
-   elements in the array is larger than 1, because the truth value
+   elements in the array is not 1, because the truth value
    of such arrays is ambiguous. Use :meth:`.any() <dpnp.ndarray.any>` and
    :meth:`.all() <dpnp.ndarray.all>` instead to be clear about what is meant
-   in such cases. (If the number of elements is 0, the array evaluates
-   to ``False``.)
+   in such cases. (If you wish to check for whether an array is empty,
+   use for example ``.size > 0``.)
 
 
 Unary operations:
@@ -300,6 +300,26 @@ Arithmetic:
    dpnp.ndarray.__xor__
 
 
+Arithmetic, reflected:
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   dpnp.ndarray.__radd__
+   dpnp.ndarray.__rsub__
+   dpnp.ndarray.__rmul__
+   dpnp.ndarray.__rtruediv__
+   dpnp.ndarray.__rfloordiv__
+   dpnp.ndarray.__rmod__
+   dpnp.ndarray.__rpow__
+   dpnp.ndarray.__rlshift__
+   dpnp.ndarray.__rrshift__
+   dpnp.ndarray.__rand__
+   dpnp.ndarray.__ror__
+   dpnp.ndarray.__rxor__
+
+
 Arithmetic, in-place:
 
 .. autosummary::
@@ -326,6 +346,8 @@ Matrix Multiplication:
    :toctree: generated/
 
    dpnp.ndarray.__matmul__
+   dpnp.ndarray.__rmatmul__
+   dpnp.ndarray.__imatmul__
 
 
 Special methods
@@ -339,7 +361,7 @@ For standard library functions:
 
    dpnp.ndarray.__copy__
    dpnp.ndarray.__deepcopy__
-   .. dpnp.ndarray.__reduce__
+   dpnp.ndarray.__reduce__
    dpnp.ndarray.__setstate__
 
 Basic customization:

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -386,7 +386,8 @@ class dpnp_array:
             # AxisError should indicate that the axes argument didn't work out
             # which should mean the second operand not being 2 dimensional.
             raise ValueError(
-                "inplace matrix multiplication requires the first operand to have at least one and the second at least two dimensions."
+                "inplace matrix multiplication requires the first operand to "
+                "have at least one and the second at least two dimensions."
             )
         return self
 

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -488,9 +488,11 @@ class dpnp_array:
         return dpnp.power(self, other)
 
     def __radd__(self, other):
+        """Return ``value+self``."""
         return dpnp.add(other, self)
 
     def __rand__(self, other):
+        """Return ``value&self``."""
         return dpnp.bitwise_and(other, self)
 
     # '__rdivmod__',
@@ -502,27 +504,35 @@ class dpnp_array:
         return dpt.usm_ndarray_repr(self._array_obj, prefix="array")
 
     def __rfloordiv__(self, other):
+        """Return ``value//self``."""
         return dpnp.floor_divide(self, other)
 
     def __rlshift__(self, other):
+        """Return ``value<<self``."""
         return dpnp.left_shift(other, self)
 
     def __rmatmul__(self, other):
+        """Return ``value@self``."""
         return dpnp.matmul(other, self)
 
     def __rmod__(self, other):
+        """Return ``value%self``."""
         return dpnp.remainder(other, self)
 
     def __rmul__(self, other):
+        """Return ``value*self``."""
         return dpnp.multiply(other, self)
 
     def __ror__(self, other):
+        """Return ``value|self``."""
         return dpnp.bitwise_or(other, self)
 
     def __rpow__(self, other):
+        """Return ``value**self``."""
         return dpnp.power(other, self)
 
     def __rrshift__(self, other):
+        """Return ``value>>self``."""
         return dpnp.right_shift(other, self)
 
     def __rshift__(self, other):
@@ -530,12 +540,15 @@ class dpnp_array:
         return dpnp.right_shift(self, other)
 
     def __rsub__(self, other):
+        """Return ``value-self``."""
         return dpnp.subtract(other, self)
 
     def __rtruediv__(self, other):
+        """Return ``value/self``."""
         return dpnp.true_divide(other, self)
 
     def __rxor__(self, other):
+        """Return ``value^self``."""
         return dpnp.bitwise_xor(other, self)
 
     # '__setattr__',

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -25,6 +25,7 @@
 # *****************************************************************************
 
 import dpctl.tensor as dpt
+from dpctl.tensor._numpy_helper import AxisError
 
 import dpnp
 
@@ -379,7 +380,14 @@ class dpnp_array:
         else:
             axes = [(-2, -1), (-2, -1), (-2, -1)]
 
-        dpnp.matmul(self, other, out=self, axes=axes)
+        try:
+            dpnp.matmul(self, other, out=self, axes=axes)
+        except AxisError:
+            # AxisError should indicate that the axes argument didn't work out
+            # which should mean the second operand not being 2 dimensional.
+            raise ValueError(
+                "inplace matrix multiplication requires the first operand to have at least one and the second at least two dimensions."
+            )
         return self
 
     def __imod__(self, other):

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -372,9 +372,7 @@ class dpnp_array:
         if the result without `out` would have less dimensions than `a`.
         Since the signature of matmul is '(n?,k),(k,m?)->(n?,m?)' this is the
         case exactly when the second operand has both core dimensions.
-
-        The error here will be confusing, but for now, we enforce this by
-        passing the correct `axes=`.
+        We have to enforce this check by passing the correct `axes=`.
         """
         if self.ndim == 1:
             axes = [(-1,), (-2, -1), (-1,)]

--- a/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
+++ b/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
@@ -563,7 +563,7 @@ def _validate_axes(x1, x2, axes, func):
 
     if x1_ndim == 1 and x2_ndim == 1:
         if axes[2] != ():
-            raise TypeError("Axes item 2 should be an empty tuple.")
+            raise ValueError("Axes item 2 should be an empty tuple.")
     elif x1_ndim == 1 or x2_ndim == 1:
         axes[2] = _validate_internal(axes[2], 2, 1)
     else:

--- a/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
+++ b/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
@@ -28,7 +28,7 @@ import dpctl.tensor as dpt
 import dpctl.tensor._tensor_impl as ti
 import dpctl.utils as dpu
 import numpy
-from dpctl.tensor._numpy_helper import normalize_axis_tuple
+from dpctl.tensor._numpy_helper import AxisError, normalize_axis_tuple
 from dpctl.utils import ExecutionPlacementError
 
 import dpnp
@@ -525,7 +525,7 @@ def _validate_axes(x1, x2, axes, func):
                 )
 
             if len(axes) != 1:
-                raise ValueError(
+                raise AxisError(
                     f"Axes item {i} should be a tuple with a single element, or an integer."
                 )
         else:
@@ -533,7 +533,7 @@ def _validate_axes(x1, x2, axes, func):
             if not isinstance(axes, tuple):
                 raise TypeError(f"Axes item {i} should be a tuple.")
             if len(axes) != 2:
-                raise ValueError(
+                raise AxisError(
                     f"Axes item {i} should be a tuple with 2 elements."
                 )
 
@@ -563,7 +563,7 @@ def _validate_axes(x1, x2, axes, func):
 
     if x1_ndim == 1 and x2_ndim == 1:
         if axes[2] != ():
-            raise ValueError("Axes item 2 should be an empty tuple.")
+            raise AxisError("Axes item 2 should be an empty tuple.")
     elif x1_ndim == 1 or x2_ndim == 1:
         axes[2] = _validate_internal(axes[2], 2, 1)
     else:

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -4228,24 +4228,25 @@ class TestMatmulInplace:
 
 
 class TestMatmulInvalidCases:
+    @pytest.mark.parametrize("xp", [numpy, dpnp])
     @pytest.mark.parametrize(
-        "shape_pair",
+        "shape1, shape2",
         [
             ((3, 2), ()),
             ((), (3, 2)),
             ((), ()),
         ],
     )
-    def test_zero_dim(self, shape_pair):
-        for xp in (numpy, dpnp):
-            shape1, shape2 = shape_pair
-            x1 = xp.arange(numpy.prod(shape1), dtype=xp.float32).reshape(shape1)
-            x2 = xp.arange(numpy.prod(shape2), dtype=xp.float32).reshape(shape2)
-            with pytest.raises(ValueError):
-                xp.matmul(x1, x2)
+    def test_zero_dim(self, xp, shape1, shape2):
+        x1 = xp.arange(numpy.prod(shape1), dtype=xp.float32).reshape(shape1)
+        x2 = xp.arange(numpy.prod(shape2), dtype=xp.float32).reshape(shape2)
 
+        with pytest.raises(ValueError):
+            xp.matmul(x1, x2)
+
+    @pytest.mark.parametrize("xp", [numpy, dpnp])
     @pytest.mark.parametrize(
-        "shape_pair",
+        "shape1, shape2",
         [
             ((3,), (4,)),
             ((2, 3), (4, 5)),
@@ -4258,16 +4259,16 @@ class TestMatmulInvalidCases:
             ((6, 5, 3, 2), (3, 2, 4)),
         ],
     )
-    def test_invalid_shape(self, shape_pair):
-        for xp in (numpy, dpnp):
-            shape1, shape2 = shape_pair
-            x1 = xp.arange(numpy.prod(shape1), dtype=xp.float32).reshape(shape1)
-            x2 = xp.arange(numpy.prod(shape2), dtype=xp.float32).reshape(shape2)
-            with pytest.raises(ValueError):
-                xp.matmul(x1, x2)
+    def test_invalid_shape(self, xp, shape1, shape2):
+        x1 = xp.arange(numpy.prod(shape1), dtype=xp.float32).reshape(shape1)
+        x2 = xp.arange(numpy.prod(shape2), dtype=xp.float32).reshape(shape2)
 
+        with pytest.raises(ValueError):
+            xp.matmul(x1, x2)
+
+    @pytest.mark.parametrize("xp", [numpy, dpnp])
     @pytest.mark.parametrize(
-        "shape_pair",
+        "shape1, shape2, out_shape",
         [
             ((5, 4, 3), (3, 1), (3, 4, 1)),
             ((5, 4, 3), (3, 1), (5, 6, 1)),
@@ -4279,24 +4280,24 @@ class TestMatmulInvalidCases:
             ((4,), (3, 4, 5), (3, 6)),
         ],
     )
-    def test_invalid_shape_out(self, shape_pair):
-        for xp in (numpy, dpnp):
-            shape1, shape2, out_shape = shape_pair
-            x1 = xp.arange(numpy.prod(shape1), dtype=xp.float32).reshape(shape1)
-            x2 = xp.arange(numpy.prod(shape2), dtype=xp.float32).reshape(shape2)
-            res = xp.empty(out_shape)
-            with pytest.raises(ValueError):
-                xp.matmul(x1, x2, out=res)
+    def test_invalid_shape_out(self, xp, shape1, shape2, out_shape):
+        x1 = xp.arange(numpy.prod(shape1), dtype=xp.float32).reshape(shape1)
+        x2 = xp.arange(numpy.prod(shape2), dtype=xp.float32).reshape(shape2)
+        res = xp.empty(out_shape)
 
+        with pytest.raises(ValueError):
+            xp.matmul(x1, x2, out=res)
+
+    @pytest.mark.parametrize("xp", [numpy, dpnp])
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True)[:-2])
-    def test_invalid_dtype(self, dtype):
+    def test_invalid_dtype(self, xp, dtype):
         dpnp_dtype = get_all_dtypes(no_none=True)[-1]
-        a1 = dpnp.arange(5 * 4, dtype=dpnp_dtype).reshape(5, 4)
-        a2 = dpnp.arange(7 * 4, dtype=dpnp_dtype).reshape(4, 7)
-        dp_out = dpnp.empty((5, 7), dtype=dtype)
+        a1 = xp.arange(5 * 4, dtype=dpnp_dtype).reshape(5, 4)
+        a2 = xp.arange(7 * 4, dtype=dpnp_dtype).reshape(4, 7)
+        dp_out = xp.empty((5, 7), dtype=dtype)
 
         with pytest.raises(TypeError):
-            dpnp.matmul(a1, a2, out=dp_out)
+            xp.matmul(a1, a2, out=dp_out)
 
     def test_exe_q(self):
         x1 = dpnp.ones((5, 4), sycl_queue=dpctl.SyclQueue())
@@ -4310,13 +4311,14 @@ class TestMatmulInvalidCases:
         with pytest.raises(ExecutionPlacementError):
             dpnp.matmul(x1, x2, out=out)
 
-    def test_matmul_casting(self):
-        a1 = dpnp.arange(2 * 4, dtype=dpnp.float32).reshape(2, 4)
-        a2 = dpnp.arange(4 * 3).reshape(4, 3)
+    @pytest.mark.parametrize("xp", [numpy, dpnp])
+    def test_matmul_casting(self, xp):
+        a1 = xp.arange(2 * 4, dtype=xp.float32).reshape(2, 4)
+        a2 = xp.arange(4 * 3).reshape(4, 3)
 
-        res = dpnp.empty((2, 3), dtype=dpnp.int64)
+        res = xp.empty((2, 3), dtype=xp.int64)
         with pytest.raises(TypeError):
-            dpnp.matmul(a1, a2, out=res, casting="safe")
+            xp.matmul(a1, a2, out=res, casting="safe")
 
     def test_matmul_not_implemented(self):
         a1 = dpnp.arange(2 * 4).reshape(2, 4)
@@ -4332,52 +4334,53 @@ class TestMatmulInvalidCases:
         with pytest.raises(NotImplementedError):
             dpnp.matmul(a1, a2, axis=2)
 
-    def test_matmul_axes(self):
-        a1 = dpnp.arange(120).reshape(2, 5, 3, 4)
-        a2 = dpnp.arange(120).reshape(4, 2, 5, 3)
+    @pytest.mark.parametrize("xp", [numpy, dpnp])
+    def test_matmul_axes(self, xp):
+        a1 = xp.arange(120).reshape(2, 5, 3, 4)
+        a2 = xp.arange(120).reshape(4, 2, 5, 3)
 
         # axes must be a list
         axes = ((3, 1), (2, 0), (0, 1))
         with pytest.raises(TypeError):
-            dpnp.matmul(a1, a2, axes=axes)
+            xp.matmul(a1, a2, axes=axes)
 
         # axes must be be a list of three tuples
         axes = [(3, 1), (2, 0)]
         with pytest.raises(ValueError):
-            dpnp.matmul(a1, a2, axes=axes)
+            xp.matmul(a1, a2, axes=axes)
 
         # axes item should be a tuple
         axes = [(3, 1), (2, 0), [0, 1]]
         with pytest.raises(TypeError):
-            dpnp.matmul(a1, a2, axes=axes)
+            xp.matmul(a1, a2, axes=axes)
 
         # axes item should be a tuple with 2 elements
         axes = [(3, 1), (2, 0), (0, 1, 2)]
         with pytest.raises(ValueError):
-            dpnp.matmul(a1, a2, axes=axes)
+            xp.matmul(a1, a2, axes=axes)
 
         # axes must be an integer
         axes = [(3, 1), (2, 0), (0.0, 1)]
         with pytest.raises(TypeError):
-            dpnp.matmul(a1, a2, axes=axes)
+            xp.matmul(a1, a2, axes=axes)
 
         # axes item 2 should be an empty tuple
-        a = dpnp.arange(3)
+        a = xp.arange(3)
         axes = [0, 0, 0]
-        with pytest.raises(TypeError):
-            dpnp.matmul(a, a, axes=axes)
+        with pytest.raises(ValueError):
+            xp.matmul(a, a, axes=axes)
 
-        a = dpnp.arange(3 * 4 * 5).reshape(3, 4, 5)
-        b = dpnp.arange(3)
+        a = xp.arange(3 * 4 * 5).reshape(3, 4, 5)
+        b = xp.arange(3)
         # list object cannot be interpreted as an integer
         axes = [(1, 0), (0), [0]]
         with pytest.raises(TypeError):
-            dpnp.matmul(a, b, axes=axes)
+            xp.matmul(a, b, axes=axes)
 
         # axes item should be a tuple with a single element, or an integer
         axes = [(1, 0), (0), (0, 1)]
         with pytest.raises(ValueError):
-            dpnp.matmul(a, b, axes=axes)
+            xp.matmul(a, b, axes=axes)
 
 
 def test_elemenwise_nin_nout():

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -4216,10 +4216,16 @@ class TestMatmulInplace:
 
         expected = a @ b
         if expected.shape != a_sh:
-            with pytest.raises(ValueError):
+            if len(b_sh) == 1:
+                # check the exception matches NumPy
+                match = "inplace matrix multiplication requires"
+            else:
+                match = None
+
+            with pytest.raises(ValueError, match=match):
                 a @= b
 
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match=match):
                 ia @= ib
         else:
             ia @= ib
@@ -4356,7 +4362,7 @@ class TestMatmulInvalidCases:
 
         # axes item should be a tuple with 2 elements
         axes = [(3, 1), (2, 0), (0, 1, 2)]
-        with pytest.raises(ValueError):
+        with pytest.raises(AxisError):
             xp.matmul(a1, a2, axes=axes)
 
         # axes must be an integer
@@ -4367,7 +4373,7 @@ class TestMatmulInvalidCases:
         # axes item 2 should be an empty tuple
         a = xp.arange(3)
         axes = [0, 0, 0]
-        with pytest.raises(ValueError):
+        with pytest.raises(AxisError):
             xp.matmul(a, a, axes=axes)
 
         a = xp.arange(3 * 4 * 5).reshape(3, 4, 5)
@@ -4379,7 +4385,7 @@ class TestMatmulInvalidCases:
 
         # axes item should be a tuple with a single element, or an integer
         axes = [(1, 0), (0), (0, 1)]
-        with pytest.raises(ValueError):
+        with pytest.raises(AxisError):
             xp.matmul(a, b, axes=axes)
 
 


### PR DESCRIPTION
This PR adds support for inplace matrix multiplication via the `@=` operator.

Also the PR refactors the tests from `TestMatmulInvalidCases` class and corrects type of exception raised for invalid value passed to `axes` keyword to report `AxisError` exception there.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
