### PR TITLE
bump NumPy, CuPy and Python versions in build doc

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -36,7 +36,7 @@ jobs:
       pull-requests: write
 
     env:
-      python-ver: '3.9'
+      python-ver: '3.12'
       CHANNELS: '-c dppy/label/dev -c intel -c conda-forge --override-channels'
       NO_INTEL_CHANNELS: '-c dppy/label/dev -c conda-forge --override-channels'
       # Install the latest oneAPI compiler to work around an issue
@@ -132,16 +132,16 @@ jobs:
       - name: Install dpnp dependencies
         if: env.INSTALL_ONE_API == 'yes'
         run: |
-          mamba install numpy"<1.24" dpctl">=0.18.0dev0" cmake cython pytest ninja scikit-build ${{ env.NO_INTEL_CHANNELS }}
+          mamba install numpy dpctl">=0.18.0dev0" cmake cython pytest ninja scikit-build ${{ env.NO_INTEL_CHANNELS }}
 
       - name: Install dpnp dependencies
         if: env.INSTALL_ONE_API != 'yes'
         run: |
-          mamba install numpy"<1.24" dpctl">=0.18.0dev0" mkl-devel-dpcpp onedpl-devel tbb-devel dpcpp_linux-64 \
+          mamba install numpy dpctl">=0.18.0dev0" mkl-devel-dpcpp onedpl-devel tbb-devel dpcpp_linux-64 \
               cmake cython pytest ninja scikit-build ${{ env.CHANNELS }}
 
       - name: Install cuPy dependencies
-        run: mamba install cupy cudatoolkit=10.0
+        run: mamba install cupy
 
       - name: Conda info
         run: mamba info


### PR DESCRIPTION
In this PR, NumPy, CuPy and Python versions for building doc are updated to make sure comparison table of available functions in dpnp/NumPy/CuPy is up-to-date.

NumPy is updated from v1.23.5 to the current available v2.1.3.
CuPy is updated from v9.6.0 to the current available v13.3.0.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
