### PR TITLE
Bump DPC++ compiler min version required for proper work of `sycl::cyl_bessel_i0()`

### DIFF
--- a/dpnp/backend/kernels/elementwise_functions/i0.hpp
+++ b/dpnp/backend/kernels/elementwise_functions/i0.hpp
@@ -32,7 +32,7 @@
  * sycl::ext::intel::math::cyl_bessel_i0(x) is fully resolved.
  */
 #ifndef __SYCL_COMPILER_BESSEL_I0_SUPPORT
-#define __SYCL_COMPILER_BESSEL_I0_SUPPORT 20241111L
+#define __SYCL_COMPILER_BESSEL_I0_SUPPORT 20241114L
 #endif
 
 #if __SYCL_COMPILER_VERSION >= __SYCL_COMPILER_BESSEL_I0_SUPPORT


### PR DESCRIPTION
DPC++ compiler released 2025.0.1 version where `__SYCL_COMPILER_VERSION` is defined to `20241113`. But the fix for `sycl::ext::intel::math::cyl_bessel_i0(x)` support wasn't mapped there.

Thus the PR proposes to bump `__SYCL_COMPILER_BESSEL_I0_SUPPORT` define up to `20241114` value to exclude DPC++ compiler 2025.0.1 version.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
