### PR TITLE
Support dpnp in virtual environment on Windows out of the box

### DIFF
--- a/dpnp/__init__.py
+++ b/dpnp/__init__.py
@@ -25,6 +25,7 @@
 # *****************************************************************************
 
 import os
+import sys
 
 mypath = os.path.dirname(os.path.realpath(__file__))
 
@@ -45,9 +46,21 @@ if system() == "Windows":
     if hasattr(os, "add_dll_directory"):
         os.add_dll_directory(mypath)
         os.add_dll_directory(dpctlpath)
+
     os.environ["PATH"] = os.pathsep.join(
         [os.getenv("PATH", ""), mypath, dpctlpath]
     )
+
+    # For virtual environments on Windows, add folder with DPC++ libraries
+    # to the DLL search path
+    if sys.base_exec_prefix != sys.exec_prefix and os.path.isfile(
+        os.path.join(sys.exec_prefix, "pyvenv.cfg")
+    ):
+        dll_path = os.path.join(sys.exec_prefix, "Library", "bin")
+        if os.path.isdir(dll_path):
+            os.environ["PATH"] = os.pathsep.join(
+                [os.getenv("PATH", ""), dll_path]
+            )
 
 # Borrowed from DPCTL
 from dpctl.tensor import DLDeviceType


### PR DESCRIPTION
Since location of "Library\bin" in the virtual environment is not on the default search path, importing of `dpnp` fails due to unmet dependencies towards oneMKL libraries.

The PR proposes to extend `"PATH"` environment on Windows in the virtual environment with a path to `"Library\bin"` directory.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
