### PR TITLE
Remove links to `isnat` function from docs

### DIFF
--- a/doc/reference/logic.rst
+++ b/doc/reference/logic.rst
@@ -12,12 +12,10 @@ Truth value testing
 
    dpnp.all
    dpnp.any
-   dpnp.in1d
-   dpnp.isin
 
 
-Infinities and NaNs
--------------------
+Array contents
+--------------
 
 .. autosummary::
    :toctree: generated/
@@ -45,7 +43,7 @@ Array type testing
    dpnp.isscalar
 
 
-Logic operations
+Logical operations
 ----------------
 
 .. autosummary::

--- a/doc/reference/ufunc.rst
+++ b/doc/reference/ufunc.rst
@@ -161,7 +161,6 @@ Floating functions
    dpnp.isfinite
    dpnp.isinf
    dpnp.isnan
-   dpnp.isnat
    dpnp.fabs
    dpnp.signbit
    dpnp.copysign

--- a/dpnp/dpnp_iface_logic.py
+++ b/dpnp/dpnp_iface_logic.py
@@ -1168,8 +1168,6 @@ See Also
 :obj:`dpnp.isposinf` : Test element-wise for positive infinity,
                         return result as bool array.
 :obj:`dpnp.isfinite` : Test element-wise for finiteness.
-:obj:`dpnp.isnat` : Test element-wise for NaT (not a time)
-                    and return result as a boolean array.
 
 Examples
 --------


### PR DESCRIPTION
`isnat` function is not planning to be supported by dpnp, because it requires an input array with datetime or timedelta data type.
The PR proposes to clean up the documentation and to remove the links to `isnat` function.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
