### PR TITLE
Bump conda-build version from `24.9.0` to `24.11.1`

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -13,7 +13,7 @@ env:
   # Follow oneAPI installation instruction for conda, since intel channel is not longer available
   # CHANNELS: '-c dppy/label/dev -c intel -c conda-forge --override-channels'
   CHANNELS: '-c dppy/label/dev -c https://software.repos.intel.com/python/conda/ -c conda-forge --override-channels'
-  CONDA_BUILD_VERSION: '24.9.0'
+  CONDA_BUILD_VERSION: '24.11.1'
   CONDA_INDEX_VERSION: '0.5.0'
   RERUN_TESTS_ON_FAILURE: 'true'
   RUN_TESTS_MAX_ATTEMPTS: 2


### PR DESCRIPTION
The PR proposes to switch `conda-build` version from `24.9.0` to `24.11.1`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
