### PR TITLE
Declaring required dependencies for wheel package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ Programming Language :: Python :: Implementation :: CPython
 Topic :: Software Development
 Topic :: Scientific/Engineering
 Operating System :: Microsoft :: Windows
+Operating System :: POSIX :: Linux
 Operating System :: POSIX
 Operating System :: Unix
 """
@@ -82,4 +83,6 @@ setup(
         ]
     },
     include_package_data=False,
+    python_requires=">=3.9,<3.14",
+    install_requires=["dpctl >= 0.19.0dev0", "numpy"],
 )


### PR DESCRIPTION
The wheel package misses `requires_dist` entry in package info, but dpnp package has a decency on numpy and dpctl packages.
The PR proposes to declare required dependencies in `setup.py`.

Thus the package info of dpnp wheel package built in public CI will include:
```bash
requires_python: >=3.9,<3.14
requires_dist: ['dpctl>=0.19.0dev0', 'numpy']
```
and for internal CI:
```bash
requires_python: >=3.9,<3.14
requires_dist: ['dpctl>=0.19.0dev0', 'numpy', 'dpcpp-cpp-rt', 'onemkl-sycl-blas', 'onemkl-sycl-dft', 'onemkl-sycl-lapack', 'onemkl-sycl-rng', 'onemkl-sycl-stats', 'onemkl-sycl-vm']
```

Note that this PR also specifies a requirement on supported range of python versions.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
