### PR TITLE
Remove TEST_SCOPE to run all tests in public CI

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -19,54 +19,6 @@ env:
   RERUN_TESTS_ON_FAILURE: 'true'
   RUN_TESTS_MAX_ATTEMPTS: 2
   TEST_ENV_NAME: 'test'
-  TEST_SCOPE: >-
-      test_absolute.py
-      test_amin_amax.py
-      test_arithmetic.py
-      test_arraycreation.py
-      test_arraymanipulation.py
-      test_arraypad.py
-      test_bitwise.py
-      test_copy.py
-      test_counting.py
-      test_fft.py
-      test_fill.py
-      test_flat.py
-      test_histogram.py
-      test_indexing.py
-      test_linalg.py
-      test_logic.py
-      test_manipulation.py
-      test_mathematical.py
-      test_mixins.py
-      test_nanfunctions.py
-      test_ndarray.py
-      test_outer.py
-      test_product.py
-      test_random_state.py
-      test_search.py
-      test_sort.py
-      test_special.py
-      test_statistics.py
-      test_sum.py
-      test_sycl_queue.py
-      test_umath.py
-      test_usm_type.py
-      third_party/cupy/core_tests
-      third_party/cupy/fft_tests
-      third_party/cupy/creation_tests
-      third_party/cupy/indexing_tests
-      third_party/cupy/lib_tests
-      third_party/cupy/linalg_tests
-      third_party/cupy/logic_tests
-      third_party/cupy/manipulation_tests
-      third_party/cupy/math_tests
-      third_party/cupy/padding_tests
-      third_party/cupy/sorting_tests
-      third_party/cupy/statistics_tests/test_histogram.py
-      third_party/cupy/statistics_tests/test_meanvar.py
-      third_party/cupy/test_ndim.py
-      third_party/cupy/test_type_routines.py
   VER_JSON_NAME: 'version.json'
   VER_SCRIPT1: "import json; f = open('version.json', 'r'); j = json.load(f); f.close(); "
   VER_SCRIPT2: "d = j['dpnp'][0]; print('='.join((d[s] for s in ('version', 'build'))))"
@@ -263,7 +215,7 @@ jobs:
       - name: Run tests
         if: env.RERUN_TESTS_ON_FAILURE != 'true'
         run: |
-          python -m pytest -q -ra --disable-warnings -vv ${{ env.TEST_SCOPE }}
+          python -m pytest -q -ra --disable-warnings -vv .
         working-directory: ${{ env.tests-path }}
 
       - name: Run tests
@@ -279,7 +231,7 @@ jobs:
             . $CONDA/etc/profile.d/conda.sh
             conda activate ${{ env.TEST_ENV_NAME }}
             cd ${{ env.tests-path }}
-            python -m pytest -q -ra --disable-warnings -vv ${{ env.TEST_SCOPE }}
+            python -m pytest -q -ra --disable-warnings -vv .
 
   test_windows:
     name: Test ['windows-2019', python='${{ matrix.python }}']
@@ -418,7 +370,7 @@ jobs:
       - name: Run tests
         if: env.RERUN_TESTS_ON_FAILURE != 'true'
         run: |
-          python -m pytest -q -ra --disable-warnings -vv ${{ env.TEST_SCOPE }}
+          python -m pytest -q -ra --disable-warnings -vv .
         working-directory: ${{ env.tests-path }}
 
       - name: Run tests
@@ -433,7 +385,7 @@ jobs:
           command: >-
             mamba activate ${{ env.TEST_ENV_NAME }}
             & cd ${{ env.tests-path }}
-            & python -m pytest -q -ra --disable-warnings -vv ${{ env.TEST_SCOPE }}
+            & python -m pytest -q -ra --disable-warnings -vv .
 
   upload:
     name: Upload ['${{ matrix.os }}', python='${{ matrix.python }}']


### PR DESCRIPTION
This PR suggests removing `TEST_SCOPE` env variable in `conda_package.yml`  to run all available dpnp tests in public CI

All test files have been updated and run successfully in `Generate coverage data for dpnp` [action](https://github.com/IntelPython/dpnp/actions/workflows/generate_coverage.yaml)

Running all dpnp test files in public CI has been checked in #2116 (https://github.com/IntelPython/dpnp/actions/runs/11703003323/job/32594634571?pr=2116) . 


- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
