### PR TITLE
update third party tests for newly added integr dtypes (int8, int16, uint8-uint64)

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -529,7 +529,7 @@ jobs:
         env:
           DPNP_TEST_ALL_INT_TYPES: 1
         run: |
-          pytest -n auto -ra --pyargs ${{ env.PACKAGE_NAME }}.tests
+          pytest -ra --pyargs ${{ env.PACKAGE_NAME }}.tests
 
   upload:
     name: Upload ['${{ matrix.os }}', python='${{ matrix.python }}']

--- a/dpnp/dpnp_algo/dpnp_elementwise_common.py
+++ b/dpnp/dpnp_algo/dpnp_elementwise_common.py
@@ -594,7 +594,10 @@ class DPNPRound(DPNPUnaryFunc):
                 dtype = x_usm.dtype
 
             out_usm = None if out is None else dpnp.get_usm_ndarray(out)
-            x_usm = dpt.round(x_usm * 10**decimals, out=out_usm)
+            # the output of x_usm multiplied by 10^decimals should be
+            # float avoid overflow for integer dtypes
+            x_usm = dpt.multiply(x_usm, float(10**decimals))
+            x_usm = dpt.round(x_usm, out=out_usm)
             res_usm = dpt.divide(x_usm, 10**decimals, out=out_usm)
 
             if dtype is not None:

--- a/dpnp/dpnp_algo/dpnp_elementwise_common.py
+++ b/dpnp/dpnp_algo/dpnp_elementwise_common.py
@@ -590,15 +590,13 @@ class DPNPRound(DPNPUnaryFunc):
     def __call__(self, x, decimals=0, out=None, dtype=None):
         if decimals != 0:
             x_usm = dpnp.get_usm_ndarray(x)
-            if dpnp.issubdtype(x_usm.dtype, dpnp.integer) and dtype is None:
-                dtype = x_usm.dtype
-
             out_usm = None if out is None else dpnp.get_usm_ndarray(out)
-            # the output of x_usm multiplied by 10^decimals should be
-            # float to avoid overflow for integer dtypes
-            x_usm = dpt.multiply(x_usm, float(10**decimals))
-            x_usm = dpt.round(x_usm, out=out_usm)
-            res_usm = dpt.divide(x_usm, 10**decimals, out=out_usm)
+
+            if dpnp.issubdtype(x_usm.dtype, dpnp.integer):
+                res_usm = dpt.round(x_usm, out=out_usm)
+            else:
+                x_usm = dpt.round(x_usm * 10**decimals, out=out_usm)
+                res_usm = dpt.divide(x_usm, 10**decimals, out=out_usm)
 
             if dtype is not None:
                 res_usm = dpt.astype(res_usm, dtype, copy=False)

--- a/dpnp/dpnp_algo/dpnp_elementwise_common.py
+++ b/dpnp/dpnp_algo/dpnp_elementwise_common.py
@@ -595,7 +595,7 @@ class DPNPRound(DPNPUnaryFunc):
 
             out_usm = None if out is None else dpnp.get_usm_ndarray(out)
             # the output of x_usm multiplied by 10^decimals should be
-            # float avoid overflow for integer dtypes
+            # float to avoid overflow for integer dtypes
             x_usm = dpt.multiply(x_usm, float(10**decimals))
             x_usm = dpt.round(x_usm, out=out_usm)
             res_usm = dpt.divide(x_usm, 10**decimals, out=out_usm)

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -1469,9 +1469,9 @@ def copyto(dst, src, casting="same_kind", where=True):
             f"but got {type(dst)}"
         )
     if not dpnp.is_supported_array_type(src):
-        src_orig = src
+        no_dtype_attr = not hasattr(src, "dtype")
         src = dpnp.array(src, sycl_queue=dst.sycl_queue)
-        if not hasattr(src_orig, "dtype"):
+        if no_dtype_attr:
             # This case (scalar, list, etc) needs special handling to
             # behave similar to NumPy
             if dpnp.issubdtype(src, dpnp.integer) and dpnp.issubdtype(

--- a/dpnp/tests/test_sycl_queue.py
+++ b/dpnp/tests/test_sycl_queue.py
@@ -810,6 +810,7 @@ def test_reduce_hypot(device):
             [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
             [5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0],
         ),
+        pytest.param("round", [1.234, 2.567], 2),
         pytest.param("searchsorted", [11, 12, 13, 14, 15], [-10, 20, 12, 13]),
         pytest.param(
             "subtract",

--- a/dpnp/tests/test_usm_type.py
+++ b/dpnp/tests/test_usm_type.py
@@ -740,6 +740,7 @@ def test_1in_1out(func, data, usm_type):
         pytest.param("maximum", [0.0, 1.0, 2.0], [3.0, 4.0, 5.0]),
         pytest.param("minimum", [0.0, 1.0, 2.0], [3.0, 4.0, 5.0]),
         pytest.param("nextafter", [1, 2], [2, 1]),
+        pytest.param("round", [1.234, 2.567], 2),
         pytest.param("searchsorted", [11, 12, 13, 14, 15], [-10, 20, 12, 13]),
         pytest.param(
             "tensordot",

--- a/dpnp/tests/third_party/cupy/core_tests/test_elementwise.py
+++ b/dpnp/tests/third_party/cupy/core_tests/test_elementwise.py
@@ -110,7 +110,7 @@ class TestElementwiseType(unittest.TestCase):
             if xp.issubdtype(dtype, xp.unsignedinteger) or flag:
                 pytest.skip("numpy doesn't raise OverflowError")
 
-            if dtype == xp.int8 and is_win_platform():
+            if dtype in [xp.int8, xp.intc] and is_win_platform():
                 pytest.skip("numpy promotes dtype differently")
 
         a = xp.array([1], dtype=xp.int8)
@@ -160,12 +160,11 @@ class TestElementwiseType(unittest.TestCase):
             if dtype in [xp.int16, xp.int32, xp.int64, xp.longlong]:
                 pytest.skip("numpy doesn't raise OverflowError")
 
-            if dtype == xp.int8 and is_win_platform():
+            if dtype in [xp.int8, xp.intc] and is_win_platform():
                 pytest.skip("numpy promotes dtype differently")
 
         a = xp.array([0], dtype=xp.int8)
         b = xp.iinfo(dtype).min
-        res = a + b
         return a + b
 
     @testing.for_int_dtypes(no_bool=True)
@@ -175,7 +174,7 @@ class TestElementwiseType(unittest.TestCase):
             if dtype in [xp.int16, xp.int32, xp.int64, xp.longlong]:
                 pytest.skip("numpy doesn't raise OverflowError")
 
-            if dtype == xp.int8 and is_win_platform():
+            if dtype in [xp.int8, xp.intc] and is_win_platform():
                 pytest.skip("numpy promotes dtype differently")
 
         a = xp.array([-1], dtype=xp.int8)

--- a/dpnp/tests/third_party/cupy/core_tests/test_elementwise.py
+++ b/dpnp/tests/third_party/cupy/core_tests/test_elementwise.py
@@ -4,7 +4,11 @@ import numpy
 import pytest
 
 import dpnp as cupy
-from dpnp.tests.helper import has_support_aspect64
+from dpnp.tests.helper import (
+    has_support_aspect64,
+    is_win_platform,
+    numpy_version,
+)
 from dpnp.tests.third_party.cupy import testing
 
 
@@ -94,20 +98,22 @@ class TestElementwiseType(unittest.TestCase):
     @testing.for_int_dtypes(no_bool=True)
     @testing.numpy_cupy_array_equal(accept_error=OverflowError)
     def test_large_int_upper_1(self, xp, dtype):
-        a = xp.array([0], dtype=numpy.int8)
+        a = xp.array([0], dtype=xp.int8)
         b = xp.iinfo(dtype).max
         return a + b
 
     @testing.for_int_dtypes(no_bool=True)
     @testing.numpy_cupy_array_equal(accept_error=OverflowError)
     def test_large_int_upper_2(self, xp, dtype):
-        if (
-            numpy.issubdtype(dtype, numpy.unsignedinteger)
-            and numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0"
-        ):
-            pytest.skip("numpy promotes dtype differently")
+        if numpy_version() < "2.0.0":
+            flag = dtype in [xp.int16, xp.int32, xp.int64, xp.longlong]
+            if xp.issubdtype(dtype, xp.unsignedinteger) or flag:
+                pytest.skip("numpy doesn't raise OverflowError")
 
-        a = xp.array([1], dtype=numpy.int8)
+            if dtype == xp.int8 and is_win_platform():
+                pytest.skip("numpy promotes dtype differently")
+
+        a = xp.array([1], dtype=xp.int8)
         b = xp.iinfo(dtype).max - 1
         return a + b
 
@@ -116,7 +122,7 @@ class TestElementwiseType(unittest.TestCase):
     def test_large_int_upper_3(self, xp, dtype):
         if (
             numpy.issubdtype(dtype, numpy.unsignedinteger)
-            and numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0"
+            and numpy_version() < "2.0.0"
         ):
             pytest.skip("numpy promotes dtype differently")
         elif (
@@ -134,7 +140,7 @@ class TestElementwiseType(unittest.TestCase):
     def test_large_int_upper_4(self, xp, dtype):
         if (
             numpy.issubdtype(dtype, numpy.unsignedinteger)
-            and numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0"
+            and numpy_version() < "2.0.0"
         ):
             pytest.skip("numpy promotes dtype differently")
         elif (
@@ -150,14 +156,29 @@ class TestElementwiseType(unittest.TestCase):
     @testing.for_int_dtypes(no_bool=True)
     @testing.numpy_cupy_array_equal(accept_error=OverflowError)
     def test_large_int_lower_1(self, xp, dtype):
-        a = xp.array([0], dtype=numpy.int8)
+        if numpy_version() < "2.0.0":
+            if dtype in [xp.int16, xp.int32, xp.int64, xp.longlong]:
+                pytest.skip("numpy doesn't raise OverflowError")
+
+            if dtype == xp.int8 and is_win_platform():
+                pytest.skip("numpy promotes dtype differently")
+
+        a = xp.array([0], dtype=xp.int8)
         b = xp.iinfo(dtype).min
+        res = a + b
         return a + b
 
     @testing.for_int_dtypes(no_bool=True)
     @testing.numpy_cupy_array_equal(accept_error=OverflowError)
     def test_large_int_lower_2(self, xp, dtype):
-        a = xp.array([-1], dtype=numpy.int8)
+        if numpy_version() < "2.0.0":
+            if dtype in [xp.int16, xp.int32, xp.int64, xp.longlong]:
+                pytest.skip("numpy doesn't raise OverflowError")
+
+            if dtype == xp.int8 and is_win_platform():
+                pytest.skip("numpy promotes dtype differently")
+
+        a = xp.array([-1], dtype=xp.int8)
         b = xp.iinfo(dtype).min + 1
         return a + b
 
@@ -166,7 +187,7 @@ class TestElementwiseType(unittest.TestCase):
     def test_large_int_lower_3(self, xp, dtype):
         if (
             numpy.issubdtype(dtype, numpy.unsignedinteger)
-            and numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0"
+            and numpy_version() < "2.0.0"
         ):
             pytest.skip("numpy promotes dtype differently")
         elif (

--- a/dpnp/tests/third_party/cupy/core_tests/test_ndarray_complex_ops.py
+++ b/dpnp/tests/third_party/cupy/core_tests/test_ndarray_complex_ops.py
@@ -4,7 +4,6 @@ import numpy
 import pytest
 
 import dpnp as cupy
-from dpnp.tests.helper import has_support_aspect64
 from dpnp.tests.third_party.cupy import testing
 
 

--- a/dpnp/tests/third_party/cupy/core_tests/test_ndarray_complex_ops.py
+++ b/dpnp/tests/third_party/cupy/core_tests/test_ndarray_complex_ops.py
@@ -41,8 +41,10 @@ class TestConj(unittest.TestCase):
 
 class TestAngle(unittest.TestCase):
 
+    # For dtype=int8, uint8, NumPy returns float16, but dpnp returns float32
+    # so type_check=False
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_almost_equal(type_check=has_support_aspect64())
+    @testing.numpy_cupy_array_almost_equal(type_check=False)
     def test_angle(self, xp, dtype):
         x = testing.shaped_arange((2, 3), xp, dtype)
         return xp.angle(x)

--- a/dpnp/tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py
+++ b/dpnp/tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py
@@ -338,7 +338,7 @@ class TestArrayAsType:
         b = astype_without_warning(a, dst_dtype, order=order)
         a_cpu = testing.shaped_arange((2, 3, 4), numpy, src_dtype)
         b_cpu = astype_without_warning(a_cpu, dst_dtype, order=order)
-        assert b.dtype.type == b_cpu.dtype.type
+        assert b.dtype == b_cpu.dtype
 
     @testing.for_orders("CAK")
     @testing.for_all_dtypes()

--- a/dpnp/tests/third_party/cupy/creation_tests/test_ranges.py
+++ b/dpnp/tests/third_party/cupy/creation_tests/test_ranges.py
@@ -227,8 +227,8 @@ class TestRanges(unittest.TestCase):
         # TODO (ev-br): np 2.0: had to bump the default rtol on Windows
         #               and numpy 1.26+weak promotion from 0 to 5e-6
         if xp.dtype(dtype_range).kind in "u":
-            # to avoid overflow limit `val`` to be smaller
-            # than xp.iinfo(dtype_range).max
+            # to avoid overflow, limit `val` to be smaller
+            # than xp.iinfo(dtype).max
             if dtype_range == xp.uint8 or dtype_out == xp.uint8:
                 val = 125
             else:

--- a/dpnp/tests/third_party/cupy/creation_tests/test_ranges.py
+++ b/dpnp/tests/third_party/cupy/creation_tests/test_ranges.py
@@ -227,7 +227,11 @@ class TestRanges(unittest.TestCase):
         # TODO (ev-br): np 2.0: had to bump the default rtol on Windows
         #               and numpy 1.26+weak promotion from 0 to 5e-6
         if xp.dtype(dtype_range).kind in "u":
-            start = xp.array([160, 120], dtype=dtype_range)
+            if dtype_range == xp.uint8 or dtype_out == xp.uint8:
+                val = 125
+            else:
+                val = 160
+            start = xp.array([val, 120], dtype=dtype_range)
         else:
             start = xp.array([-120, 120], dtype=dtype_range)
         stop = 0

--- a/dpnp/tests/third_party/cupy/creation_tests/test_ranges.py
+++ b/dpnp/tests/third_party/cupy/creation_tests/test_ranges.py
@@ -227,6 +227,8 @@ class TestRanges(unittest.TestCase):
         # TODO (ev-br): np 2.0: had to bump the default rtol on Windows
         #               and numpy 1.26+weak promotion from 0 to 5e-6
         if xp.dtype(dtype_range).kind in "u":
+            # to avoid overflow limit `val`` to be smaller
+            # than xp.iinfo(dtype_range).max
             if dtype_range == xp.uint8 or dtype_out == xp.uint8:
                 val = 125
             else:

--- a/dpnp/tests/third_party/cupy/indexing_tests/test_indexing.py
+++ b/dpnp/tests/third_party/cupy/indexing_tests/test_indexing.py
@@ -204,6 +204,10 @@ class TestChoose(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_choose(self, xp, dtype):
+        # TODO: include additional dtype when dpnp#2201 is merged
+        dtype_list = [xp.int8, xp.int16]
+        if dtype in dtype_list or xp.issubdtype(dtype, xp.unsignedinteger):
+            pytest.skip("dpnp.choose() does not support new integer dtypes.")
         a = xp.array([0, 2, 1, 2])
         c = testing.shaped_arange((3, 4), xp, dtype)
         return a.choose(c)

--- a/dpnp/tests/third_party/cupy/linalg_tests/test_einsum.py
+++ b/dpnp/tests/third_party/cupy/linalg_tests/test_einsum.py
@@ -464,6 +464,7 @@ class TestEinSumUnaryOperationWithScalar:
     )
 )
 class TestEinSumBinaryOperation:
+    # no_int8=True is added to avoid overflow
     @testing.for_all_dtypes_combination(["dtype_a", "dtype_b"], no_int8=True)
     @testing.numpy_cupy_allclose(
         type_check=has_support_aspect64(), contiguous_check=False

--- a/dpnp/tests/third_party/cupy/linalg_tests/test_einsum.py
+++ b/dpnp/tests/third_party/cupy/linalg_tests/test_einsum.py
@@ -471,6 +471,8 @@ class TestEinSumBinaryOperation:
         type_check=has_support_aspect64(), contiguous_check=False
     )
     def test_einsum_binary(self, xp, dtype_a, dtype_b):
+        if all(dtype in [xp.int8, xp.uint8] for dtype in [dtype_a, dtype_b]):
+            pytest.skip("avoid overflow")
         a = testing.shaped_arange(self.shape_a, xp, dtype_a)
         b = testing.shaped_arange(self.shape_b, xp, dtype_b)
         # casting should be added for dpnp to allow cast int64 to float32
@@ -555,6 +557,7 @@ class TestEinSumBinaryOperationWithScalar:
     )
 )
 class TestEinSumTernaryOperation:
+
     @testing.for_all_dtypes_combination(
         ["dtype_a", "dtype_b", "dtype_c"], no_bool=False, no_float16=False
     )
@@ -562,6 +565,12 @@ class TestEinSumTernaryOperation:
         type_check=has_support_aspect64(), contiguous_check=False
     )
     def test_einsum_ternary(self, xp, dtype_a, dtype_b, dtype_c):
+        flag = all(
+            dtype in [xp.int8, xp.uint8]
+            for dtype in [dtype_a, dtype_b, dtype_c]
+        )
+        if self.subscripts == "ij,jk,kl" and flag:
+            pytest.skip("avoid overflow")
         a = testing.shaped_arange(self.shape_a, xp, dtype_a)
         b = testing.shaped_arange(self.shape_b, xp, dtype_b)
         c = testing.shaped_arange(self.shape_c, xp, dtype_c)

--- a/dpnp/tests/third_party/cupy/linalg_tests/test_einsum.py
+++ b/dpnp/tests/third_party/cupy/linalg_tests/test_einsum.py
@@ -464,15 +464,11 @@ class TestEinSumUnaryOperationWithScalar:
     )
 )
 class TestEinSumBinaryOperation:
-    @testing.for_all_dtypes_combination(
-        ["dtype_a", "dtype_b"], no_bool=False, no_float16=False
-    )
+    @testing.for_all_dtypes_combination(["dtype_a", "dtype_b"], no_int8=True)
     @testing.numpy_cupy_allclose(
         type_check=has_support_aspect64(), contiguous_check=False
     )
     def test_einsum_binary(self, xp, dtype_a, dtype_b):
-        if all(dtype in [xp.int8, xp.uint8] for dtype in [dtype_a, dtype_b]):
-            pytest.skip("avoid overflow")
         a = testing.shaped_arange(self.shape_a, xp, dtype_a)
         b = testing.shaped_arange(self.shape_b, xp, dtype_b)
         # casting should be added for dpnp to allow cast int64 to float32
@@ -558,9 +554,7 @@ class TestEinSumBinaryOperationWithScalar:
 )
 class TestEinSumTernaryOperation:
 
-    @testing.for_all_dtypes_combination(
-        ["dtype_a", "dtype_b", "dtype_c"], no_bool=False, no_float16=False
-    )
+    @testing.for_all_dtypes_combination(["dtype_a", "dtype_b", "dtype_c"])
     @testing.numpy_cupy_allclose(
         type_check=has_support_aspect64(), contiguous_check=False
     )

--- a/dpnp/tests/third_party/cupy/linalg_tests/test_product.py
+++ b/dpnp/tests/third_party/cupy/linalg_tests/test_product.py
@@ -40,21 +40,9 @@ from dpnp.tests.third_party.cupy import testing
 )
 class TestDot(unittest.TestCase):
 
-    # Avoid overflow
-    skip_dtypes = {
-        (numpy.int8, numpy.int8),
-        (numpy.int8, numpy.uint8),
-        (numpy.uint8, numpy.uint8),
-    }
-
-    @testing.for_all_dtypes_combination(["dtype_a", "dtype_b"])
+    @testing.for_all_dtypes_combination(["dtype_a", "dtype_b"], no_int8=True)
     @testing.numpy_cupy_allclose(type_check=has_support_aspect64())
     def test_dot(self, xp, dtype_a, dtype_b):
-        if (dtype_a, dtype_b) in self.skip_dtypes or (
-            dtype_b,
-            dtype_a,
-        ) in self.skip_dtypes:
-            pytest.skip("avoid overflow")
         shape_a, shape_b = self.shape
         if self.trans_a:
             a = testing.shaped_arange(shape_a[::-1], xp, dtype_a).T
@@ -250,20 +238,16 @@ class TestProduct:
         b = testing.shaped_arange((2,), xp, dtype)
         return xp.dot(a, b)
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(no_int8=True)
     @testing.numpy_cupy_allclose()
     def test_transposed_dot(self, xp, dtype):
-        if dtype in [numpy.int8, numpy.uint8]:
-            pytest.skip("avoid overflow")
         a = testing.shaped_arange((2, 3, 4), xp, dtype).transpose(1, 0, 2)
         b = testing.shaped_arange((2, 3, 4), xp, dtype).transpose(0, 2, 1)
         return xp.dot(a, b)
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(no_int8=True)
     @testing.numpy_cupy_allclose()
     def test_transposed_dot_with_out(self, xp, dtype):
-        if dtype in [numpy.int8, numpy.uint8]:
-            pytest.skip("avoid overflow")
         a = testing.shaped_arange((2, 3, 4), xp, dtype).transpose(1, 0, 2)
         b = testing.shaped_arange((4, 2, 3), xp, dtype).transpose(2, 0, 1)
         c = xp.ndarray((3, 2, 3, 2), dtype=dtype)
@@ -336,20 +320,16 @@ class TestProduct:
         b = testing.shaped_reverse_arange((5,), xp, dtype)[::-1]
         return xp.inner(a, b)
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(no_int8=True)
     @testing.numpy_cupy_allclose()
     def test_multidim_inner(self, xp, dtype):
-        if dtype in [numpy.int8, numpy.uint8]:
-            pytest.skip("avoid overflow")
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         b = testing.shaped_arange((3, 2, 4), xp, dtype)
         return xp.inner(a, b)
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(no_int8=True)
     @testing.numpy_cupy_allclose()
     def test_transposed_higher_order_inner(self, xp, dtype):
-        if dtype in [numpy.int8, numpy.uint8]:
-            pytest.skip("avoid overflow")
         a = testing.shaped_arange((2, 4, 3), xp, dtype).transpose(2, 0, 1)
         b = testing.shaped_arange((4, 2, 3), xp, dtype).transpose(1, 2, 0)
         return xp.inner(a, b)
@@ -375,20 +355,16 @@ class TestProduct:
         b = testing.shaped_arange((4, 5), xp, dtype)
         return xp.outer(a, b)
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(no_int8=True)
     @testing.numpy_cupy_allclose()
     def test_tensordot(self, xp, dtype):
-        if dtype in [numpy.int8, numpy.uint8]:
-            pytest.skip("avoid overflow")
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         b = testing.shaped_arange((3, 4, 5), xp, dtype)
         return xp.tensordot(a, b)
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(no_int8=True)
     @testing.numpy_cupy_allclose()
     def test_transposed_tensordot(self, xp, dtype):
-        if dtype in [numpy.int8, numpy.uint8]:
-            pytest.skip("avoid overflow")
         a = testing.shaped_arange((2, 3, 4), xp, dtype).transpose(1, 0, 2)
         b = testing.shaped_arange((4, 3, 2), xp, dtype).transpose(2, 0, 1)
         return xp.tensordot(a, b)
@@ -540,19 +516,15 @@ class TestMatrixPower(unittest.TestCase):
         a = testing.shaped_arange((3, 3), xp, dtype)
         return xp.linalg.matrix_power(a, 1)
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(no_int8=True)
     @testing.numpy_cupy_allclose()
     def test_matrix_power_2(self, xp, dtype):
-        if dtype in [numpy.int8, numpy.uint8]:
-            pytest.skip("avoid overflow")
         a = testing.shaped_arange((3, 3), xp, dtype)
         return xp.linalg.matrix_power(a, 2)
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(no_int8=True)
     @testing.numpy_cupy_allclose()
     def test_matrix_power_3(self, xp, dtype):
-        if dtype in [numpy.int8, numpy.uint8]:
-            pytest.skip("avoid overflow")
         a = testing.shaped_arange((3, 3), xp, dtype)
         return xp.linalg.matrix_power(a, 3)
 

--- a/dpnp/tests/third_party/cupy/linalg_tests/test_product.py
+++ b/dpnp/tests/third_party/cupy/linalg_tests/test_product.py
@@ -40,9 +40,21 @@ from dpnp.tests.third_party.cupy import testing
 )
 class TestDot(unittest.TestCase):
 
+    # Avoid overflow
+    skip_dtypes = {
+        (numpy.int8, numpy.int8),
+        (numpy.int8, numpy.uint8),
+        (numpy.uint8, numpy.uint8),
+    }
+
     @testing.for_all_dtypes_combination(["dtype_a", "dtype_b"])
     @testing.numpy_cupy_allclose(type_check=has_support_aspect64())
     def test_dot(self, xp, dtype_a, dtype_b):
+        if (dtype_a, dtype_b) in self.skip_dtypes or (
+            dtype_b,
+            dtype_a,
+        ) in self.skip_dtypes:
+            pytest.skip("avoid overflow")
         shape_a, shape_b = self.shape
         if self.trans_a:
             a = testing.shaped_arange(shape_a[::-1], xp, dtype_a).T
@@ -241,6 +253,8 @@ class TestProduct:
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_transposed_dot(self, xp, dtype):
+        if dtype in [numpy.int8, numpy.uint8]:
+            pytest.skip("avoid overflow")
         a = testing.shaped_arange((2, 3, 4), xp, dtype).transpose(1, 0, 2)
         b = testing.shaped_arange((2, 3, 4), xp, dtype).transpose(0, 2, 1)
         return xp.dot(a, b)
@@ -248,6 +262,8 @@ class TestProduct:
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_transposed_dot_with_out(self, xp, dtype):
+        if dtype in [numpy.int8, numpy.uint8]:
+            pytest.skip("avoid overflow")
         a = testing.shaped_arange((2, 3, 4), xp, dtype).transpose(1, 0, 2)
         b = testing.shaped_arange((4, 2, 3), xp, dtype).transpose(2, 0, 1)
         c = xp.ndarray((3, 2, 3, 2), dtype=dtype)
@@ -323,6 +339,8 @@ class TestProduct:
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_multidim_inner(self, xp, dtype):
+        if dtype in [numpy.int8, numpy.uint8]:
+            pytest.skip("avoid overflow")
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         b = testing.shaped_arange((3, 2, 4), xp, dtype)
         return xp.inner(a, b)
@@ -330,6 +348,8 @@ class TestProduct:
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_transposed_higher_order_inner(self, xp, dtype):
+        if dtype in [numpy.int8, numpy.uint8]:
+            pytest.skip("avoid overflow")
         a = testing.shaped_arange((2, 4, 3), xp, dtype).transpose(2, 0, 1)
         b = testing.shaped_arange((4, 2, 3), xp, dtype).transpose(1, 2, 0)
         return xp.inner(a, b)
@@ -358,6 +378,8 @@ class TestProduct:
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_tensordot(self, xp, dtype):
+        if dtype in [numpy.int8, numpy.uint8]:
+            pytest.skip("avoid overflow")
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         b = testing.shaped_arange((3, 4, 5), xp, dtype)
         return xp.tensordot(a, b)
@@ -365,6 +387,8 @@ class TestProduct:
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_transposed_tensordot(self, xp, dtype):
+        if dtype in [numpy.int8, numpy.uint8]:
+            pytest.skip("avoid overflow")
         a = testing.shaped_arange((2, 3, 4), xp, dtype).transpose(1, 0, 2)
         b = testing.shaped_arange((4, 3, 2), xp, dtype).transpose(2, 0, 1)
         return xp.tensordot(a, b)
@@ -519,12 +543,16 @@ class TestMatrixPower(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_matrix_power_2(self, xp, dtype):
+        if dtype in [numpy.int8, numpy.uint8]:
+            pytest.skip("avoid overflow")
         a = testing.shaped_arange((3, 3), xp, dtype)
         return xp.linalg.matrix_power(a, 2)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_matrix_power_3(self, xp, dtype):
+        if dtype in [numpy.int8, numpy.uint8]:
+            pytest.skip("avoid overflow")
         a = testing.shaped_arange((3, 3), xp, dtype)
         return xp.linalg.matrix_power(a, 3)
 

--- a/dpnp/tests/third_party/cupy/linalg_tests/test_product.py
+++ b/dpnp/tests/third_party/cupy/linalg_tests/test_product.py
@@ -39,7 +39,8 @@ from dpnp.tests.third_party.cupy import testing
     )
 )
 class TestDot(unittest.TestCase):
-
+    # no_int8=True is added to avoid overflow for shape=((2, 3, 4), (3, 4, 2))
+    # and ((2, 3), (3, 4)) cases on cpu
     @testing.for_all_dtypes_combination(["dtype_a", "dtype_b"], no_int8=True)
     @testing.numpy_cupy_allclose(type_check=has_support_aspect64())
     def test_dot(self, xp, dtype_a, dtype_b):
@@ -320,6 +321,7 @@ class TestProduct:
         b = testing.shaped_reverse_arange((5,), xp, dtype)[::-1]
         return xp.inner(a, b)
 
+    # no_int8=True is added to avoid overflow
     @testing.for_all_dtypes(no_int8=True)
     @testing.numpy_cupy_allclose()
     def test_multidim_inner(self, xp, dtype):
@@ -327,6 +329,7 @@ class TestProduct:
         b = testing.shaped_arange((3, 2, 4), xp, dtype)
         return xp.inner(a, b)
 
+    # no_int8=True is added to avoid overflow
     @testing.for_all_dtypes(no_int8=True)
     @testing.numpy_cupy_allclose()
     def test_transposed_higher_order_inner(self, xp, dtype):
@@ -355,6 +358,7 @@ class TestProduct:
         b = testing.shaped_arange((4, 5), xp, dtype)
         return xp.outer(a, b)
 
+    # no_int8=True is added to avoid overflow
     @testing.for_all_dtypes(no_int8=True)
     @testing.numpy_cupy_allclose()
     def test_tensordot(self, xp, dtype):
@@ -362,6 +366,7 @@ class TestProduct:
         b = testing.shaped_arange((3, 4, 5), xp, dtype)
         return xp.tensordot(a, b)
 
+    # no_int8=True is added to avoid overflow
     @testing.for_all_dtypes(no_int8=True)
     @testing.numpy_cupy_allclose()
     def test_transposed_tensordot(self, xp, dtype):
@@ -516,12 +521,14 @@ class TestMatrixPower(unittest.TestCase):
         a = testing.shaped_arange((3, 3), xp, dtype)
         return xp.linalg.matrix_power(a, 1)
 
+    # no_int8=True is added to avoid overflow
     @testing.for_all_dtypes(no_int8=True)
     @testing.numpy_cupy_allclose()
     def test_matrix_power_2(self, xp, dtype):
         a = testing.shaped_arange((3, 3), xp, dtype)
         return xp.linalg.matrix_power(a, 2)
 
+    # no_int8=True is added to avoid overflow
     @testing.for_all_dtypes(no_int8=True)
     @testing.numpy_cupy_allclose()
     def test_matrix_power_3(self, xp, dtype):

--- a/dpnp/tests/third_party/cupy/logic_tests/test_comparison.py
+++ b/dpnp/tests/third_party/cupy/logic_tests/test_comparison.py
@@ -242,11 +242,9 @@ class TestAllclose(unittest.TestCase):
 
 class TestIsclose(unittest.TestCase):
 
-    @testing.for_all_dtypes(no_complex=True)
+    @testing.for_all_dtypes(no_complex=True, no_int8=True)
     @testing.numpy_cupy_array_equal()
     def test_is_close_finite(self, xp, dtype):
-        if dtype in [xp.int8, xp.uint8]:
-            pytest.skip("avoid overflow")
         # In numpy<1.10 this test fails when dtype is bool
         a = xp.array([0.9e-5, 1.1e-5, 1000 + 1e-4, 1000 - 1e-4]).astype(dtype)
         b = xp.array([0, 0, 1000, 1000]).astype(dtype)

--- a/dpnp/tests/third_party/cupy/logic_tests/test_comparison.py
+++ b/dpnp/tests/third_party/cupy/logic_tests/test_comparison.py
@@ -242,6 +242,7 @@ class TestAllclose(unittest.TestCase):
 
 class TestIsclose(unittest.TestCase):
 
+    # no_int8=True is added to avoid overflow
     @testing.for_all_dtypes(no_complex=True, no_int8=True)
     @testing.numpy_cupy_array_equal()
     def test_is_close_finite(self, xp, dtype):

--- a/dpnp/tests/third_party/cupy/logic_tests/test_comparison.py
+++ b/dpnp/tests/third_party/cupy/logic_tests/test_comparison.py
@@ -245,6 +245,8 @@ class TestIsclose(unittest.TestCase):
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_array_equal()
     def test_is_close_finite(self, xp, dtype):
+        if dtype in [xp.int8, xp.uint8]:
+            pytest.skip("avoid overflow")
         # In numpy<1.10 this test fails when dtype is bool
         a = xp.array([0.9e-5, 1.1e-5, 1000 + 1e-4, 1000 - 1e-4]).astype(dtype)
         b = xp.array([0, 0, 1000, 1000]).astype(dtype)

--- a/dpnp/tests/third_party/cupy/math_tests/test_matmul.py
+++ b/dpnp/tests/third_party/cupy/math_tests/test_matmul.py
@@ -60,39 +60,22 @@ from dpnp.tests.third_party.cupy import testing
 )
 class TestMatmul(unittest.TestCase):
 
-    # Avoid overflow
-    skip_dtypes = {
-        (numpy.int8, numpy.int8),
-        (numpy.int8, numpy.uint8),
-        (numpy.uint8, numpy.uint8),
-    }
-
-    @testing.for_all_dtypes(name="dtype1")
-    @testing.for_all_dtypes(name="dtype2")
+    @testing.for_all_dtypes(name="dtype1", no_int8=True)
+    @testing.for_all_dtypes(name="dtype2", no_int8=True)
     @testing.numpy_cupy_allclose(
         rtol=1e-3, atol=1e-3, type_check=has_support_aspect64()
     )  # required for uint8
     def test_operator_matmul(self, xp, dtype1, dtype2):
-        if (dtype1, dtype2) in self.skip_dtypes or (
-            dtype2,
-            dtype1,
-        ) in self.skip_dtypes:
-            pytest.skip("avoid overflow")
         x1 = testing.shaped_arange(self.shape_pair[0], xp, dtype1)
         x2 = testing.shaped_arange(self.shape_pair[1], xp, dtype2)
         return operator.matmul(x1, x2)
 
-    @testing.for_all_dtypes(name="dtype1")
-    @testing.for_all_dtypes(name="dtype2")
+    @testing.for_all_dtypes(name="dtype1", no_int8=True)
+    @testing.for_all_dtypes(name="dtype2", no_int8=True)
     @testing.numpy_cupy_allclose(
         rtol=1e-3, atol=1e-3, type_check=has_support_aspect64()
     )  # required for uint8
     def test_cupy_matmul(self, xp, dtype1, dtype2):
-        if (dtype1, dtype2) in self.skip_dtypes or (
-            dtype2,
-            dtype1,
-        ) in self.skip_dtypes:
-            pytest.skip("avoid overflow")
         x1 = testing.shaped_arange(self.shape_pair[0], xp, dtype1)
         x2 = testing.shaped_arange(self.shape_pair[1], xp, dtype2)
         return xp.matmul(x1, x2)
@@ -114,25 +97,12 @@ class TestMatmul(unittest.TestCase):
 )
 class TestMatmulOut(unittest.TestCase):
 
-    # Avoid overflow
-    skip_dtypes = {
-        (numpy.int8, numpy.int8),
-        (numpy.int8, numpy.uint8),
-        (numpy.uint8, numpy.uint8),
-    }
-
-    @testing.for_all_dtypes(name="dtype1")
-    @testing.for_all_dtypes(name="dtype2")
+    @testing.for_all_dtypes(name="dtype1", no_int8=True)
+    @testing.for_all_dtypes(name="dtype2", no_int8=True)
     @testing.numpy_cupy_allclose(
         rtol=1e-3, atol=1e-3, accept_error=TypeError  # required for uint8
     )
     def test_cupy_matmul_noncontiguous(self, xp, dtype1, dtype2):
-        if (dtype1, dtype2) in self.skip_dtypes or (
-            dtype2,
-            dtype1,
-        ) in self.skip_dtypes:
-            pytest.skip("avoid overflow")
-
         x1 = testing.shaped_arange(self.shape_pair[0], xp, dtype1)
         x2 = testing.shaped_arange(self.shape_pair[1], xp, dtype2)
         out = xp.zeros(self.shape_pair[2], dtype=dtype1)[::-1]
@@ -170,11 +140,9 @@ class TestMatmulOutOverlap:
 
 class TestMatmulStrides:
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(no_int8=True)
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-3)  # required for uint8
     def test_relaxed_c_contiguous_input(self, xp, dtype):
-        if dtype in [numpy.int8, numpy.uint8]:
-            pytest.skip("avoid overflow")
         x1 = testing.shaped_arange((2, 2, 3), xp, dtype)[:, None, :, :]
         x2 = testing.shaped_arange((2, 1, 3, 1), xp, dtype)
         return x1 @ x2

--- a/dpnp/tests/third_party/cupy/math_tests/test_matmul.py
+++ b/dpnp/tests/third_party/cupy/math_tests/test_matmul.py
@@ -60,6 +60,7 @@ from dpnp.tests.third_party.cupy import testing
 )
 class TestMatmul(unittest.TestCase):
 
+    # no_int8=True is added to avoid overflow
     @testing.for_all_dtypes(name="dtype1", no_int8=True)
     @testing.for_all_dtypes(name="dtype2", no_int8=True)
     @testing.numpy_cupy_allclose(
@@ -70,6 +71,7 @@ class TestMatmul(unittest.TestCase):
         x2 = testing.shaped_arange(self.shape_pair[1], xp, dtype2)
         return operator.matmul(x1, x2)
 
+    # no_int8=True is added to avoid overflow
     @testing.for_all_dtypes(name="dtype1", no_int8=True)
     @testing.for_all_dtypes(name="dtype2", no_int8=True)
     @testing.numpy_cupy_allclose(
@@ -97,6 +99,7 @@ class TestMatmul(unittest.TestCase):
 )
 class TestMatmulOut(unittest.TestCase):
 
+    # no_int8=True is added to avoid overflow
     @testing.for_all_dtypes(name="dtype1", no_int8=True)
     @testing.for_all_dtypes(name="dtype2", no_int8=True)
     @testing.numpy_cupy_allclose(
@@ -140,6 +143,7 @@ class TestMatmulOutOverlap:
 
 class TestMatmulStrides:
 
+    # no_int8=True is added to avoid overflow
     @testing.for_all_dtypes(no_int8=True)
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-3)  # required for uint8
     def test_relaxed_c_contiguous_input(self, xp, dtype):

--- a/dpnp/tests/third_party/cupy/math_tests/test_matmul.py
+++ b/dpnp/tests/third_party/cupy/math_tests/test_matmul.py
@@ -60,12 +60,24 @@ from dpnp.tests.third_party.cupy import testing
 )
 class TestMatmul(unittest.TestCase):
 
+    # Avoid overflow
+    skip_dtypes = {
+        (numpy.int8, numpy.int8),
+        (numpy.int8, numpy.uint8),
+        (numpy.uint8, numpy.uint8),
+    }
+
     @testing.for_all_dtypes(name="dtype1")
     @testing.for_all_dtypes(name="dtype2")
     @testing.numpy_cupy_allclose(
         rtol=1e-3, atol=1e-3, type_check=has_support_aspect64()
     )  # required for uint8
     def test_operator_matmul(self, xp, dtype1, dtype2):
+        if (dtype1, dtype2) in self.skip_dtypes or (
+            dtype2,
+            dtype1,
+        ) in self.skip_dtypes:
+            pytest.skip("avoid overflow")
         x1 = testing.shaped_arange(self.shape_pair[0], xp, dtype1)
         x2 = testing.shaped_arange(self.shape_pair[1], xp, dtype2)
         return operator.matmul(x1, x2)
@@ -76,6 +88,11 @@ class TestMatmul(unittest.TestCase):
         rtol=1e-3, atol=1e-3, type_check=has_support_aspect64()
     )  # required for uint8
     def test_cupy_matmul(self, xp, dtype1, dtype2):
+        if (dtype1, dtype2) in self.skip_dtypes or (
+            dtype2,
+            dtype1,
+        ) in self.skip_dtypes:
+            pytest.skip("avoid overflow")
         x1 = testing.shaped_arange(self.shape_pair[0], xp, dtype1)
         x2 = testing.shaped_arange(self.shape_pair[1], xp, dtype2)
         return xp.matmul(x1, x2)
@@ -97,12 +114,25 @@ class TestMatmul(unittest.TestCase):
 )
 class TestMatmulOut(unittest.TestCase):
 
+    # Avoid overflow
+    skip_dtypes = {
+        (numpy.int8, numpy.int8),
+        (numpy.int8, numpy.uint8),
+        (numpy.uint8, numpy.uint8),
+    }
+
     @testing.for_all_dtypes(name="dtype1")
     @testing.for_all_dtypes(name="dtype2")
     @testing.numpy_cupy_allclose(
         rtol=1e-3, atol=1e-3, accept_error=TypeError  # required for uint8
     )
     def test_cupy_matmul_noncontiguous(self, xp, dtype1, dtype2):
+        if (dtype1, dtype2) in self.skip_dtypes or (
+            dtype2,
+            dtype1,
+        ) in self.skip_dtypes:
+            pytest.skip("avoid overflow")
+
         x1 = testing.shaped_arange(self.shape_pair[0], xp, dtype1)
         x2 = testing.shaped_arange(self.shape_pair[1], xp, dtype2)
         out = xp.zeros(self.shape_pair[2], dtype=dtype1)[::-1]
@@ -143,6 +173,8 @@ class TestMatmulStrides:
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-3)  # required for uint8
     def test_relaxed_c_contiguous_input(self, xp, dtype):
+        if dtype in [numpy.int8, numpy.uint8]:
+            pytest.skip("avoid overflow")
         x1 = testing.shaped_arange((2, 2, 3), xp, dtype)[:, None, :, :]
         x2 = testing.shaped_arange((2, 1, 3, 1), xp, dtype)
         return x1 @ x2
@@ -171,6 +203,7 @@ class TestMatmulLarge(unittest.TestCase):
 
     # Avoid overflow
     skip_dtypes = {
+        (numpy.int8, numpy.int8),
         (numpy.int8, numpy.uint8),
         (numpy.int8, numpy.int16),
         (numpy.int8, numpy.float16),

--- a/dpnp/tests/third_party/cupy/math_tests/test_misc.py
+++ b/dpnp/tests/third_party/cupy/math_tests/test_misc.py
@@ -176,7 +176,8 @@ class TestMisc:
         self.check_unary("sqrt")
 
     @testing.for_all_dtypes(no_complex=True)
-    @testing.numpy_cupy_allclose(atol=1e-5, type_check=has_support_aspect64())
+    # atol=1e-3 is needed for int8
+    @testing.numpy_cupy_allclose(atol=1e-3, type_check=has_support_aspect64())
     def test_cbrt(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return xp.cbrt(a)

--- a/dpnp/tests/third_party/cupy/math_tests/test_trigonometric.py
+++ b/dpnp/tests/third_party/cupy/math_tests/test_trigonometric.py
@@ -7,7 +7,9 @@ from dpnp.tests.third_party.cupy import testing
 class TestTrigonometric(unittest.TestCase):
 
     @testing.for_all_dtypes(no_complex=True)
-    @testing.numpy_cupy_allclose(atol=1e-5, type_check=has_support_aspect64())
+    @testing.numpy_cupy_allclose(
+        atol=1e-4, rtol=0.001, type_check=has_support_aspect64()
+    )
     def check_unary(self, name, xp, dtype):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return getattr(xp, name)(a)

--- a/dpnp/tests/third_party/cupy/random_tests/test_permutations.py
+++ b/dpnp/tests/third_party/cupy/random_tests/test_permutations.py
@@ -38,6 +38,11 @@ class TestPermutations(unittest.TestCase):
 
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     def test_permutation_sort_1dim(self, dtype):
+        flag = cupy.issubdtype(dtype, cupy.unsignedinteger)
+        if flag or dtype in [cupy.int8, cupy.int16]:
+            pytest.skip(
+                "dpnp.random.permutation() does not support new integer dtypes."
+            )
         cupy_random = self._xp_random(cupy)
         a = cupy.arange(10, dtype=dtype)
         b = cupy.copy(a)
@@ -47,6 +52,11 @@ class TestPermutations(unittest.TestCase):
 
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     def test_permutation_sort_ndim(self, dtype):
+        flag = cupy.issubdtype(dtype, cupy.unsignedinteger)
+        if flag or dtype in [cupy.int8, cupy.int16]:
+            pytest.skip(
+                "dpnp.random.permutation() does not support new integer dtypes."
+            )
         cupy_random = self._xp_random(cupy)
         a = cupy.arange(15, dtype=dtype).reshape(5, 3)
         b = cupy.copy(a)
@@ -58,6 +68,11 @@ class TestPermutations(unittest.TestCase):
 
     @testing.for_all_dtypes()
     def test_permutation_seed1(self, dtype):
+        flag = cupy.issubdtype(dtype, cupy.unsignedinteger)
+        if flag or dtype in [cupy.int8, cupy.int16]:
+            pytest.skip(
+                "dpnp.random.permutation() does not support new integer dtypes."
+            )
         a = testing.shaped_random((10,), cupy, dtype)
         b = cupy.copy(a)
 
@@ -89,6 +104,11 @@ class TestShuffle(unittest.TestCase):
 
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     def test_shuffle_sort_1dim(self, dtype):
+        flag = cupy.issubdtype(dtype, cupy.unsignedinteger)
+        if flag or dtype in [cupy.int8, cupy.int16]:
+            pytest.skip(
+                "dpnp.random.shuffle() does not support new integer dtypes."
+            )
         a = cupy.arange(10, dtype=dtype)
         b = cupy.copy(a)
         cupy.random.shuffle(a)
@@ -96,6 +116,11 @@ class TestShuffle(unittest.TestCase):
 
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     def test_shuffle_sort_ndim(self, dtype):
+        flag = cupy.issubdtype(dtype, cupy.unsignedinteger)
+        if flag or dtype in [cupy.int8, cupy.int16]:
+            pytest.skip(
+                "dpnp.random.shuffle() does not support new integer dtypes."
+            )
         a = cupy.arange(15, dtype=dtype).reshape(5, 3)
         b = cupy.copy(a)
         cupy.random.shuffle(a)
@@ -105,6 +130,11 @@ class TestShuffle(unittest.TestCase):
 
     @testing.for_all_dtypes()
     def test_shuffle_seed1(self, dtype):
+        flag = cupy.issubdtype(dtype, cupy.unsignedinteger)
+        if flag or dtype in [cupy.int8, cupy.int16]:
+            pytest.skip(
+                "dpnp.random.shuffle() does not support new integer dtypes."
+            )
         a = testing.shaped_random((10,), cupy, dtype)
         b = cupy.copy(a)
         cupy.random.seed(0)

--- a/dpnp/tests/third_party/cupy/sorting_tests/test_sort.py
+++ b/dpnp/tests/third_party/cupy/sorting_tests/test_sort.py
@@ -478,6 +478,9 @@ class TestPartition(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_equal()
     def test_partition_one_dim(self, xp, dtype):
+        flag = xp.issubdtype(dtype, xp.unsignedinteger)
+        if flag or dtype in [xp.int8, xp.int16]:
+            pytest.skip("dpnp.partition() does not support new integer dtypes.")
         a = testing.shaped_random((self.length,), xp, dtype)
         kth = 2
         x = self.partition(a, kth)

--- a/dpnp/tests/third_party/cupy/testing/_loops.py
+++ b/dpnp/tests/third_party/cupy/testing/_loops.py
@@ -1104,7 +1104,7 @@ def _make_all_dtypes(no_float16, no_bool, no_complex, no_int8):
 
     if no_int8:
         dtypes = tuple(
-            dtype for dtype in dtypes if dtype not in [numpy.int8, numpy.uint8]
+            filter(lambda dt: dt not in [numpy.int8, numpy.uint8], dtypes)
         )
 
     if config.complex_types and not no_complex:

--- a/dpnp/tests/third_party/cupy/testing/_loops.py
+++ b/dpnp/tests/third_party/cupy/testing/_loops.py
@@ -1091,7 +1091,7 @@ _regular_dtypes = _regular_float_dtypes + _int_bool_dtypes
 _dtypes = _float_dtypes + _int_bool_dtypes
 
 
-def _make_all_dtypes(no_float16, no_bool, no_complex):
+def _make_all_dtypes(no_float16, no_bool, no_complex, no_int8):
     if no_float16:
         dtypes = _regular_float_dtypes
     else:
@@ -1102,6 +1102,12 @@ def _make_all_dtypes(no_float16, no_bool, no_complex):
     else:
         dtypes += _int_bool_dtypes
 
+    if no_int8:
+        _dtypes = list(dtypes)
+        _dtypes.remove(numpy.int8)
+        _dtypes.remove(numpy.uint8)
+        dtypes = tuple(_dtypes)
+
     if config.complex_types and not no_complex:
         dtypes += _complex_dtypes
 
@@ -1109,7 +1115,11 @@ def _make_all_dtypes(no_float16, no_bool, no_complex):
 
 
 def for_all_dtypes(
-    name="dtype", no_float16=False, no_bool=False, no_complex=False
+    name="dtype",
+    no_float16=False,
+    no_bool=False,
+    no_complex=False,
+    no_int8=False,
 ):
     """Decorator that checks the fixture with all dtypes.
 
@@ -1121,6 +1131,9 @@ def for_all_dtypes(
              omitted from candidate dtypes.
          no_complex(bool): If ``True``, ``numpy.complex64`` and
              ``numpy.complex128`` are omitted from candidate dtypes.
+         no_int8(bool): If ``True``, ``numpy.int8`` and
+             ``numpy.uint8`` are omitted from candidate dtypes.
+             This option is generally used to avoid overflow.
 
     dtypes to be tested: ``numpy.complex64`` (optional),
     ``numpy.complex128`` (optional),
@@ -1164,7 +1177,7 @@ def for_all_dtypes(
     .. seealso:: :func:`cupy.testing.for_dtypes`
     """
     return for_dtypes(
-        _make_all_dtypes(no_float16, no_bool, no_complex), name=name
+        _make_all_dtypes(no_float16, no_bool, no_complex, no_int8), name=name
     )
 
 
@@ -1334,6 +1347,7 @@ def for_all_dtypes_combination(
     no_bool=False,
     full=None,
     no_complex=False,
+    no_int8=False,
 ):
     """Decorator that checks the fixture with a product set of all dtypes.
 
@@ -1347,12 +1361,15 @@ def for_all_dtypes_combination(
              will be tested.
              Otherwise, the subset of combinations will be tested
              (see description in :func:`cupy.testing.for_dtypes_combination`).
-         no_complex(bool): If, True, ``numpy.complex64`` and
+         no_complex(bool): If, ``True``, ``numpy.complex64`` and
              ``numpy.complex128`` are omitted from candidate dtypes.
+         no_int8(bool): If, ``True``, ``numpy.int8`` and
+             ``numpy.uint8`` are omitted from candidate dtypes.
+             This option is generally used to avoid overflow.
 
     .. seealso:: :func:`cupy.testing.for_dtypes_combination`
     """
-    types = _make_all_dtypes(no_float16, no_bool, no_complex)
+    types = _make_all_dtypes(no_float16, no_bool, no_complex, no_int8)
     return for_dtypes_combination(types, names, full)
 
 

--- a/dpnp/tests/third_party/cupy/testing/_loops.py
+++ b/dpnp/tests/third_party/cupy/testing/_loops.py
@@ -1103,10 +1103,9 @@ def _make_all_dtypes(no_float16, no_bool, no_complex, no_int8):
         dtypes += _int_bool_dtypes
 
     if no_int8:
-        _dtypes = list(dtypes)
-        _dtypes.remove(numpy.int8)
-        _dtypes.remove(numpy.uint8)
-        dtypes = tuple(_dtypes)
+        dtypes = tuple(
+            dtype for dtype in dtypes if dtype not in [numpy.int8, numpy.uint8]
+        )
 
     if config.complex_types and not no_complex:
         dtypes += _complex_dtypes


### PR DESCRIPTION
In this PR, third party tests are update to pass with newly added integer dtypes (int8, int16, uint8, uint16, uint32, uint64).
This PR is in continuation of https://github.com/IntelPython/dpnp/pull/2233.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
