### PR TITLE
Follow recommendation on the interaction with `numpy.ndarray` in binary ops

### DIFF
--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -192,7 +192,9 @@ class dpnp_array:
     # '__array_prepare__',
     # '__array_priority__',
     # '__array_struct__',
-    # '__array_ufunc__',
+
+    __array_ufunc__ = None
+
     # '__array_wrap__',
 
     def __array_namespace__(self, /, *, api_version=None):

--- a/dpnp/tests/helper.py
+++ b/dpnp/tests/helper.py
@@ -161,6 +161,20 @@ def get_all_dtypes(
     return dtypes
 
 
+def get_array(xp, a):
+    """
+    Cast input array `a` to a type supported by `xp` initerface.
+
+    Implicit conversion of either DPNP or DPCTL array to a NumPy array is not
+    allowed. Input array has to be explicitly casted with `asnumpy` function.
+
+    """
+
+    if xp is numpy and dpnp.is_supported_array_type(a):
+        return dpnp.asnumpy(a)
+    return a
+
+
 def generate_random_numpy_array(
     shape,
     dtype=None,

--- a/dpnp/tests/helper.py
+++ b/dpnp/tests/helper.py
@@ -163,7 +163,7 @@ def get_all_dtypes(
 
 def get_array(xp, a):
     """
-    Cast input array `a` to a type supported by `xp` initerface.
+    Cast input array `a` to a type supported by `xp` interface.
 
     Implicit conversion of either DPNP or DPCTL array to a NumPy array is not
     allowed. Input array has to be explicitly casted with `asnumpy` function.

--- a/dpnp/tests/test_arraycreation.py
+++ b/dpnp/tests/test_arraycreation.py
@@ -17,6 +17,7 @@ import dpnp
 from .helper import (
     assert_dtype_allclose,
     get_all_dtypes,
+    get_array,
 )
 from .third_party.cupy import testing
 
@@ -768,7 +769,7 @@ def test_space_numpy_dtype(func, start_dtype, stop_dtype):
     ],
 )
 def test_linspace_arrays(start, stop):
-    func = lambda xp: xp.linspace(start, stop, 10)
+    func = lambda xp: xp.linspace(get_array(xp, start), get_array(xp, stop), 10)
     assert func(numpy).shape == func(dpnp).shape
 
 

--- a/dpnp/tests/test_linalg.py
+++ b/dpnp/tests/test_linalg.py
@@ -1935,7 +1935,7 @@ class TestMatrixRank:
 
         np_rank = numpy.linalg.matrix_rank(a)
         dp_rank = dpnp.linalg.matrix_rank(a_dp)
-        assert np_rank == dp_rank
+        assert dp_rank.asnumpy() == np_rank
 
     @pytest.mark.parametrize("dtype", get_all_dtypes())
     @pytest.mark.parametrize(
@@ -1953,7 +1953,7 @@ class TestMatrixRank:
 
         np_rank = numpy.linalg.matrix_rank(a, hermitian=True)
         dp_rank = dpnp.linalg.matrix_rank(a_dp, hermitian=True)
-        assert np_rank == dp_rank
+        assert dp_rank.asnumpy() == np_rank
 
     @pytest.mark.parametrize(
         "high_tol, low_tol",
@@ -1986,7 +1986,7 @@ class TestMatrixRank:
         dp_rank_high_tol = dpnp.linalg.matrix_rank(
             a_dp, hermitian=True, tol=dp_high_tol
         )
-        assert np_rank_high_tol == dp_rank_high_tol
+        assert dp_rank_high_tol.asnumpy() == np_rank_high_tol
 
         np_rank_low_tol = numpy.linalg.matrix_rank(
             a, hermitian=True, tol=low_tol
@@ -1994,7 +1994,7 @@ class TestMatrixRank:
         dp_rank_low_tol = dpnp.linalg.matrix_rank(
             a_dp, hermitian=True, tol=dp_low_tol
         )
-        assert np_rank_low_tol == dp_rank_low_tol
+        assert dp_rank_low_tol.asnumpy() == np_rank_low_tol
 
     # rtol kwarg was added in numpy 2.0
     @testing.with_requires("numpy>=2.0")
@@ -2807,15 +2807,14 @@ class TestSvd:
             for i in range(min(dp_a.shape[-2], dp_a.shape[-1])):
                 dpnp_diag_s[..., i, i] = dp_s[..., i]
                 reconstructed = dpnp.dot(dp_u, dpnp.dot(dpnp_diag_s, dp_vt))
-            # TODO: use assert dpnp.allclose() inside check_decomposition()
-            # when it will support complex dtypes
-            assert_allclose(dp_a, reconstructed, rtol=tol, atol=1e-4)
+
+            assert dpnp.allclose(dp_a, reconstructed, rtol=tol, atol=1e-4)
 
         assert_allclose(dp_s, np_s, rtol=tol, atol=1e-03)
 
         if compute_vt:
             for i in range(min(dp_a.shape[-2], dp_a.shape[-1])):
-                if np_u[..., 0, i] * dp_u[..., 0, i] < 0:
+                if np_u[..., 0, i] * dpnp.asnumpy(dp_u[..., 0, i]) < 0:
                     np_u[..., :, i] = -np_u[..., :, i]
                     np_vt[..., i, :] = -np_vt[..., i, :]
             for i in range(numpy.count_nonzero(np_s > tol)):

--- a/dpnp/tests/test_manipulation.py
+++ b/dpnp/tests/test_manipulation.py
@@ -15,6 +15,7 @@ import dpnp
 from .helper import (
     assert_dtype_allclose,
     get_all_dtypes,
+    get_array,
     get_complex_dtypes,
     get_float_complex_dtypes,
     get_float_dtypes,
@@ -1232,7 +1233,10 @@ class TestRot90:
     def test_axes_type(self, axes):
         a = numpy.ones((50, 40, 3))
         ia = dpnp.array(a)
-        assert_equal(dpnp.rot90(ia, axes=axes), numpy.rot90(a, axes=axes))
+        assert_equal(
+            dpnp.rot90(ia, axes=axes),
+            numpy.rot90(a, axes=get_array(numpy, axes)),
+        )
 
     def test_rotation_axes(self):
         a = numpy.arange(8).reshape((2, 2, 2))

--- a/dpnp/tests/test_ndarray.py
+++ b/dpnp/tests/test_ndarray.py
@@ -150,6 +150,27 @@ class TestArrayNamespace:
         )
 
 
+class TestArrayUfunc:
+    def test_add(self):
+        a = numpy.ones(10)
+        b = dpnp.ones(10)
+        msg = "An array must be any of supported type"
+
+        with assert_raises_regex(TypeError, msg):
+            a + b
+
+        with assert_raises_regex(TypeError, msg):
+            b + a
+
+    def test_add_inplace(self):
+        a = numpy.ones(10)
+        b = dpnp.ones(10)
+        with assert_raises_regex(
+            TypeError, "operand 'dpnp_array' does not support ufuncs"
+        ):
+            a += b
+
+
 class TestItem:
     @pytest.mark.parametrize("args", [2, 7, (1, 2), (2, 0)])
     def test_basic(self, args):


### PR DESCRIPTION
The PR proposes to follow NEP-13 [recommendations](https://numpy.org/neps/nep-0013-ufunc-overrides.html#behavior-in-combination-with-python-s-binary-operations) on how to interact with `numpy.ndarray` in binary the operations.

It will set `__array_ufunc__ = None` which means that dpnp implements Python binary operations freely and so `numpy.ufuncs` called on this argument will raise `TypeError`:
```python
a = numpy.ones(10)
b = dpnp.ones(10)
a += b
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[9], line 1
----> 1 a += b

TypeError: operand 'dpnp_array' does not support ufuncs (__array_ufunc__=None)
```
And an elementwise operation with `numpy.ndarray` will cause an explicit exception in dpnp:
```python
a + b
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[4], line 1
----> 1 a + b

File ~/code/dpnp/dpnp/dpnp_array.py:518, in dpnp_array.__radd__(self, other)
    516 def __radd__(self, other):
    517     """Return ``value+self``."""
--> 518     return dpnp.add(other, self)

File ~/code/dpnp/dpnp/dpnp_algo/dpnp_elementwise_common.py:314, in DPNPBinaryFunc.__call__(self, x1, x2, out, where, order, dtype, subok, **kwargs)
    303 def __call__(
    304     self,
    305     x1,
   (...)
    312     **kwargs,
    313 ):
--> 314     dpnp.check_supported_arrays_type(
    315         x1, x2, scalar_type=True, all_scalars=False
    316     )
    317     if kwargs:
    318         raise NotImplementedError(
    319             f"Requested function={self.name_} with kwargs={kwargs} "
    320             "isn't currently supported."
    321         )

File ~/code/dpnp/dpnp/dpnp_iface.py:400, in check_supported_arrays_type(scalar_type, all_scalars, *arrays)
    397     if scalar_type and dpnp.isscalar(a):
    398         continue
--> 400     raise TypeError(
    401         f"An array must be any of supported type, but got {type(a)}"
    402     )
    404 if len(arrays) > 0 and not (all_scalars or any_is_array):
    405     raise TypeError(
    406         "At least one input must be of supported array type, "
    407         "but got all scalars."
    408     )

TypeError: An array must be any of supported type, but got <class 'numpy.ndarray'>
```

Previously it works as in a way:
```python
a = numpy.ones(10)
b = dpnp.ones(10)

a + b
# Out:
# array([array(2.), array(2.), array(2.), array(2.), array(2.), array(2.),
#        array(2.), array(2.), array(2.), array(2.)], dtype=object)
```

Note, some updates in tests from #2260 have been mapped to that PR.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
