### PR TITLE
update tests for newly added integr dtypes (int8, int16, uint8-uint64)

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -274,7 +274,7 @@ jobs:
         env:
             DPNP_TEST_ALL_INT_TYPES: 1
         run: |
-            pytest -n auto -ra --pyargs ${{ env.PACKAGE_NAME }}.tests
+            pytest -ra --pyargs ${{ env.PACKAGE_NAME }}.tests
 
   test_windows:
     name: Test ['windows-2019', python='${{ matrix.python }}']

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -107,7 +107,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10', '3.11']
 
     continue-on-error: true
 
@@ -193,7 +193,7 @@ jobs:
             python -m pytest -n auto -ra --pyargs ${{ env.PACKAGE_NAME }}.tests
 
   test_linux_all_dtypes:
-    name: Test ['ubuntu-latest', python='${{ matrix.python }}']
+    name: Test ['ubuntu-latest-all-dtypes', python='${{ matrix.python }}']
 
     needs: build
 
@@ -289,7 +289,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10', '3.11']
 
     continue-on-error: true
 
@@ -409,7 +409,7 @@ jobs:
             python -m pytest -n auto -ra --pyargs ${{ env.PACKAGE_NAME }}.tests
 
   test_windows_all_dtypes:
-    name: Test ['windows-2019', python='${{ matrix.python }}']
+    name: Test ['windows-2019-all-dtypes', python='${{ matrix.python }}']
 
     needs: build
 

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -148,7 +148,7 @@ jobs:
 
       - name: Test conda channel
         run: |
-          mamba search ${{ env.PACKAGE_NAME }} -c ${{ env.channel-path }} --override-channels --info --json > ${{ env.ver-json-path }}
+          conda search ${{ env.PACKAGE_NAME }} -c ${{ env.channel-path }} --override-channels --info --json > ${{ env.ver-json-path }}
           cat ${{ env.ver-json-path }}
 
       - name: Get package version
@@ -182,7 +182,7 @@ jobs:
         id: run_tests_linux
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
         with:
-          timeout_minutes: 10
+          timeout_minutes: 12
           max_attempts: ${{ env.RUN_TESTS_MAX_ATTEMPTS }}
           retry_on: any
           command: |
@@ -348,7 +348,7 @@ jobs:
       - name: Test conda channel
         run: |
           @echo on
-          mamba search ${{ env.PACKAGE_NAME }} -c ${{ env.channel-path }} --override-channels --info --json > ${{ env.ver-json-path }}
+          conda search ${{ env.PACKAGE_NAME }} -c ${{ env.channel-path }} --override-channels --info --json > ${{ env.ver-json-path }}
 
       - name: Dump version.json
         run: more ${{ env.ver-json-path }}

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -529,7 +529,7 @@ jobs:
         env:
           DPNP_TEST_ALL_INT_TYPES: 1
         run: |
-          pytest -n auto -ra --pyargs ${{ env.PACKAGE_NAME }}.tests
+          pytest -ra --pyargs ${{ env.PACKAGE_NAME }}.tests
 
   upload:
     name: Upload ['${{ matrix.os }}', python='${{ matrix.python }}']

--- a/dpnp/backend/kernels/dpnp_krnl_common.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_common.cpp
@@ -40,7 +40,7 @@
  * sycl::ext::oneapi::experimental::properties was added.
  */
 #ifndef __SYCL_COMPILER_REDUCTION_PROPERTIES_SUPPORT
-#define __SYCL_COMPILER_REDUCTION_PROPERTIES_SUPPORT 20241210L
+#define __SYCL_COMPILER_REDUCTION_PROPERTIES_SUPPORT 20241208L
 #endif
 
 namespace mkl_blas = oneapi::mkl::blas;

--- a/dpnp/backend/kernels/dpnp_krnl_common.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_common.cpp
@@ -40,7 +40,7 @@
  * sycl::ext::oneapi::experimental::properties was added.
  */
 #ifndef __SYCL_COMPILER_REDUCTION_PROPERTIES_SUPPORT
-#define __SYCL_COMPILER_REDUCTION_PROPERTIES_SUPPORT 20241129
+#define __SYCL_COMPILER_REDUCTION_PROPERTIES_SUPPORT 20241210L
 #endif
 
 namespace mkl_blas = oneapi::mkl::blas;

--- a/dpnp/backend/kernels/elementwise_functions/i0.hpp
+++ b/dpnp/backend/kernels/elementwise_functions/i0.hpp
@@ -32,7 +32,7 @@
  * sycl::ext::intel::math::cyl_bessel_i0(x) is fully resolved.
  */
 #ifndef __SYCL_COMPILER_BESSEL_I0_SUPPORT
-#define __SYCL_COMPILER_BESSEL_I0_SUPPORT 20241210L
+#define __SYCL_COMPILER_BESSEL_I0_SUPPORT 20241208L
 #endif
 
 #if __SYCL_COMPILER_VERSION >= __SYCL_COMPILER_BESSEL_I0_SUPPORT

--- a/dpnp/backend/kernels/elementwise_functions/i0.hpp
+++ b/dpnp/backend/kernels/elementwise_functions/i0.hpp
@@ -32,7 +32,7 @@
  * sycl::ext::intel::math::cyl_bessel_i0(x) is fully resolved.
  */
 #ifndef __SYCL_COMPILER_BESSEL_I0_SUPPORT
-#define __SYCL_COMPILER_BESSEL_I0_SUPPORT 20241114L
+#define __SYCL_COMPILER_BESSEL_I0_SUPPORT 20241210L
 #endif
 
 #if __SYCL_COMPILER_VERSION >= __SYCL_COMPILER_BESSEL_I0_SUPPORT

--- a/dpnp/dpnp_algo/dpnp_elementwise_common.py
+++ b/dpnp/dpnp_algo/dpnp_elementwise_common.py
@@ -590,12 +590,13 @@ class DPNPRound(DPNPUnaryFunc):
     def __call__(self, x, decimals=0, out=None, dtype=None):
         if decimals != 0:
             x_usm = dpnp.get_usm_ndarray(x)
-            if dpnp.issubdtype(x_usm.dtype, dpnp.integer) and dtype is None:
-                dtype = x_usm.dtype
-
             out_usm = None if out is None else dpnp.get_usm_ndarray(out)
-            x_usm = dpt.round(x_usm * 10**decimals, out=out_usm)
-            res_usm = dpt.divide(x_usm, 10**decimals, out=out_usm)
+
+            if dpnp.issubdtype(x_usm.dtype, dpnp.integer):
+                res_usm = dpt.round(x_usm, out=out_usm)
+            else:
+                x_usm = dpt.round(x_usm * 10**decimals, out=out_usm)
+                res_usm = dpt.divide(x_usm, 10**decimals, out=out_usm)
 
             if dtype is not None:
                 res_usm = dpt.astype(res_usm, dtype, copy=False)

--- a/dpnp/dpnp_iface_linearalgebra.py
+++ b/dpnp/dpnp_iface_linearalgebra.py
@@ -73,7 +73,10 @@ def _call_multiply(a, b, out=None):
     sc, arr = (a, b) if dpnp.isscalar(a) else (b, a)
     sc_dtype = map_dtype_to_device(type(sc), arr.sycl_device)
     res_dtype = dpnp.result_type(sc_dtype, arr)
-    res = dpnp.multiply(a, b, dtype=res_dtype)
+    if out is not None and out.dtype == arr.dtype:
+        res = dpnp.multiply(a, b, out=out)
+    else:
+        res = dpnp.multiply(a, b, dtype=res_dtype)
     return dpnp.get_result_array(res, out, casting="no")
 
 

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -1469,7 +1469,20 @@ def copyto(dst, src, casting="same_kind", where=True):
             f"but got {type(dst)}"
         )
     if not dpnp.is_supported_array_type(src):
+        no_dtype_attr = not hasattr(src, "dtype")
         src = dpnp.array(src, sycl_queue=dst.sycl_queue)
+        if no_dtype_attr:
+            # This case (scalar, list, etc) needs special handling to
+            # behave similar to NumPy
+            if dpnp.issubdtype(src, dpnp.integer) and dpnp.issubdtype(
+                dst, dpnp.unsignedinteger
+            ):
+                if dpnp.any(src < 0):
+                    raise OverflowError(
+                        "Cannot copy negative values to an unsigned int array"
+                    )
+
+                src = src.astype(dst.dtype)
 
     if not dpnp.can_cast(src.dtype, dst.dtype, casting=casting):
         raise TypeError(

--- a/dpnp/dpnp_iface_nanfunctions.py
+++ b/dpnp/dpnp_iface_nanfunctions.py
@@ -987,7 +987,7 @@ def nanstd(
     ddof : {int, float}, optional
         Means Delta Degrees of Freedom. The divisor used in calculations
         is ``N - ddof``, where ``N`` the number of non-NaN elements.
-        Default: `0.0`.
+        Default: ``0.0``.
     keepdims : {None, bool}, optional
         If ``True``, the reduced axes (dimensions) are included in the result
         as singleton dimensions, so that the returned array remains
@@ -1087,7 +1087,7 @@ def nanvar(
     ddof : {int, float}, optional
         Means Delta Degrees of Freedom.  The divisor used in calculations
         is ``N - ddof``, where ``N`` represents the number of non-NaN elements.
-        Default: `0.0`.
+        Default: ``0.0``.
     keepdims : {None, bool}, optional
         If ``True``, the reduced axes (dimensions) are included in the result
         as singleton dimensions, so that the returned array remains

--- a/dpnp/fft/dpnp_utils_fft.py
+++ b/dpnp/fft/dpnp_utils_fft.py
@@ -282,7 +282,7 @@ def _copy_array(x, complex_input):
         # r2c FFT, if input is integer or float16 dtype, convert to
         # float32 or float64 depending on device capabilities
         copy_flag = True
-        if dtype in [dpnp.float16]:
+        if dtype == dpnp.float16:
             dtype = dpnp.float32
         else:
             dtype = map_dtype_to_device(dpnp.float64, x.sycl_device)

--- a/dpnp/fft/dpnp_utils_fft.py
+++ b/dpnp/fft/dpnp_utils_fft.py
@@ -282,7 +282,10 @@ def _copy_array(x, complex_input):
         # r2c FFT, if input is integer or float16 dtype, convert to
         # float32 or float64 depending on device capabilities
         copy_flag = True
-        dtype = map_dtype_to_device(dpnp.float64, x.sycl_device)
+        if dtype in [dpnp.float16]:
+            dtype = dpnp.float32
+        else:
+            dtype = map_dtype_to_device(dpnp.float64, x.sycl_device)
 
     if copy_flag:
         x_copy = dpnp.empty_like(x, dtype=dtype, order="C")

--- a/dpnp/tests/helper.py
+++ b/dpnp/tests/helper.py
@@ -191,7 +191,13 @@ def get_all_dtypes(
 
 
 def generate_random_numpy_array(
-    shape, dtype=None, hermitian=False, seed_value=None, low=-10, high=10
+    shape,
+    dtype=None,
+    order="C",
+    hermitian=False,
+    seed_value=None,
+    low=-10,
+    high=10,
 ):
     """
     Generate a random numpy array with the specified shape and dtype.
@@ -207,6 +213,9 @@ def generate_random_numpy_array(
         Desired data-type for the output array.
         If not specified, data type will be determined by numpy.
         Default : ``None``
+    order : {"C", "F"}, optional
+        Specify the memory layout of the output array.
+        Default: ``"C"``.
     hermitian : bool, optional
         If True, generates a Hermitian (symmetric if `dtype` is real) matrix.
         Default : ``False``
@@ -223,7 +232,7 @@ def generate_random_numpy_array(
     Returns
     -------
     out : numpy.ndarray
-        A random numpy array of the specified shape and dtype.
+        A random numpy array of the specified shape, dtype and memory layout.
         The array is Hermitian or symmetric if `hermitian` is True.
 
     Note:
@@ -256,6 +265,10 @@ def generate_random_numpy_array(
             a = a.reshape(orig_shape)
         else:
             a = numpy.conj(a.T) @ a
+
+    # a.reshape(shape) returns an array in C order by default
+    if order != "C" and a.ndim > 1:
+        a = numpy.array(a, order=order)
     return a
 
 

--- a/dpnp/tests/helper.py
+++ b/dpnp/tests/helper.py
@@ -142,6 +142,12 @@ def get_float_complex_dtypes(no_float16=True, device=None):
     return dtypes
 
 
+def get_abs_array(data, dtype=None):
+    if numpy.issubdtype(dtype, numpy.unsignedinteger):
+        data = numpy.abs(data)
+    return numpy.array(data, dtype=dtype)
+
+
 def get_all_dtypes(
     no_bool=False,
     no_float16=True,

--- a/dpnp/tests/test_amin_amax.py
+++ b/dpnp/tests/test_amin_amax.py
@@ -4,23 +4,19 @@ from numpy.testing import assert_allclose, assert_array_equal
 
 import dpnp
 
-from .helper import get_all_dtypes
+from .helper import get_abs_array, get_all_dtypes
 
 
 @pytest.mark.parametrize("func", ["amax", "amin"])
 @pytest.mark.parametrize("keepdims", [True, False])
 @pytest.mark.parametrize("dtype", get_all_dtypes())
 def test_amax_amin(func, keepdims, dtype):
-    a = numpy.array(
-        [
-            [[-2.0, 3.0], [9.1, 0.2]],
-            [[-2.0, 5.0], [-2, -1.2]],
-            [[1.0, -2.0], [5.0, -1.1]],
-        ],
-    )
-    if numpy.issubdtype(dtype, numpy.unsignedinteger):
-        a = numpy.abs(a)
-    a = a.astype(dtype)
+    a = [
+        [[-2.0, 3.0], [9.1, 0.2]],
+        [[-2.0, 5.0], [-2, -1.2]],
+        [[1.0, -2.0], [5.0, -1.1]],
+    ]
+    a = get_abs_array(a, dtype)
     ia = dpnp.array(a)
 
     for axis in range(len(a)):

--- a/dpnp/tests/test_amin_amax.py
+++ b/dpnp/tests/test_amin_amax.py
@@ -17,8 +17,10 @@ def test_amax_amin(func, keepdims, dtype):
             [[-2.0, 5.0], [-2, -1.2]],
             [[1.0, -2.0], [5.0, -1.1]],
         ],
-        dtype=dtype,
     )
+    if numpy.issubdtype(dtype, numpy.unsignedinteger):
+        a = numpy.abs(a)
+    a = a.astype(dtype)
     ia = dpnp.array(a)
 
     for axis in range(len(a)):
@@ -28,20 +30,20 @@ def test_amax_amin(func, keepdims, dtype):
 
 
 def _get_min_max_input(type, shape):
-    size = 1
-    for i in range(len(shape)):
-        size *= shape[i]
-
+    size = numpy.prod(shape)
     a = numpy.arange(size, dtype=type)
-    a[int(size / 2)] = size * size
-    a[int(size / 3)] = -(size * size)
+    a[int(size / 2)] = size + 5
+    if numpy.issubdtype(type, numpy.unsignedinteger):
+        a[int(size / 3)] = size
+    else:
+        a[int(size / 3)] = -(size + 5)
 
     return a.reshape(shape)
 
 
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
 @pytest.mark.parametrize(
-    "shape", [(4,), (2, 3), (4, 5, 6)], ids=["(4,)", "(2,3)", "(4,5,6)"]
+    "shape", [(4,), (2, 3), (4, 5, 6)], ids=["(4,)", "(2, 3)", "(4, 5, 6)"]
 )
 def test_amax_diff_shape(dtype, shape):
     a = _get_min_max_input(dtype, shape)
@@ -59,7 +61,7 @@ def test_amax_diff_shape(dtype, shape):
 
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
 @pytest.mark.parametrize(
-    "shape", [(4,), (2, 3), (4, 5, 6)], ids=["(4,)", "(2,3)", "(4,5,6)"]
+    "shape", [(4,), (2, 3), (4, 5, 6)], ids=["(4,)", "(2, 3)", "(4, 5, 6)"]
 )
 def test_amin_diff_shape(dtype, shape):
     a = _get_min_max_input(dtype, shape)

--- a/dpnp/tests/test_arraycreation.py
+++ b/dpnp/tests/test_arraycreation.py
@@ -182,10 +182,12 @@ def test_exception_subok(func, args):
     "dtype", get_all_dtypes(no_bool=True, no_float16=False)
 )
 def test_arange(start, stop, step, dtype):
-    rtol_mult = 2
-    if dpnp.issubdtype(dtype, dpnp.float16):
-        # numpy casts to float32 type when computes float16 data
-        rtol_mult = 4
+    if numpy.issubdtype(dtype, numpy.unsignedinteger):
+        start = abs(start)
+        stop = abs(stop) if stop else None
+
+    # numpy casts to float32 type when computes float16 data
+    rtol_mult = 4 if dpnp.issubdtype(dtype, dpnp.float16) else 2
 
     func = lambda xp: xp.arange(start, stop=stop, step=step, dtype=dtype)
 
@@ -701,7 +703,7 @@ def test_dpctl_tensor_input(func, args):
 
 
 @pytest.mark.parametrize("start", [0, -5, 10, -2.5, 9.7])
-@pytest.mark.parametrize("stop", [0, 10, -2, 20.5, 1000])
+@pytest.mark.parametrize("stop", [0, 10, -2, 20.5, 120])
 @pytest.mark.parametrize(
     "num",
     [1, 5, numpy.array(10), dpnp.array(17), dpt.asarray(100)],
@@ -850,7 +852,7 @@ def test_space_num_error():
 @pytest.mark.parametrize("endpoint", [True, False])
 def test_geomspace(sign, dtype, num, endpoint):
     start = 2 * sign
-    stop = 256 * sign
+    stop = 127 * sign
 
     func = lambda xp: xp.geomspace(
         start, stop, num, endpoint=endpoint, dtype=dtype

--- a/dpnp/tests/test_arraycreation.py
+++ b/dpnp/tests/test_arraycreation.py
@@ -14,10 +14,7 @@ from numpy.testing import (
 
 import dpnp
 
-from .helper import (
-    assert_dtype_allclose,
-    get_all_dtypes,
-)
+from .helper import assert_dtype_allclose, get_all_dtypes
 from .third_party.cupy import testing
 
 
@@ -176,8 +173,8 @@ def test_exception_subok(func, args):
 
 
 @pytest.mark.parametrize("start", [0, -5, 10, -2.5, 9.7])
-@pytest.mark.parametrize("stop", [None, 10, -2, 20.5, 1000])
-@pytest.mark.parametrize("step", [None, 1, 2.7, -1.6, 100])
+@pytest.mark.parametrize("stop", [None, 10, -2, 20.5, 100])
+@pytest.mark.parametrize("step", [None, 1, 2.7, -1.6, 80])
 @pytest.mark.parametrize(
     "dtype", get_all_dtypes(no_bool=True, no_float16=False)
 )

--- a/dpnp/tests/test_bitwise.py
+++ b/dpnp/tests/test_bitwise.py
@@ -167,7 +167,8 @@ class TestBitwise:
 
 @pytest.mark.parametrize("dtype", get_integer_dtypes())
 def test_invert_out(dtype):
-    np_a = numpy.arange(-5, 5, dtype=dtype)
+    low = 0 if numpy.issubdtype(dtype, numpy.unsignedinteger) else -5
+    np_a = numpy.arange(low, 5, dtype=dtype)
     dp_a = inp.array(np_a)
 
     expected = numpy.invert(np_a)

--- a/dpnp/tests/test_fft.py
+++ b/dpnp/tests/test_fft.py
@@ -380,7 +380,7 @@ class TestFft2:
     @pytest.mark.parametrize("norm", [None, "forward", "backward", "ortho"])
     @pytest.mark.parametrize("order", ["C", "F"])
     def test_fft2(self, dtype, axes, norm, order):
-        a_np = generate_random_numpy_array((2, 3, 4), dtype)
+        a_np = generate_random_numpy_array((2, 3, 4), dtype, order)
         a = dpnp.array(a_np)
 
         result = dpnp.fft.fft2(a, axes=axes, norm=norm)
@@ -442,7 +442,7 @@ class TestFftn:
     @pytest.mark.parametrize("norm", [None, "backward", "forward", "ortho"])
     @pytest.mark.parametrize("order", ["C", "F"])
     def test_fftn(self, dtype, axes, norm, order):
-        a_np = generate_random_numpy_array((2, 3, 4, 5), dtype)
+        a_np = generate_random_numpy_array((2, 3, 4, 5), dtype, order)
         a = dpnp.array(a_np)
 
         result = dpnp.fft.fftn(a, axes=axes, norm=norm)
@@ -696,8 +696,7 @@ class TestIrfft:
     @pytest.mark.parametrize("norm", [None, "backward", "forward", "ortho"])
     @pytest.mark.parametrize("order", ["C", "F"])
     def test_irfft_1D_on_3D_array(self, dtype, n, axis, norm, order):
-        x = generate_random_numpy_array((4, 5, 6), dtype)
-        a_np = numpy.array(x, order=order)
+        a_np = generate_random_numpy_array((4, 5, 6), dtype, order)
         # each 1-D array of input should be Hermitian
         if axis == 0:
             a_np[0].imag = 0
@@ -937,8 +936,7 @@ class TestRfft2:
     @pytest.mark.parametrize("norm", [None, "backward", "forward", "ortho"])
     @pytest.mark.parametrize("order", ["C", "F"])
     def test_rfft2(self, dtype, axes, norm, order):
-        x = generate_random_numpy_array((2, 3, 4), dtype)
-        a_np = numpy.array(x, order=order)
+        a_np = generate_random_numpy_array((2, 3, 4), dtype, order)
         a = dpnp.asarray(a_np)
 
         result = dpnp.fft.rfft2(a, axes=axes, norm=norm)
@@ -1002,8 +1000,7 @@ class TestRfftn:
     @pytest.mark.parametrize("norm", [None, "backward", "forward", "ortho"])
     @pytest.mark.parametrize("order", ["C", "F"])
     def test_rfftn(self, dtype, axes, norm, order):
-        x = generate_random_numpy_array((2, 3, 4, 5), dtype)
-        a_np = numpy.array(x, order=order)
+        a_np = generate_random_numpy_array((2, 3, 4, 5), dtype, order)
         a = dpnp.asarray(a_np)
 
         result = dpnp.fft.rfftn(a, axes=axes, norm=norm)

--- a/dpnp/tests/test_fft.py
+++ b/dpnp/tests/test_fft.py
@@ -816,7 +816,10 @@ class TestRfft:
 
         result = dpnp.fft.rfft(a, n=n, norm=norm)
         expected = numpy.fft.rfft(a_np, n=n, norm=norm)
-        assert_dtype_allclose(result, expected, check_only_type_kind=True)
+        factor = 120 if dtype in [dpnp.int8, dpnp.uint8] else 8
+        assert_dtype_allclose(
+            result, expected, factor=factor, check_only_type_kind=True
+        )
 
     @pytest.mark.parametrize("n", [None, 5, 20])
     @pytest.mark.parametrize("norm", [None, "backward", "forward", "ortho"])

--- a/dpnp/tests/test_histogram.py
+++ b/dpnp/tests/test_histogram.py
@@ -44,6 +44,9 @@ class TestDigitize:
         ],
     )
     def test_digitize(self, x, bins, dtype, right):
+        if numpy.issubdtype(dtype, numpy.unsignedinteger) and bins[0] == -4:
+            x = numpy.abs(x)
+            bins = numpy.array([0, 2, 4, 6, 8])
         x = x.astype(dtype)
         bins = bins.astype(dtype)
         x_dp = dpnp.array(x)
@@ -527,18 +530,26 @@ class TestBincount:
         v = numpy.random.randint(0, upper_bound, size=n, dtype=dtype)
         iv = dpnp.array(v)
 
-        expected_hist = numpy.bincount(v)
-        result_hist = dpnp.bincount(iv)
-        assert_array_equal(result_hist, expected_hist)
+        if numpy.issubdtype(dtype, numpy.uint64):
+            assert_raises(TypeError, numpy.bincount, v)
+            assert_raises(ValueError, dpnp.bincount, iv)
+        else:
+            expected_hist = numpy.bincount(v)
+            result_hist = dpnp.bincount(iv)
+            assert_array_equal(result_hist, expected_hist)
 
     @pytest.mark.parametrize("dtype", get_integer_dtypes())
     def test_arange_data(self, dtype):
         v = numpy.arange(100).astype(dtype)
         iv = dpnp.array(v)
 
-        expected_hist = numpy.bincount(v)
-        result_hist = dpnp.bincount(iv)
-        assert_array_equal(result_hist, expected_hist)
+        if numpy.issubdtype(dtype, numpy.uint64):
+            assert_raises(TypeError, numpy.bincount, v)
+            assert_raises(ValueError, dpnp.bincount, iv)
+        else:
+            expected_hist = numpy.bincount(v)
+            result_hist = dpnp.bincount(iv)
+            assert_array_equal(result_hist, expected_hist)
 
     @pytest.mark.parametrize("xp", [numpy, dpnp])
     def test_negative_values(self, xp):

--- a/dpnp/tests/test_histogram.py
+++ b/dpnp/tests/test_histogram.py
@@ -14,6 +14,7 @@ import dpnp
 
 from .helper import (
     assert_dtype_allclose,
+    get_abs_array,
     get_all_dtypes,
     get_float_dtypes,
     get_integer_dtypes,
@@ -44,10 +45,10 @@ class TestDigitize:
         ],
     )
     def test_digitize(self, x, bins, dtype, right):
+        x = get_abs_array(x, dtype)
         if numpy.issubdtype(dtype, numpy.unsignedinteger) and bins[0] == -4:
-            x = numpy.abs(x)
+            # bins should be monotonically increasing, cannot use get_abs_array
             bins = numpy.array([0, 2, 4, 6, 8])
-        x = x.astype(dtype)
         bins = bins.astype(dtype)
         x_dp = dpnp.array(x)
         bins_dp = dpnp.array(bins)
@@ -531,6 +532,7 @@ class TestBincount:
         iv = dpnp.array(v)
 
         if numpy.issubdtype(dtype, numpy.uint64):
+            # discussed in numpy issue 17760
             assert_raises(TypeError, numpy.bincount, v)
             assert_raises(ValueError, dpnp.bincount, iv)
         else:

--- a/dpnp/tests/test_histogram.py
+++ b/dpnp/tests/test_histogram.py
@@ -46,9 +46,11 @@ class TestDigitize:
     )
     def test_digitize(self, x, bins, dtype, right):
         x = get_abs_array(x, dtype)
-        if numpy.issubdtype(dtype, numpy.unsignedinteger) and bins[0] == -4:
-            # bins should be monotonically increasing, cannot use get_abs_array
-            bins = numpy.array([0, 2, 4, 6, 8])
+        if numpy.issubdtype(dtype, numpy.unsignedinteger):
+            min_bin = bins.min()
+            if min_bin < 0:
+                # bins should be monotonically increasing, cannot use get_abs_array
+                bins -= min_bin
         bins = bins.astype(dtype)
         x_dp = dpnp.array(x)
         bins_dp = dpnp.array(bins)

--- a/dpnp/tests/test_indexing.py
+++ b/dpnp/tests/test_indexing.py
@@ -703,8 +703,8 @@ class TestTake:
         elif numpy.issubdtype(ind_dt, numpy.uint64):
             # For this special case, although casting `ind_dt` to numpy.intp
             # is not safe, both NumPy and dpnp work properly
-            # NumPy < "2.2.0" raises an error on Windows
-            if numpy_version() < "2.2.0" and is_win_platform():
+            # NumPy < "2.2.0" raises an error
+            if numpy_version() < "2.2.0":
                 ind = ind.astype(numpy.int64)
             result = dpnp.take(ia, iind, mode=mode)
             expected = numpy.take(a, ind, mode=mode)

--- a/dpnp/tests/test_indexing.py
+++ b/dpnp/tests/test_indexing.py
@@ -17,7 +17,12 @@ from numpy.testing import (
 import dpnp
 from dpnp.dpnp_array import dpnp_array
 
-from .helper import get_all_dtypes, get_integer_dtypes, has_support_aspect64
+from .helper import (
+    get_abs_array,
+    get_all_dtypes,
+    get_integer_dtypes,
+    has_support_aspect64,
+)
 from .third_party.cupy import testing
 
 
@@ -122,14 +127,8 @@ class TestExtins:
     @pytest.mark.parametrize("a_dt", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize("cond_dt", get_all_dtypes(no_none=True))
     def test_extract_diff_dtypes(self, a_dt, cond_dt):
-        x = [-2, -1, 0, 1, 2, 3]
-        y = [1, -1, 2, 0, -2, 3]
-        if numpy.issubdtype(a_dt, numpy.unsignedinteger):
-            x = numpy.abs(x)
-        a = numpy.array(x, dtype=a_dt)
-        if numpy.issubdtype(cond_dt, numpy.unsignedinteger):
-            y = numpy.abs(y)
-        cond = numpy.array(y, dtype=cond_dt)
+        a = get_abs_array([-2, -1, 0, 1, 2, 3], a_dt)
+        cond = get_abs_array([1, -1, 2, 0, -2, 3], cond_dt)
         ia, icond = dpnp.array(a), dpnp.array(cond)
 
         result = dpnp.extract(icond, ia)
@@ -459,17 +458,12 @@ class TestPut:
     )
     @pytest.mark.parametrize("mode", ["clip", "wrap"])
     def test_input_1d(self, a_dt, indices, ind_dt, vals, mode):
-        x = [-2, -1, 0, 1, 2]
-        if numpy.issubdtype(a_dt, numpy.unsignedinteger):
-            x = numpy.abs(x)
-        a = numpy.array(x, dtype=a_dt)
+        a = get_abs_array([-2, -1, 0, 1, 2], a_dt)
         b = numpy.copy(a)
         ia = dpnp.array(a)
         ib = dpnp.array(b)
 
-        if numpy.issubdtype(ind_dt, numpy.unsignedinteger):
-            indices = numpy.abs(indices)
-        ind = numpy.array(indices, dtype=ind_dt)
+        ind = get_abs_array(indices, ind_dt)
         if ind_dt == dpnp.bool and ind.all():
             ind[0] = False  # to get rid of duplicate indices
         iind = dpnp.array(ind)
@@ -510,16 +504,11 @@ class TestPut:
     @pytest.mark.parametrize("ind_dt", get_integer_dtypes())
     @pytest.mark.parametrize("mode", ["clip", "wrap"])
     def test_input_2d(self, a_dt, indices, ind_dt, mode):
-        x = [[-1, 0, 1], [-2, -3, -4], [2, 3, 4]]
-        if numpy.issubdtype(a_dt, numpy.unsignedinteger):
-            x = numpy.abs(x)
-        a = numpy.array(x, dtype=a_dt)
+        a = get_abs_array([[-1, 0, 1], [-2, -3, -4], [2, 3, 4]], a_dt)
         ia = dpnp.array(a)
         vals = [10, 20]
 
-        if numpy.issubdtype(ind_dt, numpy.unsignedinteger):
-            indices = numpy.abs(indices)
-        ind = numpy.array(indices, dtype=ind_dt)
+        ind = get_abs_array(indices, ind_dt)
         iind = dpnp.array(ind)
 
         if numpy.issubdtype(ind_dt, numpy.uint64):
@@ -707,13 +696,8 @@ class TestTake:
     )
     @pytest.mark.parametrize("mode", ["clip", "wrap"])
     def test_1d(self, a_dt, ind_dt, indices, mode):
-        x = [-2, -1, 0, 1, 2]
-        if numpy.issubdtype(a_dt, numpy.unsignedinteger):
-            x = numpy.abs(x)
-        a = numpy.array(x, dtype=a_dt)
-        if numpy.issubdtype(ind_dt, numpy.unsignedinteger):
-            indices = numpy.abs(indices)
-        ind = numpy.array(indices, dtype=ind_dt)
+        a = get_abs_array([-2, -1, 0, 1, 2], a_dt)
+        ind = get_abs_array(indices, ind_dt)
         ia, iind = dpnp.array(a), dpnp.array(ind)
 
         if numpy.can_cast(ind_dt, numpy.intp, casting="safe"):
@@ -739,13 +723,8 @@ class TestTake:
     @pytest.mark.parametrize("mode", ["clip", "wrap"])
     @pytest.mark.parametrize("axis", [0, 1])
     def test_2d(self, a_dt, ind_dt, indices, mode, axis):
-        x = [[-1, 0, 1], [-2, -3, -4], [2, 3, 4]]
-        if numpy.issubdtype(a_dt, numpy.unsignedinteger):
-            x = numpy.abs(x)
-        a = numpy.array(x, dtype=a_dt)
-        if numpy.issubdtype(ind_dt, numpy.unsignedinteger):
-            indices = numpy.abs(indices)
-        ind = numpy.array(indices, dtype=ind_dt)
+        a = get_abs_array([[-1, 0, 1], [-2, -3, -4], [2, 3, 4]], a_dt)
+        ind = get_abs_array(indices, ind_dt)
         ia, iind = dpnp.array(a), dpnp.array(ind)
 
         if numpy.issubdtype(ind_dt, numpy.uint64):
@@ -761,16 +740,11 @@ class TestTake:
     @pytest.mark.parametrize("a_dt", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize("mode", ["clip", "wrap"])
     def test_over_index(self, a_dt, mode):
-        x = [-2, -1, 0, 1, 2]
-        y = [-2, 2]
-        if numpy.issubdtype(a_dt, numpy.unsignedinteger):
-            x = numpy.abs(x)
-            y = numpy.abs(y)
-        a = dpnp.array(x, dtype=a_dt)
+        a = get_abs_array([-2, -1, 0, 1, 2], a_dt)
         ind = dpnp.array([-5, 5], dtype=numpy.intp)
 
         result = dpnp.take(a, ind, mode=mode)
-        expected = dpnp.array(y, dtype=a.dtype)
+        expected = get_abs_array([-2, 2], a_dt)
         assert_array_equal(result, expected)
 
     @pytest.mark.parametrize("xp", [numpy, dpnp])

--- a/dpnp/tests/test_indexing.py
+++ b/dpnp/tests/test_indexing.py
@@ -137,10 +137,7 @@ class TestExtins:
 
     @pytest.mark.parametrize("a_dt", get_all_dtypes(no_none=True))
     def test_extract_list_cond(self, a_dt):
-        x = [-2, -1, 0, 1, 2, 3]
-        if numpy.issubdtype(a_dt, numpy.unsignedinteger):
-            x = numpy.abs(x)
-        a = numpy.array(x, dtype=a_dt)
+        a = get_abs_array([-2, -1, 0, 1, 2, 3], a_dt)
         cond = [1, -1, 2, 0, -2, 3]
         ia = dpnp.array(a)
 
@@ -393,10 +390,7 @@ class TestNonzero:
 
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     def test_1d(self, dtype):
-        x = [1, 0, 2, -1, 0, 0, 8]
-        if numpy.issubdtype(dtype, numpy.unsignedinteger):
-            x = numpy.abs(x)
-        a = numpy.array(x, dtype=dtype)
+        a = get_abs_array([1, 0, 2, -1, 0, 0, 8], dtype)
         ia = dpnp.array(a)
 
         np_res = numpy.nonzero(a)

--- a/dpnp/tests/test_indexing.py
+++ b/dpnp/tests/test_indexing.py
@@ -741,6 +741,7 @@ class TestTake:
     @pytest.mark.parametrize("mode", ["clip", "wrap"])
     def test_over_index(self, a_dt, mode):
         a = get_abs_array([-2, -1, 0, 1, 2], a_dt)
+        a = dpnp.array(a)
         ind = dpnp.array([-5, 5], dtype=numpy.intp)
 
         result = dpnp.take(a, ind, mode=mode)

--- a/dpnp/tests/test_indexing.py
+++ b/dpnp/tests/test_indexing.py
@@ -22,6 +22,8 @@ from .helper import (
     get_all_dtypes,
     get_integer_dtypes,
     has_support_aspect64,
+    is_win_platform,
+    numpy_version,
 )
 from .third_party.cupy import testing
 
@@ -700,10 +702,12 @@ class TestTake:
             assert_array_equal(result, expected)
         elif numpy.issubdtype(ind_dt, numpy.uint64):
             # For this special case, although casting `ind_dt` to numpy.intp
-            # is not safe, dpnp do not raise an error
-            # NumPy only raises an error on Windows
+            # is not safe, both NumPy and dpnp work properly
+            # NumPy < "2.2.0" raises an error on Windows
+            if numpy_version() < "2.2.0" and is_win_platform():
+                ind = ind.astype(numpy.int64)
             result = dpnp.take(ia, iind, mode=mode)
-            expected = numpy.take(a, ind.astype(numpy.int64), mode=mode)
+            expected = numpy.take(a, ind, mode=mode)
             assert_array_equal(result, expected)
         else:
             assert_raises(TypeError, ia.take, iind, mode=mode)

--- a/dpnp/tests/test_linalg.py
+++ b/dpnp/tests/test_linalg.py
@@ -2124,9 +2124,7 @@ class TestNorm:
             assert_dtype_allclose(result, expected)
 
     @pytest.mark.usefixtures("suppress_divide_numpy_warnings")
-    @pytest.mark.parametrize(
-        "dtype", get_all_dtypes(xfail_dtypes=[dpnp.uint64])
-    )
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize(
         "ord", [None, -dpnp.inf, -2, -1, 0, 1, 2, 3.5, dpnp.inf]
     )
@@ -2141,9 +2139,7 @@ class TestNorm:
         assert_dtype_allclose(result, expected)
 
     @pytest.mark.usefixtures("suppress_divide_numpy_warnings")
-    @pytest.mark.parametrize(
-        "dtype", get_all_dtypes(xfail_dtypes=[dpnp.uint64])
-    )
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize(
         "ord", [None, -dpnp.inf, -2, -1, 1, 2, 3, dpnp.inf, "fro", "nuc"]
     )
@@ -2170,9 +2166,7 @@ class TestNorm:
     @pytest.mark.usefixtures("suppress_divide_numpy_warnings")
     @pytest.mark.parametrize(
         "dtype",
-        get_all_dtypes(
-            no_none=True, xfail_dtypes=[dpnp.uint16, dpnp.uint32, dpnp.uint64]
-        ),
+        get_all_dtypes(no_none=True),
     )
     @pytest.mark.parametrize(
         "ord", [None, -dpnp.inf, -2, -1, 1, 2, 3, dpnp.inf, "fro", "nuc"]
@@ -2204,10 +2198,7 @@ class TestNorm:
             assert_dtype_allclose(result, expected)
 
     @pytest.mark.usefixtures("suppress_divide_numpy_warnings")
-    @pytest.mark.parametrize(
-        "dtype",
-        get_all_dtypes(xfail_dtypes=[dpnp.uint16, dpnp.uint32, dpnp.uint64]),
-    )
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize(
         "ord", [None, -dpnp.inf, -2, -1, 1, 2, 3, dpnp.inf, "fro", "nuc"]
     )

--- a/dpnp/tests/test_linalg.py
+++ b/dpnp/tests/test_linalg.py
@@ -503,10 +503,9 @@ class TestEigenvalue:
         # non-symmetric for eig() and eigvals()
         is_hermitian = func in ("eigh, eigvalsh")
         a = generate_random_numpy_array(
-            shape, dtype, hermitian=is_hermitian, low=-4, high=4
+            shape, dtype, order, hermitian=is_hermitian, low=-4, high=4
         )
-        a_order = numpy.array(a, order=order)
-        a_dp = dpnp.array(a, order=order)
+        a_dp = dpnp.array(a)
 
         # NumPy with OneMKL and with rocSOLVER sorts in ascending order,
         # so w's should be directly comparable.
@@ -514,13 +513,13 @@ class TestEigenvalue:
         # constructing eigenvectors, so v's are not directly comparable and
         # we verify them through the eigen equation A*v=w*v.
         if func in ("eig", "eigh"):
-            w, _ = getattr(numpy.linalg, func)(a_order)
+            w, _ = getattr(numpy.linalg, func)(a)
             w_dp, v_dp = getattr(dpnp.linalg, func)(a_dp)
 
             self.assert_eigen_decomposition(a_dp, w_dp, v_dp)
 
         else:  # eighvals or eigvalsh
-            w = getattr(numpy.linalg, func)(a_order)
+            w = getattr(numpy.linalg, func)(a)
             w_dp = getattr(dpnp.linalg, func)(a_dp)
 
         assert_dtype_allclose(w_dp, w, factor=24)

--- a/dpnp/tests/test_manipulation.py
+++ b/dpnp/tests/test_manipulation.py
@@ -30,7 +30,9 @@ testdata += [
 ]
 testdata += [
     ([1, -1, 0], dtype)
-    for dtype in get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
+    for dtype in get_all_dtypes(
+        no_none=True, no_bool=True, no_complex=True, no_unsigned=True
+    )
 ]
 testdata += [([0.1, 0.0, -0.1], dtype) for dtype in get_float_dtypes()]
 testdata += [([1j, -1j, 1 - 2j], dtype) for dtype in get_complex_dtypes()]
@@ -1719,7 +1721,7 @@ class TestUnique:
         expected = numpy.unique(a, axis=axis)
         assert_array_equal(result, expected)
 
-    @pytest.mark.parametrize("dt", get_integer_dtypes())
+    @pytest.mark.parametrize("dt", get_integer_dtypes(no_unsigned=True))
     def test_2d_axis_signed_inetger(self, dt):
         a = numpy.array([[-1], [0]], dtype=dt)
         ia = dpnp.array(a)

--- a/dpnp/tests/test_mathematical.py
+++ b/dpnp/tests/test_mathematical.py
@@ -67,7 +67,8 @@ class TestAngle:
         result = dpnp.angle(dp_a, deg=deg)
 
         # For dtype=int8, uint8, NumPy returns float16, but dpnp returns float32
-        assert_dtype_allclose(result, expected, check_only_type_kind=True)
+        dt_int8 = dtype in [dpnp.int8, dpnp.uint8]
+        assert_dtype_allclose(result, expected, check_only_type_kind=dt_int8)
 
     @pytest.mark.parametrize("dtype", get_complex_dtypes())
     def test_angle_complex(self, dtype, deg):
@@ -1352,8 +1353,7 @@ class TestI0:
         expected = numpy.i0(a)
         # NumPy promotes result of integer inputs to float64, but dpnp
         # follows Type Promotion Rules
-        skip_dtype = [numpy.int8, numpy.int16, numpy.uint8, numpy.uint16]
-        flag = True if dt in skip_dtype else False
+        flag = dt in [numpy.int8, numpy.int16, numpy.uint8, numpy.uint16]
         assert_dtype_allclose(result, expected, check_only_type_kind=flag)
 
     @pytest.mark.parametrize("dt", get_float_dtypes())
@@ -2034,7 +2034,8 @@ class TestSinc:
         expected = numpy.sinc(a)
         # numpy promotes result for integer inputs to float64 dtype, but dpnp
         # follows Type Promotion Rules similar to other trigonometric functions
-        assert_dtype_allclose(result, expected, check_only_type_kind=True)
+        flag = dt in [numpy.int8, numpy.int16, numpy.uint8, numpy.uint16]
+        assert_dtype_allclose(result, expected, check_only_type_kind=flag)
 
     def test_bool(self):
         a = numpy.array([True, False, True])
@@ -2054,7 +2055,8 @@ class TestSinc:
         expected = numpy.sinc(a)
         # numpy promotes result for integer inputs to float64 dtype, but dpnp
         # follows Type Promotion Rules similar to other trigonometric functions
-        assert_dtype_allclose(result, expected, check_only_type_kind=True)
+        flag = dt in [numpy.int8, numpy.int16, numpy.uint8, numpy.uint16]
+        assert_dtype_allclose(result, expected, check_only_type_kind=flag)
 
     # TODO: add a proper NumPy version once resolved
     @testing.with_requires("numpy>=2.0.0")
@@ -2499,7 +2501,7 @@ def test_divide_scalar(shape, dtype):
 )
 def test_negative(data, dtype):
     np_a = numpy.array(data, dtype=dtype)
-    dpnp_a = dpnp.array(data, dtype=dtype)
+    dpnp_a = dpnp.array(np_a)
 
     result = dpnp.negative(dpnp_a)
     expected = numpy.negative(np_a)
@@ -2529,12 +2531,10 @@ def test_negative_boolean():
     [[[1.0, -1.0], [0.1, -0.1]], [-2, -1, 0, 1, 2]],
     ids=["[[1., -1.], [0.1, -0.1]]", "[-2, -1, 0, 1, 2]"],
 )
-@pytest.mark.parametrize(
-    "dtype", get_all_dtypes(no_bool=True, no_unsigned=True)
-)
+@pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
 def test_positive(data, dtype):
-    np_a = numpy.array(data, dtype=dtype)
-    dpnp_a = dpnp.array(data, dtype=dtype)
+    np_a = get_abs_array(data, dtype=dtype)
+    dpnp_a = dpnp.array(np_a)
 
     result = dpnp.positive(dpnp_a)
     expected = numpy.positive(np_a)

--- a/dpnp/tests/test_mathematical.py
+++ b/dpnp/tests/test_mathematical.py
@@ -32,6 +32,7 @@ from .helper import (
     get_integer_dtypes,
     has_support_aspect16,
     has_support_aspect64,
+    numpy_version,
 )
 from .test_umath import (
     _get_numpy_arrays_1in_1out,
@@ -1408,7 +1409,7 @@ class TestLdexp:
     @pytest.mark.parametrize("exp_dt", get_integer_dtypes())
     def test_basic(self, mant_dt, exp_dt):
         if (
-            numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0"
+            numpy_version() < "2.0.0"
             and exp_dt == numpy.int64
             and numpy.dtype("l") != numpy.int64
         ):
@@ -1421,9 +1422,7 @@ class TestLdexp:
         if dpnp.issubdtype(exp_dt, dpnp.uint64):
             assert_raises(ValueError, dpnp.ldexp, imant, iexp)
             assert_raises(TypeError, numpy.ldexp, mant, exp)
-        elif numpy.lib.NumpyVersion(
-            numpy.__version__
-        ) < "2.0.0" and dpnp.issubdtype(exp_dt, dpnp.uint32):
+        elif numpy_version() < "2.0.0" and dpnp.issubdtype(exp_dt, dpnp.uint32):
             # For this special case, NumPy < "2.0.0" raises an error on Windows
             result = dpnp.ldexp(imant, iexp)
             expected = numpy.ldexp(mant, exp.astype(numpy.int32))
@@ -2130,7 +2129,7 @@ class TestSpacing:
 
         result = dpnp.spacing(ia)
         expected = numpy.spacing(a)
-        if numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0":
+        if numpy_version() < "2.0.0":
             assert_equal(result, expected)
         else:
             # numpy.spacing(-0.0) == numpy.spacing(0.0), i.e. NumPy returns
@@ -2193,7 +2192,7 @@ class TestSpacing:
 
 class TestTrapezoid:
     def get_numpy_func(self):
-        if numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0":
+        if numpy_version() < "2.0.0":
             # `trapz` is deprecated in NumPy 2.0
             return numpy.trapz
         return numpy.trapezoid
@@ -2753,10 +2752,7 @@ class TestRoundingFuncs:
         # NumPy < 2.0.0 while output has the dtype of input for NumPy >= 2.0.0
         # (dpnp follows the latter behavior except for boolean dtype where it
         # returns int8)
-        if (
-            numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0"
-            or dtype == numpy.bool
-        ):
+        if numpy_version() < "2.0.0" or dtype == numpy.bool:
             check_type = False
         else:
             check_type = True

--- a/dpnp/tests/test_nanfunctions.py
+++ b/dpnp/tests/test_nanfunctions.py
@@ -15,6 +15,7 @@ import dpnp
 
 from .helper import (
     assert_dtype_allclose,
+    get_abs_array,
     get_all_dtypes,
     get_complex_dtypes,
     get_float_complex_dtypes,
@@ -648,7 +649,7 @@ class TestNanStd:
     )
     def test_nanstd(self, array, dtype):
         try:
-            a = numpy.array(array, dtype=dtype)
+            a = get_abs_array(array, dtype=dtype)
         except:
             pytest.skip("floating datat type is needed to store NaN")
         ia = dpnp.array(a)
@@ -835,9 +836,9 @@ class TestNanVar:
     )
     def test_nanvar(self, array, dtype):
         try:
-            a = numpy.array(array, dtype=dtype)
+            a = get_abs_array(array, dtype=dtype)
         except:
-            pytest.skip("floating datat type is needed to store NaN")
+            pytest.skip("floating data type is needed to store NaN")
         ia = dpnp.array(a)
         for ddof in range(a.ndim):
             expected = numpy.nanvar(a, ddof=ddof)

--- a/dpnp/tests/test_nanfunctions.py
+++ b/dpnp/tests/test_nanfunctions.py
@@ -586,7 +586,7 @@ class TestNanProd:
     @pytest.mark.parametrize("out_dt", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize("dtype", get_all_dtypes())
     def test_nanprod_out_dtype(self, arr_dt, out_dt, dtype):
-        a = numpy.arange(10, 20).reshape((2, 5)).astype(dtype=arr_dt)
+        a = numpy.arange(1, 7).reshape((2, 3)).astype(dtype=arr_dt)
         out = numpy.zeros_like(a, shape=(2,), dtype=out_dt)
 
         ia = dpnp.array(a)

--- a/dpnp/tests/test_ndarray.py
+++ b/dpnp/tests/test_ndarray.py
@@ -23,6 +23,8 @@ from .third_party.cupy import testing
     ids=["[-2, -1, 0, 1, 2]", "[[-2, -1], [1, 2]]", "[]"],
 )
 def test_astype(arr, arr_dtype, res_dtype):
+    if numpy.issubdtype(arr_dtype, numpy.unsignedinteger):
+        arr = numpy.abs(arr)
     numpy_array = numpy.array(arr, dtype=arr_dtype)
     dpnp_array = dpnp.array(numpy_array)
     expected = numpy_array.astype(res_dtype)
@@ -43,6 +45,8 @@ def test_astype_subok_error():
     ids=["[-2, -1, 0, 1, 2]", "[[-2, -1], [1, 2]]", "[]"],
 )
 def test_flatten(arr, arr_dtype):
+    if numpy.issubdtype(arr_dtype, numpy.unsignedinteger):
+        arr = numpy.abs(arr)
     numpy_array = numpy.array(arr, dtype=arr_dtype)
     dpnp_array = dpnp.array(arr, dtype=arr_dtype)
     expected = numpy_array.flatten()

--- a/dpnp/tests/test_ndarray.py
+++ b/dpnp/tests/test_ndarray.py
@@ -6,6 +6,7 @@ from numpy.testing import assert_allclose, assert_array_equal
 import dpnp
 
 from .helper import (
+    get_abs_array,
     get_all_dtypes,
     get_complex_dtypes,
     get_float_dtypes,
@@ -23,9 +24,7 @@ from .third_party.cupy import testing
     ids=["[-2, -1, 0, 1, 2]", "[[-2, -1], [1, 2]]", "[]"],
 )
 def test_astype(arr, arr_dtype, res_dtype):
-    if numpy.issubdtype(arr_dtype, numpy.unsignedinteger):
-        arr = numpy.abs(arr)
-    numpy_array = numpy.array(arr, dtype=arr_dtype)
+    numpy_array = get_abs_array(arr, arr_dtype)
     dpnp_array = dpnp.array(numpy_array)
     expected = numpy_array.astype(res_dtype)
     result = dpnp_array.astype(res_dtype)
@@ -45,10 +44,8 @@ def test_astype_subok_error():
     ids=["[-2, -1, 0, 1, 2]", "[[-2, -1], [1, 2]]", "[]"],
 )
 def test_flatten(arr, arr_dtype):
-    if numpy.issubdtype(arr_dtype, numpy.unsignedinteger):
-        arr = numpy.abs(arr)
-    numpy_array = numpy.array(arr, dtype=arr_dtype)
-    dpnp_array = dpnp.array(arr, dtype=arr_dtype)
+    numpy_array = get_abs_array(arr, arr_dtype)
+    dpnp_array = dpnp.array(numpy_array)
     expected = numpy_array.flatten()
     result = dpnp_array.flatten()
     assert_array_equal(expected, result)

--- a/dpnp/tests/test_outer.py
+++ b/dpnp/tests/test_outer.py
@@ -59,14 +59,14 @@ class TestScalarOuter(unittest.TestCase):
     @testing.numpy_cupy_allclose(type_check=False)
     def test_first_is_scalar(self, xp, dtype):
         scalar = 4
-        a = xp.arange(5**3, dtype=dtype).reshape(5, 5, 5)
+        a = xp.arange(24, dtype=dtype).reshape(2, 3, 4)
         return xp.outer(scalar, a)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(type_check=False)
     def test_second_is_scalar(self, xp, dtype):
-        scalar = 7
-        a = xp.arange(5**3, dtype=dtype).reshape(5, 5, 5)
+        scalar = 5
+        a = xp.arange(24, dtype=dtype).reshape(2, 3, 4)
         return xp.outer(a, scalar)
 
 

--- a/dpnp/tests/test_product.py
+++ b/dpnp/tests/test_product.py
@@ -12,6 +12,8 @@ from .helper import (
     generate_random_numpy_array,
     get_all_dtypes,
     get_complex_dtypes,
+    is_win_platform,
+    numpy_version,
 )
 from .third_party.cupy import testing
 
@@ -508,8 +510,9 @@ class TestKron:
 
         result = dpnp.kron(ib, a)
         expected = numpy.kron(b, a)
-        # NumPy returns incorrect dtype on Windows, add check_type=False
-        assert_dtype_allclose(result, expected, check_type=False)
+        # NumPy returns incorrect dtype on Windows
+        flag = not is_win_platform() if numpy_version() < "2.0.0" else True
+        assert_dtype_allclose(result, expected, check_type=flag)
 
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize(

--- a/dpnp/tests/test_product.py
+++ b/dpnp/tests/test_product.py
@@ -510,8 +510,9 @@ class TestKron:
 
         result = dpnp.kron(ib, a)
         expected = numpy.kron(b, a)
-        # NumPy returns incorrect dtype on Windows
-        flag = not is_win_platform() if numpy_version() < "2.0.0" else True
+        # NumPy returns incorrect dtype for numpy_version() < "2.0.0"
+        flag = dtype in [numpy.int64, numpy.float64, numpy.complex128]
+        flag = flag or numpy_version() >= "2.0.0"
         assert_dtype_allclose(result, expected, check_type=flag)
 
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))

--- a/dpnp/tests/test_product.py
+++ b/dpnp/tests/test_product.py
@@ -5,6 +5,7 @@ from dpctl.utils import ExecutionPlacementError
 from numpy.testing import assert_raises
 
 import dpnp
+from dpnp.dpnp_utils import map_dtype_to_device
 
 from .helper import (
     assert_dtype_allclose,
@@ -13,18 +14,6 @@ from .helper import (
     get_complex_dtypes,
 )
 from .third_party.cupy import testing
-
-
-def _assert_selective_dtype_allclose(result, expected, dtype):
-    # For numpy.dot, numpy.vdot, numpy.kron, numpy.inner, and numpy.tensordot,
-    # when inputs are an scalar (which has the default dtype of platform) and
-    # an array, the scalar dtype precision determines the output dtype
-    # precision. In dpnp, we rely on dpnp.multiply for scalar-array product
-    # and array (not scalar) determines output dtype precision of dpnp.multiply
-    if dtype in [numpy.int32, numpy.float32, numpy.complex64]:
-        assert_dtype_allclose(result, expected, check_only_type_kind=True)
-    else:
-        assert_dtype_allclose(result, expected)
 
 
 class TestCross:
@@ -221,11 +210,11 @@ class TestDot:
 
         result = dpnp.dot(a, ib)
         expected = numpy.dot(a, b)
-        _assert_selective_dtype_allclose(result, expected, dtype)
+        assert_dtype_allclose(result, expected)
 
         result = dpnp.dot(ib, a)
         expected = numpy.dot(b, a)
-        _assert_selective_dtype_allclose(result, expected, dtype)
+        assert_dtype_allclose(result, expected)
 
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize(
@@ -256,8 +245,8 @@ class TestDot:
         ],
     )
     def test_basic(self, dtype, shape1, shape2):
-        a = generate_random_numpy_array(shape1, dtype)
-        b = generate_random_numpy_array(shape2, dtype)
+        a = generate_random_numpy_array(shape1, dtype, low=-5, high=5)
+        b = generate_random_numpy_array(shape2, dtype, low=-5, high=5)
         ia = dpnp.array(a)
         ib = dpnp.array(b)
 
@@ -288,12 +277,15 @@ class TestDot:
         b = generate_random_numpy_array(10, dtype)
         ib = dpnp.array(b)
 
-        dp_out = dpnp.empty(10, dtype=dtype)
+        np_res_dtype = numpy.result_type(type(a), b)
+        out = numpy.empty(10, dtype=np_res_dtype)
+        dp_res_dtype = map_dtype_to_device(np_res_dtype, ib.sycl_device)
+        dp_out = dpnp.array(out, dtype=dp_res_dtype)
         result = dpnp.dot(a, ib, out=dp_out)
-        expected = numpy.dot(a, b)
+        expected = numpy.dot(a, b, out=out)
 
         assert result is dp_out
-        _assert_selective_dtype_allclose(result, expected, dtype)
+        assert_dtype_allclose(result, expected)
 
     @pytest.mark.parametrize("dtype", get_all_dtypes())
     @pytest.mark.parametrize(
@@ -324,8 +316,8 @@ class TestDot:
         ],
     )
     def test_out(self, dtype, shape1, shape2, out_shape):
-        a = generate_random_numpy_array(shape1, dtype)
-        b = generate_random_numpy_array(shape2, dtype)
+        a = generate_random_numpy_array(shape1, dtype, low=-5, high=5)
+        b = generate_random_numpy_array(shape2, dtype, low=-5, high=5)
         ia = dpnp.array(a)
         ib = dpnp.array(b)
 
@@ -376,7 +368,9 @@ class TestDot:
         # output data type is incorrect
         dp_out = dpnp.empty((10,), dtype=dpnp.complex64)
         out = numpy.empty((10,), dtype=numpy.complex64)
-        assert_raises(ValueError, dpnp.dot, ia, ib, out=dp_out)
+        # For scalar dpnp raises TypeError, and for empty array raises ValueError
+        # NumPy raises ValueError for both cases
+        assert_raises((TypeError, ValueError), dpnp.dot, ia, ib, out=dp_out)
         assert_raises(ValueError, numpy.dot, a, b, out=out)
 
         # output shape is incorrect
@@ -442,11 +436,11 @@ class TestInner:
 
         result = dpnp.inner(a, ib)
         expected = numpy.inner(a, b)
-        _assert_selective_dtype_allclose(result, expected, dtype)
+        assert_dtype_allclose(result, expected)
 
         result = dpnp.inner(ib, a)
         expected = numpy.inner(b, a)
-        _assert_selective_dtype_allclose(result, expected, dtype)
+        assert_dtype_allclose(result, expected)
 
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize(
@@ -460,8 +454,8 @@ class TestInner:
         ],
     )
     def test_basic(self, dtype, shape1, shape2):
-        a = generate_random_numpy_array(shape1, dtype)
-        b = generate_random_numpy_array(shape2, dtype)
+        a = generate_random_numpy_array(shape1, dtype, low=-5, high=5)
+        b = generate_random_numpy_array(shape2, dtype, low=-5, high=5)
         ia = dpnp.array(a)
         ib = dpnp.array(b)
 
@@ -510,11 +504,12 @@ class TestKron:
 
         result = dpnp.kron(a, ib)
         expected = numpy.kron(a, b)
-        _assert_selective_dtype_allclose(result, expected, dtype)
+        assert_dtype_allclose(result, expected)
 
         result = dpnp.kron(ib, a)
         expected = numpy.kron(b, a)
-        _assert_selective_dtype_allclose(result, expected, dtype)
+        # NumPy returns incorrect dtype on Windows, add check_type=False
+        assert_dtype_allclose(result, expected, check_type=False)
 
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize(
@@ -611,7 +606,7 @@ class TestMultiDot:
             ((6,), (6, 10), (10, 7), (7, 8)),
             ((4, 6), (6, 10), (10, 7), (7,)),
             ((6,), (6, 10), (10, 7), (7,)),
-            ((4, 6), (6, 9), (9, 7), (7, 8), (8, 3)),
+            ((4, 6), (6, 2), (2, 7), (7, 5), (5, 3)),
         ],
         ids=[
             "two_arrays",
@@ -631,7 +626,7 @@ class TestMultiDot:
         numpy_array_list = []
         dpnp_array_list = []
         for shape in shapes:
-            a = generate_random_numpy_array(shape, dtype)
+            a = generate_random_numpy_array(shape, dtype, low=-2, high=2)
             ia = dpnp.array(a)
 
             numpy_array_list.append(a)
@@ -655,7 +650,7 @@ class TestMultiDot:
             ((6,), (6, 10), (10, 7), (7, 8), (8,)),
             ((4, 6), (6, 10), (10, 7), (7,), (4,)),
             ((6,), (6, 10), (10, 7), (7,), ()),
-            ((4, 6), (6, 9), (9, 7), (7, 8), (8, 3), (4, 3)),
+            ((4, 6), (6, 2), (2, 7), (7, 5), (5, 3), (4, 3)),
         ],
         ids=[
             "two_arrays",
@@ -675,7 +670,7 @@ class TestMultiDot:
         numpy_array_list = []
         dpnp_array_list = []
         for shape in shapes[:-1]:
-            a = generate_random_numpy_array(shape, dtype)
+            a = generate_random_numpy_array(shape, dtype, low=-2, high=2)
             ia = dpnp.array(a)
 
             numpy_array_list.append(a)
@@ -762,17 +757,17 @@ class TestTensordot:
 
         result = dpnp.tensordot(a, ib, axes=0)
         expected = numpy.tensordot(a, b, axes=0)
-        _assert_selective_dtype_allclose(result, expected, dtype)
+        assert_dtype_allclose(result, expected)
 
         result = dpnp.tensordot(ib, a, axes=0)
         expected = numpy.tensordot(b, a, axes=0)
-        _assert_selective_dtype_allclose(result, expected, dtype)
+        assert_dtype_allclose(result, expected)
 
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize("axes", [0, 1, 2])
     def test_basic(self, dtype, axes):
-        a = generate_random_numpy_array((4, 4, 4), dtype)
-        b = generate_random_numpy_array((4, 4, 4), dtype)
+        a = generate_random_numpy_array((4, 4, 4), dtype, low=-5, high=5)
+        b = generate_random_numpy_array((4, 4, 4), dtype, low=-5, high=5)
         ia = dpnp.array(a)
         ib = dpnp.array(b)
 
@@ -792,8 +787,8 @@ class TestTensordot:
         ],
     )
     def test_axes(self, dtype, axes):
-        a = generate_random_numpy_array((2, 5, 3, 4), dtype)
-        b = generate_random_numpy_array((4, 2, 5, 3), dtype)
+        a = generate_random_numpy_array((2, 5, 3, 4), dtype, low=-5, high=5)
+        b = generate_random_numpy_array((4, 2, 5, 3), dtype, low=-5, high=5)
         ia = dpnp.array(a)
         ib = dpnp.array(b)
 
@@ -804,8 +799,8 @@ class TestTensordot:
     @pytest.mark.parametrize("dtype1", get_all_dtypes())
     @pytest.mark.parametrize("dtype2", get_all_dtypes())
     def test_input_dtype_matrix(self, dtype1, dtype2):
-        a = generate_random_numpy_array((3, 4, 5), dtype1)
-        b = generate_random_numpy_array((4, 5, 2), dtype2)
+        a = generate_random_numpy_array((3, 4, 5), dtype1, low=-5, high=5)
+        b = generate_random_numpy_array((4, 5, 2), dtype2, low=-5, high=5)
         ia = dpnp.array(a)
         ib = dpnp.array(b)
 
@@ -896,11 +891,11 @@ class TestVdot:
 
         result = dpnp.vdot(ia, b)
         expected = numpy.vdot(a, b)
-        _assert_selective_dtype_allclose(result, expected, dtype)
+        assert_dtype_allclose(result, expected)
 
         result = dpnp.vdot(b, ia)
         expected = numpy.vdot(b, a)
-        _assert_selective_dtype_allclose(result, expected, dtype)
+        assert_dtype_allclose(result, expected)
 
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize(

--- a/dpnp/tests/test_sort.py
+++ b/dpnp/tests/test_sort.py
@@ -369,8 +369,13 @@ class TestSortComplex:
         assert result.dtype == expected.dtype
 
 
-@pytest.mark.parametrize("kth", [0, 1], ids=["0", "1"])
-@pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
+@pytest.mark.parametrize("kth", [0, 1])
+@pytest.mark.parametrize(
+    "dtype",
+    get_all_dtypes(
+        no_none=True, no_unsigned=True, xfail_dtypes=[dpnp.int8, dpnp.int16]
+    ),
+)
 @pytest.mark.parametrize(
     "array",
     [

--- a/dpnp/tests/test_strides.py
+++ b/dpnp/tests/test_strides.py
@@ -163,13 +163,8 @@ def test_logsumexp(dtype):
     expected = numpy.logaddexp.reduce(a)
     # for int8, uint8, NumPy returns float16 but dpnp returns float64
     # for int16, uint16, NumPy returns float32 but dpnp returns float64
-    if dtype in [dpnp.int8, dpnp.uint8, dpnp.int16, dpnp.uint16]:
-        check_only_type_kind = True
-    else:
-        check_only_type_kind = False
-    assert_dtype_allclose(
-        result, expected, check_only_type_kind=check_only_type_kind
-    )
+    flag = dtype in [dpnp.int8, dpnp.uint8, dpnp.int16, dpnp.uint16]
+    assert_dtype_allclose(result, expected, check_only_type_kind=flag)
 
 
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True))
@@ -181,13 +176,8 @@ def test_cumlogsumexp(dtype):
     expected = numpy.logaddexp.accumulate(a)
     # for int8, uint8, NumPy returns float16 but dpnp returns float64
     # for int16, uint16, NumPy returns float32 but dpnp returns float64
-    if dtype in [dpnp.int8, dpnp.uint8, dpnp.int16, dpnp.uint16]:
-        check_only_type_kind = True
-    else:
-        check_only_type_kind = False
-    assert_dtype_allclose(
-        result, expected, check_only_type_kind=check_only_type_kind
-    )
+    flag = dtype in [dpnp.int8, dpnp.uint8, dpnp.int16, dpnp.uint16]
+    assert_dtype_allclose(result, expected, check_only_type_kind=flag)
 
 
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True))
@@ -199,13 +189,8 @@ def test_reduce_hypot(dtype):
     expected = numpy.hypot.reduce(a)
     # for int8, uint8, NumPy returns float16 but dpnp returns float64
     # for int16, uint16, NumPy returns float32 but dpnp returns float64
-    if dtype in [dpnp.int8, dpnp.uint8, dpnp.int16, dpnp.uint16]:
-        check_only_type_kind = True
-    else:
-        check_only_type_kind = False
-    assert_dtype_allclose(
-        result, expected, check_only_type_kind=check_only_type_kind
-    )
+    flag = dtype in [dpnp.int8, dpnp.uint8, dpnp.int16, dpnp.uint16]
+    assert_dtype_allclose(result, expected, check_only_type_kind=flag)
 
 
 @pytest.mark.parametrize(

--- a/dpnp/tests/test_strides.py
+++ b/dpnp/tests/test_strides.py
@@ -161,7 +161,15 @@ def test_logsumexp(dtype):
 
     result = dpnp.logsumexp(dpa)
     expected = numpy.logaddexp.reduce(a)
-    assert_allclose(result, expected)
+    # for int8, uint8, NumPy returns float16 but dpnp returns float64
+    # for int16, uint16, NumPy returns float32 but dpnp returns float64
+    if dtype in [dpnp.int8, dpnp.uint8, dpnp.int16, dpnp.uint16]:
+        check_only_type_kind = True
+    else:
+        check_only_type_kind = False
+    assert_dtype_allclose(
+        result, expected, check_only_type_kind=check_only_type_kind
+    )
 
 
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True))
@@ -171,7 +179,15 @@ def test_cumlogsumexp(dtype):
 
     result = dpnp.cumlogsumexp(dpa)
     expected = numpy.logaddexp.accumulate(a)
-    assert_allclose(result, expected)
+    # for int8, uint8, NumPy returns float16 but dpnp returns float64
+    # for int16, uint16, NumPy returns float32 but dpnp returns float64
+    if dtype in [dpnp.int8, dpnp.uint8, dpnp.int16, dpnp.uint16]:
+        check_only_type_kind = True
+    else:
+        check_only_type_kind = False
+    assert_dtype_allclose(
+        result, expected, check_only_type_kind=check_only_type_kind
+    )
 
 
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True))
@@ -181,15 +197,29 @@ def test_reduce_hypot(dtype):
 
     result = dpnp.reduce_hypot(dpa)
     expected = numpy.hypot.reduce(a)
-    assert_allclose(result, expected)
-
-
-@pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True))
-@pytest.mark.parametrize("shape", [(10,)], ids=["(10,)"])
-def test_strides_erf(dtype, shape):
-    a = dpnp.reshape(
-        dpnp.linspace(-1, 1, num=numpy.prod(shape), dtype=dtype), shape
+    # for int8, uint8, NumPy returns float16 but dpnp returns float64
+    # for int16, uint16, NumPy returns float32 but dpnp returns float64
+    if dtype in [dpnp.int8, dpnp.uint8, dpnp.int16, dpnp.uint16]:
+        check_only_type_kind = True
+    else:
+        check_only_type_kind = False
+    assert_dtype_allclose(
+        result, expected, check_only_type_kind=check_only_type_kind
     )
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    get_all_dtypes(
+        no_none=True,
+        no_bool=True,
+        no_complex=True,
+        no_unsigned=True,
+        xfail_dtypes=[dpnp.int8, dpnp.int16],
+    ),
+)
+def test_strides_erf(dtype):
+    a = dpnp.linspace(-1, 1, num=10, dtype=dtype)
     b = a[::2]
 
     result = dpnp.erf(b)

--- a/dpnp/tests/test_sum.py
+++ b/dpnp/tests/test_sum.py
@@ -58,11 +58,11 @@ def test_sum(shape, dtype_in, dtype_out, transpose, keepdims, order):
         ):
             # If summation is zero and dtype=numpy.bool is passed to numpy.sum
             # NumPy returns True which is not correct
-            numpy_res = a_np.sum(axis=axis, keepdims=keepdims)
-            numpy_res = numpy_res.astype(numpy.bool_)
+            a = a.astype(dpnp.bool)
+            dpnp_res = a.sum(axis=axis, dtype=dtype_out, keepdims=keepdims)
         else:
-            numpy_res = a_np.sum(axis=axis, dtype=dtype_out, keepdims=keepdims)
-        dpnp_res = a.sum(axis=axis, dtype=dtype_out, keepdims=keepdims)
+            dpnp_res = a.sum(axis=axis, dtype=dtype_out, keepdims=keepdims)
+        numpy_res = a_np.sum(axis=axis, dtype=dtype_out, keepdims=keepdims)
         assert_dtype_allclose(dpnp_res, numpy_res, factor=16)
 
 

--- a/dpnp/tests/test_sum.py
+++ b/dpnp/tests/test_sum.py
@@ -56,8 +56,7 @@ def test_sum(shape, dtype_in, dtype_out, transpose, keepdims, order):
             and numpy.issubdtype(dtype_in, numpy.signedinteger)
             and not a_np.sum(axis=axis).all()
         ):
-            # If summation is zero and dtype=numpy.bool is passed to numpy.sum
-            # NumPy returns True which is not correct
+            # TODO: remove workaround when dpctl-issue#1944 is resolved
             a = a.astype(dpnp.bool)
             dpnp_res = a.sum(axis=axis, dtype=dtype_out, keepdims=keepdims)
         else:

--- a/dpnp/tests/test_sum.py
+++ b/dpnp/tests/test_sum.py
@@ -51,12 +51,15 @@ def test_sum(shape, dtype_in, dtype_out, transpose, keepdims, order):
     axes.append(tuple(axes_range))
 
     for axis in axes:
-        if numpy.issubdtype(dtype_out, numpy.bool_):
+        if (
+            numpy.issubdtype(dtype_out, numpy.bool_)
+            and numpy.issubdtype(dtype_in, numpy.signedinteger)
+            and not a_np.sum(axis=axis).all()
+        ):
             # If summation is zero and dtype=numpy.bool is passed to numpy.sum
             # NumPy returns True which is not correct
-            numpy_res = a_np.sum(axis=axis, keepdims=keepdims).astype(
-                numpy.bool_
-            )
+            numpy_res = a_np.sum(axis=axis, keepdims=keepdims)
+            numpy_res = numpy_res.astype(numpy.bool_)
         else:
             numpy_res = a_np.sum(axis=axis, dtype=dtype_out, keepdims=keepdims)
         dpnp_res = a.sum(axis=axis, dtype=dtype_out, keepdims=keepdims)

--- a/dpnp/tests/test_sum.py
+++ b/dpnp/tests/test_sum.py
@@ -37,8 +37,7 @@ from .helper import (
 @pytest.mark.parametrize("keepdims", [True, False])
 @pytest.mark.parametrize("order", ["C", "F"])
 def test_sum(shape, dtype_in, dtype_out, transpose, keepdims, order):
-    a_np = generate_random_numpy_array(shape, dtype_in)
-    a_np = numpy.array(a_np, order=order)
+    a_np = generate_random_numpy_array(shape, dtype_in, order)
     a = dpnp.asarray(a_np)
 
     if transpose:

--- a/dpnp/tests/test_sycl_queue.py
+++ b/dpnp/tests/test_sycl_queue.py
@@ -810,6 +810,7 @@ def test_reduce_hypot(device):
             [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
             [5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0],
         ),
+        pytest.param("round", [1.234, 2.567], 2),
         pytest.param("searchsorted", [11, 12, 13, 14, 15], [-10, 20, 12, 13]),
         pytest.param(
             "subtract",

--- a/dpnp/tests/test_umath.py
+++ b/dpnp/tests/test_umath.py
@@ -12,6 +12,7 @@ import dpnp
 
 from .helper import (
     assert_dtype_allclose,
+    get_abs_array,
     get_all_dtypes,
     get_float_complex_dtypes,
     get_float_dtypes,
@@ -325,10 +326,7 @@ class TestDegrees:
         "dtype", get_all_dtypes(no_none=True, no_complex=True)
     )
     def test_basic(self, dtype):
-        x = [numpy.pi, -0.5 * numpy.pi]
-        if numpy.issubdtype(dtype, numpy.unsignedinteger):
-            x = numpy.abs(x)
-        a = numpy.array(x, dtype=dtype)
+        a = get_abs_array([numpy.pi, -0.5 * numpy.pi], dtype)
         ia = dpnp.array(a)
 
         result = dpnp.degrees(ia)
@@ -524,10 +522,7 @@ class TestRadians:
         "dtype", get_all_dtypes(no_none=True, no_complex=True)
     )
     def test_basic(self, dtype):
-        x = [120.0, -90.0]
-        if numpy.issubdtype(dtype, numpy.unsignedinteger):
-            x = numpy.abs(x)
-        a = numpy.array(x, dtype=dtype)
+        a = get_abs_array([120.0, -90.0], dtype)
         ia = dpnp.array(a)
 
         result = dpnp.radians(ia)

--- a/dpnp/tests/test_usm_type.py
+++ b/dpnp/tests/test_usm_type.py
@@ -740,6 +740,7 @@ def test_1in_1out(func, data, usm_type):
         pytest.param("maximum", [0.0, 1.0, 2.0], [3.0, 4.0, 5.0]),
         pytest.param("minimum", [0.0, 1.0, 2.0], [3.0, 4.0, 5.0]),
         pytest.param("nextafter", [1, 2], [2, 1]),
+        pytest.param("round", [1.234, 2.567], 2),
         pytest.param("searchsorted", [11, 12, 13, 14, 15], [-10, 20, 12, 13]),
         pytest.param(
             "tensordot",

--- a/dpnp/tests/third_party/cupy/core_tests/test_elementwise.py
+++ b/dpnp/tests/third_party/cupy/core_tests/test_elementwise.py
@@ -4,7 +4,11 @@ import numpy
 import pytest
 
 import dpnp as cupy
-from dpnp.tests.helper import has_support_aspect64
+from dpnp.tests.helper import (
+    has_support_aspect64,
+    is_win_platform,
+    numpy_version,
+)
 from dpnp.tests.third_party.cupy import testing
 
 
@@ -94,20 +98,22 @@ class TestElementwiseType(unittest.TestCase):
     @testing.for_int_dtypes(no_bool=True)
     @testing.numpy_cupy_array_equal(accept_error=OverflowError)
     def test_large_int_upper_1(self, xp, dtype):
-        a = xp.array([0], dtype=numpy.int8)
+        a = xp.array([0], dtype=xp.int8)
         b = xp.iinfo(dtype).max
         return a + b
 
     @testing.for_int_dtypes(no_bool=True)
     @testing.numpy_cupy_array_equal(accept_error=OverflowError)
     def test_large_int_upper_2(self, xp, dtype):
-        if (
-            numpy.issubdtype(dtype, numpy.unsignedinteger)
-            and numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0"
-        ):
-            pytest.skip("numpy promotes dtype differently")
+        if numpy_version() < "2.0.0":
+            flag = dtype in [xp.int16, xp.int32, xp.int64, xp.longlong]
+            if xp.issubdtype(dtype, xp.unsignedinteger) or flag:
+                pytest.skip("numpy doesn't raise OverflowError")
 
-        a = xp.array([1], dtype=numpy.int8)
+            if dtype in [xp.int8, xp.intc] and is_win_platform():
+                pytest.skip("numpy promotes dtype differently")
+
+        a = xp.array([1], dtype=xp.int8)
         b = xp.iinfo(dtype).max - 1
         return a + b
 
@@ -116,7 +122,7 @@ class TestElementwiseType(unittest.TestCase):
     def test_large_int_upper_3(self, xp, dtype):
         if (
             numpy.issubdtype(dtype, numpy.unsignedinteger)
-            and numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0"
+            and numpy_version() < "2.0.0"
         ):
             pytest.skip("numpy promotes dtype differently")
         elif (
@@ -134,7 +140,7 @@ class TestElementwiseType(unittest.TestCase):
     def test_large_int_upper_4(self, xp, dtype):
         if (
             numpy.issubdtype(dtype, numpy.unsignedinteger)
-            and numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0"
+            and numpy_version() < "2.0.0"
         ):
             pytest.skip("numpy promotes dtype differently")
         elif (
@@ -150,14 +156,28 @@ class TestElementwiseType(unittest.TestCase):
     @testing.for_int_dtypes(no_bool=True)
     @testing.numpy_cupy_array_equal(accept_error=OverflowError)
     def test_large_int_lower_1(self, xp, dtype):
-        a = xp.array([0], dtype=numpy.int8)
+        if numpy_version() < "2.0.0":
+            if dtype in [xp.int16, xp.int32, xp.int64, xp.longlong]:
+                pytest.skip("numpy doesn't raise OverflowError")
+
+            if dtype in [xp.int8, xp.intc] and is_win_platform():
+                pytest.skip("numpy promotes dtype differently")
+
+        a = xp.array([0], dtype=xp.int8)
         b = xp.iinfo(dtype).min
         return a + b
 
     @testing.for_int_dtypes(no_bool=True)
     @testing.numpy_cupy_array_equal(accept_error=OverflowError)
     def test_large_int_lower_2(self, xp, dtype):
-        a = xp.array([-1], dtype=numpy.int8)
+        if numpy_version() < "2.0.0":
+            if dtype in [xp.int16, xp.int32, xp.int64, xp.longlong]:
+                pytest.skip("numpy doesn't raise OverflowError")
+
+            if dtype in [xp.int8, xp.intc] and is_win_platform():
+                pytest.skip("numpy promotes dtype differently")
+
+        a = xp.array([-1], dtype=xp.int8)
         b = xp.iinfo(dtype).min + 1
         return a + b
 
@@ -166,7 +186,7 @@ class TestElementwiseType(unittest.TestCase):
     def test_large_int_lower_3(self, xp, dtype):
         if (
             numpy.issubdtype(dtype, numpy.unsignedinteger)
-            and numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0"
+            and numpy_version() < "2.0.0"
         ):
             pytest.skip("numpy promotes dtype differently")
         elif (

--- a/dpnp/tests/third_party/cupy/core_tests/test_ndarray_complex_ops.py
+++ b/dpnp/tests/third_party/cupy/core_tests/test_ndarray_complex_ops.py
@@ -4,7 +4,6 @@ import numpy
 import pytest
 
 import dpnp as cupy
-from dpnp.tests.helper import has_support_aspect64
 from dpnp.tests.third_party.cupy import testing
 
 
@@ -41,8 +40,10 @@ class TestConj(unittest.TestCase):
 
 class TestAngle(unittest.TestCase):
 
+    # For dtype=int8, uint8, NumPy returns float16, but dpnp returns float32
+    # so type_check=False
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_almost_equal(type_check=has_support_aspect64())
+    @testing.numpy_cupy_array_almost_equal(type_check=False)
     def test_angle(self, xp, dtype):
         x = testing.shaped_arange((2, 3), xp, dtype)
         return xp.angle(x)

--- a/dpnp/tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py
+++ b/dpnp/tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py
@@ -338,7 +338,7 @@ class TestArrayAsType:
         b = astype_without_warning(a, dst_dtype, order=order)
         a_cpu = testing.shaped_arange((2, 3, 4), numpy, src_dtype)
         b_cpu = astype_without_warning(a_cpu, dst_dtype, order=order)
-        assert b.dtype.type == b_cpu.dtype.type
+        assert b.dtype == b_cpu.dtype
 
     @testing.for_orders("CAK")
     @testing.for_all_dtypes()

--- a/dpnp/tests/third_party/cupy/creation_tests/test_ranges.py
+++ b/dpnp/tests/third_party/cupy/creation_tests/test_ranges.py
@@ -227,7 +227,13 @@ class TestRanges(unittest.TestCase):
         # TODO (ev-br): np 2.0: had to bump the default rtol on Windows
         #               and numpy 1.26+weak promotion from 0 to 5e-6
         if xp.dtype(dtype_range).kind in "u":
-            start = xp.array([160, 120], dtype=dtype_range)
+            # to avoid overflow, limit `val` to be smaller
+            # than xp.iinfo(dtype).max
+            if dtype_range == xp.uint8 or dtype_out == xp.uint8:
+                val = 125
+            else:
+                val = 160
+            start = xp.array([val, 120], dtype=dtype_range)
         else:
             start = xp.array([-120, 120], dtype=dtype_range)
         stop = 0

--- a/dpnp/tests/third_party/cupy/indexing_tests/test_indexing.py
+++ b/dpnp/tests/third_party/cupy/indexing_tests/test_indexing.py
@@ -204,6 +204,10 @@ class TestChoose(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_choose(self, xp, dtype):
+        # TODO: include additional dtype when dpnp#2201 is merged
+        dtype_list = [xp.int8, xp.int16]
+        if dtype in dtype_list or xp.issubdtype(dtype, xp.unsignedinteger):
+            pytest.skip("dpnp.choose() does not support new integer dtypes.")
         a = xp.array([0, 2, 1, 2])
         c = testing.shaped_arange((3, 4), xp, dtype)
         return a.choose(c)

--- a/dpnp/tests/third_party/cupy/linalg_tests/test_einsum.py
+++ b/dpnp/tests/third_party/cupy/linalg_tests/test_einsum.py
@@ -464,9 +464,8 @@ class TestEinSumUnaryOperationWithScalar:
     )
 )
 class TestEinSumBinaryOperation:
-    @testing.for_all_dtypes_combination(
-        ["dtype_a", "dtype_b"], no_bool=False, no_float16=False
-    )
+    # no_int8=True is added to avoid overflow
+    @testing.for_all_dtypes_combination(["dtype_a", "dtype_b"], no_int8=True)
     @testing.numpy_cupy_allclose(
         type_check=has_support_aspect64(), contiguous_check=False
     )
@@ -555,13 +554,18 @@ class TestEinSumBinaryOperationWithScalar:
     )
 )
 class TestEinSumTernaryOperation:
-    @testing.for_all_dtypes_combination(
-        ["dtype_a", "dtype_b", "dtype_c"], no_bool=False, no_float16=False
-    )
+
+    @testing.for_all_dtypes_combination(["dtype_a", "dtype_b", "dtype_c"])
     @testing.numpy_cupy_allclose(
         type_check=has_support_aspect64(), contiguous_check=False
     )
     def test_einsum_ternary(self, xp, dtype_a, dtype_b, dtype_c):
+        flag = all(
+            dtype in [xp.int8, xp.uint8]
+            for dtype in [dtype_a, dtype_b, dtype_c]
+        )
+        if self.subscripts == "ij,jk,kl" and flag:
+            pytest.skip("avoid overflow")
         a = testing.shaped_arange(self.shape_a, xp, dtype_a)
         b = testing.shaped_arange(self.shape_b, xp, dtype_b)
         c = testing.shaped_arange(self.shape_c, xp, dtype_c)

--- a/dpnp/tests/third_party/cupy/linalg_tests/test_product.py
+++ b/dpnp/tests/third_party/cupy/linalg_tests/test_product.py
@@ -39,8 +39,9 @@ from dpnp.tests.third_party.cupy import testing
     )
 )
 class TestDot(unittest.TestCase):
-
-    @testing.for_all_dtypes_combination(["dtype_a", "dtype_b"])
+    # no_int8=True is added to avoid overflow for shape=((2, 3, 4), (3, 4, 2))
+    # and ((2, 3), (3, 4)) cases on cpu
+    @testing.for_all_dtypes_combination(["dtype_a", "dtype_b"], no_int8=True)
     @testing.numpy_cupy_allclose(type_check=has_support_aspect64())
     def test_dot(self, xp, dtype_a, dtype_b):
         shape_a, shape_b = self.shape
@@ -238,14 +239,14 @@ class TestProduct:
         b = testing.shaped_arange((2,), xp, dtype)
         return xp.dot(a, b)
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(no_int8=True)
     @testing.numpy_cupy_allclose()
     def test_transposed_dot(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype).transpose(1, 0, 2)
         b = testing.shaped_arange((2, 3, 4), xp, dtype).transpose(0, 2, 1)
         return xp.dot(a, b)
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(no_int8=True)
     @testing.numpy_cupy_allclose()
     def test_transposed_dot_with_out(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype).transpose(1, 0, 2)
@@ -320,14 +321,16 @@ class TestProduct:
         b = testing.shaped_reverse_arange((5,), xp, dtype)[::-1]
         return xp.inner(a, b)
 
-    @testing.for_all_dtypes()
+    # no_int8=True is added to avoid overflow
+    @testing.for_all_dtypes(no_int8=True)
     @testing.numpy_cupy_allclose()
     def test_multidim_inner(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         b = testing.shaped_arange((3, 2, 4), xp, dtype)
         return xp.inner(a, b)
 
-    @testing.for_all_dtypes()
+    # no_int8=True is added to avoid overflow
+    @testing.for_all_dtypes(no_int8=True)
     @testing.numpy_cupy_allclose()
     def test_transposed_higher_order_inner(self, xp, dtype):
         a = testing.shaped_arange((2, 4, 3), xp, dtype).transpose(2, 0, 1)
@@ -355,14 +358,16 @@ class TestProduct:
         b = testing.shaped_arange((4, 5), xp, dtype)
         return xp.outer(a, b)
 
-    @testing.for_all_dtypes()
+    # no_int8=True is added to avoid overflow
+    @testing.for_all_dtypes(no_int8=True)
     @testing.numpy_cupy_allclose()
     def test_tensordot(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         b = testing.shaped_arange((3, 4, 5), xp, dtype)
         return xp.tensordot(a, b)
 
-    @testing.for_all_dtypes()
+    # no_int8=True is added to avoid overflow
+    @testing.for_all_dtypes(no_int8=True)
     @testing.numpy_cupy_allclose()
     def test_transposed_tensordot(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype).transpose(1, 0, 2)
@@ -516,13 +521,15 @@ class TestMatrixPower(unittest.TestCase):
         a = testing.shaped_arange((3, 3), xp, dtype)
         return xp.linalg.matrix_power(a, 1)
 
-    @testing.for_all_dtypes()
+    # no_int8=True is added to avoid overflow
+    @testing.for_all_dtypes(no_int8=True)
     @testing.numpy_cupy_allclose()
     def test_matrix_power_2(self, xp, dtype):
         a = testing.shaped_arange((3, 3), xp, dtype)
         return xp.linalg.matrix_power(a, 2)
 
-    @testing.for_all_dtypes()
+    # no_int8=True is added to avoid overflow
+    @testing.for_all_dtypes(no_int8=True)
     @testing.numpy_cupy_allclose()
     def test_matrix_power_3(self, xp, dtype):
         a = testing.shaped_arange((3, 3), xp, dtype)

--- a/dpnp/tests/third_party/cupy/logic_tests/test_comparison.py
+++ b/dpnp/tests/third_party/cupy/logic_tests/test_comparison.py
@@ -242,7 +242,8 @@ class TestAllclose(unittest.TestCase):
 
 class TestIsclose(unittest.TestCase):
 
-    @testing.for_all_dtypes(no_complex=True)
+    # no_int8=True is added to avoid overflow
+    @testing.for_all_dtypes(no_complex=True, no_int8=True)
     @testing.numpy_cupy_array_equal()
     def test_is_close_finite(self, xp, dtype):
         # In numpy<1.10 this test fails when dtype is bool

--- a/dpnp/tests/third_party/cupy/math_tests/test_matmul.py
+++ b/dpnp/tests/third_party/cupy/math_tests/test_matmul.py
@@ -60,8 +60,9 @@ from dpnp.tests.third_party.cupy import testing
 )
 class TestMatmul(unittest.TestCase):
 
-    @testing.for_all_dtypes(name="dtype1")
-    @testing.for_all_dtypes(name="dtype2")
+    # no_int8=True is added to avoid overflow
+    @testing.for_all_dtypes(name="dtype1", no_int8=True)
+    @testing.for_all_dtypes(name="dtype2", no_int8=True)
     @testing.numpy_cupy_allclose(
         rtol=1e-3, atol=1e-3, type_check=has_support_aspect64()
     )  # required for uint8
@@ -70,8 +71,9 @@ class TestMatmul(unittest.TestCase):
         x2 = testing.shaped_arange(self.shape_pair[1], xp, dtype2)
         return operator.matmul(x1, x2)
 
-    @testing.for_all_dtypes(name="dtype1")
-    @testing.for_all_dtypes(name="dtype2")
+    # no_int8=True is added to avoid overflow
+    @testing.for_all_dtypes(name="dtype1", no_int8=True)
+    @testing.for_all_dtypes(name="dtype2", no_int8=True)
     @testing.numpy_cupy_allclose(
         rtol=1e-3, atol=1e-3, type_check=has_support_aspect64()
     )  # required for uint8
@@ -97,8 +99,9 @@ class TestMatmul(unittest.TestCase):
 )
 class TestMatmulOut(unittest.TestCase):
 
-    @testing.for_all_dtypes(name="dtype1")
-    @testing.for_all_dtypes(name="dtype2")
+    # no_int8=True is added to avoid overflow
+    @testing.for_all_dtypes(name="dtype1", no_int8=True)
+    @testing.for_all_dtypes(name="dtype2", no_int8=True)
     @testing.numpy_cupy_allclose(
         rtol=1e-3, atol=1e-3, accept_error=TypeError  # required for uint8
     )
@@ -140,7 +143,8 @@ class TestMatmulOutOverlap:
 
 class TestMatmulStrides:
 
-    @testing.for_all_dtypes()
+    # no_int8=True is added to avoid overflow
+    @testing.for_all_dtypes(no_int8=True)
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-3)  # required for uint8
     def test_relaxed_c_contiguous_input(self, xp, dtype):
         x1 = testing.shaped_arange((2, 2, 3), xp, dtype)[:, None, :, :]
@@ -171,6 +175,7 @@ class TestMatmulLarge(unittest.TestCase):
 
     # Avoid overflow
     skip_dtypes = {
+        (numpy.int8, numpy.int8),
         (numpy.int8, numpy.uint8),
         (numpy.int8, numpy.int16),
         (numpy.int8, numpy.float16),

--- a/dpnp/tests/third_party/cupy/math_tests/test_misc.py
+++ b/dpnp/tests/third_party/cupy/math_tests/test_misc.py
@@ -176,7 +176,8 @@ class TestMisc:
         self.check_unary("sqrt")
 
     @testing.for_all_dtypes(no_complex=True)
-    @testing.numpy_cupy_allclose(atol=1e-5, type_check=has_support_aspect64())
+    # atol=1e-3 is needed for int8
+    @testing.numpy_cupy_allclose(atol=1e-3, type_check=has_support_aspect64())
     def test_cbrt(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return xp.cbrt(a)

--- a/dpnp/tests/third_party/cupy/math_tests/test_trigonometric.py
+++ b/dpnp/tests/third_party/cupy/math_tests/test_trigonometric.py
@@ -7,7 +7,9 @@ from dpnp.tests.third_party.cupy import testing
 class TestTrigonometric(unittest.TestCase):
 
     @testing.for_all_dtypes(no_complex=True)
-    @testing.numpy_cupy_allclose(atol=1e-5, type_check=has_support_aspect64())
+    @testing.numpy_cupy_allclose(
+        atol=1e-4, rtol=0.001, type_check=has_support_aspect64()
+    )
     def check_unary(self, name, xp, dtype):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return getattr(xp, name)(a)

--- a/dpnp/tests/third_party/cupy/random_tests/test_permutations.py
+++ b/dpnp/tests/third_party/cupy/random_tests/test_permutations.py
@@ -38,6 +38,11 @@ class TestPermutations(unittest.TestCase):
 
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     def test_permutation_sort_1dim(self, dtype):
+        flag = cupy.issubdtype(dtype, cupy.unsignedinteger)
+        if flag or dtype in [cupy.int8, cupy.int16]:
+            pytest.skip(
+                "dpnp.random.permutation() does not support new integer dtypes."
+            )
         cupy_random = self._xp_random(cupy)
         a = cupy.arange(10, dtype=dtype)
         b = cupy.copy(a)
@@ -47,6 +52,11 @@ class TestPermutations(unittest.TestCase):
 
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     def test_permutation_sort_ndim(self, dtype):
+        flag = cupy.issubdtype(dtype, cupy.unsignedinteger)
+        if flag or dtype in [cupy.int8, cupy.int16]:
+            pytest.skip(
+                "dpnp.random.permutation() does not support new integer dtypes."
+            )
         cupy_random = self._xp_random(cupy)
         a = cupy.arange(15, dtype=dtype).reshape(5, 3)
         b = cupy.copy(a)
@@ -58,6 +68,11 @@ class TestPermutations(unittest.TestCase):
 
     @testing.for_all_dtypes()
     def test_permutation_seed1(self, dtype):
+        flag = cupy.issubdtype(dtype, cupy.unsignedinteger)
+        if flag or dtype in [cupy.int8, cupy.int16]:
+            pytest.skip(
+                "dpnp.random.permutation() does not support new integer dtypes."
+            )
         a = testing.shaped_random((10,), cupy, dtype)
         b = cupy.copy(a)
 
@@ -89,6 +104,11 @@ class TestShuffle(unittest.TestCase):
 
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     def test_shuffle_sort_1dim(self, dtype):
+        flag = cupy.issubdtype(dtype, cupy.unsignedinteger)
+        if flag or dtype in [cupy.int8, cupy.int16]:
+            pytest.skip(
+                "dpnp.random.shuffle() does not support new integer dtypes."
+            )
         a = cupy.arange(10, dtype=dtype)
         b = cupy.copy(a)
         cupy.random.shuffle(a)
@@ -96,6 +116,11 @@ class TestShuffle(unittest.TestCase):
 
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     def test_shuffle_sort_ndim(self, dtype):
+        flag = cupy.issubdtype(dtype, cupy.unsignedinteger)
+        if flag or dtype in [cupy.int8, cupy.int16]:
+            pytest.skip(
+                "dpnp.random.shuffle() does not support new integer dtypes."
+            )
         a = cupy.arange(15, dtype=dtype).reshape(5, 3)
         b = cupy.copy(a)
         cupy.random.shuffle(a)
@@ -105,6 +130,11 @@ class TestShuffle(unittest.TestCase):
 
     @testing.for_all_dtypes()
     def test_shuffle_seed1(self, dtype):
+        flag = cupy.issubdtype(dtype, cupy.unsignedinteger)
+        if flag or dtype in [cupy.int8, cupy.int16]:
+            pytest.skip(
+                "dpnp.random.shuffle() does not support new integer dtypes."
+            )
         a = testing.shaped_random((10,), cupy, dtype)
         b = cupy.copy(a)
         cupy.random.seed(0)

--- a/dpnp/tests/third_party/cupy/sorting_tests/test_sort.py
+++ b/dpnp/tests/third_party/cupy/sorting_tests/test_sort.py
@@ -478,6 +478,9 @@ class TestPartition(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_equal()
     def test_partition_one_dim(self, xp, dtype):
+        flag = xp.issubdtype(dtype, xp.unsignedinteger)
+        if flag or dtype in [xp.int8, xp.int16]:
+            pytest.skip("dpnp.partition() does not support new integer dtypes.")
         a = testing.shaped_random((self.length,), xp, dtype)
         kth = 2
         x = self.partition(a, kth)

--- a/dpnp/tests/third_party/cupy/testing/_loops.py
+++ b/dpnp/tests/third_party/cupy/testing/_loops.py
@@ -1082,30 +1082,17 @@ def _get_int_bool_dtypes():
 
 _complex_dtypes = _get_supported_complex_dtypes()
 _regular_float_dtypes = _get_supported_float_dtypes()
-_float_dtypes = _get_float_dtypes()
-_signed_dtypes = _get_signed_dtypes()
-_unsigned_dtypes = _get_unsigned_dtypes()
-_int_dtypes = _get_int_dtypes()
-_int_bool_dtypes = _get_int_bool_dtypes()
+_float_dtypes = _regular_float_dtypes
+_signed_dtypes = ()
+_unsigned_dtypes = tuple(numpy.dtype(i).type for i in "BHILQ")
+_int_dtypes = _signed_dtypes + _unsigned_dtypes
+_int_bool_dtypes = _int_dtypes
 _regular_dtypes = _regular_float_dtypes + _int_bool_dtypes
 _dtypes = _float_dtypes + _int_bool_dtypes
 
 
 def _make_all_dtypes(no_float16, no_bool, no_complex):
-    if no_float16:
-        dtypes = _regular_float_dtypes
-    else:
-        dtypes = _float_dtypes
-
-    if no_bool:
-        dtypes += _int_dtypes
-    else:
-        dtypes += _int_bool_dtypes
-
-    if config.complex_types and not no_complex:
-        dtypes += _complex_dtypes
-
-    return dtypes
+    return (numpy.int64, numpy.int32) + _get_supported_float_dtypes()
 
 
 def for_all_dtypes(

--- a/dpnp/tests/third_party/cupy/testing/_loops.py
+++ b/dpnp/tests/third_party/cupy/testing/_loops.py
@@ -251,7 +251,7 @@ def _make_positive_masks(impl, args, kw, name, sp_name, scipy_name):
     assert error is None
     if not isinstance(result, (tuple, list)):
         result = (result,)
-    return [cupy.asnumpy(r) >= 0 for r in result]
+    return [r >= 0 for r in result]
 
 
 def _contains_signed_and_unsigned(kw):
@@ -411,8 +411,8 @@ numpy: {}""".format(
                     if cupy_r.shape == ():
                         skip = (mask == 0).all()
                     else:
-                        cupy_r = cupy_r[mask].get()
-                        numpy_r = numpy_r[mask]
+                        cupy_r = cupy_r[mask]
+                        numpy_r = numpy_r[mask.asnumpy()]
 
                 if not skip:
                     check_func(cupy_r, numpy_r)
@@ -1082,21 +1082,43 @@ def _get_int_bool_dtypes():
 
 _complex_dtypes = _get_supported_complex_dtypes()
 _regular_float_dtypes = _get_supported_float_dtypes()
-_float_dtypes = _regular_float_dtypes
-_signed_dtypes = ()
-_unsigned_dtypes = tuple(numpy.dtype(i).type for i in "BHILQ")
-_int_dtypes = _signed_dtypes + _unsigned_dtypes
-_int_bool_dtypes = _int_dtypes
+_float_dtypes = _get_float_dtypes()
+_signed_dtypes = _get_signed_dtypes()
+_unsigned_dtypes = _get_unsigned_dtypes()
+_int_dtypes = _get_int_dtypes()
+_int_bool_dtypes = _get_int_bool_dtypes()
 _regular_dtypes = _regular_float_dtypes + _int_bool_dtypes
 _dtypes = _float_dtypes + _int_bool_dtypes
 
 
-def _make_all_dtypes(no_float16, no_bool, no_complex):
-    return (numpy.int64, numpy.int32) + _get_supported_float_dtypes()
+def _make_all_dtypes(no_float16, no_bool, no_complex, no_int8):
+    if no_float16:
+        dtypes = _regular_float_dtypes
+    else:
+        dtypes = _float_dtypes
+
+    if no_bool:
+        dtypes += _int_dtypes
+    else:
+        dtypes += _int_bool_dtypes
+
+    if no_int8:
+        dtypes = tuple(
+            filter(lambda dt: dt not in [numpy.int8, numpy.uint8], dtypes)
+        )
+
+    if config.complex_types and not no_complex:
+        dtypes += _complex_dtypes
+
+    return dtypes
 
 
 def for_all_dtypes(
-    name="dtype", no_float16=False, no_bool=False, no_complex=False
+    name="dtype",
+    no_float16=False,
+    no_bool=False,
+    no_complex=False,
+    no_int8=False,
 ):
     """Decorator that checks the fixture with all dtypes.
 
@@ -1108,6 +1130,9 @@ def for_all_dtypes(
              omitted from candidate dtypes.
          no_complex(bool): If ``True``, ``numpy.complex64`` and
              ``numpy.complex128`` are omitted from candidate dtypes.
+         no_int8(bool): If ``True``, ``numpy.int8`` and
+             ``numpy.uint8`` are omitted from candidate dtypes.
+             This option is generally used to avoid overflow.
 
     dtypes to be tested: ``numpy.complex64`` (optional),
     ``numpy.complex128`` (optional),
@@ -1151,7 +1176,7 @@ def for_all_dtypes(
     .. seealso:: :func:`cupy.testing.for_dtypes`
     """
     return for_dtypes(
-        _make_all_dtypes(no_float16, no_bool, no_complex), name=name
+        _make_all_dtypes(no_float16, no_bool, no_complex, no_int8), name=name
     )
 
 
@@ -1321,6 +1346,7 @@ def for_all_dtypes_combination(
     no_bool=False,
     full=None,
     no_complex=False,
+    no_int8=False,
 ):
     """Decorator that checks the fixture with a product set of all dtypes.
 
@@ -1334,12 +1360,15 @@ def for_all_dtypes_combination(
              will be tested.
              Otherwise, the subset of combinations will be tested
              (see description in :func:`cupy.testing.for_dtypes_combination`).
-         no_complex(bool): If, True, ``numpy.complex64`` and
+         no_complex(bool): If, ``True``, ``numpy.complex64`` and
              ``numpy.complex128`` are omitted from candidate dtypes.
+         no_int8(bool): If, ``True``, ``numpy.int8`` and
+             ``numpy.uint8`` are omitted from candidate dtypes.
+             This option is generally used to avoid overflow.
 
     .. seealso:: :func:`cupy.testing.for_dtypes_combination`
     """
-    types = _make_all_dtypes(no_float16, no_bool, no_complex)
+    types = _make_all_dtypes(no_float16, no_bool, no_complex, no_int8)
     return for_dtypes_combination(types, names, full)
 
 


### PR DESCRIPTION
In this PR, tests are update to  pass with newly added integer dtypes (int8, int16, uint8, uint16, uint32, uint64).
This PR is in continuation of https://github.com/IntelPython/dpnp/pull/2230.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
