### PR TITLE
Align with numpy 2.2

### DIFF
--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -2170,11 +2170,12 @@ def insert(arr, obj, values, axis=None):
     ----------
     arr : array_like
         Input array.
-    obj : {slice, int, array-like of ints}
+    obj : {slice, int, array-like of ints or bools}
         Object that defines the index or indices before which `values` is
         inserted. It supports multiple insertions when `obj` is a single
         scalar or a sequence with one element (similar to calling insert
         multiple times).
+        Boolean indices are treated as a mask of elements to insert.
     values : array_like
         Values to insert into `arr`. If the type of `values` is different
         from that of `arr`, `values` is converted to the type of `arr`.
@@ -2266,20 +2267,12 @@ def insert(arr, obj, values, axis=None):
             obj, sycl_queue=params.exec_q, usm_type=params.usm_type
         )
         if indices.dtype == dpnp.bool:
-            warnings.warn(
-                "In the future insert will treat boolean arrays and array-likes"
-                " as a boolean index instead of casting it to integers",
-                FutureWarning,
-                stacklevel=2,
-            )
-            indices = indices.astype(dpnp.intp)
-            # TODO: Code after warning period:
-            # if indices.ndim != 1:
-            #    raise ValueError(
-            #        "boolean array argument `obj` to insert must be "
-            #        "one-dimensional"
-            #    )
-            # indices = dpnp.nonzero(indices)[0]
+            if indices.ndim != 1:
+                raise ValueError(
+                    "boolean array argument obj to insert "
+                    "must be one dimensional"
+                )
+            indices = dpnp.flatnonzero(indices)
         elif indices.ndim > 1:
             raise ValueError(
                 "index array argument `obj` to insert must be one-dimensional "

--- a/dpnp/dpnp_utils/dpnp_utils_statistics.py
+++ b/dpnp/dpnp_utils/dpnp_utils_statistics.py
@@ -153,7 +153,7 @@ def dpnp_cov(m, y=None, rowvar=True, dtype=None):
         elif x.ndim == 1:
             x = x[dpnp.newaxis, :]
 
-        if not rowvar and x.shape[0] != 1:
+        if not rowvar and x.ndim != 1:
             x = x.T
 
         if x.dtype != dtype:

--- a/dpnp/tests/test_manipulation.py
+++ b/dpnp/tests/test_manipulation.py
@@ -584,7 +584,7 @@ class TestInsert:
         [True, [False], numpy.array([True] * 4), [True, False, True, False]],
     )
     def test_boolean_obj(self, obj):
-        if numpy_version() >= "2.2.0" and not isinstance(numpy.ndarray):
+        if numpy_version() >= "2.2.0" and not isinstance(obj, numpy.ndarray):
             # numpy.insert raises exception
             # TODO: remove once NumPy resolves that
             obj = numpy.array(obj)

--- a/dpnp/tests/test_manipulation.py
+++ b/dpnp/tests/test_manipulation.py
@@ -4,7 +4,12 @@ import dpctl.tensor as dpt
 import numpy
 import pytest
 from dpctl.tensor._numpy_helper import AxisError
-from numpy.testing import assert_array_equal, assert_equal, assert_raises
+from numpy.testing import (
+    assert_array_equal,
+    assert_equal,
+    assert_raises,
+    numpy_version,
+)
 
 import dpnp
 
@@ -579,6 +584,11 @@ class TestInsert:
         [True, [False], numpy.array([True] * 4), [True, False, True, False]],
     )
     def test_boolean_obj(self, obj):
+        if numpy_version() >= "2.2.0" and not isinstance(numpy.ndarray):
+            # numpy.insert raises exception
+            # TODO: remove once NumPy resolves that
+            obj = numpy.array(obj)
+
         a = numpy.array([1, 2, 3])
         ia = dpnp.array(a)
         assert_equal(dpnp.insert(ia, obj, 9), numpy.insert(a, obj, 9))

--- a/dpnp/tests/test_manipulation.py
+++ b/dpnp/tests/test_manipulation.py
@@ -20,7 +20,6 @@ from .helper import (
     get_float_dtypes,
     get_integer_dtypes,
     has_support_aspect64,
-    numpy_version,
 )
 from .third_party.cupy import testing
 
@@ -578,13 +577,13 @@ class TestInsert:
         result = dpnp.insert(ia, obj, values)
         assert_equal(result, expected)
 
-    @pytest.mark.filterwarnings("ignore::FutureWarning")
+    @testing.with_requires("numpy>=2.2")
     @pytest.mark.parametrize(
         "obj",
-        [True, [False], numpy.array([True] * 4), [True, False, True, False]],
+        [[False], numpy.array([True] * 4), [True, False, True, False]],
     )
     def test_boolean_obj(self, obj):
-        if numpy_version() >= "2.2.0" and not isinstance(obj, numpy.ndarray):
+        if not isinstance(obj, numpy.ndarray):
             # numpy.insert raises exception
             # TODO: remove once NumPy resolves that
             obj = numpy.array(obj)
@@ -592,6 +591,19 @@ class TestInsert:
         a = numpy.array([1, 2, 3])
         ia = dpnp.array(a)
         assert_equal(dpnp.insert(ia, obj, 9), numpy.insert(a, obj, 9))
+
+    @testing.with_requires("numpy>=2.2")
+    @pytest.mark.parametrize("xp", [dpnp, numpy])
+    @pytest.mark.parametrize(
+        "obj_data",
+        [True, [[True, False], [True, False]]],
+        ids=["0d", "2d"],
+    )
+    def test_boolean_obj_error(self, xp, obj_data):
+        a = xp.array([1, 2, 3])
+        obj = xp.array(obj_data)
+        with pytest.raises(ValueError):
+            xp.insert(a, obj, 9)
 
     def test_1D_array(self):
         a = numpy.array([1, 2, 3])

--- a/dpnp/tests/test_manipulation.py
+++ b/dpnp/tests/test_manipulation.py
@@ -1394,6 +1394,9 @@ class TestTrimZeros:
         expected = numpy.trim_zeros(a)
         assert_array_equal(result, expected)
 
+    # TODO: modify once SAT-7616
+    # numpy 2.2 validates trim rules
+    @testing.with_requires("numpy<2.2")
     def test_trim_no_rule(self):
         a = numpy.array([0, 0, 1, 0, 2, 3, 4, 0])
         ia = dpnp.array(a)

--- a/dpnp/tests/test_manipulation.py
+++ b/dpnp/tests/test_manipulation.py
@@ -8,7 +8,6 @@ from numpy.testing import (
     assert_array_equal,
     assert_equal,
     assert_raises,
-    numpy_version,
 )
 
 import dpnp
@@ -21,6 +20,7 @@ from .helper import (
     get_float_dtypes,
     get_integer_dtypes,
     has_support_aspect64,
+    numpy_version,
 )
 from .third_party.cupy import testing
 

--- a/dpnp/tests/test_statistics.py
+++ b/dpnp/tests/test_statistics.py
@@ -614,7 +614,7 @@ class TestCov:
     @pytest.mark.parametrize(
         "dtype", get_all_dtypes(no_bool=True, no_none=True, no_complex=True)
     )
-    def test_false_rowvar(self, dtype):
+    def test_false_rowvar_dtype(self, dtype):
         a = numpy.array([[0, 2], [1, 1], [2, 0]], dtype=dtype)
         ia = dpnp.array(a)
 
@@ -623,7 +623,8 @@ class TestCov:
 
     # numpy 2.2 properly transposes 2d array when rowvar=False
     @with_requires("numpy>=2.2")
-    def test_false_rowvar(self):
+    @pytest.mark.filterwarnings("ignore::RuntimeWarning")
+    def test_false_rowvar_1x3(self):
         a = numpy.array([[0, 1, 2]])
         ia = dpnp.array(a)
 

--- a/dpnp/tests/test_statistics.py
+++ b/dpnp/tests/test_statistics.py
@@ -16,6 +16,7 @@ from .helper import (
     get_float_complex_dtypes,
     has_support_aspect64,
 )
+from .third_party.cupy.testing import with_requires
 
 
 class TestAverage:
@@ -619,6 +620,8 @@ def test_cov_rowvar(dtype):
     assert_allclose(numpy.cov(b, rowvar=False), dpnp.cov(a, rowvar=False))
 
 
+# numpy 2.2 properly transposes 2d array when rowvar=False
+@with_requires("numpy>=2.2")
 @pytest.mark.parametrize(
     "dtype", get_all_dtypes(no_bool=True, no_none=True, no_complex=True)
 )

--- a/dpnp/tests/test_statistics.py
+++ b/dpnp/tests/test_statistics.py
@@ -610,25 +610,36 @@ class TestCorrcoef:
         assert_dtype_allclose(result, expected)
 
 
-@pytest.mark.parametrize(
-    "dtype", get_all_dtypes(no_bool=True, no_none=True, no_complex=True)
-)
-def test_cov_rowvar(dtype):
-    a = dpnp.array([[0, 2], [1, 1], [2, 0]], dtype=dtype)
-    b = numpy.array([[0, 2], [1, 1], [2, 0]], dtype=dtype)
-    assert_allclose(dpnp.cov(a.T), dpnp.cov(a, rowvar=False))
-    assert_allclose(numpy.cov(b, rowvar=False), dpnp.cov(a, rowvar=False))
+class TestCov:
+    @pytest.mark.parametrize(
+        "dtype", get_all_dtypes(no_bool=True, no_none=True, no_complex=True)
+    )
+    def test_false_rowvar(self, dtype):
+        a = numpy.array([[0, 2], [1, 1], [2, 0]], dtype=dtype)
+        ia = dpnp.array(a)
 
+        assert_allclose(dpnp.cov(ia.T), dpnp.cov(ia, rowvar=False))
+        assert_allclose(dpnp.cov(ia, rowvar=False), numpy.cov(a, rowvar=False))
 
-# numpy 2.2 properly transposes 2d array when rowvar=False
-@with_requires("numpy>=2.2")
-@pytest.mark.parametrize(
-    "dtype", get_all_dtypes(no_bool=True, no_none=True, no_complex=True)
-)
-def test_cov_1D_rowvar(dtype):
-    a = dpnp.array([[0, 1, 2]], dtype=dtype)
-    b = numpy.array([[0, 1, 2]], dtype=dtype)
-    assert_allclose(numpy.cov(b, rowvar=False), dpnp.cov(a, rowvar=False))
+    # numpy 2.2 properly transposes 2d array when rowvar=False
+    @with_requires("numpy>=2.2")
+    def test_1D_false_rowvar(self):
+        a = numpy.array([0, 1, 2])
+        ia = dpnp.array(a)
+
+        expected = numpy.cov(a, rowvar=False)
+        result = dpnp.cov(ia, rowvar=False)
+        assert_allclose(expected, result)
+
+    # numpy 2.2 properly transposes 2d array when rowvar=False
+    @with_requires("numpy>=2.2")
+    def test_2D_rowvar(self):
+        a = numpy.ones((3, 1))
+        ia = dpnp.array(a)
+
+        expected = numpy.cov(a, ddof=0, rowvar=True)
+        result = dpnp.cov(ia, ddof=0, rowvar=True)
+        assert_allclose(expected, result)
 
 
 @pytest.mark.parametrize("axis", [None, 0, 1])

--- a/dpnp/tests/test_statistics.py
+++ b/dpnp/tests/test_statistics.py
@@ -623,8 +623,8 @@ class TestCov:
 
     # numpy 2.2 properly transposes 2d array when rowvar=False
     @with_requires("numpy>=2.2")
-    def test_1D_false_rowvar(self):
-        a = numpy.array([0, 1, 2])
+    def test_false_rowvar(self):
+        a = numpy.array([[0, 1, 2]])
         ia = dpnp.array(a)
 
         expected = numpy.cov(a, rowvar=False)
@@ -633,7 +633,8 @@ class TestCov:
 
     # numpy 2.2 properly transposes 2d array when rowvar=False
     @with_requires("numpy>=2.2")
-    def test_2D_rowvar(self):
+    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
+    def test_true_rowvar(self):
         a = numpy.ones((3, 1))
         ia = dpnp.array(a)
 

--- a/dpnp/tests/test_umath.py
+++ b/dpnp/tests/test_umath.py
@@ -73,9 +73,10 @@ def get_id(val):
 
 
 # implement missing umaths and to remove the list
-# SAT-7323 bitwise_count
 new_umaths_numpy_20 = [
-    "bitwise_count",
+    "bitwise_count",  # SAT-7323
+    "matvec",  # SAT-7615
+    "vecmat",  # SAT-7615
 ]
 
 

--- a/dpnp/tests/third_party/cupy/manipulation_tests/test_add_remove.py
+++ b/dpnp/tests/third_party/cupy/manipulation_tests/test_add_remove.py
@@ -394,6 +394,8 @@ class TestTrim_zeros(unittest.TestCase):
             with pytest.raises(TypeError):
                 xp.trim_zeros(a, trim=self.trim)
 
+    # TODO: remove once SAT-7616
+    @testing.with_requires("numpy<2.2")
     @testing.for_all_dtypes()
     def test_trim_ndim(self, dtype):
         for xp in (numpy, cupy):

--- a/dpnp/tests/third_party/cupy/manipulation_tests/test_add_remove.py
+++ b/dpnp/tests/third_party/cupy/manipulation_tests/test_add_remove.py
@@ -387,6 +387,8 @@ class TestTrim_zeros(unittest.TestCase):
         a = xp.array([1, 0, 2, 3, 0, 5, 0, 0, 0], dtype=dtype)
         return xp.trim_zeros(a, trim=self.trim)
 
+    # TODO: remove once SAT-7616
+    @testing.with_requires("numpy<2.2")
     @testing.for_all_dtypes()
     def test_trim_zero_dim(self, dtype):
         for xp in (numpy, cupy):

--- a/dpnp/tests/third_party/cupy/statistics_tests/test_correlation.py
+++ b/dpnp/tests/third_party/cupy/statistics_tests/test_correlation.py
@@ -127,12 +127,14 @@ class TestCov(unittest.TestCase):
                 )
 
     @pytest.mark.usefixtures("allow_fall_back_on_numpy")
+    @pytest.mark.filterwarnings("ignore::RuntimeWarning")
     def test_cov(self):
         self.check((2, 3))
         self.check((2,), (2,))
-        if numpy_version() < "2.2.0":
-            # TODO: remove once numpy 2.2 resolve an error
-            self.check((1, 3), (1, 3), rowvar=False)
+        if numpy_version() >= "2.2.0":
+            # TODO: enable once numpy 2.2 resolves ValueError
+            # self.check((1, 3), (1, 3), rowvar=False)
+            self.check((1, 3), (1, 1), rowvar=False)  # TODO: remove
         self.check((2, 3), (2, 3), rowvar=False)
         self.check((2, 3), bias=True)
         self.check((2, 3), ddof=2)

--- a/dpnp/tests/third_party/cupy/statistics_tests/test_correlation.py
+++ b/dpnp/tests/third_party/cupy/statistics_tests/test_correlation.py
@@ -4,7 +4,7 @@ import numpy
 import pytest
 
 import dpnp as cupy
-from dpnp.tests.helper import has_support_aspect64
+from dpnp.tests.helper import has_support_aspect64, numpy_version
 from dpnp.tests.third_party.cupy import testing
 
 
@@ -130,7 +130,9 @@ class TestCov(unittest.TestCase):
     def test_cov(self):
         self.check((2, 3))
         self.check((2,), (2,))
-        self.check((1, 3), (1, 3), rowvar=False)
+        if numpy_version() < "2.2.0":
+            # TODO: remove once numpy 2.2 resolve an error
+            self.check((1, 3), (1, 3), rowvar=False)
         self.check((2, 3), (2, 3), rowvar=False)
         self.check((2, 3), bias=True)
         self.check((2, 3), ddof=2)


### PR DESCRIPTION
The PR proposes to align with changes implemented in `numpy 2.2`:
- Update `dpnp.cov` to properly transpose 2d array with `rowvar=False`.
- Handle boolean arrays in `dpnp.insert` as a mask.
- Mute or workaround tests with fail due to numpy issues in `numpy.insert` and `numpy.cov`.
- Mute tests with are not passing due to new numpy behavior (new `matvec` and `vecmat` ufuncs, support of 2d array in `trim_zeros`).

`matvec` and `vecmat` ufuncs and `trim_zeros` functions will be separately.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
