### PR TITLE
Bump SYCL compiler min version required

### DIFF
--- a/dpnp/backend/kernels/dpnp_krnl_common.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_common.cpp
@@ -40,7 +40,7 @@
  * sycl::ext::oneapi::experimental::properties was added.
  */
 #ifndef __SYCL_COMPILER_REDUCTION_PROPERTIES_SUPPORT
-#define __SYCL_COMPILER_REDUCTION_PROPERTIES_SUPPORT 20241129
+#define __SYCL_COMPILER_REDUCTION_PROPERTIES_SUPPORT 20241210L
 #endif
 
 namespace mkl_blas = oneapi::mkl::blas;

--- a/dpnp/backend/kernels/elementwise_functions/i0.hpp
+++ b/dpnp/backend/kernels/elementwise_functions/i0.hpp
@@ -32,7 +32,7 @@
  * sycl::ext::intel::math::cyl_bessel_i0(x) is fully resolved.
  */
 #ifndef __SYCL_COMPILER_BESSEL_I0_SUPPORT
-#define __SYCL_COMPILER_BESSEL_I0_SUPPORT 20241114L
+#define __SYCL_COMPILER_BESSEL_I0_SUPPORT 20241210L
 #endif
 
 #if __SYCL_COMPILER_VERSION >= __SYCL_COMPILER_BESSEL_I0_SUPPORT


### PR DESCRIPTION
DPC++ compiler released 2025.0.4 version where `__SYCL_COMPILER_VERSION` is defined to `20241205`. But the fixes from #2211 and for `sycl::ext::intel::math::cyl_bessel_i0(x)` support weren't mapped there.

Thus the PR proposes to bump `__SYCL_COMPILER_REDUCTION_PROPERTIES_SUPPORT` and `__SYCL_COMPILER_BESSEL_I0_SUPPORT` defines up to `20241210` value to exclude DPC++ compiler 2025.0.4 version.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
