### PR TITLE
Unskip test_distr in TestNormal and TestRandN

### DIFF
--- a/dpnp/tests/test_random_state.py
+++ b/dpnp/tests/test_random_state.py
@@ -35,9 +35,6 @@ def get_default_floating():
 
 
 class TestNormal:
-    # TODO: Temporary skip due to incorrect results in public CI
-    # (ARM architecture) with the new MKL package 2024.2.0 (SAT-7080)
-    @pytest.mark.skipif(is_cpu_device(), reason="SAT-7080")
     @pytest.mark.parametrize(
         "dtype",
         [dpnp.float32, dpnp.float64, None],
@@ -608,9 +605,6 @@ class TestRandInt:
 
 
 class TestRandN:
-    # TODO: Temporary skip due to incorrect results in public CI
-    # (ARM architecture) with the new MKL package 2024.2.0 (SAT-7080)
-    @pytest.mark.skipif(is_cpu_device(), reason="SAT-7080")
     @pytest.mark.parametrize(
         "usm_type",
         ["host", "device", "shared"],


### PR DESCRIPTION
This PR suggests removing test skip for **test_dist** in **TestNormal** and ### TestRandN  since the problem has been fixed in MKL since 2024.2.1 version.
These tests pass successfully in public CI on Windows.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
