### PR TITLE
Disallow `minlength=None` in `dpnp.bincount`

### DIFF
--- a/dpnp/dpnp_iface_histograms.py
+++ b/dpnp/dpnp_iface_histograms.py
@@ -424,6 +424,7 @@ def digitize(x, bins, right=False):
         increasing or decreasing.
     right : bool, optional
         Indicates whether the intervals include the right or the left bin edge.
+
         Default: ``False``.
 
     Returns
@@ -683,6 +684,7 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
         given range.
         If `bins` is a sequence, it defines the bin edges, including the
         rightmost edge, allowing for non-uniform bin widths.
+
         Default: ``10``.
     range : {None, 2-tuple of float}, optional
         The lower and upper range of the bins. If not provided, range is simply
@@ -691,12 +693,14 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
         affects the automatic bin computation as well. While bin width is
         computed to be optimal based on the actual data within `range`, the bin
         count will fill the entire range including portions containing no data.
+
         Default: ``None``.
     weights : {None, dpnp.ndarray, usm_ndarray}, optional
         An array of weights, of the same shape as `a`. Each value in `a` only
         contributes its associated weight towards the bin count (instead of 1).
         This is currently not used by any of the bin estimators, but may be in
         the future.
+
         Default: ``None``.
 
     Returns

--- a/dpnp/dpnp_iface_histograms.py
+++ b/dpnp/dpnp_iface_histograms.py
@@ -225,17 +225,23 @@ def _get_bin_edges(a, bins, range, usm_type):
 
 
 def _bincount_validate(x, weights, minlength):
+    dpnp.check_supported_arrays_type(x)
     if x.ndim > 1:
         raise ValueError("object too deep for desired array")
+
     if x.ndim < 1:
         raise ValueError("object of too small depth for desired array")
+
     if not dpnp.issubdtype(x.dtype, dpnp.integer) and not dpnp.issubdtype(
         x.dtype, dpnp.bool
     ):
         raise TypeError("x must be an integer array")
+
     if weights is not None:
+        dpnp.check_supported_arrays_type(weights)
         if x.shape != weights.shape:
             raise ValueError("The weights and x don't have the same length.")
+
         if not (
             dpnp.issubdtype(weights.dtype, dpnp.integer)
             or dpnp.issubdtype(weights.dtype, dpnp.floating)
@@ -245,10 +251,12 @@ def _bincount_validate(x, weights, minlength):
                 f"Weights must be integer or float. Got {weights.dtype}"
             )
 
-    if minlength is not None:
-        minlength = int(minlength)
-        if minlength < 0:
-            raise ValueError("minlength must be non-negative")
+    if minlength is None:
+        raise TypeError("use 0 instead of None for minlength")
+
+    minlength = int(minlength)
+    if minlength < 0:
+        raise ValueError("minlength must be non-negative")
 
 
 def _bincount_run_native(
@@ -262,9 +270,7 @@ def _bincount_run_native(
     if min_v < 0:
         raise ValueError("x argument must have no negative arguments")
 
-    size = int(dpnp.max(max_v)) + 1
-    if minlength is not None:
-        size = max(size, minlength)
+    size = max(int(max_v) + 1, minlength)
 
     # bincount implementation uses atomics, but atomics doesn't work with
     # host usm memory
@@ -299,9 +305,9 @@ def _bincount_run_native(
     return n_casted
 
 
-def bincount(x, weights=None, minlength=None):
+def bincount(x, weights=None, minlength=0):
     """
-    bincount(x, /, weights=None, minlength=None)
+    bincount(x, /, weights=None, minlength=0)
 
     Count number of occurrences of each value in array of non-negative ints.
 
@@ -313,10 +319,12 @@ def bincount(x, weights=None, minlength=None):
         Input 1-dimensional array with non-negative integer values.
     weights : {None, dpnp.ndarray, usm_ndarray}, optional
         Weights, array of the same shape as `x`.
+
         Default: ``None``
-    minlength : {None, int}, optional
+    minlength : int, optional
         A minimum number of bins for the output array.
-        Default: ``None``
+
+        Default: ``0``
 
     Returns
     -------

--- a/dpnp/tests/helper.py
+++ b/dpnp/tests/helper.py
@@ -6,7 +6,8 @@ import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 
 import dpnp
-from dpnp.tests import config
+
+from . import config
 
 
 def assert_dtype_allclose(
@@ -86,14 +87,14 @@ def assert_dtype_allclose(
                 assert dpnp_arr.dtype == numpy_arr.dtype
 
 
-def get_integer_dtypes(no_unsigned=False):
+def get_integer_dtypes(all_int_types=False, no_unsigned=False):
     """
     Build a list of integer types supported by DPNP.
     """
 
     dtypes = [dpnp.int32, dpnp.int64]
 
-    if config.all_int_types:
+    if config.all_int_types or all_int_types:
         dtypes += [dpnp.int8, dpnp.int16]
         if not no_unsigned:
             dtypes += [dpnp.uint8, dpnp.uint16, dpnp.uint32, dpnp.uint64]

--- a/dpnp/tests/test_histogram.py
+++ b/dpnp/tests/test_histogram.py
@@ -282,9 +282,10 @@ class TestHistogram:
         assert_dtype_allclose(result_hist, expected_hist)
         assert_dtype_allclose(result_edges, expected_edges)
 
-    def test_integer_weights(self):
+    @pytest.mark.parametrize("dt", get_integer_dtypes(all_int_types=True))
+    def test_integer_weights(self, dt):
         v = numpy.array([1, 2, 2, 4])
-        w = numpy.array([4, 3, 2, 1])
+        w = numpy.array([4, 3, 2, 1], dtype=dt)
 
         iv = dpnp.array(v)
         iw = dpnp.array(w)

--- a/dpnp/tests/test_histogram.py
+++ b/dpnp/tests/test_histogram.py
@@ -7,7 +7,6 @@ from numpy.testing import (
     assert_array_equal,
     assert_raises,
     assert_raises_regex,
-    suppress_warnings,
 )
 
 import dpnp
@@ -18,6 +17,7 @@ from .helper import (
     get_float_dtypes,
     get_integer_dtypes,
     has_support_aspect64,
+    numpy_version,
 )
 
 
@@ -598,10 +598,21 @@ class TestBincount:
         result = dpnp.bincount(dpnp_a, minlength=minlength)
         assert_allclose(expected, result)
 
-    # TODO: uncomment once numpy 2.3.0 is released
-    # @testing.with_requires("numpy>=2.3")
-    # @pytest.mark.parametrize("xp", [dpnp, numpy])
-    @pytest.mark.parametrize("xp", [dpnp])
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
+    @pytest.mark.parametrize(
+        "xp",
+        [
+            dpnp,
+            pytest.param(
+                numpy,
+                marks=pytest.mark.xfail(
+                    numpy_version() < "2.3.0",
+                    reason="numpy deprecates but accepts that",
+                    strict=True,
+                ),
+            ),
+        ],
+    )
     def test_minlength_none(self, xp):
         a = xp.array([1, 2, 3])
         assert_raises_regex(


### PR DESCRIPTION
`minlength=None` was deprecated for `numpy.bincount` since numpy `1.14` and numpy is going to raise `TypeError` exception in `2.3.0` release.

The PR propose to update implementation of `dpnp.bincount` and to disallow `minlength=None` in the same way as it will be implemented in NumPy 2.3.0.

Additionally there is explicit type check of input arrays added through `dpnp.check_supported_arrays_type` calls at validation step.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
