### PR TITLE
Update docstrings in indexing functions 

### DIFF
--- a/dpnp/dpnp_algo/dpnp_elementwise_common.py
+++ b/dpnp/dpnp_algo/dpnp_elementwise_common.py
@@ -411,7 +411,7 @@ class DPNPBinaryFunc(BinaryElementwiseFunc):
         order : {None, "C", "F", "A", "K"}, optional
             Memory layout of the newly output array, Cannot be provided
             together with `out`. Default: ``"K"``.
-        dtype : {None, dtype}, optional
+        dtype : {None, str, dtype object}, optional
             If provided, the destination array will have this dtype. Cannot be
             provided together with `out`. Default: ``None``.
 

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -789,7 +789,7 @@ class dpnp_array:
         ----------
         x1 : {dpnp.ndarray, usm_ndarray}
             Array data type casting.
-        dtype : dtype
+        dtype : {None, str, dtype object}
             Target data type.
         order : {"C", "F", "A", "K"}, optional
             Row-major (C-style) or column-major (Fortran-style) order.

--- a/dpnp/dpnp_iface.py
+++ b/dpnp/dpnp_iface.py
@@ -217,7 +217,7 @@ def astype(x1, dtype, order="K", casting="unsafe", copy=True, device=None):
     ----------
     x1 : {dpnp.ndarray, usm_ndarray}
         Array data type casting.
-    dtype : dtype
+    dtype : {None, str, dtype object}
         Target data type.
     order : {'C', 'F', 'A', 'K'}
         Row-major (C-style) or column-major (Fortran-style) order.
@@ -281,7 +281,7 @@ def as_usm_ndarray(a, dtype=None, device=None, usm_type=None, sycl_queue=None):
     ----------
     a : {array_like, scalar}
         Input array or scalar.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         The desired dtype for the result array if new array is creating. If not
         given, a default dtype will be used that can represent the values (by
         considering Promotion Type Rule and device capabilities when necessary).

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -203,7 +203,7 @@ def arange(
     step : {int, real}, optional
         Spacing between values. The default `step` size is 1. If `step`
         is specified as a position argument, `start` must also be given.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         The desired dtype for the array. If not given, a default dtype will be
         used that can represent the values (by considering Promotion Type Rule
         and device capabilities when necessary).
@@ -306,7 +306,7 @@ def array(
         Input data, in any form that can be converted to an array. This
         includes scalars, lists, lists of tuples, tuples, tuples of tuples,
         tuples of lists, and ndarrays.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         The desired dtype for the array. If not given, a default dtype will be
         used that can represent the values (by considering Promotion Type Rule
         and device capabilities when necessary).
@@ -462,7 +462,7 @@ def asanyarray(
         Input data, in any form that can be converted to an array. This
         includes scalars, lists, lists of tuples, tuples, tuples of tuples,
         tuples of lists, and ndarrays.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         The desired dtype for the array. If not given, a default dtype will be
         used that can represent the values (by considering Promotion Type Rule
         and device capabilities when necessary).
@@ -565,7 +565,7 @@ def asarray(
         Input data, in any form that can be converted to an array. This
         includes scalars, lists, lists of tuples, tuples, tuples of tuples,
         tuples of lists, and ndarrays.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         The desired dtype for the array. If not given, a default dtype will be
         used that can represent the values (by considering Promotion Type Rule
         and device capabilities when necessary).
@@ -670,7 +670,7 @@ def ascontiguousarray(
         Input data, in any form that can be converted to an array. This
         includes scalars, lists, lists of tuples, tuples, tuples of tuples,
         tuples of lists, and ndarrays.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         The desired dtype for the array. If not given, a default dtype will be
         used that can represent the values (by considering Promotion Type Rule
         and device capabilities when necessary).
@@ -782,7 +782,7 @@ def asfortranarray(
         Input data, in any form that can be converted to an array. This
         includes scalars, lists, lists of tuples, tuples, tuples of tuples,
         tuples of lists, and ndarrays.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         The desired dtype for the array. If not given, a default dtype will be
         used that can represent the values (by considering Promotion Type Rule
         and device capabilities when necessary).
@@ -1219,7 +1219,7 @@ def empty(
     ----------
     shape : {int, sequence of ints}
         Shape of the new array, e.g., (2, 3) or 2.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
@@ -1320,7 +1320,7 @@ def empty_like(
     a : {dpnp.ndarray, usm_ndarray}
         The shape and dtype of `a` define these same attributes
         of the returned array.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
@@ -1433,7 +1433,7 @@ def eye(
         Index of the diagonal: 0 (the default) refers to the main diagonal,
         a positive value refers to an upper diagonal, and a negative value to
         a lower diagonal.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
@@ -1541,7 +1541,7 @@ def frombuffer(
     ----------
     buffer : buffer_like
         An object that exposes the buffer interface.
-    dtype : data-type, optional
+    dtype : {None, str, dtype object}, optional
         Data-type of the returned array.
         Default is the default floating point data type for the device where
         the returned array is allocated.
@@ -1646,7 +1646,7 @@ def fromfile(
     ----------
     file : file or str or Path
         Open file object or filename.
-    dtype : data-type, optional
+    dtype : {None, str, dtype object}, optional
         Data type of the returned array.
         For binary files, it is used to determine the size and byte-order
         of the items in the file.
@@ -1779,7 +1779,7 @@ def fromfunction(
     shape : (N,) tuple of ints
         Shape of the output array, which also determines the shape of
         the coordinate arrays passed to `function`.
-    dtype : data-type, optional
+    dtype : {None, str, dtype object}, optional
         Data-type of the coordinate arrays passed to `function`.
         Default is the default floating point data type for the device where
         the returned array is allocated.
@@ -1887,7 +1887,7 @@ def fromiter(
     ----------
     iter : iterable object
         An iterable object providing data for the array.
-    dtype : data-type
+    dtype : {None, str, dtype object}
         The data-type of the returned array.
     count : int, optional
         The number of items to read from *iterable*. The default is -1,
@@ -1981,7 +1981,7 @@ def fromstring(
     ----------
     string : str
         A string containing the data.
-    dtype : data-type, optional
+    dtype : {None, str, dtype object}, optional
         The data type of the array.
         For binary input data, the data must be in exactly this format.
         Default is the default floating point data type for the device where
@@ -2159,7 +2159,7 @@ def full(
         Fill value, in any form that can be converted to an array. This
         includes scalars, lists, lists of tuples, tuples, tuples of tuples,
         tuples of lists, and ndarrays.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
@@ -2263,7 +2263,7 @@ def full_like(
         Fill value, in any form that can be converted to an array. This
         includes scalars, lists, lists of tuples, tuples, tuples of tuples,
         tuples of lists, and ndarrays.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
@@ -2382,7 +2382,7 @@ def geomspace(
     num : int, optional
         Number of samples to generate.
         Default: ``50``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         The desired dtype for the array. If not given, a default dtype will be
         used that can represent the values (by considering Promotion Type Rule
         and device capabilities when necessary).
@@ -2492,7 +2492,7 @@ def identity(
     ----------
     n : int
         Number of rows (and columns) in `n` x `n` output.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
@@ -2607,7 +2607,7 @@ def linspace(
         of tuples, tuples of lists, and ndarrays. If `endpoint` is set to
         ``False`` the sequence consists of all but the last of ``num + 1``
         evenly spaced samples, so that `stop` is excluded.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         The desired dtype for the array. If not given, a default dtype will be
         used that can represent the values (by considering Promotion Type Rule
         and device capabilities when necessary).
@@ -2716,7 +2716,7 @@ def loadtxt(
         is ``.gz`` or ``.bz2``, the file is first decompressed. Note that
         generators must return bytes or strings. The strings in a list or
         produced by a generator are treated as lines.
-    dtype : data-type, optional
+    dtype : {None, str, dtype object}, optional
         Data-type of the resulting array.
         Default is the default floating point data type for the device where
         the returned array is allocated.
@@ -2858,7 +2858,7 @@ def logspace(
         The `step` size between the elements in ``ln(samples) / ln(base)``
         (or log_base(samples)) is uniform.
         Default: ``10.0``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         The desired dtype for the array. If not given, a default dtype will be
         used that can represent the values (by considering Promotion Type Rule
         and device capabilities when necessary).
@@ -3196,7 +3196,7 @@ def ones(
     ----------
     shape : {int, sequence of ints}
         Shape of the new array, e.g., (2, 3) or 2.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
@@ -3303,7 +3303,7 @@ def ones_like(
     a : {dpnp.ndarray, usm_ndarray}
         The shape and dtype of `a` define these same attributes
         of the returned array.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
@@ -3408,7 +3408,7 @@ def trace(a, offset=0, axis1=0, axis2=1, dtype=None, out=None):
         Axes to be used as the first and second axis of the 2-D sub-arrays from
         which the diagonals should be taken. Defaults are the first two axes of
         `a`.
-    dtype : dtype, optional
+    dtype : {None, str, dtype object}, optional
         Determines the data-type of the returned array and of the accumulator
         where the elements are summed. If `dtype` has the value ``None`` and
         `a` is of integer type of precision less than the default integer
@@ -3480,7 +3480,7 @@ def tri(
         The sub-diagonal at and below which the array is filled. k = 0 is
         the main diagonal, while k < 0 is below it, and k > 0 is above.
         Default: ``0``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.
@@ -3841,7 +3841,7 @@ def zeros(
     ----------
     shape : {int, sequence of ints}
         Shape of the new array, e.g., (2, 3) or 2.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         The desired dtype for the array, e.g., `dpnp.int32`.
         Default is the default floating point data type for the device where
         input array is allocated.
@@ -3948,7 +3948,7 @@ def zeros_like(
     a : {dpnp.ndarray, usm_ndarray}
         The shape and dtype of `a` define these same attributes
         of the returned array.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         The desired dtype for the array, e.g., dpnp.int32.
         Default is the default floating point data type for the device where
         input array is allocated.

--- a/dpnp/dpnp_iface_indexing.py
+++ b/dpnp/dpnp_iface_indexing.py
@@ -1983,9 +1983,9 @@ def select(condlist, choicelist, default=0):
 
     >>> x = np.arange(6)
     >>> condlist = [x<3, x>3]
-    >>> choicelist = [x, x**2]
+    >>> choicelist = [-x, x**2]
     >>> np.select(condlist, choicelist, 42)
-    array([ 0,  1,  2, 42, 16, 25])
+    array([ 0, -1, -2, 42, 16, 25])
 
     When multiple conditions are satisfied, the first one encountered in
     `condlist` is used.

--- a/dpnp/dpnp_iface_indexing.py
+++ b/dpnp/dpnp_iface_indexing.py
@@ -201,6 +201,7 @@ def choose(a, choices, out=None, mode="wrap"):
     out : {None, dpnp.ndarray, usm_ndarray}, optional
         If provided, the result will be placed in this array. It should
         be of the appropriate shape and dtype.
+
         Default: ``None``.
     mode : {"wrap", "clip"}, optional
         Specifies how out-of-bounds indices will be handled. Possible values
@@ -365,10 +366,12 @@ def compress(condition, a, axis=None, out=None):
     axis : {None, int}, optional
         Axis along which to extract slices. If ``None``, works over the
         flattened array.
+
         Default: ``None``.
     out : {None, dpnp.ndarray, usm_ndarray}, optional
         If provided, the result will be placed in this array. It should
         be of the appropriate shape and dtype.
+
         Default: ``None``.
 
     Returns
@@ -461,7 +464,9 @@ def diag_indices(n, ndim=2, device=None, usm_type="device", sycl_queue=None):
         The size, along each dimension, of the arrays for which the returned
         indices can be used.
     ndim : int, optional
-        The number of dimensions. Default: ``2``.
+        The number of dimensions.
+
+        Default: ``2``.
     device : {None, string, SyclDevice, SyclQueue}, optional
         An array API concept of device where the output array is created.
         The `device` can be ``None`` (the default), an OneAPI filter selector
@@ -469,13 +474,18 @@ def diag_indices(n, ndim=2, device=None, usm_type="device", sycl_queue=None):
         a non-partitioned SYCL device, an instance of :class:`dpctl.SyclQueue`,
         or a `Device` object returned by
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
+
+        Default: ``None``.
     usm_type : {"device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
+
+        Default: ``"device"``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying. The
         `sycl_queue` can be passed as ``None`` (the default), which means
         to get the SYCL queue from `device` keyword if present or to use
         a default queue.
+
         Default: ``None``.
 
     Returns
@@ -620,13 +630,19 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
         Array from which the diagonals are taken.
     offset : int, optional
         Offset of the diagonal from the main diagonal. Can be positive or
-        negative. Defaults to main diagonal (``0``).
+        negative. Defaults to main diagonal.
+
+        Default: ``0``.
     axis1 : int, optional
         Axis to be used as the first axis of the 2-D sub-arrays from which
-        the diagonals should be taken. Defaults to first axis (``0``).
+        the diagonals should be taken. Defaults to first axis.
+
+        Default: ``0``.
     axis2 : int, optional
         Axis to be used as the second axis of the 2-D sub-arrays from
-        which the diagonals should be taken. Defaults to second axis (``1``).
+        which the diagonals should be taken. Defaults to second axis.
+
+        Default: ``1``.
 
     Returns
     -------
@@ -859,7 +875,9 @@ def fill_diagonal(a, val, wrap=False):
         diagonal entries.
     wrap : bool
         It enables the diagonal "wrapped" after N columns. This affects only
-        tall matrices. Default: ``False``.
+        tall matrices.
+
+        Default: ``False``.
 
     See Also
     --------
@@ -1047,11 +1065,15 @@ def indices(
     ----------
     dimensions : sequence of ints
         The shape of the grid.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         Data type of the result.
+
+        Default: ``int``.
     sparse : {None, boolean}, optional
         Return a sparse representation of the grid instead of a dense
-        representation. Default is ``False``.
+        representation.
+
+        Default is ``False``.
     device : {None, string, SyclDevice, SyclQueue}, optional
         An array API concept of device where the output array is created.
         The `device` can be ``None`` (the default), an OneAPI filter selector
@@ -1059,13 +1081,18 @@ def indices(
         a non-partitioned SYCL device, an instance of :class:`dpctl.SyclQueue`,
         or a `Device` object returned by
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
+
+        Default: ``None``.
     usm_type : {"device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
+
+        Default: ``"device"``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying. The
         `sycl_queue` can be passed as ``None`` (the default), which means
         to get the SYCL queue from `device` keyword if present or to use
         a default queue.
+
         Default: ``None``.
 
     Returns
@@ -1308,7 +1335,9 @@ def mask_indices(
     k : scalar
         An optional argument which is passed through to `mask_func`. Functions
         like :obj:`dpnp.triu`, :obj:`dpnp.tril` take a second argument that is
-        interpreted as an offset. Default: ``0``.
+        interpreted as an offset.
+
+        Default: ``0``.
     device : {None, string, SyclDevice, SyclQueue}, optional
         An array API concept of device where the output array is created.
         The `device` can be ``None`` (the default), an OneAPI filter selector
@@ -1316,13 +1345,18 @@ def mask_indices(
         a non-partitioned SYCL device, an instance of :class:`dpctl.SyclQueue`,
         or a `Device` object returned by
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
+
+        Default: ``None``.
     usm_type : {"device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
+
+        Default: ``"device"``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying. The
         `sycl_queue` can be passed as ``None`` (the default), which means
         to get the SYCL queue from `device` keyword if present or to use
         a default queue.
+
         Default: ``None``.
 
     Returns
@@ -1630,6 +1664,7 @@ def put(a, ind, v, /, *, axis=None, mode="wrap"):
     axis : {None, int}, optional
         The axis along which the values will be placed. If `a` is 1-D array,
         this argument is optional.
+
         Default: ``None``.
     mode : {'wrap', 'clip'}, optional
         Specifies how out-of-bounds indices will behave.
@@ -1848,10 +1883,12 @@ def ravel_multi_index(multi_index, dims, mode="raise", order="C"):
 
         In ``"clip"`` mode, a negative index which would normally wrap will
         clip to 0 instead.
+
         Default: ``"raise"``.
     order : {None, "C", "F"}, optional
         Determines whether the multi-index should be viewed as indexing in
         row-major (C-style) or column-major (Fortran-style) order.
+
         Default: ``"C"``.
 
     Returns
@@ -1952,7 +1989,9 @@ def select(condlist, choicelist, default=0):
         to be of the same length as `condlist`.
     default : {scalar, dpnp.ndarray, usm_ndarray}, optional
         The element inserted in `output` when all conditions evaluate to
-        ``False``. Default: ``0``.
+        ``False``.
+
+        Default: ``0``.
 
     Returns
     -------
@@ -2074,10 +2113,12 @@ def take(a, indices, /, *, axis=None, out=None, mode="wrap"):
     axis : {None, int, bool, 0-d array of integer dtype}, optional
         The axis over which to select values. By default, the flattened
         input array is used.
+
         Default: ``None``.
     out : {None, dpnp.ndarray, usm_ndarray}, optional (Ni..., Nj..., Nk...)
         If provided, the result will be placed in this array. It should
         be of the appropriate shape and dtype.
+
         Default: ``None``.
     mode : {"wrap", "clip"}, optional
         Specifies how out-of-bounds indices will be handled. Possible values
@@ -2298,11 +2339,15 @@ def tril_indices(
         The row dimension of the arrays for which the returned
         indices will be valid.
     k : int, optional
-        Diagonal offset (see :obj:`dpnp.tril` for details). Default: ``0``.
+        Diagonal offset (see :obj:`dpnp.tril` for details).
+
+        Default: ``0``.
     m : {None, int}, optional
         The column dimension of the arrays for which the returned
         arrays will be valid.
-        By default `m` is taken equal to `n`. Default: ``None``.
+        By default `m` is taken equal to `n`.
+
+        Default: ``None``.
     device : {None, string, SyclDevice, SyclQueue}, optional
         An array API concept of device where the output array is created.
         The `device` can be ``None`` (the default), an OneAPI filter selector
@@ -2310,13 +2355,18 @@ def tril_indices(
         a non-partitioned SYCL device, an instance of :class:`dpctl.SyclQueue`,
         or a `Device` object returned by
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
+
+        Default: ``None``.
     usm_type : {"device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
+
+        Default: ``"device"``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying. The
         `sycl_queue` can be passed as ``None`` (the default), which means
         to get the SYCL queue from `device` keyword if present or to use
         a default queue.
+
         Default: ``None``.
 
     Returns
@@ -2411,7 +2461,9 @@ def tril_indices_from(arr, k=0):
         The indices will be valid for square arrays whose dimensions are
         the same as arr.
     k : int, optional
-        Diagonal offset (see :obj:`dpnp.tril` for details). Default: ``0``.
+        Diagonal offset (see :obj:`dpnp.tril` for details).
+
+        Default: ``0``.
 
     Returns
     -------
@@ -2496,11 +2548,15 @@ def triu_indices(
         The size of the arrays for which the returned indices will
         be valid.
     k : int, optional
-        Diagonal offset (see :obj:`dpnp.triu` for details). Default: ``0``.
+        Diagonal offset (see :obj:`dpnp.triu` for details).
+
+        Default: ``0``.
     m : int, optional
         The column dimension of the arrays for which the returned
         arrays will be valid.
-        By default `m` is taken equal to `n`. Default: ``None``.
+        By default `m` is taken equal to `n`.
+
+        Default: ``None``.
     device : {None, string, SyclDevice, SyclQueue}, optional
         An array API concept of device where the output array is created.
         The `device` can be ``None`` (the default), an OneAPI filter selector
@@ -2508,13 +2564,18 @@ def triu_indices(
         a non-partitioned SYCL device, an instance of :class:`dpctl.SyclQueue`,
         or a `Device` object returned by
         :obj:`dpnp.dpnp_array.dpnp_array.device` property.
+
+        Default: ``"device"``.
     usm_type : {"device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
+
+        Default: ``None``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying. The
         `sycl_queue` can be passed as ``None`` (the default), which means
         to get the SYCL queue from `device` keyword if present or to use
         a default queue.
+
         Default: ``None``.
 
     Returns
@@ -2611,7 +2672,9 @@ def triu_indices_from(arr, k=0):
         The indices will be valid for square arrays whose dimensions are
         the same as arr.
     k : int, optional
-        Diagonal offset (see :obj:`dpnp.triu` for details). Default: ``0``.
+        Diagonal offset (see :obj:`dpnp.triu` for details).
+
+        Default: ``0``.
 
     Returns
     -------
@@ -2694,6 +2757,7 @@ def unravel_index(indices, shape, order="C"):
     order : {None, "C", "F"}, optional
         Determines whether the indices should be viewed as indexing in
         row-major (C-style) or column-major (Fortran-style) order.
+
         Default: ``"C"``.
 
     Returns

--- a/dpnp/dpnp_iface_linearalgebra.py
+++ b/dpnp/dpnp_iface_linearalgebra.py
@@ -192,7 +192,7 @@ def einsum(
         These are the arrays for the operation.
     out : {dpnp.ndarrays, usm_ndarray, None}, optional
         If provided, the calculation is done into this array.
-    dtype : {dtype, None}, optional
+    dtype : {None, str, dtype object}, optional
         If provided, forces the calculation to use the data type specified.
         Default: ``None``.
     order : {"C", "F", "A", "K"}, optional
@@ -757,7 +757,7 @@ def matmul(
         (of the calculated values) will be cast if necessary.
 
         Default: ``None``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         Type to use in computing the matrix product. By default, the returned
         array will have data type that is determined by considering
         Promotion Type Rule and device capabilities.
@@ -937,7 +937,7 @@ def matvec(
         If not provided or ``None``, a freshly-allocated array is used.
 
         Default: ``None``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         Type to use in computing the matrix product. By default, the returned
         array will have data type that is determined by considering
         Promotion Type Rule and device capabilities.
@@ -1327,7 +1327,7 @@ def vecdot(
         Memory layout of the newly output array, if parameter `out` is ``None``.
 
         Default: ``"K"``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         Type to use in computing the vector dot product. By default, the
         returned array will have data type that is determined by considering
         Promotion Type Rule and device capabilities.
@@ -1441,7 +1441,7 @@ def vecmat(
         If not provided or ``None``, a freshly-allocated array is used.
 
         Default: ``None``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         Type to use in computing the matrix product. By default, the returned
         array will have data type that is determined by considering
         Promotion Type Rule and device capabilities.

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -1073,7 +1073,7 @@ def cumprod(a, axis=None, dtype=None, out=None):
         compute the cumulative product over the flattened array.
 
         Default: ``None``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         Type of the returned array and of the accumulator in which the elements
         are multiplied. If `dtype` is not specified, it defaults to the dtype
         of `a`, unless `a` has an integer dtype with a precision less than that
@@ -1158,7 +1158,7 @@ def cumsum(a, axis=None, dtype=None, out=None):
         the cumulative sum over the flattened array.
 
         Default: ``None``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         Type of the returned array and of the accumulator in which the elements
         are summed. If `dtype` is not specified, it defaults to the dtype of
         `a`, unless `a` has an integer dtype with a precision less than that of
@@ -1255,7 +1255,7 @@ def cumulative_prod(
         one dimension `axis` is required.
 
         Default: ``None``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         Type of the returned array and of the accumulator in which the elements
         are summed. If `dtype` is not specified, it defaults to the dtype of
         `x`, unless `x` has an integer dtype with a precision less than that of
@@ -1344,7 +1344,7 @@ def cumulative_sum(
         one dimension `axis` is required.
 
         Default: ``None``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         Type of the returned array and of the accumulator in which the elements
         are summed. If `dtype` is not specified, it defaults to the dtype of
         `x`, unless `x` has an integer dtype with a precision less than that of
@@ -3564,7 +3564,7 @@ def prod(
         before.
 
         Default: ``None``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         The type of the returned array, as well as of the accumulator in which
         the elements are multiplied. The dtype of `a` is used by default unless
         `a` has an integer dtype of less precision than the default platform
@@ -4360,7 +4360,7 @@ def sum(
         before.
 
         Default: ``None``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         The type of the returned array and of the accumulator in which the
         elements are summed. The dtype of `a` is used by default unless `a` has
         an integer dtype of less precision than the default platform integer.

--- a/dpnp/dpnp_iface_nanfunctions.py
+++ b/dpnp/dpnp_iface_nanfunctions.py
@@ -266,7 +266,7 @@ def nancumprod(a, axis=None, dtype=None, out=None):
         is to compute the cumulative product over the flattened array.
 
         Default: ``None``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         Type of the returned array and of the accumulator in which the elements
         are summed. If `dtype` is not specified, it defaults to the dtype of
         `a`, unless `a` has an integer dtype with a precision less than that of
@@ -336,7 +336,7 @@ def nancumsum(a, axis=None, dtype=None, out=None):
         compute the cumulative sum over the flattened array.
 
         Default: ``None``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         Type of the returned array and of the accumulator in which the elements
         are summed. If `dtype` is not specified, it defaults to the dtype of
         `a`, unless `a` has an integer dtype with a precision less than that of
@@ -499,7 +499,7 @@ def nanmean(a, axis=None, dtype=None, out=None, keepdims=False, *, where=True):
         axes. If ``None``, the mean is computed over the entire array.
 
         Default: ``None``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         Type to use in computing the mean. By default, if `a` has a
         floating-point data type, the returned array will have
         the same data type as `a`.
@@ -823,7 +823,7 @@ def nanprod(
         compute the product of the flattened array.
 
         Default: ``None``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         The type of the returned array and of the accumulator in which the
         elements are multiplied. By default, the dtype of `a` is used. An
         exception is when `a` has an integer type with less precision than
@@ -920,7 +920,7 @@ def nansum(
         the sum of the flattened array.
 
         Default: ``None``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         The type of the returned array and of the accumulator in which the
         elements are summed. By default, the dtype of `a` is used. An exception
         is when `a` has an integer type with less precision than the platform
@@ -1029,7 +1029,7 @@ def nanstd(
         computed over the entire array.
 
         Default: ``None``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         Type to use in computing the standard deviation. By default, if `a` has
         a floating-point data type, the returned array will have the same data
         type as `a`. If `a` has a boolean or integral data type, the returned
@@ -1177,7 +1177,7 @@ def nanvar(
         axes. If ``None``, the variance is computed over the entire array.
 
         Default: ``None``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         Type to use in computing the variance. By default, if `a` has a
         floating-point data type, the returned array will have
         the same data type as `a`. If `a` has a boolean or integral data type,

--- a/dpnp/dpnp_iface_statistics.py
+++ b/dpnp/dpnp_iface_statistics.py
@@ -381,7 +381,7 @@ def corrcoef(x, y=None, rowvar=True, *, dtype=None):
         contain observations.
 
         Default: ``True``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         Data-type of the result.
 
         Default: ``None``.
@@ -908,7 +908,7 @@ def mean(a, /, axis=None, dtype=None, out=None, keepdims=False, *, where=True):
         axes. If ``None``, the mean is computed over the entire array.
 
         Default: ``None``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         Type to use in computing the mean. By default, if `a` has a
         floating-point data type, the returned array will have
         the same data type as `a`.
@@ -1271,7 +1271,7 @@ def std(
         is computed over the entire array.
 
         Default: ``None``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         Type to use in computing the standard deviation. By default, if `a` has
         a floating-point data type, the returned array will have the same data
         type as `a`. If `a` has a boolean or integral data type, the returned
@@ -1465,7 +1465,7 @@ def var(
         axes. If ``None``, the variance is computed over the entire array.
 
         Default: ``None``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         Type to use in computing the variance. By default, if `a` has a
         floating-point data type, the returned array will have the same data
         type as `a`. If `a` has a boolean or integral data type, the returned

--- a/dpnp/dpnp_iface_trigonometric.py
+++ b/dpnp/dpnp_iface_trigonometric.py
@@ -832,7 +832,7 @@ def cumlogsumexp(
         integers, values are computed over multiple axes. If ``None``, the
         result is computed over the entire array.
         Default: ``None``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         Data type of the returned array. If ``None``, the default data type is
         inferred from the "kind" of the input array data type.
 
@@ -1642,7 +1642,7 @@ def logsumexp(x, /, *, axis=None, dtype=None, keepdims=False, out=None):
         integers, values are computed over multiple axes. If ``None``, the
         result is computed over the entire array.
         Default: ``None``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         Data type of the returned array. If ``None``, the default data type is
         inferred from the "kind" of the input array data type.
 
@@ -1892,7 +1892,7 @@ def reduce_hypot(x, /, *, axis=None, dtype=None, keepdims=False, out=None):
         integers, values are computed over multiple axes. If ``None``, the
         result is computed over the entire array.
         Default: ``None``.
-    dtype : {None, dtype}, optional
+    dtype : {None, str, dtype object}, optional
         Data type of the returned array. If ``None``, the default data type is
         inferred from the "kind" of the input array data type.
 

--- a/dpnp/linalg/dpnp_iface_linalg.py
+++ b/dpnp/linalg/dpnp_iface_linalg.py
@@ -2152,7 +2152,7 @@ def trace(x, /, *, offset=0, dtype=None):
             * offset < 0: off-diagonal below the main diagonal.
 
         Default: ``0``.
-    dtype : dtype, optional
+    dtype : {None, str, dtype object}, optional
         Determines the data-type of the returned array and of the accumulator
         where the elements are summed. If `dtype` has the value ``None`` and
         `a` is of integer type of precision less than the default integer


### PR DESCRIPTION
The PR proposes to implement documentation improvements, including:
- correct example in `dpnp.select`
- updates docstrings for indexing functions to have a blank line prior `Default` value
- align description of `dtype` keyword across all functions

Note, updates in other files with adding blank line prior `Default` will be covered separately.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
