### PR TITLE
Use `dpctl.tensor.matmul` in the backend of `dpnp.matmul` when inputs are integer

### DIFF
--- a/.github/workflows/array-api-skips.txt
+++ b/.github/workflows/array-api-skips.txt
@@ -26,13 +26,10 @@ array_api_tests/test_linalg.py::test_svd
 array_api_tests/test_linalg.py::test_qr
 array_api_tests/test_operators_and_elementwise_functions.py::test_clip
 
-# unexpected result is returned
+# unexpected result is returned - unmute when dpctl-1986 is resolved
 array_api_tests/test_operators_and_elementwise_functions.py::test_asin
 array_api_tests/test_operators_and_elementwise_functions.py::test_asinh
 
 # missing 'correction' keyword argument
 array_api_tests/test_signatures.py::test_func_signature[std]
 array_api_tests/test_signatures.py::test_func_signature[var]
-
-# arrays have different values
-array_api_tests/test_linalg.py::test_linalg_tensordot

--- a/.github/workflows/check-mkl-interfaces.yaml
+++ b/.github/workflows/check-mkl-interfaces.yaml
@@ -216,7 +216,7 @@ jobs:
         id: run_tests
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
         with:
-          timeout_minutes: 12
+          timeout_minutes: 15
           max_attempts: ${{ env.RUN_TESTS_MAX_ATTEMPTS }}
           retry_on: any
           command: |

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -355,7 +355,7 @@ jobs:
         id: run_tests_win
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
         with:
-          timeout_minutes: 15
+          timeout_minutes: 17
           max_attempts: ${{ env.RUN_TESTS_MAX_ATTEMPTS }}
           retry_on: any
           command: |

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -218,7 +218,7 @@ jobs:
         id: run_tests_linux
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
         with:
-          timeout_minutes: 12
+          timeout_minutes: 15
           max_attempts: ${{ env.RUN_TESTS_MAX_ATTEMPTS }}
           retry_on: any
           command: |

--- a/.github/workflows/cron-run-tests.yaml
+++ b/.github/workflows/cron-run-tests.yaml
@@ -143,7 +143,7 @@ jobs:
         id: run_tests_win
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
         with:
-          timeout_minutes: 15
+          timeout_minutes: 17
           max_attempts: ${{ env.RUN_TESTS_MAX_ATTEMPTS }}
           retry_on: any
           command: |

--- a/.github/workflows/cron-run-tests.yaml
+++ b/.github/workflows/cron-run-tests.yaml
@@ -126,7 +126,7 @@ jobs:
         id: run_tests_linux
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
         with:
-          timeout_minutes: 12
+          timeout_minutes: 15
           max_attempts: ${{ env.RUN_TESTS_MAX_ATTEMPTS }}
           retry_on: any
           command: |

--- a/dpnp/backend/extensions/blas/blas_py.cpp
+++ b/dpnp/backend/extensions/blas/blas_py.cpp
@@ -146,14 +146,14 @@ PYBIND11_MODULE(_blas_impl, m)
 
     {
         m.def(
-            "_row_major_is_available",
-            [](void) {
-#if defined(USE_ONEMKL_CUBLAS)
-                return false;
-#else
+            "_using_onemkl_interfaces",
+            []() {
+#ifdef USE_ONEMKL_INTERFACES
                 return true;
-#endif // USE_ONEMKL_CUBLAS
+#else
+                return false;
+#endif
             },
-            "Check if the onemkl::blas::row_major can be used.");
+            "Check if the OneMKL interfaces are being used.");
     }
 }

--- a/dpnp/backend/extensions/blas/blas_py.cpp
+++ b/dpnp/backend/extensions/blas/blas_py.cpp
@@ -142,6 +142,9 @@ PYBIND11_MODULE(_blas_impl, m)
               py::arg("sycl_queue"), py::arg("matrixA"), py::arg("vectorX"),
               py::arg("vectorY"), py::arg("transpose"),
               py::arg("depends") = py::list());
+    }
+
+    {
         m.def(
             "_row_major_is_available",
             [](void) {

--- a/dpnp/tests/test_product.py
+++ b/dpnp/tests/test_product.py
@@ -888,7 +888,7 @@ class TestMatmul:
     def test_strided1(self, dtype, stride):
         for dim in [1, 2, 3, 4]:
             shape = tuple(20 for _ in range(dim))
-            A = numpy.random.rand(*shape).astype(dtype)
+            A = generate_random_numpy_array(shape, dtype)
             iA = dpnp.array(A)
             slices = tuple(slice(None, None, stride[i]) for i in range(dim))
             a = A[slices]
@@ -897,13 +897,13 @@ class TestMatmul:
             # the 2D base is not c-contiguous nor f-contigous
             result = dpnp.matmul(ia, ia)
             expected = numpy.matmul(a, a)
-            assert_dtype_allclose(result, expected)
+            assert_dtype_allclose(result, expected, factor=16)
 
             iOUT = dpnp.empty(shape, dtype=result.dtype)
             iout = iOUT[slices]
             result = dpnp.matmul(ia, ia, out=iout)
             assert result is iout
-            assert_dtype_allclose(result, expected)
+            assert_dtype_allclose(result, expected, factor=16)
 
     @pytest.mark.parametrize("dtype", _selected_dtypes)
     @pytest.mark.parametrize(
@@ -915,7 +915,7 @@ class TestMatmul:
         # one dimension (axis=-3) is strided
         # if negative stride, copy is needed and the base becomes c-contiguous
         # otherwise the base remains the same as input in gemm_batch
-        A = numpy.random.rand(*shape).astype(dtype)
+        A = generate_random_numpy_array(shape, dtype)
         iA = dpnp.array(A)
         if transpose:
             A = numpy.moveaxis(A, (-2, -1), (-1, -2))
@@ -948,7 +948,7 @@ class TestMatmul:
         # For positive stride, no copy but reshape makes the base c-contiguous.
         stride0, stride1 = stride
         shape = (12, 10, 3, 3)  # 4D array
-        A = numpy.random.rand(*shape).astype(dtype)
+        A = generate_random_numpy_array(shape, dtype)
         iA = dpnp.array(A)
         if transpose:
             A = numpy.moveaxis(A, (-2, -1), (-1, -2))
@@ -980,7 +980,7 @@ class TestMatmul:
         else:
             s1 = shape[-1]
             s2 = shape[-2]
-        a = numpy.random.rand(*shape).astype(dtype)
+        a = generate_random_numpy_array(shape, dtype)
         ia = dpnp.array(a)
         if transpose:
             a = numpy.moveaxis(a, (-2, -1), (-1, -2))
@@ -1016,7 +1016,7 @@ class TestMatmul:
         else:
             s1 = shape[-1]
             s2 = shape[-2]
-        a = numpy.random.rand(*shape).astype(dtype)
+        a = generate_random_numpy_array(shape, dtype)
         ia = dpnp.array(a)
         if transpose:
             a = numpy.moveaxis(a, (-2, -1), (-1, -2))

--- a/dpnp/tests/test_product.py
+++ b/dpnp/tests/test_product.py
@@ -1159,8 +1159,8 @@ class TestMatmul:
     )
     def test_special_case(self, dt_out, shape1, shape2):
         # Although inputs are int, gemm will be used for calculation
-        a = numpy.ones(shape1, dtype=numpy.int8)
-        b = numpy.ones(shape2, dtype=numpy.int8)
+        a = generate_random_numpy_array(shape1, dtype=numpy.int8)
+        b = generate_random_numpy_array(shape2, dtype=numpy.int8)
         ia, ib = dpnp.array(a), dpnp.array(b)
 
         result = dpnp.matmul(ia, ib, dtype=dt_out)
@@ -1172,8 +1172,8 @@ class TestMatmul:
         assert_dtype_allclose(result, expected)
 
     def test_bool(self):
-        a = numpy.ones((3, 4), dtype=dpnp.bool)
-        b = numpy.ones((4, 5), dtype=dpnp.bool)
+        a = generate_random_numpy_array((3, 4), dtype=dpnp.bool)
+        b = generate_random_numpy_array((4, 5), dtype=dpnp.bool)
         ia, ib = dpnp.array(a), dpnp.array(b)
 
         # the output is (3, 4) array filled with 4


### PR DESCRIPTION
resolves #2270 

OneMath (OneMKL) routines (`gemm`, `gemv`, `gemm_batch`) for matrix multiplication only support floating point data types. If inputs are integer, to use OneMath we need to upcasting them to floating point dtypes, perform the calculation and then cast back the result to integer dtypes which is unsafe and we may loose some information for large integers.
In this PR, the logic for `dpnp.matmul` is updated to use `dpctl.tensor.matmul` when result has a integer dtypes.

**Performance Analysis**
```bash
$ sycl-ls
[level_zero:gpu][level_zero:0] Intel(R) oneAPI Unified Runtime over Level-Zero, Intel(R) Data Center GPU Max 1100 12.60.7 [1.6.31294+9]
[opencl:cpu][opencl:0] Intel(R) OpenCL, Intel(R) Xeon(R) Platinum 8480+ OpenCL 3.0 (Build 0) [2025.19.1.0.16_160000]
[opencl:gpu][opencl:1] Intel(R) OpenCL Graphics, Intel(R) Data Center GPU Max 1100 OpenCL 3.0 NEO  [24.39.31294]
```
```python
import numpy, dpnp

# Case 1 - matrix-matrix multiplication
n=1024
a=numpy.ones((n,n), dtype="i8")
%timeit numpy.matmul(a, a)

ia=dpnp.array(a, device="gpu")
%timeit dpnp.matmul(ia, ia); ia.sycl_queue.wait()

# Case 2 - Matrix-vector multiplication
n=4096*4
a=numpy.ones((n,n), dtype="i8")
b=numpy.ones((n,), dtype="i8")
%timeit numpy.matmul(a, b)

ia=dpnp.array(a, device="gpu")
ib=dpnp.array(b, device="gpu")
%timeit dpnp.matmul(ia, ib); ia.sycl_queue.wait()

# Case 3 - Vector-matrix multiplication
n=4096*4
a=numpy.ones((n,n), dtype="i8")
b=numpy.ones((n,), dtype="i8")
%timeit numpy.matmul(b, a)

ia=dpnp.array(a, device="gpu")
ib=dpnp.array(b, device="gpu")
%timeit dpnp.matmul(ib, ia); ia.sycl_queue.wait()

# Case 4 - batch matrix-matrix multiplication
n=256
a=numpy.ones((n,n,n), dtype="i8")
%timeit numpy.matmul(a, a)

ia=dpnp.array(a, device="gpu")
%timeit dpnp.matmul(ia, ia); ia.sycl_queue.wait()
```

| Case # - n      | NumPy              | dpnp - Xeon        | dpnp - PVC        |
|---------------------------|--------------------|--------------------|--------------------|
| Case1 - 1024            | 4.98 s ± 867 μs    | 9.82 ms ± 40.6 μs  | 3.34 ms ± 4.16 μs |
| Case2 - 4096×16  | 4.2 s ± 616 μs     | 9.77 s ± 112 ms    | 1.27 s ± 2.04 ms  |
| Case3 - 4096×4   | 9.6 s ± 3.3 ms     | 94.6 ms ± 2.15 ms  | 50.9 ms ± 38.2 μs |
| Case4 - 256       | 3.19 s ± 291 μs    | 48.9 ms ± 244 μs   | 10.4 ms ± 32.3 μs |

For all cases `dpnp` shows a better performance compared to `numpy` except for Case 2 on Xeon.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
