### PR TITLE
Improve performance of `dnp.nan_to_num`

### DIFF
--- a/dpnp/backend/extensions/ufunc/CMakeLists.txt
+++ b/dpnp/backend/extensions/ufunc/CMakeLists.txt
@@ -38,6 +38,7 @@ set(_elementwise_sources
     ${CMAKE_CURRENT_SOURCE_DIR}/elementwise_functions/lcm.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/elementwise_functions/ldexp.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/elementwise_functions/logaddexp2.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/elementwise_functions/nan_to_num.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/elementwise_functions/radians.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/elementwise_functions/sinc.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/elementwise_functions/spacing.cpp

--- a/dpnp/backend/extensions/ufunc/elementwise_functions/nan_to_num.cpp
+++ b/dpnp/backend/extensions/ufunc/elementwise_functions/nan_to_num.cpp
@@ -111,8 +111,8 @@ sycl::event nan_to_num_strided_call(sycl::queue &exec_q,
     const scT posinf_v = py::cast<const scT>(py_posinf);
     const scT neginf_v = py::cast<const scT>(py_neginf);
 
-    using dpnp::kernels::nan_to_num::nan_to_num_impl;
-    sycl::event to_num_ev = nan_to_num_impl<T, scT>(
+    using dpnp::kernels::nan_to_num::nan_to_num_strided_impl;
+    sycl::event to_num_ev = nan_to_num_strided_impl<T, scT>(
         exec_q, nd, nelems, shape_strides, nan_v, posinf_v, neginf_v, arg_p,
         arg_offset, dst_p, dst_offset, depends);
 

--- a/dpnp/backend/extensions/ufunc/elementwise_functions/nan_to_num.cpp
+++ b/dpnp/backend/extensions/ufunc/elementwise_functions/nan_to_num.cpp
@@ -342,8 +342,6 @@ std::pair<sycl::event, sycl::event>
         dpctl::utils::keep_args_alive(q, {src, dst}, host_tasks), comp_ev);
 }
 
-namespace py_int = dpnp::extensions::py_internal;
-
 /**
  * @brief A factory to define pairs of supported types for which
  * nan_to_num_call<T> function is available.
@@ -372,7 +370,6 @@ struct NanToNumFactory
             return nullptr;
         }
         else {
-            using ::dpnp::extensions::ufunc::impl::nan_to_num_call;
             return nan_to_num_call<T>;
         }
     }
@@ -388,7 +385,6 @@ struct NanToNumContigFactory
             return nullptr;
         }
         else {
-            using ::dpnp::extensions::ufunc::impl::nan_to_num_contig_call;
             return nan_to_num_contig_call<T>;
         }
     }

--- a/dpnp/backend/extensions/ufunc/elementwise_functions/nan_to_num.cpp
+++ b/dpnp/backend/extensions/ufunc/elementwise_functions/nan_to_num.cpp
@@ -91,25 +91,25 @@ typedef sycl::event (*nan_to_num_fn_ptr_t)(sycl::queue &,
                                            const std::vector<sycl::event> &);
 
 template <typename T>
-sycl::event nan_to_num_call(sycl::queue &exec_q,
-                            int nd,
-                            std::size_t nelems,
-                            const py::ssize_t *shape_strides,
-                            const py::object &py_nan,
-                            const py::object &py_posinf,
-                            const py::object &py_neginf,
-                            const char *arg_p,
-                            py::ssize_t arg_offset,
-                            char *dst_p,
-                            py::ssize_t dst_offset,
-                            const std::vector<sycl::event> &depends)
+sycl::event nan_to_num_strided_call(sycl::queue &exec_q,
+                                    int nd,
+                                    std::size_t nelems,
+                                    const py::ssize_t *shape_strides,
+                                    const py::object &py_nan,
+                                    const py::object &py_posinf,
+                                    const py::object &py_neginf,
+                                    const char *arg_p,
+                                    py::ssize_t arg_offset,
+                                    char *dst_p,
+                                    py::ssize_t dst_offset,
+                                    const std::vector<sycl::event> &depends)
 {
     using dpctl::tensor::type_utils::is_complex_v;
     using scT = std::conditional_t<is_complex_v<T>, value_type_of_t<T>, T>;
 
-    scT nan_v = py::cast<scT>(py_nan);
-    scT posinf_v = py::cast<scT>(py_posinf);
-    scT neginf_v = py::cast<scT>(py_neginf);
+    const scT nan_v = py::cast<const scT>(py_nan);
+    const scT posinf_v = py::cast<const scT>(py_posinf);
+    const scT neginf_v = py::cast<const scT>(py_neginf);
 
     using dpnp::kernels::nan_to_num::nan_to_num_impl;
     sycl::event to_num_ev = nan_to_num_impl<T, scT>(
@@ -142,9 +142,9 @@ sycl::event nan_to_num_contig_call(sycl::queue &exec_q,
     using dpctl::tensor::type_utils::is_complex_v;
     using scT = std::conditional_t<is_complex_v<T>, value_type_of_t<T>, T>;
 
-    scT nan_v = py::cast<scT>(py_nan);
-    scT posinf_v = py::cast<scT>(py_posinf);
-    scT neginf_v = py::cast<scT>(py_neginf);
+    const scT nan_v = py::cast<const scT>(py_nan);
+    const scT posinf_v = py::cast<const scT>(py_posinf);
+    const scT neginf_v = py::cast<const scT>(py_neginf);
 
     using dpnp::kernels::nan_to_num::nan_to_num_contig_impl;
     sycl::event to_num_contig_ev = nan_to_num_contig_impl<T, scT>(
@@ -331,7 +331,7 @@ std::pair<sycl::event, sycl::event>
 
 /**
  * @brief A factory to define pairs of supported types for which
- * nan_to_num_call<T> function is available.
+ * nan-to-num function is available.
  *
  * @tparam T Type of input vector `a` and of result vector `y`.
  */
@@ -357,7 +357,7 @@ struct NanToNumFactory
             return nullptr;
         }
         else {
-            return nan_to_num_call<T>;
+            return nan_to_num_strided_call<T>;
         }
     }
 };

--- a/dpnp/backend/extensions/ufunc/elementwise_functions/nan_to_num.cpp
+++ b/dpnp/backend/extensions/ufunc/elementwise_functions/nan_to_num.cpp
@@ -23,7 +23,14 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //*****************************************************************************
 
+#include <algorithm>
+#include <complex>
 #include <stdexcept>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 #include <sycl/sycl.hpp>
 
@@ -145,12 +152,8 @@ std::pair<sycl::event, sycl::event>
     const py::ssize_t *src_shape = src.get_shape_raw();
     const py::ssize_t *dst_shape = dst.get_shape_raw();
 
-    bool shapes_equal(true);
-    size_t nelems(1);
-    for (int i = 0; i < src_nd; ++i) {
-        nelems *= static_cast<size_t>(src_shape[i]);
-        shapes_equal = shapes_equal && (src_shape[i] == dst_shape[i]);
-    }
+    size_t nelems = src.get_size();
+    bool shapes_equal = std::equal(src_shape, src_shape + src_nd, dst_shape);
     if (!shapes_equal) {
         throw py::value_error("Array shapes are not the same.");
     }

--- a/dpnp/backend/extensions/ufunc/elementwise_functions/nan_to_num.cpp
+++ b/dpnp/backend/extensions/ufunc/elementwise_functions/nan_to_num.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <complex>
+#include <cstddef>
 #include <stdexcept>
 #include <string>
 #include <tuple>
@@ -78,7 +79,7 @@ using value_type_of_t = typename value_type_of<T>::type;
 
 typedef sycl::event (*nan_to_num_fn_ptr_t)(sycl::queue &,
                                            int,
-                                           size_t,
+                                           std::size_t,
                                            const py::ssize_t *,
                                            const py::object &,
                                            const py::object &,
@@ -92,7 +93,7 @@ typedef sycl::event (*nan_to_num_fn_ptr_t)(sycl::queue &,
 template <typename T>
 sycl::event nan_to_num_call(sycl::queue &exec_q,
                             int nd,
-                            size_t nelems,
+                            std::size_t nelems,
                             const py::ssize_t *shape_strides,
                             const py::object &py_nan,
                             const py::object &py_posinf,
@@ -120,7 +121,7 @@ sycl::event nan_to_num_call(sycl::queue &exec_q,
 
 typedef sycl::event (*nan_to_num_contig_fn_ptr_t)(
     sycl::queue &,
-    size_t,
+    std::size_t,
     const py::object &,
     const py::object &,
     const py::object &,
@@ -130,7 +131,7 @@ typedef sycl::event (*nan_to_num_contig_fn_ptr_t)(
 
 template <typename T>
 sycl::event nan_to_num_contig_call(sycl::queue &exec_q,
-                                   size_t nelems,
+                                   std::size_t nelems,
                                    const py::object &py_nan,
                                    const py::object &py_posinf,
                                    const py::object &py_neginf,
@@ -191,7 +192,7 @@ std::pair<sycl::event, sycl::event>
     const py::ssize_t *src_shape = src.get_shape_raw();
     const py::ssize_t *dst_shape = dst.get_shape_raw();
 
-    size_t nelems = src.get_size();
+    std::size_t nelems = src.get_size();
     bool shapes_equal = std::equal(src_shape, src_shape + src_nd, dst_shape);
     if (!shapes_equal) {
         throw py::value_error("Array shapes are not the same.");

--- a/dpnp/backend/extensions/ufunc/elementwise_functions/nan_to_num.hpp
+++ b/dpnp/backend/extensions/ufunc/elementwise_functions/nan_to_num.hpp
@@ -1,5 +1,5 @@
 //*****************************************************************************
-// Copyright (c) 2024-2025, Intel Corporation
+// Copyright (c) 2024, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -23,51 +23,13 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //*****************************************************************************
 
-#include <pybind11/pybind11.h>
+#pragma once
 
-#include "degrees.hpp"
-#include "fabs.hpp"
-#include "fix.hpp"
-#include "float_power.hpp"
-#include "fmax.hpp"
-#include "fmin.hpp"
-#include "fmod.hpp"
-#include "gcd.hpp"
-#include "heaviside.hpp"
-#include "i0.hpp"
-#include "lcm.hpp"
-#include "ldexp.hpp"
-#include "logaddexp2.hpp"
-#include "nan_to_num.hpp"
-#include "radians.hpp"
-#include "sinc.hpp"
-#include "spacing.hpp"
+#include <pybind11/pybind11.h>
 
 namespace py = pybind11;
 
 namespace dpnp::extensions::ufunc
 {
-/**
- * @brief Add elementwise functions to Python module
- */
-void init_elementwise_functions(py::module_ m)
-{
-    init_degrees(m);
-    init_fabs(m);
-    init_fix(m);
-    init_float_power(m);
-    init_fmax(m);
-    init_fmin(m);
-    init_fmod(m);
-    init_gcd(m);
-    init_heaviside(m);
-    init_i0(m);
-    init_lcm(m);
-    init_ldexp(m);
-    init_logaddexp2(m);
-    init_nan_to_num(m);
-    init_radians(m);
-    init_sinc(m);
-    init_spacing(m);
-}
+void init_nan_to_num(py::module_ m);
 } // namespace dpnp::extensions::ufunc

--- a/dpnp/backend/kernels/elementwise_functions/nan_to_num.hpp
+++ b/dpnp/backend/kernels/elementwise_functions/nan_to_num.hpp
@@ -97,7 +97,7 @@ template <typename T, typename scT>
 sycl::event nan_to_num_impl(sycl::queue &q,
                             size_t nelems,
                             int nd,
-                            const ssize_t *shape_strides,
+                            const dpctl::tensor::ssize_t *shape_strides,
                             const scT nan,
                             const scT posinf,
                             const scT neginf,

--- a/dpnp/backend/kernels/elementwise_functions/nan_to_num.hpp
+++ b/dpnp/backend/kernels/elementwise_functions/nan_to_num.hpp
@@ -39,7 +39,7 @@ namespace dpnp::kernels::nan_to_num
 {
 
 template <typename T>
-T to_num(const T v, const T nan, const T posinf, const T neginf)
+inline T to_num(const T v, const T nan, const T posinf, const T neginf)
 {
     return (sycl::isnan(v))   ? nan
            : (sycl::isinf(v)) ? (v > 0) ? posinf : neginf

--- a/dpnp/backend/kernels/elementwise_functions/nan_to_num.hpp
+++ b/dpnp/backend/kernels/elementwise_functions/nan_to_num.hpp
@@ -95,16 +95,16 @@ class NanToNumKernel;
 
 template <typename T, typename scT>
 sycl::event nan_to_num_impl(sycl::queue &q,
-                            size_t nelems,
-                            int nd,
+                            const size_t nelems,
+                            const int nd,
                             const dpctl::tensor::ssize_t *shape_strides,
                             const scT nan,
                             const scT posinf,
                             const scT neginf,
                             const char *in_cp,
-                            dpctl::tensor::ssize_t in_offset,
+                            const dpctl::tensor::ssize_t in_offset,
                             char *out_cp,
-                            dpctl::tensor::ssize_t out_offset,
+                            const dpctl::tensor::ssize_t out_offset,
                             const std::vector<sycl::event> &depends)
 {
     dpctl::tensor::type_utils::validate_type_for_device<T>(q);
@@ -132,7 +132,7 @@ class NanToNumContigKernel;
 
 template <typename T, typename scT>
 sycl::event nan_to_num_contig_impl(sycl::queue &q,
-                                   size_t nelems,
+                                   const size_t nelems,
                                    const scT nan,
                                    const scT posinf,
                                    const scT neginf,

--- a/dpnp/backend/kernels/elementwise_functions/nan_to_num.hpp
+++ b/dpnp/backend/kernels/elementwise_functions/nan_to_num.hpp
@@ -190,18 +190,18 @@ public:
 };
 
 template <typename T, typename scT>
-sycl::event nan_to_num_impl(sycl::queue &q,
-                            const size_t nelems,
-                            const int nd,
-                            const dpctl::tensor::ssize_t *shape_strides,
-                            const scT nan,
-                            const scT posinf,
-                            const scT neginf,
-                            const char *in_cp,
-                            const dpctl::tensor::ssize_t in_offset,
-                            char *out_cp,
-                            const dpctl::tensor::ssize_t out_offset,
-                            const std::vector<sycl::event> &depends)
+sycl::event nan_to_num_strided_impl(sycl::queue &q,
+                                    const size_t nelems,
+                                    const int nd,
+                                    const dpctl::tensor::ssize_t *shape_strides,
+                                    const scT nan,
+                                    const scT posinf,
+                                    const scT neginf,
+                                    const char *in_cp,
+                                    const dpctl::tensor::ssize_t in_offset,
+                                    char *out_cp,
+                                    const dpctl::tensor::ssize_t out_offset,
+                                    const std::vector<sycl::event> &depends)
 {
     dpctl::tensor::type_utils::validate_type_for_device<T>(q);
 

--- a/dpnp/backend/kernels/elementwise_functions/nan_to_num.hpp
+++ b/dpnp/backend/kernels/elementwise_functions/nan_to_num.hpp
@@ -67,8 +67,8 @@ public:
         const dpctl::tensor::ssize_t &inp_offset = offsets_.get_first_offset();
         const dpctl::tensor::ssize_t &out_offset = offsets_.get_second_offset();
 
-        using dpctl::tensor::type_utils::is_complex;
-        if constexpr (is_complex<T>::value) {
+        using dpctl::tensor::type_utils::is_complex_v;
+        if constexpr (is_complex_v<T>) {
             using realT = typename T::value_type;
             static_assert(std::is_same_v<realT, scT>);
             T z = inp_[inp_offset];

--- a/dpnp/backend/kernels/elementwise_functions/nan_to_num.hpp
+++ b/dpnp/backend/kernels/elementwise_functions/nan_to_num.hpp
@@ -1,0 +1,130 @@
+//*****************************************************************************
+// Copyright (c) 2024, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//*****************************************************************************
+
+#pragma once
+
+#include <complex>
+#include <cstddef>
+#include <vector>
+
+#include <sycl/sycl.hpp>
+// dpctl tensor headers
+#include "kernels/dpctl_tensor_types.hpp"
+#include "utils/offset_utils.hpp"
+#include "utils/type_utils.hpp"
+
+namespace dpnp::kernels::nan_to_num
+{
+
+template <typename T>
+T to_num(const T v, const T nan, const T posinf, const T neginf)
+{
+    return (sycl::isnan(v))   ? nan
+           : (sycl::isinf(v)) ? (v > 0) ? posinf : neginf
+                              : v;
+}
+
+template <typename T, typename scT, typename InOutIndexerT>
+struct NanToNumFunctor
+{
+public:
+    NanToNumFunctor(const T *inp,
+                    T *out,
+                    const InOutIndexerT &inp_out_indexer,
+                    const scT nan,
+                    const scT posinf,
+                    const scT neginf)
+        : inp_(inp), out_(out), inp_out_indexer_(inp_out_indexer), nan_(nan),
+          posinf_(posinf), neginf_(neginf)
+    {
+    }
+
+    void operator()(sycl::id<1> wid) const
+    {
+        const auto &offsets_ = inp_out_indexer_(wid.get(0));
+        const dpctl::tensor::ssize_t &inp_offset = offsets_.get_first_offset();
+        const dpctl::tensor::ssize_t &out_offset = offsets_.get_second_offset();
+
+        using dpctl::tensor::type_utils::is_complex;
+        if constexpr (is_complex<T>::value) {
+            using realT = typename T::value_type;
+            static_assert(std::is_same_v<realT, scT>);
+            T z = inp_[inp_offset];
+            realT x = to_num(z.real(), nan_, posinf_, neginf_);
+            realT y = to_num(z.imag(), nan_, posinf_, neginf_);
+            out_[out_offset] = T{x, y};
+        }
+        else {
+            out_[out_offset] = to_num(inp_[inp_offset], nan_, posinf_, neginf_);
+        }
+    }
+
+private:
+    const T *inp_ = nullptr;
+    T *out_ = nullptr;
+    const InOutIndexerT inp_out_indexer_;
+    const scT nan_;
+    const scT posinf_;
+    const scT neginf_;
+};
+
+template <typename T>
+class NanToNumKernel;
+
+template <typename T, typename scT>
+sycl::event nan_to_num_impl(sycl::queue &q,
+                            size_t nelems,
+                            int nd,
+                            const ssize_t *shape_strides,
+                            const scT nan,
+                            const scT posinf,
+                            const scT neginf,
+                            const char *in_cp,
+                            dpctl::tensor::ssize_t in_offset,
+                            char *out_cp,
+                            dpctl::tensor::ssize_t out_offset,
+                            const std::vector<sycl::event> &depends)
+{
+    dpctl::tensor::type_utils::validate_type_for_device<T>(q);
+
+    const T *in_tp = reinterpret_cast<const T *>(in_cp);
+    T *out_tp = reinterpret_cast<T *>(out_cp);
+
+    using InOutIndexerT =
+        typename dpctl::tensor::offset_utils::TwoOffsets_StridedIndexer;
+    const InOutIndexerT indexer{nd, in_offset, out_offset, shape_strides};
+
+    sycl::event comp_ev = q.submit([&](sycl::handler &cgh) {
+        cgh.depends_on(depends);
+
+        using KernelName = NanToNumKernel<T>;
+        cgh.parallel_for<KernelName>(
+            {nelems}, NanToNumFunctor<T, scT, InOutIndexerT>(
+                          in_tp, out_tp, indexer, nan, posinf, neginf));
+    });
+    return comp_ev;
+}
+
+} // namespace dpnp::kernels::nan_to_num

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -3125,21 +3125,11 @@ def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
             "nan must be a scalar of an integer, float, bool, "
             f"but got {type(nan)}"
         )
-
-    out = dpnp.empty_like(x) if copy else x
     x_type = x.dtype.type
 
     if not issubclass(x_type, dpnp.inexact):
-        return x
+        return x.copy() if copy else x
 
-    parts = (
-        (x.real, x.imag) if issubclass(x_type, dpnp.complexfloating) else (x,)
-    )
-    parts_out = (
-        (out.real, out.imag)
-        if issubclass(x_type, dpnp.complexfloating)
-        else (out,)
-    )
     max_f, min_f = _get_max_min(x.real.dtype)
     if posinf is not None:
         if not isinstance(posinf, (int, float)):
@@ -3156,16 +3146,26 @@ def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
             )
         min_f = neginf
 
-    for part, part_out in zip(parts, parts_out):
-        nan_mask = dpnp.isnan(part)
-        posinf_mask = dpnp.isposinf(part)
-        neginf_mask = dpnp.isneginf(part)
+    if copy:
+        out = dpnp.empty_like(x)
+    else:
+        if not x.flags.writable:
+            raise ValueError("copy is required for read-only array `x`")
+        out = x
 
-        part = dpnp.where(nan_mask, nan, part, out=part_out)
-        part = dpnp.where(posinf_mask, max_f, part, out=part_out)
-        part = dpnp.where(neginf_mask, min_f, part, out=part_out)
+    x_ary = dpnp.get_usm_ndarray(x)
+    out_ary = dpnp.get_usm_ndarray(out)
 
-    return out
+    q = x.sycl_queue
+    _manager = dpu.SequentialOrderManager[q]
+
+    h_ev, comp_ev = ufi._nan_to_num(
+        x_ary, nan, max_f, min_f, out_ary, q, depends=_manager.submitted_events
+    )
+
+    _manager.add_event_pair(h_ev, comp_ev)
+
+    return dpnp.get_result_array(out_ary) if copy else x
 
 
 _NEGATIVE_DOCSTRING = """

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -3128,7 +3128,7 @@ def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
     x_type = x.dtype.type
 
     if not issubclass(x_type, dpnp.inexact):
-        return x.copy() if copy else x
+        return dpnp.copy(x) if copy else x
 
     max_f, min_f = _get_max_min(x.real.dtype)
     if posinf is not None:

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -3128,7 +3128,7 @@ def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
     x_type = x.dtype.type
 
     if not issubclass(x_type, dpnp.inexact):
-        return dpnp.copy(x) if copy else x
+        return dpnp.copy(x) if copy else dpnp.get_result_array(x)
 
     max_f, min_f = _get_max_min(x.real.dtype)
     if posinf is not None:
@@ -3165,7 +3165,7 @@ def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
 
     _manager.add_event_pair(h_ev, comp_ev)
 
-    return dpnp.get_result_array(out) if copy else x
+    return dpnp.get_result_array(out)
 
 
 _NEGATIVE_DOCSTRING = """

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -3165,7 +3165,7 @@ def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
 
     _manager.add_event_pair(h_ev, comp_ev)
 
-    return dpnp.get_result_array(out_ary) if copy else x
+    return dpnp.get_result_array(out) if copy else x
 
 
 _NEGATIVE_DOCSTRING = """

--- a/dpnp/tests/test_mathematical.py
+++ b/dpnp/tests/test_mathematical.py
@@ -1558,6 +1558,27 @@ class TestNanToNum:
         with pytest.raises(TypeError):
             dpnp.nan_to_num(ia, **{kwarg: value})
 
+    def test_error_readonly(self):
+        a = dpnp.array([0, 1, dpnp.nan, dpnp.inf, -dpnp.inf])
+        a.flags.writable = False
+        with pytest.raises(ValueError):
+            dpnp.nan_to_num(a, copy=False)
+
+    @pytest.mark.parametrize("copy", [True, False])
+    @pytest.mark.parametrize("dt", get_all_dtypes(no_bool=True, no_none=True))
+    def test_nan_to_num_strided(self, copy, dt):
+        n = 10
+        dt = numpy.dtype(dt)
+        np_a = numpy.arange(2 * n, dtype=dt)
+        dp_a = dpnp.arange(2 * n, dtype=dt)
+        if dt.kind in "fc":
+            np_a[::4] = numpy.nan
+            dp_a[::4] = dpnp.nan
+        dp_r = dpnp.nan_to_num(dp_a[::-2], copy=copy, nan=57.0)
+        np_r = numpy.nan_to_num(np_a[::-2], copy=copy, nan=57.0)
+
+        assert_dtype_allclose(dp_r, np_r)
+
 
 class TestProd:
     @pytest.mark.parametrize("axis", [None, 0, 1, -1, 2, -2, (1, 2), (0, -2)])


### PR DESCRIPTION
This PR adds a dedicated kernel for `dnp.nan_to_num` to improve its performance. This reduces the number of kernel calls to at most one in all cases.

A kernel for both strided and contiguous inputs have been added, to avoid additional allocation of device memory for trivial strides when input is fully C- or F-contiguous.

For example of performance gains, using Max GPU

master:
```python
In [1]: import dpnp as dnp

In [2]: import numpy as np

In [3]: x_np = np.random.randn(10**9)

In [4]: x_np[np.random.choice(x_np.size, 200, replace=False)] = np.nan

In [5]: x = dnp.asarray(x_np)

In [6]: q = x.sycl_queue

In [7]: %time r = dnp.nan_to_num(x); q.wait()
CPU times: user 394 ms, sys: 43.8 ms, total: 438 ms
Wall time: 304 ms

In [8]: %time r = dnp.nan_to_num(x); q.wait()
CPU times: user 333 ms, sys: 31.8 ms, total: 364 ms
Wall time: 134 ms
```

on branch:
```python
In [8]: %time r = dnp.nan_to_num(x); q.wait()
CPU times: user 49.6 ms, sys: 8.1 ms, total: 57.7 ms
Wall time: 60.9 ms

In [9]: %time r = dnp.nan_to_num(x); q.wait()
CPU times: user 22.9 ms, sys: 16 ms, total: 38.9 ms
Wall time: 19.7 ms
```

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [X] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
