### PR TITLE
Add `order` agrument to `generate_random_numpy_array()`

### DIFF
--- a/dpnp/tests/helper.py
+++ b/dpnp/tests/helper.py
@@ -162,7 +162,13 @@ def get_all_dtypes(
 
 
 def generate_random_numpy_array(
-    shape, dtype=None, hermitian=False, seed_value=None, low=-10, high=10
+    shape,
+    dtype=None,
+    order="C",
+    hermitian=False,
+    seed_value=None,
+    low=-10,
+    high=10,
 ):
     """
     Generate a random numpy array with the specified shape and dtype.
@@ -178,6 +184,9 @@ def generate_random_numpy_array(
         Desired data-type for the output array.
         If not specified, data type will be determined by numpy.
         Default : ``None``
+    order : {"C", "F"}, optional
+        Specify the memory layout of the output array.
+        Default: ``"C"``.
     hermitian : bool, optional
         If True, generates a Hermitian (symmetric if `dtype` is real) matrix.
         Default : ``False``
@@ -194,7 +203,7 @@ def generate_random_numpy_array(
     Returns
     -------
     out : numpy.ndarray
-        A random numpy array of the specified shape and dtype.
+        A random numpy array of the specified shape, dtype and memory layout.
         The array is Hermitian or symmetric if `hermitian` is True.
 
     Note:
@@ -224,6 +233,10 @@ def generate_random_numpy_array(
             a = a.reshape(orig_shape)
         else:
             a = numpy.conj(a.T) @ a
+
+    # a.reshape(shape) returns an array in C order by default
+    if order != "C" and a.ndim > 1:
+        a = numpy.array(a, order=order)
     return a
 
 

--- a/dpnp/tests/test_fft.py
+++ b/dpnp/tests/test_fft.py
@@ -380,8 +380,7 @@ class TestFft2:
     @pytest.mark.parametrize("norm", [None, "forward", "backward", "ortho"])
     @pytest.mark.parametrize("order", ["C", "F"])
     def test_fft2(self, dtype, axes, norm, order):
-        x = generate_random_numpy_array((2, 3, 4), dtype)
-        a_np = numpy.array(x, order=order)
+        a_np = generate_random_numpy_array((2, 3, 4), dtype, order)
         a = dpnp.array(a_np)
 
         result = dpnp.fft.fft2(a, axes=axes, norm=norm)
@@ -443,8 +442,7 @@ class TestFftn:
     @pytest.mark.parametrize("norm", [None, "backward", "forward", "ortho"])
     @pytest.mark.parametrize("order", ["C", "F"])
     def test_fftn(self, dtype, axes, norm, order):
-        x = generate_random_numpy_array((2, 3, 4, 5), dtype)
-        a_np = numpy.array(x, order=order)
+        a_np = generate_random_numpy_array((2, 3, 4, 5), dtype, order)
         a = dpnp.array(a_np)
 
         result = dpnp.fft.fftn(a, axes=axes, norm=norm)
@@ -698,8 +696,7 @@ class TestIrfft:
     @pytest.mark.parametrize("norm", [None, "backward", "forward", "ortho"])
     @pytest.mark.parametrize("order", ["C", "F"])
     def test_irfft_1D_on_3D_array(self, dtype, n, axis, norm, order):
-        x = generate_random_numpy_array((4, 5, 6), dtype)
-        a_np = numpy.array(x, order=order)
+        a_np = generate_random_numpy_array((4, 5, 6), dtype, order)
         # each 1-D array of input should be Hermitian
         if axis == 0:
             a_np[0].imag = 0
@@ -936,8 +933,7 @@ class TestRfft2:
     @pytest.mark.parametrize("norm", [None, "backward", "forward", "ortho"])
     @pytest.mark.parametrize("order", ["C", "F"])
     def test_rfft2(self, dtype, axes, norm, order):
-        x = generate_random_numpy_array((2, 3, 4), dtype)
-        a_np = numpy.array(x, order=order)
+        a_np = generate_random_numpy_array((2, 3, 4), dtype, order)
         a = dpnp.asarray(a_np)
 
         result = dpnp.fft.rfft2(a, axes=axes, norm=norm)
@@ -1001,8 +997,7 @@ class TestRfftn:
     @pytest.mark.parametrize("norm", [None, "backward", "forward", "ortho"])
     @pytest.mark.parametrize("order", ["C", "F"])
     def test_rfftn(self, dtype, axes, norm, order):
-        x = generate_random_numpy_array((2, 3, 4, 5), dtype)
-        a_np = numpy.array(x, order=order)
+        a_np = generate_random_numpy_array((2, 3, 4, 5), dtype, order)
         a = dpnp.asarray(a_np)
 
         result = dpnp.fft.rfftn(a, axes=axes, norm=norm)

--- a/dpnp/tests/test_fft.py
+++ b/dpnp/tests/test_fft.py
@@ -380,7 +380,8 @@ class TestFft2:
     @pytest.mark.parametrize("norm", [None, "forward", "backward", "ortho"])
     @pytest.mark.parametrize("order", ["C", "F"])
     def test_fft2(self, dtype, axes, norm, order):
-        a_np = generate_random_numpy_array((2, 3, 4), dtype)
+        x = generate_random_numpy_array((2, 3, 4), dtype)
+        a_np = numpy.array(x, order=order)
         a = dpnp.array(a_np)
 
         result = dpnp.fft.fft2(a, axes=axes, norm=norm)
@@ -442,7 +443,8 @@ class TestFftn:
     @pytest.mark.parametrize("norm", [None, "backward", "forward", "ortho"])
     @pytest.mark.parametrize("order", ["C", "F"])
     def test_fftn(self, dtype, axes, norm, order):
-        a_np = generate_random_numpy_array((2, 3, 4, 5), dtype)
+        x = generate_random_numpy_array((2, 3, 4, 5), dtype)
+        a_np = numpy.array(x, order=order)
         a = dpnp.array(a_np)
 
         result = dpnp.fft.fftn(a, axes=axes, norm=norm)

--- a/dpnp/tests/test_linalg.py
+++ b/dpnp/tests/test_linalg.py
@@ -503,10 +503,9 @@ class TestEigenvalue:
         # non-symmetric for eig() and eigvals()
         is_hermitian = func in ("eigh, eigvalsh")
         a = generate_random_numpy_array(
-            shape, dtype, hermitian=is_hermitian, low=-4, high=4
+            shape, dtype, order, hermitian=is_hermitian, low=-4, high=4
         )
-        a_order = numpy.array(a, order=order)
-        a_dp = dpnp.array(a, order=order)
+        a_dp = dpnp.array(a)
 
         # NumPy with OneMKL and with rocSOLVER sorts in ascending order,
         # so w's should be directly comparable.
@@ -514,13 +513,13 @@ class TestEigenvalue:
         # constructing eigenvectors, so v's are not directly comparable and
         # we verify them through the eigen equation A*v=w*v.
         if func in ("eig", "eigh"):
-            w, _ = getattr(numpy.linalg, func)(a_order)
+            w, _ = getattr(numpy.linalg, func)(a)
             w_dp, v_dp = getattr(dpnp.linalg, func)(a_dp)
 
             self.assert_eigen_decomposition(a_dp, w_dp, v_dp)
 
         else:  # eighvals or eigvalsh
-            w = getattr(numpy.linalg, func)(a_order)
+            w = getattr(numpy.linalg, func)(a)
             w_dp = getattr(dpnp.linalg, func)(a_dp)
 
         assert_dtype_allclose(w_dp, w, factor=24)


### PR DESCRIPTION
This PR suggests updating the helper function `generate_random_numpy_array()` by adding an argument `order` to generate arrays in different orders

Additionally 
Input generation for tests was changed in #2227  , now `test_fft2` and `test_fftn` do not use `order` parameter.
This PR suggests to update these tests to use input data with different orders


- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
