### PR TITLE
Temporary mute a test for `dpnp.correlate`

### DIFF
--- a/dpnp/tests/test_usm_type.py
+++ b/dpnp/tests/test_usm_type.py
@@ -13,6 +13,7 @@ from dpnp.dpnp_utils import get_usm_allocations
 from .helper import (
     assert_dtype_allclose,
     generate_random_numpy_array,
+    is_win_platform,
 )
 
 list_of_usm_types = ["device", "shared", "host"]
@@ -796,6 +797,9 @@ def test_1in_1out(func, data, usm_type):
 @pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
 @pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
 def test_2in_1out(func, data1, data2, usm_type_x, usm_type_y):
+    if func == "correlate" and is_win_platform():
+        pytest.skip("due to SAT-7693")
+
     x = dp.array(data1, usm_type=usm_type_x)
     y = dp.array(data2, usm_type=usm_type_y)
     z = getattr(dp, func)(x, y)


### PR DESCRIPTION
`dpnp.correlate` with input arrays of different USM types produces sporadic crashes on Windows in internal CI.
The PR proposes to temporary mute them until the issue is resolved.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
