### PR TITLE
Update recently updated tests to run properly when no fp64

### DIFF
--- a/dpnp/tests/test_arraycreation.py
+++ b/dpnp/tests/test_arraycreation.py
@@ -924,9 +924,9 @@ def test_logspace_axis(axis):
 
 
 def test_logspace_list_input():
-    res_np = numpy.logspace([0], [2], base=[5])
-    res_dp = dpnp.logspace([0], [2], base=[5])
-    assert_allclose(res_dp, res_np)
+    expected = numpy.logspace([0], [2], base=[5])
+    result = dpnp.logspace([0], [2], base=[5])
+    assert_dtype_allclose(result, expected)
 
 
 @pytest.mark.parametrize(

--- a/dpnp/tests/test_sort.py
+++ b/dpnp/tests/test_sort.py
@@ -31,7 +31,7 @@ class TestArgsort:
 
     @pytest.mark.parametrize("axis", [None, -2, -1, 0, 1, 2])
     def test_axis(self, axis):
-        a = generate_random_numpy_array((3, 4, 3))
+        a = generate_random_numpy_array((3, 4, 3), dtype="i8")
         ia = dpnp.array(a)
 
         result = dpnp.argsort(ia, axis=axis)
@@ -40,13 +40,13 @@ class TestArgsort:
 
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize("axis", [None, -2, -1, 0, 1])
-    def test_ndarray(self, dtype, axis):
+    def test_ndarray_method(self, dtype, axis):
         a = generate_random_numpy_array((6, 2), dtype)
         ia = dpnp.array(a)
 
         result = ia.argsort(axis=axis)
         expected = a.argsort(axis=axis, kind="stable")
-        assert_array_equal(result, expected)
+        assert_dtype_allclose(result, expected)
 
     # this test validates that all different options of kind in dpnp are stable
     @pytest.mark.parametrize("kind", [None, "stable", "mergesort", "radixsort"])
@@ -291,16 +291,16 @@ class TestSort:
 
     @pytest.mark.parametrize("axis", [None, -2, -1, 0, 1, 2])
     def test_axis(self, axis):
-        a = generate_random_numpy_array((3, 4, 3))
+        a = generate_random_numpy_array((3, 4, 3), dtype="i8")
         ia = dpnp.array(a)
 
         result = dpnp.sort(ia, axis=axis)
         expected = numpy.sort(a, axis=axis)
         assert_array_equal(result, expected)
 
-    @pytest.mark.parametrize("dtype", get_all_dtypes())
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize("axis", [-2, -1, 0, 1])
-    def test_ndarray(self, dtype, axis):
+    def test_ndarray_method(self, dtype, axis):
         a = generate_random_numpy_array((6, 2), dtype)
         ia = dpnp.array(a)
 

--- a/dpnp/tests/test_sort.py
+++ b/dpnp/tests/test_sort.py
@@ -35,7 +35,7 @@ class TestArgsort:
         ia = dpnp.array(a)
 
         result = dpnp.argsort(ia, axis=axis)
-        expected = numpy.argsort(a, axis=axis)
+        expected = numpy.argsort(a, axis=axis, kind="stable")
         assert_array_equal(result, expected)
 
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
@@ -295,7 +295,7 @@ class TestSort:
         ia = dpnp.array(a)
 
         result = dpnp.sort(ia, axis=axis)
-        expected = numpy.sort(a, axis=axis)
+        expected = numpy.sort(a, axis=axis, kind="stable")
         assert_array_equal(result, expected)
 
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))


### PR DESCRIPTION
Some of the tests which were updated by latest PRs don't work properly when running on a device without fp64 support.
The PR is intended to resolve that and to implement proper check of the resulting arrays for impacted tests.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
