### PR TITLE
Move `dpnp.from_dlpack` to array creation routine

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -220,6 +220,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "numpy": ("https://docs.scipy.org/doc/numpy/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/reference/", None),
+    "dpctl": ("https://intelpython.github.io/dpctl/latest/", None),
 }
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.

--- a/dpnp/__init__.py
+++ b/dpnp/__init__.py
@@ -49,6 +49,9 @@ if system() == "Windows":
         [os.getenv("PATH", ""), mypath, dpctlpath]
     )
 
+# Borrowed from DPCTL
+from dpctl.tensor import DLDeviceType
+
 from dpnp.dpnp_array import dpnp_array as ndarray
 from dpnp.dpnp_flatiter import flatiter as flatiter
 from dpnp.dpnp_iface_types import *

--- a/dpnp/dpnp_iface.py
+++ b/dpnp/dpnp_iface.py
@@ -62,7 +62,6 @@ __all__ = [
     "check_limitations",
     "check_supported_arrays_type",
     "default_float_type",
-    "from_dlpack",
     "get_dpnp_descriptor",
     "get_include",
     "get_normalized_queue_device",
@@ -441,60 +440,6 @@ def default_float_type(device=None, sycl_queue=None):
         device=device, sycl_queue=sycl_queue
     )
     return map_dtype_to_device(float64, _sycl_queue.sycl_device)
-
-
-def from_dlpack(obj, /, *, device=None, copy=None):
-    """
-    Create a dpnp array from a Python object implementing the ``__dlpack__``
-    protocol.
-
-    See https://dmlc.github.io/dlpack/latest/ for more details.
-
-    Parameters
-    ----------
-    obj : object
-        A Python object representing an array that implements the ``__dlpack__``
-        and ``__dlpack_device__`` methods.
-    device : {:class:`dpctl.SyclDevice`, :class:`dpctl.SyclQueue`,
-              :class:`dpctl.tensor.Device`, tuple, None}, optional
-        Array API concept of a device where the output array is to be placed.
-        ``device`` can be ``None``, an oneAPI filter selector string,
-        an instance of :class:`dpctl.SyclDevice` corresponding to
-        a non-partitioned SYCL device, an instance of :class:`dpctl.SyclQueue`,
-        a :class:`dpctl.tensor.Device` object returned by
-        :attr:`dpctl.tensor.usm_ndarray.device`, or a 2-tuple matching
-        the format of the output of the ``__dlpack_device__`` method,
-        an integer enumerator representing the device type followed by
-        an integer representing the index of the device.
-        Default: ``None``.
-    copy {bool, None}, optional
-        Boolean indicating whether or not to copy the input.
-
-        * If `copy``is ``True``, the input will always be copied.
-        * If ``False``, a ``BufferError`` will be raised if a copy is deemed
-          necessary.
-        * If ``None``, a copy will be made only if deemed necessary, otherwise,
-          the existing memory buffer will be reused.
-
-        Default: ``None``.
-
-    Returns
-    -------
-    out : dpnp_array
-        Returns a new dpnp array containing the data from another array
-        (obj) with the ``__dlpack__`` method on the same device as object.
-
-    Raises
-    ------
-    TypeError:
-        if `obj` does not implement ``__dlpack__`` method
-    ValueError:
-        if the input array resides on an unsupported device
-
-    """
-
-    usm_res = dpt.from_dlpack(obj, device=device, copy=copy)
-    return dpnp_array._create_from_usm_ndarray(usm_res)
 
 
 def get_dpnp_descriptor(

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -2084,7 +2084,7 @@ def from_dlpack(x, /, *, device=None, copy=None):
     copy : {bool, None}, optional
         Boolean indicating whether or not to copy the input.
 
-        * If `copy``is ``True``, the input will always be copied.
+        * If `copy` is ``True``, the input will always be copied.
         * If ``False``, a ``BufferError`` will be raised if a copy is deemed
           necessary.
         * If ``None``, a copy will be made only if deemed necessary, otherwise,

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -2077,9 +2077,8 @@ def from_dlpack(x, /, *, device=None, copy=None):
         * ``(device_type, device_id)`` : 2-tuple matching the format of the
           output of the ``__dlpack_device__`` method: an integer enumerator
           representing the device type followed by an integer representing
-          the index of the device. The only supported
-          :class:`dpctl.tensor.DLDeviceType` device types are ``"kDLCPU"``
-          and ``"kDLOneAPI"``.
+          the index of the device. The only supported :class:`dpnp.DLDeviceType`
+          device types are ``"kDLCPU"`` and ``"kDLOneAPI"``.
 
         Default: ``None``.
     copy : {bool, None}, optional

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -75,6 +75,7 @@ __all__ = [
     "fromfunction",
     "fromiter",
     "fromstring",
+    "from_dlpack",
     "full",
     "full_like",
     "geomspace",
@@ -2045,6 +2046,67 @@ def fromstring(
         usm_type=usm_type,
         sycl_queue=sycl_queue,
     )
+
+
+def from_dlpack(x, /, *, device=None, copy=None):
+    """
+    Create a dpnp array from a Python object implementing the ``__dlpack__``
+    protocol.
+
+    For full documentation refer to :obj:`numpy.from_dlpack`.
+
+    Parameters
+    ----------
+    x : object
+        A Python object representing an array that implements the ``__dlpack__``
+        and ``__dlpack_device__`` methods.
+    device : {None, tuple, SyclDevice, SyclQueue, Device}, optional
+        Array API concept of a device where the output array is to be placed.
+        ``device`` can be ``None``, an oneAPI filter selector string,
+        an instance of :class:`dpctl.SyclDevice` corresponding to
+        a non-partitioned SYCL device, an instance of :class:`dpctl.SyclQueue`,
+        a :class:`dpctl.tensor.Device` object returned by
+        :attr:`dpctl.tensor.usm_ndarray.device`, or a 2-tuple matching
+        the format of the output of the ``__dlpack_device__`` method,
+        an integer enumerator representing the device type followed by
+        an integer representing the index of the device.
+        Default: ``None``.
+    copy : {bool, None}, optional
+        Boolean indicating whether or not to copy the input.
+
+        * If `copy``is ``True``, the input will always be copied.
+        * If ``False``, a ``BufferError`` will be raised if a copy is deemed
+          necessary.
+        * If ``None``, a copy will be made only if deemed necessary, otherwise,
+          the existing memory buffer will be reused.
+
+        Default: ``None``.
+
+    Returns
+    -------
+    out : dpnp.ndarray
+        Returns a new dpnp array containing the data from another array `obj`
+        with the ``__dlpack__`` method on the same device as object.
+
+    Raises
+    ------
+    TypeError:
+        if `obj` does not implement ``__dlpack__`` method
+    ValueError:
+        if the input array resides on an unsupported device
+
+    Examples
+    --------
+    >>> import dpnp as np
+    >>> import numpy
+    >>> x = numpy.arange(10)
+    >>> # create a view of the numpy array "x" in dpnp:
+    >>> y = np.from_dlpack(x)
+
+    """
+
+    usm_res = dpt.from_dlpack(x, device=device, copy=copy)
+    return dpnp_array._create_from_usm_ndarray(usm_res)
 
 
 def full(

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -2066,20 +2066,20 @@ def from_dlpack(x, /, *, device=None, copy=None):
 
         * ``None`` : The data remains on the same device.
         * oneAPI filter selector string : SYCL device selected by filter
-            selector string.
+          selector string.
         * :class:`dpctl.SyclDevice` : Explicit SYCL device that must correspond
-            to a non-partitioned SYCL device.
+          to a non-partitioned SYCL device.
         * :class:`dpctl.SyclQueue` : Implies SYCL device targeted by the SYCL
-            queue.
+          queue.
         * :class:`dpctl.tensor.Device` : Implies SYCL device
-            ``device.sycl_queue``. The `device` object is obtained via
-            :attr:`dpctl.tensor.usm_ndarray.device`.
+          ``device.sycl_queue``. The `device` object is obtained via
+          :attr:`dpctl.tensor.usm_ndarray.device`.
         * ``(device_type, device_id)`` : 2-tuple matching the format of the
-            output of the ``__dlpack_device__`` method: an integer enumerator
-            representing the device type followed by an integer representing
-            the index of the device. The only supported
-            :class:`dpctl.tensor.DLDeviceType` device types are ``"kDLCPU"``
-            and ``"kDLOneAPI"``.
+          output of the ``__dlpack_device__`` method: an integer enumerator
+          representing the device type followed by an integer representing
+          the index of the device. The only supported
+          :class:`dpctl.tensor.DLDeviceType` device types are ``"kDLCPU"``
+          and ``"kDLOneAPI"``.
 
         Default: ``None``.
     copy : {bool, None}, optional

--- a/dpnp/tests/test_dlpack.py
+++ b/dpnp/tests/test_dlpack.py
@@ -8,8 +8,6 @@ from .helper import (
     get_all_dtypes,
 )
 
-device_oneAPI = 14  # DLDeviceType.kDLOneAPI
-
 
 class TestDLPack:
     @pytest.mark.parametrize("stream", [None, 1])
@@ -56,11 +54,11 @@ class TestDLPack:
 
     def test_device(self):
         x = dpnp.arange(5)
-        assert x.__dlpack_device__()[0] == device_oneAPI
+        assert x.__dlpack_device__()[0] == dpnp.DLDeviceType.kDLOneAPI
         y = dpnp.from_dlpack(x)
-        assert y.__dlpack_device__()[0] == device_oneAPI
+        assert y.__dlpack_device__()[0] == dpnp.DLDeviceType.kDLOneAPI
         z = y[::2]
-        assert z.__dlpack_device__()[0] == device_oneAPI
+        assert z.__dlpack_device__()[0] == dpnp.DLDeviceType.kDLOneAPI
 
     def test_ndim0(self):
         x = dpnp.array(1.0)
@@ -72,3 +70,15 @@ class TestDLPack:
         y = dpnp.from_dlpack(x, device=x.__dlpack_device__())
         assert x.device == y.device
         assert x.get_array()._pointer == y.get_array()._pointer
+
+    def test_numpy_input(self):
+        x = numpy.arange(10)
+
+        y = dpnp.from_dlpack(x)
+        assert isinstance(y, numpy.ndarray)
+        assert y.ctypes.data == x.ctypes.data
+        assert y.dtype == x.dtype
+
+        z = dpnp.from_dlpack(x, device=(dpnp.DLDeviceType.kDLCPU, 0))
+        assert isinstance(z, numpy.ndarray)
+        assert z.dtype == y.dtype


### PR DESCRIPTION
The PR proposes to move `dpnp.from_dlpack` function to `dpnp/dpnp_iface_arraycreation.py` and to update docstring description, because there were formatting issues with rendered documentation of `dpnp.from_dlpack`.

Also sphinx configuration was tuned to add mapping towards dpctl documentation pages.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
