### PR TITLE
temporary mute a test for `dpnp.pad`

### DIFF
--- a/tests/test_arraypad.py
+++ b/tests/test_arraypad.py
@@ -12,7 +12,7 @@ import dpnp
 from dpnp.dpnp_utils.dpnp_utils_pad import _as_pairs as dpnp_as_pairs
 from tests.third_party.cupy import testing
 
-from .helper import assert_dtype_allclose, get_all_dtypes
+from .helper import assert_dtype_allclose, get_all_dtypes, has_support_aspect64
 
 
 class TestPad:
@@ -384,6 +384,7 @@ class TestPad:
         result = dpnp.pad(a_dp, pad_width, mode=mode, reflect_type=reflect_type)
         assert_array_equal(result, expected)
 
+    @pytest.mark.skipif(not has_support_aspect64(), reason="dpctl-gh-1887")
     @pytest.mark.parametrize("data", [[[4, 5, 6], [6, 7, 8]], [[4, 5, 6]]])
     @pytest.mark.parametrize("pad_width", [10, (5, 7)])
     @pytest.mark.parametrize("mode", ["reflect", "symmetric"])


### PR DESCRIPTION
In this PR, a test for array padding is temporary muted because of https://github.com/IntelPython/dpctl/issues/1887

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
