### PR TITLE
Update `TestSpacing::test_zeros` 

### DIFF
--- a/dpnp/tests/test_mathematical.py
+++ b/dpnp/tests/test_mathematical.py
@@ -2112,13 +2112,13 @@ class TestSpacing:
         result = dpnp.spacing(ia)
         expected = numpy.spacing(a)
         if numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0":
-            assert_equal(result, expected)
+            assert_dtype_allclose(result, expected)
         else:
             # numpy.spacing(-0.0) == numpy.spacing(0.0), i.e. NumPy returns
             # positive value (looks as a bug in NumPy), because for any other
             # negative input the NumPy result will be also a negative value.
             expected[1] *= -1
-            assert_equal(result, expected)
+            assert_dtype_allclose(result, expected)
 
     @pytest.mark.parametrize("dt", get_float_dtypes(no_float16=False))
     @pytest.mark.parametrize("val", [1, 1e-5, 1000])


### PR DESCRIPTION
This PR suggests using `assert_dtype_allclose` instead of `assert_equal` to fix failures on CUDA tests caused by excessive precision for float32.

```
Mismatched elements: 2 / 2 (100%)
E           Max absolute difference among violations: 1.1754942e-38
E           Max relative difference among violations: 8388607.
E            ACTUAL: array([ 1.175494e-38, -1.175494e-38], dtype=float32)
E            DESIRED: array([ 1.e-45, -1.e-45], dtype=float32)
```

```
$ ONEAPI_DEVICE_SELECTOR=cuda pytest dpnp/tests/test_mathematical.py::TestSpacing::test_zeros
==============================2 passed in 1.18s =================================
```

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
