### PR TITLE
Bump oneMKL version to `0.6` and add new `--onemkl-interfaces-dir` option

### DIFF
--- a/.github/workflows/check-mkl-interfaces.yaml
+++ b/.github/workflows/check-mkl-interfaces.yaml
@@ -1,0 +1,100 @@
+name: Test oneMKL interfaces
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions: read-all
+
+env:
+  CHANNELS: '-c dppy/label/dev -c https://software.repos.intel.com/python/conda/ -c conda-forge --override-channels'
+  BUILD_DEP_PKGS: >-
+      mkl-devel-dpcpp
+      tbb-devel
+      dpctl
+      onedpl-devel
+      setuptools
+      python
+      numpy">=2.0"
+      cython
+      cmake
+      ninja
+      scikit-build
+
+jobs:
+  build_and_test:
+    name: Run on ['${{ matrix.os }}', python='${{ matrix.python }}']
+
+    strategy:
+      matrix:
+        python: ['3.12']
+        os: [ubuntu-22.04] # windows-2019 - no DFT support for Windows in oneMKL
+
+    permissions:
+      # Needed to cancel any previous runs that are not completed for a given workflow
+      actions: write
+
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: ${{ matrix.os == 'windows-2019' && 'cmd /C CALL {0}' || 'bash -el {0}' }}
+
+    continue-on-error: true
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout DPNP repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup miniconda
+        uses: conda-incubator/setup-miniconda@d2e6a045a86077fb6cad6f5adf368e9076ddaa8d # v3.1.0
+        with:
+          miniforge-version: latest
+          use-mamba: 'true'
+          channels: conda-forge
+          conda-remove-defaults: 'true'
+          python-version: ${{ matrix.python }}
+          activate-environment: 'test_onemkl_interfaces'
+
+      # Sometimes `mamba install ...` fails due to slow download speed rate, so disable the check in mamba
+      - name: Disable speed limit check in mamba
+        run: echo "MAMBA_NO_LOW_SPEED_LIMIT=1" >> $GITHUB_ENV
+
+      - name: Install dpnp build dependencies
+        run: |
+          mamba install ${{ env.DPCPP_PKG }} ${{ env.BUILD_DEP_PKGS }} ${{ env.CHANNELS }}
+        env:
+          DPCPP_PKG: ${{ matrix.os == 'windows-2019' && 'dpcpp_win-64 vs_win-64=2017.9' || 'dpcpp_linux-64' }}
+
+      - name: Conda info
+        run: |
+          mamba info
+          mamba list
+
+      - name: Build and install DPNP package
+        run: |
+          python scripts/build_locally.py --onemkl-interfaces --verbose
+
+      - name: Smoke test
+        run: |
+          python -m dpctl -f
+          python -c "import dpnp; print(dpnp.__version__)"
+
+      - name: Install pytest
+        run: |
+          mamba install pytest ${{ env.CHANNELS }}
+
+      - name: Run tests
+        run: |
+          python -m pytest -ra --pyargs dpnp.tests
+        env:
+          SYCL_CACHE_PERSISTENT: 1

--- a/.github/workflows/check-mkl-interfaces.yaml
+++ b/.github/workflows/check-mkl-interfaces.yaml
@@ -10,6 +10,7 @@ permissions: read-all
 
 env:
   CHANNELS: '-c dppy/label/dev -c https://software.repos.intel.com/python/conda/ -c conda-forge --override-channels'
+  TEST_ENV_NAME: 'test_onemkl_interfaces'
   BUILD_DEP_PKGS: >-
       mkl-devel-dpcpp
       tbb-devel
@@ -24,8 +25,8 @@ env:
       scikit-build
 
 jobs:
-  build_and_test:
-    name: Run on ['${{ matrix.os }}', python='${{ matrix.python }}']
+  test_by_tag:
+    name: Run on ['${{ matrix.os }}', python='${{ matrix.python }}'] with oneMKL tag
 
     strategy:
       matrix:
@@ -42,7 +43,7 @@ jobs:
       run:
         shell: ${{ matrix.os == 'windows-2019' && 'cmd /C CALL {0}' || 'bash -el {0}' }}
 
-    continue-on-error: true
+    continue-on-error: false
 
     steps:
       - name: Cancel Previous Runs
@@ -63,7 +64,7 @@ jobs:
           channels: conda-forge
           conda-remove-defaults: 'true'
           python-version: ${{ matrix.python }}
-          activate-environment: 'test_onemkl_interfaces'
+          activate-environment: ${{ env.TEST_ENV_NAME }}
 
       # Sometimes `mamba install ...` fails due to slow download speed rate, so disable the check in mamba
       - name: Disable speed limit check in mamba
@@ -83,6 +84,96 @@ jobs:
       - name: Build and install DPNP package
         run: |
           python scripts/build_locally.py --onemkl-interfaces --verbose
+
+      - name: Smoke test
+        run: |
+          python -m dpctl -f
+          python -c "import dpnp; print(dpnp.__version__)"
+
+      - name: Install pytest
+        run: |
+          mamba install pytest ${{ env.CHANNELS }}
+
+      - name: Run tests
+        run: |
+          python -m pytest -ra --pyargs dpnp.tests
+        env:
+          SYCL_CACHE_PERSISTENT: 1
+
+  test_by_branch:
+    name: Run on ['${{ matrix.os }}', python='${{ matrix.python }}'] with oneMKL develop branch
+
+    strategy:
+      matrix:
+        python: ['3.12']
+        os: [ubuntu-22.04] # windows-2019 - no DFT support for Windows in oneMKL
+
+    permissions:
+      # Needed to cancel any previous runs that are not completed for a given workflow
+      actions: write
+
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: ${{ matrix.os == 'windows-2019' && 'cmd /C CALL {0}' || 'bash -el {0}' }}
+
+    continue-on-error: true
+
+    env:
+      onemkl-source-dir: '${{ github.workspace }}/onemkl/'
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout DPNP repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Checkout oneMKL repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: 'oneapi-src/oneMKL'
+          ref: 'develop'
+          path: ${{ env.onemkl-source-dir }}
+          fetch-depth: 0
+
+      - name: oneMKL ls info
+        run: |
+          ls -la ${{ env.onemkl-source-dir }}
+
+      - name: Setup miniconda
+        uses: conda-incubator/setup-miniconda@d2e6a045a86077fb6cad6f5adf368e9076ddaa8d # v3.1.0
+        with:
+          miniforge-version: latest
+          use-mamba: 'true'
+          channels: conda-forge
+          conda-remove-defaults: 'true'
+          python-version: ${{ matrix.python }}
+          activate-environment: ${{ env.TEST_ENV_NAME }}
+
+      # Sometimes `mamba install ...` fails due to slow download speed rate, so disable the check in mamba
+      - name: Disable speed limit check in mamba
+        run: echo "MAMBA_NO_LOW_SPEED_LIMIT=1" >> $GITHUB_ENV
+
+      - name: Install dpnp build dependencies
+        run: |
+          mamba install ${{ env.DPCPP_PKG }} ${{ env.BUILD_DEP_PKGS }} ${{ env.CHANNELS }}
+        env:
+          DPCPP_PKG: ${{ matrix.os == 'windows-2019' && 'dpcpp_win-64 vs_win-64=2017.9' || 'dpcpp_linux-64' }}
+
+      - name: Conda info
+        run: |
+          mamba info
+          mamba list
+
+      - name: Build and install DPNP package
+        run: |
+          python scripts/build_locally.py --onemkl-interfaces --onemkl-interfaces-dir=${{ env.onemkl-source-dir }} --verbose
 
       - name: Smoke test
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ if(_use_onemkl_interfaces)
     FetchContent_Declare(
             onemkl_interfaces_library
             GIT_REPOSITORY https://github.com/oneapi-src/oneMKL.git
-            GIT_TAG f2d2dcb4213a435bb60fbb88320c5f24892423ce
+            GIT_TAG 8f4312ef966420b9b8b4b82b9d5c22e2c91a1fe7  # v0.6
     )
     FetchContent_MakeAvailable(onemkl_interfaces_library)
     set(CMAKE_INSTALL_RPATH "${CMAKE_BINARY_DIR}/lib")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,11 +114,17 @@ if(_use_onemkl_interfaces)
         set(ENABLE_MKLGPU_BACKEND False)
         set(ENABLE_MKLCPU_BACKEND False)
     endif()
-    FetchContent_Declare(
-            onemkl_interfaces_library
-            GIT_REPOSITORY https://github.com/oneapi-src/oneMKL.git
-            GIT_TAG 8f4312ef966420b9b8b4b82b9d5c22e2c91a1fe7  # v0.6
-    )
+
+    if(DPNP_ONEMKL_INTERFACES_DIR)
+        FetchContent_Declare(onemkl_interfaces_library SOURCE_DIR "${DPNP_ONEMKL_INTERFACES_DIR}")
+    else()
+        FetchContent_Declare(
+                onemkl_interfaces_library
+                GIT_REPOSITORY https://github.com/oneapi-src/oneMKL.git
+                GIT_TAG 8f4312ef966420b9b8b4b82b9d5c22e2c91a1fe7  # v0.6
+        )
+    endif()
+
     FetchContent_MakeAvailable(onemkl_interfaces_library)
     set(CMAKE_INSTALL_RPATH "${CMAKE_BINARY_DIR}/lib")
 endif()

--- a/scripts/build_locally.py
+++ b/scripts/build_locally.py
@@ -40,6 +40,7 @@ def run(
     cmake_opts="",
     target="intel",
     onemkl_interfaces=False,
+    onemkl_interfaces_dir=None,
 ):
     build_system = None
 
@@ -108,6 +109,13 @@ def run(
             "-DDPNP_USE_ONEMKL_INTERFACES=ON",
         ]
 
+        if onemkl_interfaces_dir:
+            cmake_args += [
+                f"-DDPNP_ONEMKL_INTERFACES_DIR={onemkl_interfaces_dir}",
+            ]
+    elif onemkl_interfaces_dir:
+        RuntimeError("--onemkl-interfaces-dir option is not supported")
+
     subprocess.check_call(
         cmake_args, shell=False, cwd=setup_dir, env=os.environ
     )
@@ -175,6 +183,13 @@ if __name__ == "__main__":
         dest="onemkl_interfaces",
         action="store_true",
     )
+    driver.add_argument(
+        "--onemkl-interfaces-dir",
+        help="Local directory with source of oneMKL Interfaces",
+        dest="onemkl_interfaces_dir",
+        default=None,
+        type=str,
+    )
     args = parser.parse_args()
 
     args_to_validate = [
@@ -230,4 +245,5 @@ if __name__ == "__main__":
         cmake_opts=args.cmake_opts,
         target=args.target,
         onemkl_interfaces=args.onemkl_interfaces,
+        onemkl_interfaces_dir=args.onemkl_interfaces_dir,
     )


### PR DESCRIPTION
The PR proposes to bump oneMKL version up to latest release `0.6`.

Also as a validation step it is proposed to add GitHub action with will build dpnp with oneMKL interface on Linux and run tests.
The action is not assumed to be run on Windows, because oneMKL has quite limited support there (i.e. no DFT support).

This PR implements new `--onemkl-interfaces-dir=` option of `python scripts/build_locally.py` script to pass a path towards a local checkout directory with oneMKL source.
The action is extended to consider the validation of the new option.

The PR closes #2163.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
