### PR TITLE
Remove mentioning of `tostring` method

### DIFF
--- a/doc/reference/ndarray.rst
+++ b/doc/reference/ndarray.rst
@@ -134,7 +134,6 @@ Array conversion
 
    dpnp.ndarray.item
    dpnp.ndarray.tolist
-   dpnp.ndarray.tostring
    dpnp.ndarray.tobytes
    dpnp.ndarray.tofile
    dpnp.ndarray.dump

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -1860,7 +1860,6 @@ class dpnp_array:
     # 'tobytes',
     # 'tofile',
     # 'tolist',
-    # 'tostring',
 
     def trace(self, offset=0, axis1=0, axis2=1, dtype=None, out=None):
         """


### PR DESCRIPTION
`numpy.ndarray.tostring` method was deprecated since `1.19` and is going to be removed in `2.3.0` release.

This PR proposes to remove mentioning of `tostring` method in a list of rendered documentation and as TODO method for implementation in `dpnp.ndarray`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
