### PR TITLE
Resolve issues in public CI (part #2)

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -89,7 +89,6 @@ jobs:
         run: |
           sudo apt-get install enchant-2
 
-      # https://github.com/marketplace/actions/checkout
       - name: Install nvidia-cuda support drivers
         run: |
           sudo add-apt-repository ppa:graphics-drivers/ppa
@@ -102,8 +101,20 @@ jobs:
         with:
           fetch-depth: 0
 
-      # https://github.com/marketplace/actions/setup-miniconda
       - name: Setup miniconda
+        id: setup_miniconda
+        continue-on-error: true
+        uses: conda-incubator/setup-miniconda@d2e6a045a86077fb6cad6f5adf368e9076ddaa8d # v3.1.0
+        with:
+          miniforge-version: latest
+          use-mamba: 'true'
+          channels: conda-forge
+          conda-remove-defaults: 'true'
+          python-version: ${{ env.python-ver }}
+          activate-environment: 'docs'
+
+      - name: ReSetup miniconda
+        if: steps.setup_miniconda.outcome == 'failure'
         uses: conda-incubator/setup-miniconda@d2e6a045a86077fb6cad6f5adf368e9076ddaa8d # v3.1.0
         with:
           miniforge-version: latest

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -28,6 +28,7 @@ jobs:
     name: Build
 
     strategy:
+      fail-fast: false
       matrix:
         python: ['3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-22.04, windows-2019]
@@ -41,8 +42,6 @@ jobs:
     defaults:
       run:
         shell: ${{ matrix.os == 'windows-2019' && 'cmd /C CALL {0}' || 'bash -el {0}' }}
-
-    continue-on-error: true
 
     steps:
       - name: Cancel Previous Runs
@@ -122,11 +121,10 @@ jobs:
         shell: bash -el {0}
 
     strategy:
+      fail-fast: false
       matrix:
         python: ['3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest]
-
-    continue-on-error: true
 
     env:
       channel-path: '${{ github.workspace }}/channel/'
@@ -180,11 +178,19 @@ jobs:
         run: mamba remove conda-index
 
       - name: Install dpnp
+        id: install_dpnp
+        continue-on-error: true
         run: |
           mamba install ${{ env.PACKAGE_NAME }}=${{ env.PACKAGE_VERSION }} pytest python=${{ matrix.python }} ${{ env.TEST_CHANNELS }}
         env:
           TEST_CHANNELS: '-c ${{ env.channel-path }} ${{ env.CHANNELS }}'
-          MAMBA_NO_LOW_SPEED_LIMIT: 1
+
+      - name: ReInstall dpnp
+        if: steps.install_dpnp.outcome == 'failure'
+        run: |
+          mamba install ${{ env.PACKAGE_NAME }}=${{ env.PACKAGE_VERSION }} pytest python=${{ matrix.python }} ${{ env.TEST_CHANNELS }}
+        env:
+          TEST_CHANNELS: '-c ${{ env.channel-path }} ${{ env.CHANNELS }}'
 
       - name: List installed packages
         run: mamba list
@@ -226,11 +232,10 @@ jobs:
         shell: cmd /C CALL {0}
 
     strategy:
+      fail-fast: false
       matrix:
         python: ['3.9', '3.10', '3.11', '3.12', '3.13']
         os: [windows-2019]
-
-    continue-on-error: true
 
     env:
       channel-path: '${{ github.workspace }}\channel\'

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -145,6 +145,19 @@ jobs:
           tar -xvf ${{ env.pkg-path-in-channel }}/${{ env.PACKAGE_NAME }}-*.tar.bz2 -C ${{ env.extracted-pkg-path }}
 
       - name: Setup miniconda
+        id: setup_miniconda
+        continue-on-error: true
+        uses: conda-incubator/setup-miniconda@d2e6a045a86077fb6cad6f5adf368e9076ddaa8d # v3.1.0
+        with:
+          miniforge-version: latest
+          use-mamba: 'true'
+          channels: conda-forge
+          conda-remove-defaults: 'true'
+          python-version: ${{ env.CONDA_BUILD_INDEX_ENV_PY_VER}}
+          activate-environment: ${{ env.TEST_ENV_NAME }}
+
+      - name: ReSetup miniconda
+        if: steps.setup_miniconda.outcome == 'failure'
         uses: conda-incubator/setup-miniconda@d2e6a045a86077fb6cad6f5adf368e9076ddaa8d # v3.1.0
         with:
           miniforge-version: latest

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -62,6 +62,19 @@ jobs:
           sudo apt-get install lcov
 
       - name: Setup miniconda
+        id: setup_miniconda
+        continue-on-error: true
+        uses: conda-incubator/setup-miniconda@d2e6a045a86077fb6cad6f5adf368e9076ddaa8d # v3.1.0
+        with:
+          miniforge-version: latest
+          use-mamba: 'true'
+          channels: conda-forge
+          conda-remove-defaults: 'true'
+          python-version: ${{ env.python-ver }}
+          activate-environment: 'coverage'
+
+      - name: ReSetup miniconda
+        if: steps.setup_miniconda.outcome == 'failure'
         uses: conda-incubator/setup-miniconda@d2e6a045a86077fb6cad6f5adf368e9076ddaa8d # v3.1.0
         with:
           miniforge-version: latest


### PR DESCRIPTION
The PR proposes to add fixes/improvements into the public CI:
- trigger resetup miniconda step on failure in building docs and coverage workflows
- trigger resetup miniconda & reinstall dpnp steps in case of failure within `test_linux` job of conda package workflow

Note, the PR continues work initiated in #2254 and indented to make public CI more stable.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
