### PR TITLE
Workaround for `dpnp.linalg.qr()` to run on CUDA

### DIFF
--- a/dpnp/linalg/dpnp_utils_linalg.py
+++ b/dpnp/linalg/dpnp_utils_linalg.py
@@ -399,6 +399,12 @@ def _batched_qr(a, mode="reduced"):
     )
     _manager.add_event_pair(ht_ev, geqrf_ev)
 
+    # w/a to avoid raice conditional on CUDA during multiple runs
+    # TODO: Remove it ones the OneMath issue is resolved
+    # https://github.com/uxlfoundation/oneMath/issues/626
+    if dpnp.is_cuda_backend(a_sycl_queue):
+        ht_ev.wait()
+
     if mode in ["r", "raw"]:
         if mode == "r":
             r = a_t[..., :k].swapaxes(-2, -1)
@@ -2469,6 +2475,12 @@ def dpnp_qr(a, mode="reduced"):
         a_sycl_queue, a_t.get_array(), tau_h.get_array(), depends=[copy_ev]
     )
     _manager.add_event_pair(ht_ev, geqrf_ev)
+
+    # w/a to avoid raice conditional on CUDA during multiple runs
+    # TODO: Remove it ones the OneMath issue is resolved
+    # https://github.com/uxlfoundation/oneMath/issues/626
+    if dpnp.is_cuda_backend(a_sycl_queue):
+        ht_ev.wait()
 
     if mode in ["r", "raw"]:
         if mode == "r":

--- a/dpnp/tests/third_party/cupy/linalg_tests/test_decomposition.py
+++ b/dpnp/tests/third_party/cupy/linalg_tests/test_decomposition.py
@@ -163,14 +163,7 @@ class TestCholeskyInvalid(unittest.TestCase):
 class TestQRDecomposition(unittest.TestCase):
 
     @testing.for_dtypes("fdFD")
-    # skip cases with 'complete' and 'reduce' modes on CUDA (SAT-7611)
     def check_mode(self, array, mode, dtype):
-        if (
-            is_cuda_device()
-            and array.size > 0
-            and mode in ["complete", "reduced"]
-        ):
-            return
         a_cpu = numpy.asarray(array, dtype=dtype)
         a_gpu = cupy.asarray(array, dtype=dtype)
         result_gpu = cupy.linalg.qr(a_gpu, mode=mode)


### PR DESCRIPTION
This PR suggests adding a workaround like waiting for host task after calling `geqrf` to avoid a race condition due to an issue in oneMath ([626](https://github.com/IntelPython/dpnp/pull/2075)) 

Also updates tests by removing old skips and adds `test_qr_large` in `TestQr` 


- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
