### PR TITLE
Add `dpnp.iterable` function

### DIFF
--- a/dpnp/dpnp_iface_indexing.py
+++ b/dpnp/dpnp_iface_indexing.py
@@ -69,6 +69,7 @@ __all__ = [
     "fill_diagonal",
     "flatnonzero",
     "indices",
+    "iterable",
     "ix_",
     "mask_indices",
     "ndindex",
@@ -1031,6 +1032,47 @@ def indices(
         else:
             res[i] = idx
     return res
+
+
+def iterable(y):
+    """
+    Check whether or not an object can be iterated over.
+
+    For full documentation refer to :obj:`numpy.iterable`.
+
+    Parameters
+    ----------
+    y : object
+        Input object.
+
+    Returns
+    -------
+    out : bool
+        Return ``True`` if the object has an iterator method or is a sequence
+        and ``False`` otherwise.
+
+    Examples
+    --------
+    >>> import dpnp as np
+    >>> np.iterable([1, 2, 3])
+    True
+    >>> np.iterable(2)
+    False
+
+    In most cases, the results of ``np.iterable(obj)`` are consistent with
+    ``isinstance(obj, collections.abc.Iterable)``. One notable exception is
+    the treatment of 0-dimensional arrays:
+
+    >>> from collections.abc import Iterable
+    >>> a = np.array(1.0)  # 0-dimensional array
+    >>> isinstance(a, Iterable)
+    True
+    >>> np.iterable(a)
+    False
+
+    """
+
+    return numpy.iterable(y)
 
 
 def ix_(*args):

--- a/dpnp/tests/test_indexing.py
+++ b/dpnp/tests/test_indexing.py
@@ -337,6 +337,14 @@ class TestIx:
         assert_raises(ValueError, xp.ix_, xp.ones(shape))
 
 
+class TestIterable:
+    @pytest.mark.parametrize("data", [[1.0], [2, 3]])
+    def test_basic(self, data):
+        a = numpy.array(data)
+        ia = dpnp.array(a)
+        assert dpnp.iterable(ia) == numpy.iterable(a)
+
+
 @pytest.mark.parametrize(
     "shape", [[1, 2, 3], [(1, 2, 3)], [(3,)], [3], [], [()], [0]]
 )


### PR DESCRIPTION
There was `__iter__` method of dpnp.ndarray implemented in scope of #2206.

While this PR proposes to add implementation of `dpnp.iterable` function which is intended to check if the object (including dpnp.ndarray) can be iterated over.
The implementation leverages on NumPy call, which is based on attempt to pass the object to `iter` function.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
