### PR TITLE
Disable GitHub workflows to be run with python 3.13

### DIFF
--- a/.github/workflows/check-mkl-interfaces.yaml
+++ b/.github/workflows/check-mkl-interfaces.yaml
@@ -10,6 +10,9 @@ permissions: read-all
 
 env:
   CHANNELS: '-c dppy/label/dev -c https://software.repos.intel.com/python/conda/ -c conda-forge --override-channels'
+  # python 3.13 is blocked since BLAS requires "mkl<2025.0" (see https://github.com/conda-forge/blas-feedstock/pull/128
+  # which depends on resolving MKL issue https://github.com/conda-forge/intel_repack-feedstock/issues/83)
+  TEST_PYTHON_VERSION: '3.12'
   TEST_ENV_NAME: 'test_onemkl_interfaces'
   RERUN_TESTS_ON_FAILURE: 'true'
   RUN_TESTS_MAX_ATTEMPTS: 2
@@ -32,7 +35,9 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.13']
+        # python 3.13 is blocked since BLAS requires "mkl<2025.0" (see https://github.com/conda-forge/blas-feedstock/pull/128
+        # which depends on resolving MKL issue https://github.com/conda-forge/intel_repack-feedstock/issues/83)
+        python: [${{ env.TEST_PYTHON_VERSION }}]
         os: [ubuntu-22.04] # windows-2019 - no DFT support for Windows in oneMKL
 
     permissions:
@@ -125,7 +130,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.13']
+        python: [${{ env.TEST_PYTHON_VERSION }}]
         os: [ubuntu-22.04] # windows-2019 - no DFT support for Windows in oneMKL
 
     permissions:

--- a/.github/workflows/check-mkl-interfaces.yaml
+++ b/.github/workflows/check-mkl-interfaces.yaml
@@ -20,7 +20,7 @@ env:
       onedpl-devel
       setuptools
       python
-      numpy">=2.0"
+      numpy
       cython
       cmake
       ninja

--- a/.github/workflows/check-mkl-interfaces.yaml
+++ b/.github/workflows/check-mkl-interfaces.yaml
@@ -10,9 +10,6 @@ permissions: read-all
 
 env:
   CHANNELS: '-c dppy/label/dev -c https://software.repos.intel.com/python/conda/ -c conda-forge --override-channels'
-  # python 3.13 is blocked since BLAS requires "mkl<2025.0" (see https://github.com/conda-forge/blas-feedstock/pull/128
-  # which depends on resolving MKL issue https://github.com/conda-forge/intel_repack-feedstock/issues/83)
-  TEST_PYTHON_VERSION: '3.12'
   TEST_ENV_NAME: 'test_onemkl_interfaces'
   RERUN_TESTS_ON_FAILURE: 'true'
   RUN_TESTS_MAX_ATTEMPTS: 2
@@ -37,7 +34,7 @@ jobs:
       matrix:
         # python 3.13 is blocked since BLAS requires "mkl<2025.0" (see https://github.com/conda-forge/blas-feedstock/pull/128
         # which depends on resolving MKL issue https://github.com/conda-forge/intel_repack-feedstock/issues/83)
-        python: [${{ env.TEST_PYTHON_VERSION }}]
+        python: ['3.12']
         os: [ubuntu-22.04] # windows-2019 - no DFT support for Windows in oneMKL
 
     permissions:
@@ -130,7 +127,9 @@ jobs:
 
     strategy:
       matrix:
-        python: [${{ env.TEST_PYTHON_VERSION }}]
+        # python 3.13 is blocked since BLAS requires "mkl<2025.0" (see https://github.com/conda-forge/blas-feedstock/pull/128
+        # which depends on resolving MKL issue https://github.com/conda-forge/intel_repack-feedstock/issues/83)
+        python: ['3.12']
         os: [ubuntu-22.04] # windows-2019 - no DFT support for Windows in oneMKL
 
     permissions:

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -16,7 +16,9 @@ env:
   CONDA_BUILD_INDEX_ENV_PY_VER: '3.12' # conda does not support python 3.13
   CONDA_BUILD_VERSION: '25.1.1'
   CONDA_INDEX_VERSION: '0.5.0'
-  LATEST_PYTHON: '3.13'
+  # python 3.13 is blocked since BLAS requires "mkl<2025.0" (see https://github.com/conda-forge/blas-feedstock/pull/128
+  # which depends on resolving MKL issue https://github.com/conda-forge/intel_repack-feedstock/issues/83)
+  LATEST_PYTHON: '3.12'
   RERUN_TESTS_ON_FAILURE: 'true'
   RUN_TESTS_MAX_ATTEMPTS: 2
   TEST_ENV_NAME: 'test'
@@ -31,7 +33,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        # python 3.13 is blocked since BLAS requires "mkl<2025.0" (see https://github.com/conda-forge/blas-feedstock/pull/128
+        # which depends on resolving MKL issue https://github.com/conda-forge/intel_repack-feedstock/issues/83)
+        python: ['3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-22.04, windows-2019]
 
     permissions:
@@ -124,7 +128,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        # python 3.13 is blocked due to MKL issue
+        python: ['3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest]
 
     env:
@@ -253,7 +258,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        # python 3.13 is blocked due to MKL issue
+        python: ['3.9', '3.10', '3.11', '3.12']
         os: [windows-2019]
 
     env:
@@ -389,7 +395,8 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        # python 3.13 is blocked due to MKL issue
+        python: ['3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-22.04, windows-2019]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/cron-run-tests.yaml
+++ b/.github/workflows/cron-run-tests.yaml
@@ -37,7 +37,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        # python 3.13 is blocked since BLAS requires "mkl<2025.0" (see https://github.com/conda-forge/blas-feedstock/pull/128
+        # which depends on resolving MKL issue https://github.com/conda-forge/intel_repack-feedstock/issues/83)
+        python: ['3.9', '3.10', '3.11', '3.12']
         runner: [ubuntu-22.04, ubuntu-24.04, windows-2019]
 
     steps:

--- a/dpnp/tests/third_party/cupy/manipulation_tests/test_basic.py
+++ b/dpnp/tests/third_party/cupy/manipulation_tests/test_basic.py
@@ -199,6 +199,7 @@ class TestBasic:
         testing.assert_array_equal(expected, dst.get())
 
 
+@testing.with_requires("numpy>=2.1")
 @testing.parameterize(
     *testing.product(
         {


### PR DESCRIPTION
There is currently no way to install dpnp with any numpy version > 2.0, because
- there is no such version available on `https://software.repos.intel.com/python/conda/` channel
- numpy from `conda-forge` channel depends on BLAS libraries which has a runtime dependency `mkl < 2025.0` (since BLAS packages with build number 29)

There is draft PR ([gh-128](https://github.com/conda-forge/blas-feedstock/pull/128)) to build BLAS with MKL version 2025.0, but it is blocked due to MKL issue ([gh-83](https://github.com/conda-forge/intel_repack-feedstock/issues/83)).

Meanwhile there was conda-forge patch ([gh-959](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/959)) merged recently to add `mkl < 2025.0` constraint to already published BLAS packaged on `conda-forge` with older build number.

DPNP package can't fulfill the requirement `mkl < 2025.0`, because it would mandate dpnp build pinning with DPC++ compiler 2024.2. While there were non-backward compatible changes between 2024.2 and 2025.x versions, that is dpnp built with 2024.2 compiler can not be installed with any DPC++ RT 2025.x version, but it is required since targeted by the upcoming release.

Thus the PR proposes to temporary disable or workaround all scenario where it is need to tests with numpy from `conda-forge` channel, including tests workflows for python 3.13 (per PR trigger and nightly) and workflow for testing of oneMath interfaces with the latest numpy.
The changes has to be rolled back once the above issues are resolved.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
