### PR TITLE
Implement `__usm_ndarray_`_ protocol

### DIFF
--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -612,6 +612,25 @@ class dpnp_array:
         """Return ``self/value``."""
         return dpnp.true_divide(self, other)
 
+    @property
+    def __usm_ndarray__(self):
+        """
+        Property to support `__usm_ndarray__` protocol.
+
+        It assumes to return :class:`dpctl.tensor.usm_ndarray` instance
+        corresponding to the content of the object.
+
+        This property is intended to speed-up conversion from
+        :class:`dpnp.ndarray` to :class:`dpctl.tensor.usm_ndarray` passed
+        into  `dpctl.tensor.asarray` function. The input object that implements
+        `__usm_ndarray__` protocol is recognized as owner of USM allocation
+        that is managed by a smart pointer, and asynchronous deallocation
+        will not involve GIL.
+
+        """
+
+        return self._array_obj
+
     def __xor__(self, other):
         """Return ``self^value``."""
         return dpnp.bitwise_xor(self, other)

--- a/dpnp/tests/test_ndarray.py
+++ b/dpnp/tests/test_ndarray.py
@@ -176,6 +176,18 @@ class TestItem:
             ia.item()
 
 
+class TestUsmNdarrayProtocol:
+    def test_basic(self):
+        a = dpnp.arange(256, dtype=dpnp.int64)
+        usm_a = dpt.asarray(a)
+
+        assert a.sycl_queue == usm_a.sycl_queue
+        assert a.usm_type == usm_a.usm_type
+        assert a.dtype == usm_a.dtype
+        assert usm_a.usm_data.reference_obj is None
+        assert (a == usm_a).all()
+
+
 def test_print_dpnp_int():
     result = repr(dpnp.array([1, 0, 2, -3, -1, 2, 21, -9], dtype="i4"))
     expected = "array([ 1,  0,  2, -3, -1,  2, 21, -9], dtype=int32)"


### PR DESCRIPTION
The PR is intended to adopt to dpctl changes implemented in [dpctl#1959](https://github.com/IntelPython/dpctl/pull/1959).

It implements support of `__usm_ndarray__` protocol for `dpnp.ndarray` and returns a property with `dpctl.tensor.usm_ndarray` instance corresponding to the content of the array object. 

This property is intended to speed-up conversion from `dpnp.ndarray` to `dpt.usm_ndarray` in `x=dpt.asarray(dpnp_array_obj)`.
The input object that implements `__usm_ndarray__` is recognized as owner of USM allocation that is managed by a smart pointer, and asynchronous deallocation of `x` need not involve GIL.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
