### PR TITLE
Fix FFT negative strides case

### DIFF
--- a/dpnp/tests/test_fft.py
+++ b/dpnp/tests/test_fft.py
@@ -378,6 +378,16 @@ class TestFft:
         out = dpnp.empty((10,), dtype=dpnp.float32)
         assert_raises(TypeError, dpnp.fft.fft, a, out=out)
 
+    @pytest.mark.parametrize(
+        "dtype", get_all_dtypes(no_none=True, no_bool=True)
+    )
+    def test_negative_stride(self, dtype):
+        a = dpnp.arange(10).astype(dtype)
+        result = dpnp.fft.fft(a[::-1])
+        expected = numpy.fft.fft(a.asnumpy()[::-1])
+
+        assert_dtype_allclose(result, expected, check_only_type_kind=True)
+
 
 class TestFft2:
     def setup_method(self):

--- a/dpnp/tests/test_fft.py
+++ b/dpnp/tests/test_fft.py
@@ -382,7 +382,7 @@ class TestFft:
         "dtype", get_all_dtypes(no_none=True, no_bool=True)
     )
     def test_negative_stride(self, dtype):
-        a = dpnp.arange(10).astype(dtype)
+        a = dpnp.arange(10, dtype=dtype)
         result = dpnp.fft.fft(a[::-1])
         expected = numpy.fft.fft(a.asnumpy()[::-1])
 


### PR DESCRIPTION
FFT implementation validate arrays for supported strides/dtypes and if needed make a copy and cast (`_copy_array`).
Old implementation didn't validate for dtype in case of negative strides resulting in incorrect type selection in `_commit_descriptor` and failures on systems without `float64` support.
