### PR TITLE
Add `__array_namespace__` method

### DIFF
--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -94,6 +94,7 @@ class dpnp_array:
             offset=offset,
             order=order,
             buffer_ctor_kwargs={"queue": sycl_queue_normalized},
+            array_namespace=dpnp,
         )
 
     @property
@@ -200,6 +201,31 @@ class dpnp_array:
     # '__array_struct__',
     # '__array_ufunc__',
     # '__array_wrap__',
+
+    def __array_namespace__(self, /, *, api_version=None):
+        """
+        Returns array namespace, member functions of which implement data API.
+
+        Parameters
+        ----------
+        api_version : str, optional
+            Request namespace compliant with given version of array API. If
+            ``None``, namespace for the most recent supported version is
+            returned.
+            Default: ``None``.
+
+        Returns
+        -------
+        out : any
+            An object representing the array API namespace. It should have
+            every top-level function defined in the specification as
+            an attribute. It may contain other public names as well, but it is
+            recommended to only include those names that are part of the
+            specification.
+
+        """
+
+        return self._array_obj.__array_namespace__(api_version=api_version)
 
     def __bool__(self):
         """``True`` if self else ``False``."""

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -353,7 +353,7 @@ class dpnp_array:
         key = _get_unwrapped_index_key(key)
 
         item = self._array_obj.__getitem__(key)
-        return dpnp._create_from_usm_ndarray(item)
+        return dpnp_array._create_from_usm_ndarray(item)
 
     # '__getstate__',
 
@@ -1777,7 +1777,7 @@ class dpnp_array:
                 axes = tuple((ndim - x - 1) for x in range(ndim))
 
             usm_res = dpt.permute_dims(self._array_obj, axes)
-        return dpnp._create_from_usm_ndarray(usm_res)
+        return dpnp_array._create_from_usm_ndarray(usm_res)
 
     def var(
         self,

--- a/dpnp/dpnp_iface_indexing.py
+++ b/dpnp/dpnp_iface_indexing.py
@@ -622,14 +622,8 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
         out_strides = a_straides[:-2] + (1,)
         out_offset = a_element_offset
 
-    return dpnp_array._create_from_usm_ndarray(
-        dpt.usm_ndarray(
-            out_shape,
-            dtype=a.dtype,
-            buffer=a.get_array(),
-            strides=out_strides,
-            offset=out_offset,
-        )
+    return dpnp_array(
+        out_shape, buffer=a, strides=out_strides, offset=out_offset
     )
 
 


### PR DESCRIPTION
The PR proposes to implement `__array_namespace__` method of dpnp ndarray, which is required to be compliant with python array API.
The method will return dpnp as an array namespace, member functions of which implement data API.

The array namespace is assumed to be stored inside dpctl tensor. So dpnp ndarray constructor is updated to explicitly pass `array_namespace=dpnp` into `dpt.usm_ndarray` call. And also to set the namespace through `_set_namespace(dpnp)` every time dpnp ndarray is created from usm_ndarray.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
