### PR TITLE
debug: errorlevel conditionals

### DIFF
--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -32,10 +32,10 @@ if not defined PYTHON (
 
 
 "%PYTHON%" -c "import dpnp; print(dpnp.__version__)"
-if errorlevel 1 exit 1
+if errorlevel neq 0 exit 1
 
 "%PYTHON%" -m dpctl -f
-if errorlevel 1 exit 1
+if errorlevel neq 0 exit 1
 
 "%PYTHON%" -m pytest -ra --pyargs dpnp
-if errorlevel 1 exit 1
+if errorlevel neq 0 exit 1

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -32,10 +32,10 @@ if not defined PYTHON (
 
 
 "%PYTHON%" -c "import dpnp; print(dpnp.__version__)"
-if errorlevel neq 0 exit 1
+if %errorlevel% neq 0 exit 1
 
 "%PYTHON%" -m dpctl -f
-if errorlevel neq 0 exit 1
+if %errorlevel% neq 0 exit 1
 
 "%PYTHON%" -m pytest -ra --pyargs dpnp
-if errorlevel neq 0 exit 1
+if %errorlevel% neq 0 exit 1


### PR DESCRIPTION
Wheels tests were failing because some python abrupt failures (or windows access violations) would use an exit code that was both non-zero and non-1.


This should capture everything that isn't an exit code of 0
