### PR TITLE
No need to extract dpnp conda package in GitHub actions

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -16,7 +16,6 @@ env:
   CONDA_BUILD_INDEX_ENV_PY_VER: '3.12' # conda does not support python 3.13
   CONDA_BUILD_VERSION: '25.1.1'
   CONDA_INDEX_VERSION: '0.5.0'
-  CONDA_CPH_VERSION: '2.4.0'
   RERUN_TESTS_ON_FAILURE: 'true'
   RUN_TESTS_MAX_ATTEMPTS: 2
   TEST_ENV_NAME: 'test'
@@ -130,7 +129,6 @@ jobs:
     env:
       channel-path: '${{ github.workspace }}/channel/'
       pkg-path-in-channel: '${{ github.workspace }}/channel/linux-64/'
-      extracted-pkg-path: '${{ github.workspace }}/pkg/'
       ver-json-path: '${{ github.workspace }}/version.json'
 
     steps:
@@ -163,14 +161,9 @@ jobs:
           python-version: ${{ env.CONDA_BUILD_INDEX_ENV_PY_VER}}
           activate-environment: ${{ env.TEST_ENV_NAME }}
 
-      - name: Install conda-index and conda-package-handling
+      - name: Install conda-index
         run: |
-          mamba install conda-index=${{ env.CONDA_INDEX_VERSION }} conda-package-handling=${{ env.CONDA_CPH_VERSION }}
-
-      - name: Extract package archive
-        run: |
-          mkdir -p ${{ env.extracted-pkg-path }}
-          cph extract ${{ env.pkg-path-in-channel }}/${{ env.PACKAGE_NAME }}-*.conda --dest ${{ env.extracted-pkg-path }}
+          mamba install conda-index=${{ env.CONDA_INDEX_VERSION }}
 
       - name: Create conda channel
         run: |
@@ -255,7 +248,6 @@ jobs:
     env:
       channel-path: '${{ github.workspace }}\channel\'
       pkg-path-in-channel: '${{ github.workspace }}\channel\win-64\'
-      extracted-pkg-path: '${{ github.workspace }}\pkg'
       ver-json-path: '${{ github.workspace }}\version.json'
       workdir: '${{ github.workspace }}'
 
@@ -269,7 +261,6 @@ jobs:
       - name: Store a path to package archive
         run: |
           @echo on
-          mkdir -p ${{ env.extracted-pkg-path }}
 
           set SEARCH_SCRIPT="DIR ${{ env.pkg-path-in-channel }} /s/b | FINDSTR /r "dpnp-.*\.conda""
           FOR /F "tokens=* USEBACKQ" %%F IN (`%SEARCH_SCRIPT%`) DO (
@@ -294,14 +285,9 @@ jobs:
           (echo CONDA_LIB_PATH=%CONDA_PREFIX%\Library\lib\) >> %GITHUB_ENV%
           (echo CONDA_LIB_BIN_PATH=%CONDA_PREFIX%\Library\bin\) >> %GITHUB_ENV%
 
-      - name: Install conda-index and conda-package-handling
+      - name: Install conda-index
         run: |
-          mamba install conda-index=${{ env.CONDA_INDEX_VERSION }} conda-package-handling=${{ env.CONDA_CPH_VERSION }}
-
-      - name: Extract package archive
-        run: |
-          cph extract %FULL_PACKAGE_PATH% --dest ${{ env.extracted-pkg-path }}
-          dir ${{ env.extracted-pkg-path }}
+          mamba install conda-index=${{ env.CONDA_INDEX_VERSION }}
 
       - name: Create conda channel
         run: |
@@ -467,7 +453,6 @@ jobs:
       array-api-skips-file: '${{ github.workspace }}/dpnp/.github/workflows/array-api-skips.txt'
       channel-path: '${{ github.workspace }}/channel/'
       pkg-path-in-channel: '${{ github.workspace }}/channel/linux-64/'
-      extracted-pkg-path: '${{ github.workspace }}/pkg/'
       ver-json-path: '${{ github.workspace }}/version.json'
 
     steps:
@@ -500,21 +485,16 @@ jobs:
           python-version: ${{ matrix.python }}
           activate-environment: 'array-api-conformity'
 
-      - name: Install conda-index and conda-package-handling
+      - name: Install conda-index
         id: install_conda_index
         continue-on-error: true
         run: |
-          mamba install conda-index=${{ env.CONDA_INDEX_VERSION }} conda-package-handling=${{ env.CONDA_CPH_VERSION }}
+          mamba install conda-index=${{ env.CONDA_INDEX_VERSION }}
 
-      - name: ReInstall conda-index and conda-package-handling
+      - name: ReInstall conda-index
         if: steps.install_conda_index.outcome == 'failure'
         run: |
-          mamba install conda-index=${{ env.CONDA_INDEX_VERSION }} conda-package-handling=${{ env.CONDA_CPH_VERSION }}
-
-      - name: Extract package archive
-        run: |
-          mkdir -p ${{ env.extracted-pkg-path }}
-          cph extract ${{ env.pkg-path-in-channel }}/${{ env.PACKAGE_NAME }}-*.conda --dest ${{ env.extracted-pkg-path }}
+          mamba install conda-index=${{ env.CONDA_INDEX_VERSION }}
 
       - name: Create conda channel
         run: |


### PR DESCRIPTION
Now it is not required to extract dpnp conda package to run the test scope, because the tests will be installed during the conda package installation and so can be run with `pytest -ra --pyargs dpnp.tests` command.

The PR propose to remove obsolete steps from `Conda package` workflow.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
