### PR TITLE
Add missing `message-id` to step which modifies PR comment

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -266,6 +266,7 @@ jobs:
       - name: Modify the comment with URL to official documentation
         uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
         with:
+          message-id: url_to_docs
           find: |
             View rendered docs @.+
           replace: |


### PR DESCRIPTION
`message-id` was added per #2271 to `mshick/add-pr-comment` steps in GitHub workflows, but one of the places was missing.

The PR proposes to resolve that and to set the expected id, otherwise the affected step couldn't find the PR comment to update it (since `message-id: add-pr-comment` which it built by default differs).

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
