### PR TITLE
Run all dpnp tests to generate coverage 

### DIFF
--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -109,7 +109,7 @@ jobs:
             conda activate coverage
             [ -f /opt/intel/oneapi/setvars.sh ] && source /opt/intel/oneapi/setvars.sh
             git clean -fxd
-            python scripts/gen_coverage.py --pytest-opts="--ignore tests/test_random.py" --verbose
+            python scripts/gen_coverage.py --verbose
 
       - name: Total number of coverage attempts
         run: |


### PR DESCRIPTION
This PR suggests removing `--ignore test_random.py` for pytest  to run generate coverage on public CI.

`test_random.py` has been updated and runs successfully on public CI.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
