### PR TITLE
Implement `dpnp.compress` and `dpnp_array.compress` method

### DIFF
--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -786,7 +786,14 @@ class dpnp_array:
 
         return dpnp.clip(self, min, max, out=out, **kwargs)
 
-    # 'compress',
+    def compress(self, condition, axis=None, out=None):
+        """
+        Select slices of an array along a given axis.
+
+        Refer to :obj:`dpnp.compress` for full documentation.
+        """
+
+        return dpnp.compress(condition, self, axis=axis, out=out)
 
     def conj(self):
         """

--- a/dpnp/dpnp_iface_indexing.py
+++ b/dpnp/dpnp_iface_indexing.py
@@ -227,7 +227,8 @@ def _take_1d_index(x, inds, axis, q, usm_type, out=None):
 
 def compress(condition, a, axis=None, out=None):
     """
-    Return selected slices of an array along given axis.
+    A copy of `a` without the slices along `axis` for which `condition` is
+    ``False``.
 
     For full documentation refer to :obj:`numpy.choose`.
 
@@ -239,9 +240,10 @@ def compress(condition, a, axis=None, out=None):
         the output is truncated to the length of `condition`.
     a : {dpnp.ndarray, usm_ndarray}
         Array to extract from.
-    axis : {int}, optional
-        Axis along which to extract slices. If `None`, works over the
+    axis : {None, int}, optional
+        Axis along which to extract slices. If ``None``, works over the
         flattened array.
+        Default: ``None``.
     out : {None, dpnp.ndarray, usm_ndarray}, optional
         If provided, the result will be placed in this array. It should
         be of the appropriate shape and dtype.
@@ -254,9 +256,41 @@ def compress(condition, a, axis=None, out=None):
 
     See also
     --------
+    :obj:`dpnp.take` :  Take elements from an array along an axis.
+    :obj:`dpnp.choose` : Construct an array from an index array and a set of
+                         arrays to choose from.
+    :obj:`dpnp.diag` : Extract a diagonal or construct a diagonal array.
+    :obj:`dpnp.diagonal` : Return specified diagonals.
+    :obj:`dpnp.select` : Return an array drawn from elements in `choicelist`,
+                         depending on conditions.
     :obj:`dpnp.ndarray.compress` : Equivalent method.
     :obj:`dpnp.extract` : Equivalent function when working on 1-D arrays.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> a = np.array([[1, 2], [3, 4], [5, 6]])
+    >>> a
+    array([[1, 2],
+           [3, 4],
+           [5, 6]])
+    >>> np.compress([0, 1], a, axis=0)
+    array([[3, 4]])
+    >>> np.compress([False, True, True], a, axis=0)
+    array([[3, 4],
+           [5, 6]])
+    >>> np.compress([False, True], a, axis=1)
+    array([[2],
+           [4],
+           [6]])
+
+    Working on the flattened array does not return slices along an axis but
+    selects elements.
+
+    >>> np.compress([False, True], a)
+    array([2])
     """
+
     dpnp.check_supported_arrays_type(a)
     if axis is None:
         if a.ndim != 1:
@@ -270,7 +304,7 @@ def compress(condition, a, axis=None, out=None):
             condition,
             dtype=dpnp.bool,
             usm_type=a_ary.usm_type,
-            sycl_queue=a_ary.q,
+            sycl_queue=a_ary.sycl_queue,
         )
     else:
         cond_ary = dpnp.get_usm_ndarray(condition)

--- a/dpnp/dpnp_iface_indexing.py
+++ b/dpnp/dpnp_iface_indexing.py
@@ -244,7 +244,7 @@ def compress(condition, a, axis=None, out=None):
     Returns
     -------
     out : dpnp.ndarray
-        A copy of the slices of `a` where `condition` is True.
+        A copy of the slices of `a` where `condition` is ``True``.
 
     See also
     --------

--- a/dpnp/dpnp_iface_indexing.py
+++ b/dpnp/dpnp_iface_indexing.py
@@ -170,10 +170,9 @@ def _take_1d_index(x, inds, axis, q, usm_type, out=None):
         raise IndexError("cannot take non-empty indices from an empty axis")
     res_sh = x_sh[:axis] + ind0.shape + x_sh[axis_end:]
 
-    orig_out = out
+    orig_out = None
     if out is not None:
-        dpnp.check_supported_arrays_type(out)
-        out = dpnp.get_usm_ndarray(out)
+        orig_out = out = dpnp.get_usm_ndarray(out)
 
         if not out.flags.writable:
             raise ValueError("provided `out` array is read-only")
@@ -286,7 +285,7 @@ def compress(condition, a, axis=None, out=None):
     inds = _nonzero_impl(cond_ary)
 
     return dpnp.get_result_array(
-        _take_1d_index(a_ary, inds, axis, exec_q, res_usm_type, out)
+        _take_1d_index(a_ary, inds, axis, exec_q, res_usm_type, out), out=out
     )
 
 

--- a/dpnp/dpnp_iface_indexing.py
+++ b/dpnp/dpnp_iface_indexing.py
@@ -227,8 +227,10 @@ def _take_1d_index(x, inds, axis, q, usm_type, out=None):
 
 def compress(condition, a, axis=None, out=None):
     """
-    A copy of `a` without the slices along `axis` for which `condition` is
-    ``False``.
+    Return selected slices of an array along given axis.
+
+    A slice of `a` is returned for each index along `axis` where `condition`
+    is ``True``.
 
     For full documentation refer to :obj:`numpy.choose`.
 
@@ -299,15 +301,13 @@ def compress(condition, a, axis=None, out=None):
     axis = normalize_axis_index(operator.index(axis), a.ndim)
 
     a_ary = dpnp.get_usm_ndarray(a)
-    if not dpnp.is_supported_array_type(condition):
-        cond_ary = dpnp.as_usm_ndarray(
-            condition,
-            dtype=dpnp.bool,
-            usm_type=a_ary.usm_type,
-            sycl_queue=a_ary.sycl_queue,
-        )
-    else:
-        cond_ary = dpnp.get_usm_ndarray(condition)
+    cond_ary = dpnp.as_usm_ndarray(
+        condition,
+        dtype=dpnp.bool,
+        usm_type=a_ary.usm_type,
+        sycl_queue=a_ary.sycl_queue,
+    )
+
     if not cond_ary.ndim == 1:
         raise ValueError(
             "`condition` must be a 1-D array or un-nested sequence"

--- a/dpnp/tests/test_indexing.py
+++ b/dpnp/tests/test_indexing.py
@@ -1387,3 +1387,22 @@ class TestCompress:
         # non-empty take from empty axis raises IndexError
         with pytest.raises(IndexError):
             dpnp.compress(condition, a, axis=1)
+
+    def test_compress_in_overlaps_out(self):
+        conditions = [False, True, True]
+        a_np = numpy.arange(6)
+        a = dpnp.arange(6)
+        cond_np = numpy.array(conditions)
+        cond = dpnp.array(conditions)
+        out = a[2:4]
+        expected = numpy.compress(cond_np, a_np, axis=None)
+        result = dpnp.compress(cond, a, axis=None, out=out)
+        assert_array_equal(expected, result)
+        assert result is out
+        assert (a[2:4] == out).all()
+
+    def test_compress_condition_not_1d(self):
+        a = dpnp.arange(4)
+        cond = dpnp.ones((1, 4), dtype="?")
+        with pytest.raises(ValueError):
+            dpnp.compress(cond, a, axis=None)

--- a/dpnp/tests/test_indexing.py
+++ b/dpnp/tests/test_indexing.py
@@ -1339,18 +1339,24 @@ class TestSelect:
 
 class TestCompress:
     def test_compress_basic(self):
+        conditions = [True, False, True]
+        a_np = numpy.arange(16).reshape(4, 4)
         a = dpnp.arange(16).reshape(4, 4)
-        condition = dpnp.asarray([True, False, True])
-        r = dpnp.compress(condition, a, axis=0)
-        assert_array_equal(r[0], a[0])
-        assert_array_equal(r[1], a[2])
+        cond_np = numpy.array(conditions)
+        cond = dpnp.array(conditions)
+        expected = numpy.compress(cond_np, a_np, axis=0)
+        result = dpnp.compress(cond, a, axis=0)
+        assert_array_equal(expected, result)
 
     @pytest.mark.parametrize("dtype", get_all_dtypes())
     def test_compress_condition_all_dtypes(self, dtype):
+        a_np = numpy.arange(10, dtype="i4")
         a = dpnp.arange(10, dtype="i4")
-        condition = dpnp.tile(dpnp.asarray([0, 1], dtype=dtype), 5)
-        r = dpnp.compress(condition, a)
-        assert_array_equal(r, a[1::2])
+        cond_np = numpy.tile(numpy.asarray([0, 1], dtype=dtype), 5)
+        cond = dpnp.tile(dpnp.asarray([0, 1], dtype=dtype), 5)
+        expected = numpy.compress(cond_np, a_np)
+        result = dpnp.compress(cond, a)
+        assert_array_equal(expected, result)
 
     def test_compress_invalid_out_errors(self):
         q1 = dpctl.SyclQueue()

--- a/dpnp/tests/test_indexing.py
+++ b/dpnp/tests/test_indexing.py
@@ -1348,6 +1348,16 @@ class TestCompress:
         result = dpnp.compress(cond, a, axis=0)
         assert_array_equal(expected, result)
 
+    def test_compress_method_basic(self):
+        conditions = [True, True, False, True]
+        a_np = numpy.arange(3 * 4).reshape(3, 4)
+        a = dpnp.arange(3 * 4).reshape(3, 4)
+        cond_np = numpy.array(conditions)
+        cond = dpnp.array(conditions)
+        expected = a_np.compress(cond_np, axis=1)
+        result = a.compress(cond, axis=1)
+        assert_array_equal(expected, result)
+
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     def test_compress_condition_all_dtypes(self, dtype):
         a_np = numpy.arange(10, dtype="i4")
@@ -1406,3 +1416,20 @@ class TestCompress:
         cond = dpnp.ones((1, 4), dtype="?")
         with pytest.raises(ValueError):
             dpnp.compress(cond, a, axis=None)
+
+    def test_compress_strided(self):
+        a = dpnp.arange(20)
+        a_np = dpnp.asnumpy(a)
+        cond = dpnp.tile(dpnp.array([True, False, False, True]), 5)
+        cond_np = dpnp.asnumpy(cond)
+        result = dpnp.compress(cond, a)
+        expected = numpy.compress(cond_np, a_np)
+        assert_array_equal(result, expected)
+        # use axis keyword
+        a = dpnp.arange(50).reshape(10, 5)
+        a_np = dpnp.asnumpy(a)
+        cond = dpnp.array(dpnp.array([True, False, False, True, False]))
+        cond_np = dpnp.asnumpy(cond)
+        result = dpnp.compress(cond, a)
+        expected = numpy.compress(cond_np, a_np)
+        assert_array_equal(result, expected)

--- a/dpnp/tests/test_indexing.py
+++ b/dpnp/tests/test_indexing.py
@@ -1348,7 +1348,7 @@ class TestCompress:
         result = dpnp.compress(cond, a, axis=0)
         assert_array_equal(expected, result)
 
-    @pytest.mark.parametrize("dtype", get_all_dtypes())
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     def test_compress_condition_all_dtypes(self, dtype):
         a_np = numpy.arange(10, dtype="i4")
         a = dpnp.arange(10, dtype="i4")

--- a/dpnp/tests/test_indexing.py
+++ b/dpnp/tests/test_indexing.py
@@ -1337,49 +1337,47 @@ class TestSelect:
             dpnp.select([x1], [x1])
 
 
-def test_compress_basic():
-    a = dpnp.arange(16).reshape(4, 4)
-    condition = dpnp.asarray([True, False, True])
-    r = dpnp.compress(condition, a, axis=0)
-    assert_array_equal(r[0], a[0])
-    assert_array_equal(r[1], a[2])
+class TestCompress:
+    def test_compress_basic(self):
+        a = dpnp.arange(16).reshape(4, 4)
+        condition = dpnp.asarray([True, False, True])
+        r = dpnp.compress(condition, a, axis=0)
+        assert_array_equal(r[0], a[0])
+        assert_array_equal(r[1], a[2])
 
+    @pytest.mark.parametrize("dtype", get_all_dtypes())
+    def test_compress_condition_all_dtypes(self, dtype):
+        a = dpnp.arange(10, dtype="i4")
+        condition = dpnp.tile(dpnp.asarray([0, 1], dtype=dtype), 5)
+        r = dpnp.compress(condition, a)
+        assert_array_equal(r, a[1::2])
 
-@pytest.mark.parametrize("dtype", get_all_dtypes())
-def test_compress_condition_all_dtypes(dtype):
-    a = dpnp.arange(10, dtype="i4")
-    condition = dpnp.tile(dpnp.asarray([0, 1], dtype=dtype), 5)
-    r = dpnp.compress(condition, a)
-    assert_array_equal(r, a[1::2])
+    def test_compress_invalid_out_errors(self):
+        q1 = dpctl.SyclQueue()
+        q2 = dpctl.SyclQueue()
+        a = dpnp.ones(10, dtype="i4", sycl_queue=q1)
+        condition = dpnp.asarray([True], sycl_queue=q1)
+        out_bad_shape = dpnp.empty_like(a)
+        with pytest.raises(ValueError):
+            dpnp.compress(condition, a, out=out_bad_shape)
+        out_bad_queue = dpnp.empty(1, dtype="i4", sycl_queue=q2)
+        with pytest.raises(ExecutionPlacementError):
+            dpnp.compress(condition, a, out=out_bad_queue)
+        out_bad_dt = dpnp.empty(1, dtype="i8", sycl_queue=q1)
+        with pytest.raises(TypeError):
+            dpnp.compress(condition, a, out=out_bad_dt)
+        out_read_only = dpnp.empty(1, dtype="i4", sycl_queue=q1)
+        out_read_only.flags.writable = False
+        with pytest.raises(ValueError):
+            dpnp.compress(condition, a, out=out_read_only)
 
-
-def test_compress_invalid_out_errors():
-    q1 = dpctl.SyclQueue()
-    q2 = dpctl.SyclQueue()
-    a = dpnp.ones(10, dtype="i4", sycl_queue=q1)
-    condition = dpnp.asarray([True], sycl_queue=q1)
-    out_bad_shape = dpnp.empty_like(a)
-    with pytest.raises(ValueError):
-        dpnp.compress(condition, a, out=out_bad_shape)
-    out_bad_queue = dpnp.empty(1, dtype="i4", sycl_queue=q2)
-    with pytest.raises(ExecutionPlacementError):
-        dpnp.compress(condition, a, out=out_bad_queue)
-    out_bad_dt = dpnp.empty(1, dtype="i8", sycl_queue=q1)
-    with pytest.raises(TypeError):
-        dpnp.compress(condition, a, out=out_bad_dt)
-    out_read_only = dpnp.empty(1, dtype="i4", sycl_queue=q1)
-    out_read_only.flags.writable = False
-    with pytest.raises(ValueError):
-        dpnp.compress(condition, a, out=out_read_only)
-
-
-def test_compress_empty_axis():
-    a = dpnp.ones((10, 0, 5), dtype="i4")
-    condition = [True, False, True]
-    r = dpnp.compress(condition, a, axis=0)
-    assert r.shape == (2, 0, 5)
-    # empty take from empty axis is permitted
-    assert dpnp.compress([False], a, axis=1).shape == (10, 0, 5)
-    # non-empty take from empty axis raises IndexError
-    with pytest.raises(IndexError):
-        dpnp.compress(condition, a, axis=1)
+    def test_compress_empty_axis(self):
+        a = dpnp.ones((10, 0, 5), dtype="i4")
+        condition = [True, False, True]
+        r = dpnp.compress(condition, a, axis=0)
+        assert r.shape == (2, 0, 5)
+        # empty take from empty axis is permitted
+        assert dpnp.compress([False], a, axis=1).shape == (10, 0, 5)
+        # non-empty take from empty axis raises IndexError
+        with pytest.raises(IndexError):
+            dpnp.compress(condition, a, axis=1)

--- a/dpnp/tests/test_indexing.py
+++ b/dpnp/tests/test_indexing.py
@@ -1365,7 +1365,7 @@ def test_compress_invalid_out_errors():
     with pytest.raises(ExecutionPlacementError):
         dpnp.compress(condition, a, out=out_bad_queue)
     out_bad_dt = dpnp.empty(1, dtype="i8", sycl_queue=q1)
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         dpnp.compress(condition, a, out=out_bad_dt)
     out_read_only = dpnp.empty(1, dtype="i4", sycl_queue=q1)
     out_read_only.flags.writable = False

--- a/dpnp/tests/test_sycl_queue.py
+++ b/dpnp/tests/test_sycl_queue.py
@@ -2855,3 +2855,24 @@ def test_ix(device_0, device_1):
     ixgrid = dpnp.ix_(x0, x1)
     assert_sycl_queue_equal(ixgrid[0].sycl_queue, x0.sycl_queue)
     assert_sycl_queue_equal(ixgrid[1].sycl_queue, x1.sycl_queue)
+
+
+@pytest.mark.parametrize(
+    "device",
+    valid_devices,
+    ids=[device.filter_string for device in valid_devices],
+)
+def test_compress(device):
+    a_np = numpy.arange(5)
+    a = dpnp.array(a_np, device=device)
+
+    cond_np = numpy.array([0, 1, 0])
+    cond = dpnp.array(cond_np, device=device)
+
+    expected = numpy.compress(cond_np, a_np, axis=None)
+    result = dpnp.compress(cond, a, axis=None)
+    assert_allclose(expected, result)
+
+    expected_queue = a.sycl_queue
+    result_queue = result.sycl_queue
+    assert_sycl_queue_equal(result_queue, expected_queue)

--- a/dpnp/tests/test_sycl_queue.py
+++ b/dpnp/tests/test_sycl_queue.py
@@ -718,6 +718,7 @@ def test_reduce_hypot(device):
         ),
         pytest.param("append", [1, 2, 3], [4, 5, 6]),
         pytest.param("arctan2", [-1, +1, +1, -1], [-1, -1, +1, +1]),
+        pytest.param("compress", [0, 1, 1, 0], [0, 1, 2, 3]),
         pytest.param("copysign", [0.0, 1.0, 2.0], [-1.0, 0.0, 1.0]),
         pytest.param(
             "corrcoef",
@@ -2855,24 +2856,3 @@ def test_ix(device_0, device_1):
     ixgrid = dpnp.ix_(x0, x1)
     assert_sycl_queue_equal(ixgrid[0].sycl_queue, x0.sycl_queue)
     assert_sycl_queue_equal(ixgrid[1].sycl_queue, x1.sycl_queue)
-
-
-@pytest.mark.parametrize(
-    "device",
-    valid_devices,
-    ids=[device.filter_string for device in valid_devices],
-)
-def test_compress(device):
-    a_np = numpy.arange(5)
-    a = dpnp.array(a_np, device=device)
-
-    cond_np = numpy.array([0, 1, 0])
-    cond = dpnp.array(cond_np, device=device)
-
-    expected = numpy.compress(cond_np, a_np, axis=None)
-    result = dpnp.compress(cond, a, axis=None)
-    assert_allclose(expected, result)
-
-    expected_queue = a.sycl_queue
-    result_queue = result.sycl_queue
-    assert_sycl_queue_equal(result_queue, expected_queue)

--- a/dpnp/tests/test_usm_type.py
+++ b/dpnp/tests/test_usm_type.py
@@ -1746,3 +1746,17 @@ def test_ix(usm_type_0, usm_type_1):
     ixgrid = dp.ix_(x0, x1)
     assert ixgrid[0].usm_type == x0.usm_type
     assert ixgrid[1].usm_type == x1.usm_type
+
+
+@pytest.mark.parametrize("usm_type_a", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize(
+    "usm_type_cond", list_of_usm_types, ids=list_of_usm_types
+)
+def test_compress(usm_type_a, usm_type_cond):
+    a = dp.arange(5, usm_type=usm_type_a)
+    cond = dp.array([False, True, True], usm_type=usm_type_cond)
+    z = dp.compress(cond, a, axis=None)
+
+    assert a.usm_type == usm_type_a
+    assert cond.usm_type == usm_type_cond
+    assert z.usm_type == du.get_coerced_usm_type([usm_type_a, usm_type_cond])

--- a/dpnp/tests/test_usm_type.py
+++ b/dpnp/tests/test_usm_type.py
@@ -686,6 +686,7 @@ def test_1in_1out(func, data, usm_type):
         ),
         pytest.param("append", [1, 2, 3], [4, 5, 6]),
         pytest.param("arctan2", [-1, +1, +1, -1], [-1, -1, +1, +1]),
+        pytest.param("compress", [False, True, True], [0, 1, 2, 3, 4]),
         pytest.param("copysign", [0.0, 1.0, 2.0], [-1.0, 0.0, 1.0]),
         pytest.param("cross", [1.0, 2.0, 3.0], [4.0, 5.0, 6.0]),
         pytest.param("digitize", [0.2, 6.4, 3.0], [0.0, 1.0, 2.5, 4.0]),
@@ -1746,17 +1747,3 @@ def test_ix(usm_type_0, usm_type_1):
     ixgrid = dp.ix_(x0, x1)
     assert ixgrid[0].usm_type == x0.usm_type
     assert ixgrid[1].usm_type == x1.usm_type
-
-
-@pytest.mark.parametrize("usm_type_a", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize(
-    "usm_type_cond", list_of_usm_types, ids=list_of_usm_types
-)
-def test_compress(usm_type_a, usm_type_cond):
-    a = dp.arange(5, usm_type=usm_type_a)
-    cond = dp.array([False, True, True], usm_type=usm_type_cond)
-    z = dp.compress(cond, a, axis=None)
-
-    assert a.usm_type == usm_type_a
-    assert cond.usm_type == usm_type_cond
-    assert z.usm_type == du.get_coerced_usm_type([usm_type_a, usm_type_cond])

--- a/dpnp/tests/third_party/cupy/indexing_tests/test_indexing.py
+++ b/dpnp/tests/third_party/cupy/indexing_tests/test_indexing.py
@@ -61,21 +61,18 @@ class TestIndexing(unittest.TestCase):
         b = testing.shaped_random((30,), xp, dtype="int64", scale=24)
         return xp.take_along_axis(a, b, axis=None)
 
-    @pytest.mark.skip("compress() is not implemented yet")
     @testing.numpy_cupy_array_equal()
     def test_compress(self, xp):
         a = testing.shaped_arange((3, 4, 5), xp)
         b = xp.array([True, False, True])
         return xp.compress(b, a, axis=1)
 
-    @pytest.mark.skip("compress() is not implemented yet")
     @testing.numpy_cupy_array_equal()
     def test_compress_no_axis(self, xp):
         a = testing.shaped_arange((3, 4, 5), xp)
         b = xp.array([True, False, True])
         return xp.compress(b, a)
 
-    @pytest.mark.skip("compress() is not implemented yet")
     @testing.for_int_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_compress_no_bool(self, xp, dtype):
@@ -83,28 +80,24 @@ class TestIndexing(unittest.TestCase):
         b = testing.shaped_arange((3,), xp, dtype)
         return xp.compress(b, a, axis=1)
 
-    @pytest.mark.skip("compress() is not implemented yet")
     @testing.numpy_cupy_array_equal()
     def test_compress_overrun_false(self, xp):
         a = testing.shaped_arange((3,), xp)
         b = xp.array([True, False, True, False, False, False])
         return xp.compress(b, a)
 
-    @pytest.mark.skip("compress() is not implemented yet")
     @testing.numpy_cupy_array_equal()
     def test_compress_empty_1dim(self, xp):
         a = testing.shaped_arange((3, 4, 5), xp)
         b = xp.array([])
         return xp.compress(b, a, axis=1)
 
-    @pytest.mark.skip("compress() is not implemented yet")
     @testing.numpy_cupy_array_equal()
     def test_compress_empty_1dim_no_axis(self, xp):
         a = testing.shaped_arange((3, 4, 5), xp)
         b = xp.array([])
         return xp.compress(b, a)
 
-    @pytest.mark.skip("compress() is not implemented yet")
     @testing.numpy_cupy_array_equal()
     def test_compress_0dim(self, xp):
         a = xp.array(3)


### PR DESCRIPTION
This PR proposes an implementation for `dpnp.compress` using `dpctl.tensor` kernels.

`nonzero` is used to accumulate the `condition` into 1d array of indices, which are then used to take the appropriate slices of the array. When `axis` is `None`, the operand array is flattened.

The coupled `dpnp_array.compress` method is implemented through a simple call to the `compress` function,

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [X] If this PR is a work in progress, are you filing the PR as a draft?
