### PR TITLE
Fix DeprecationWarning: pkg_resources

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,8 +13,6 @@ markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
     multi_gpu: marks tests that require a specified number of GPUs
 filterwarnings =
-    # pkg_resources
-    ignore:pkg_resources is deprecated as an API:DeprecationWarning
     # NumPy arccosh
     # Undefined behavior depends on the backend:
     # NumPy with OpenBLAS for np.array[1.0] does not raise a warning

--- a/tests/third_party/cupy/testing/_helper.py
+++ b/tests/third_party/cupy/testing/_helper.py
@@ -33,8 +33,10 @@ def with_requires(*requirements):
        This test case runs only when `numpy>=1.18` is installed.
 
        >>> from cupy import testing
+       ...
+       ...
        ... class Test(unittest.TestCase):
-       ...     @testing.with_requires('numpy>=1.18')
+       ...     @testing.with_requires("numpy>=1.18")
        ...     def test_for_numpy_1_18(self):
        ...         pass
 
@@ -43,8 +45,8 @@ def with_requires(*requirements):
             run a given test case.
 
     """
-    msg = "requires: {}".format(",".join(requirements))
-    return _skipif(not installed(requirements), reason=msg)
+    msg = f"requires: {','.join(requirements)}"
+    return _skipif(not installed(*requirements), reason=msg)
 
 
 def installed(*specifiers):


### PR DESCRIPTION
This PR suggests using `from packaging.requirements import Requirement` instead of  `import pkg_resources` to avoid DeprecationWarning.
These changes also remove ignoring of `DeprecationWarning` in `filterwarnings` pytest settings 

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
