### PR TITLE
update `test_search.py`, `test_special.py`, `test_statistics.py`, and `test_umath.py`

### DIFF
--- a/dpnp/tests/test_amin_amax.py
+++ b/dpnp/tests/test_amin_amax.py
@@ -22,7 +22,7 @@ def test_amax_amin(func, keepdims, dtype):
     for axis in range(len(a)):
         result = getattr(dpnp, func)(ia, axis=axis, keepdims=keepdims)
         expected = getattr(numpy, func)(a, axis=axis, keepdims=keepdims)
-        assert_allclose(expected, result)
+        assert_allclose(result, expected)
 
 
 def _get_min_max_input(type, shape):

--- a/dpnp/tests/test_arraycreation.py
+++ b/dpnp/tests/test_arraycreation.py
@@ -216,7 +216,7 @@ def test_arange(start, stop, step, dtype):
     func = lambda xp: xp.arange(start, stop=stop, step=step, dtype=dtype)
 
     exp_array = func(numpy)
-    res_array = func(dpnp).asnumpy()
+    res_array = func(dpnp)
 
     if dtype is None:
         _device = dpctl.SyclQueue().sycl_device
@@ -234,7 +234,7 @@ def test_arange(start, stop, step, dtype):
         _dtype, dpnp.complexfloating
     ):
         assert_allclose(
-            exp_array, res_array, rtol=rtol_mult * numpy.finfo(_dtype).eps
+            res_array, exp_array, rtol=rtol_mult * numpy.finfo(_dtype).eps
         )
     else:
         assert_array_equal(exp_array, res_array)
@@ -540,7 +540,7 @@ def test_vander(array, dtype, n, increase):
     a_np = numpy.array(array, dtype=dtype)
     a_dpnp = dpnp.array(array, dtype=dtype)
 
-    assert_allclose(vander_func(numpy, a_np), vander_func(dpnp, a_dpnp))
+    assert_allclose(vander_func(dpnp, a_dpnp), vander_func(numpy, a_np))
 
 
 def test_vander_raise_error():
@@ -560,7 +560,7 @@ def test_vander_raise_error():
 )
 def test_vander_seq(sequence):
     vander_func = lambda xp, x: xp.vander(x)
-    assert_allclose(vander_func(numpy, sequence), vander_func(dpnp, sequence))
+    assert_allclose(vander_func(dpnp, sequence), vander_func(numpy, sequence))
 
 
 @pytest.mark.usefixtures("suppress_complex_warning")
@@ -607,19 +607,19 @@ def test_full_order(order1, order2):
 
     assert ia.flags.c_contiguous == a.flags.c_contiguous
     assert ia.flags.f_contiguous == a.flags.f_contiguous
-    assert numpy.array_equal(dpnp.asnumpy(ia), a)
+    assert_equal(ia, a)
 
 
 def test_full_strides():
     a = numpy.full((3, 3), numpy.arange(3, dtype="i4"))
     ia = dpnp.full((3, 3), dpnp.arange(3, dtype="i4"))
     assert ia.strides == tuple(el // a.itemsize for el in a.strides)
-    assert_array_equal(dpnp.asnumpy(ia), a)
+    assert_array_equal(ia, a)
 
     a = numpy.full((3, 3), numpy.arange(6, dtype="i4")[::2])
     ia = dpnp.full((3, 3), dpnp.arange(6, dtype="i4")[::2])
     assert ia.strides == tuple(el // a.itemsize for el in a.strides)
-    assert_array_equal(dpnp.asnumpy(ia), a)
+    assert_array_equal(ia, a)
 
 
 @pytest.mark.parametrize(
@@ -891,9 +891,9 @@ def test_geomspace(sign, dtype, num, endpoint):
     dpnp_res = func(dpnp)
 
     if dtype in [numpy.int64, numpy.int32]:
-        assert_allclose(dpnp_res, np_res, rtol=1)
+        assert_allclose(dpnp_res, np_res)
     else:
-        assert_allclose(dpnp_res, np_res, rtol=1e-04)
+        assert_allclose(dpnp_res, np_res)
 
 
 @pytest.mark.parametrize("start", [1j, 1 + 1j])
@@ -902,7 +902,7 @@ def test_geomspace_complex(start, stop):
     func = lambda xp: xp.geomspace(start, stop, num=10)
     np_res = func(numpy)
     dpnp_res = func(dpnp)
-    assert_allclose(dpnp_res, np_res, rtol=1e-04)
+    assert_allclose(dpnp_res, np_res)
 
 
 @pytest.mark.parametrize("axis", [0, 1])
@@ -910,14 +910,14 @@ def test_geomspace_axis(axis):
     func = lambda xp: xp.geomspace([2, 3], [20, 15], num=10, axis=axis)
     np_res = func(numpy)
     dpnp_res = func(dpnp)
-    assert_allclose(dpnp_res, np_res, rtol=1e-04)
+    assert_allclose(dpnp_res, np_res)
 
 
 def test_geomspace_num0():
     func = lambda xp: xp.geomspace(1, 10, num=0, endpoint=False)
     np_res = func(numpy)
     dpnp_res = func(dpnp)
-    assert_allclose(dpnp_res, np_res, rtol=1e-04)
+    assert_allclose(dpnp_res, np_res)
 
 
 @pytest.mark.parametrize("dtype", get_all_dtypes())
@@ -936,9 +936,9 @@ def test_logspace(dtype, num, endpoint):
     dpnp_res = func(dpnp)
 
     if dtype in [numpy.int64, numpy.int32]:
-        assert_allclose(dpnp_res, np_res, rtol=1)
+        assert_allclose(dpnp_res, np_res)
     else:
-        assert_allclose(dpnp_res, np_res, rtol=1e-04)
+        assert_allclose(dpnp_res, np_res)
 
 
 @pytest.mark.parametrize("axis", [0, 1])

--- a/dpnp/tests/test_arraymanipulation.py
+++ b/dpnp/tests/test_arraymanipulation.py
@@ -2,12 +2,7 @@ import dpctl.tensor as dpt
 import numpy
 import pytest
 from dpctl.tensor._numpy_helper import AxisError
-from numpy.testing import (
-    assert_allclose,
-    assert_array_equal,
-    assert_equal,
-    assert_raises,
-)
+from numpy.testing import assert_array_equal, assert_equal, assert_raises
 
 import dpnp
 
@@ -171,9 +166,7 @@ class TestBroadcastArray:
         dpnp_arrays = [dpnp.asarray(Xnp) for Xnp in np_arrays]
         out_dpnp_arrays = dpnp.broadcast_arrays(*dpnp_arrays)
         for Xnp, X in zip(out_np_arrays, out_dpnp_arrays):
-            assert_array_equal(
-                Xnp, dpnp.asnumpy(X), err_msg=f"Failed for {input_shapes})"
-            )
+            assert_array_equal(Xnp, X, err_msg=f"Failed for {input_shapes})")
 
     def assert_broadcast_arrays_raise(self, input_shapes):
         dpnp_arrays = [dpnp.asarray(numpy.zeros(s)) for s in input_shapes]
@@ -186,8 +179,8 @@ class TestBroadcastArray:
         X = dpnp.asarray(Xnp)
         Y = dpnp.asarray(Ynp)
         res_X, res_Y = dpnp.broadcast_arrays(X, Y)
-        assert_array_equal(res_Xnp, dpnp.asnumpy(res_X))
-        assert_array_equal(res_Ynp, dpnp.asnumpy(res_Y))
+        assert_array_equal(res_Xnp, res_X)
+        assert_array_equal(res_Ynp, res_Y)
 
     def test_broadcast_arrays_one_off(self):
         Xnp = numpy.array([[1, 2, 3]])
@@ -196,8 +189,8 @@ class TestBroadcastArray:
         X = dpnp.asarray(Xnp)
         Y = dpnp.asarray(Ynp)
         res_X, res_Y = dpnp.broadcast_arrays(X, Y)
-        assert_array_equal(res_Xnp, dpnp.asnumpy(res_X))
-        assert_array_equal(res_Ynp, dpnp.asnumpy(res_Y))
+        assert_array_equal(res_Xnp, res_X)
+        assert_array_equal(res_Ynp, res_Y)
 
     @pytest.mark.parametrize(
         "shapes",
@@ -327,7 +320,7 @@ class TestColumnStack:
 
         np_res = numpy.column_stack((np_a, np_b))
         dp_res = dpnp.column_stack((dp_a, dp_b))
-        assert_array_equal(dp_res.asnumpy(), np_res)
+        assert_array_equal(dp_res, np_res)
 
     def test_generator(self):
         with pytest.raises(TypeError, match="arrays to stack must be"):
@@ -350,7 +343,7 @@ class TestConcatenate:
 
         dp_res = dpnp.concatenate((dp_a, dp_a), axis=0)
         np_res = numpy.concatenate((np_a, np_a), axis=0)
-        assert_equal(dp_res.asnumpy(), np_res)
+        assert_equal(dp_res, np_res)
 
         for axis in [ndim, -(ndim + 1)]:
             assert_raises(AxisError, dpnp.concatenate, (dp_a, dp_a), axis=axis)
@@ -381,7 +374,7 @@ class TestConcatenate:
             # shapes must match except for concatenation axis
             np_res = numpy.concatenate((np_a, np_b), axis=axis[0])
             dp_res = dpnp.concatenate((dp_a, dp_b), axis=axis[0])
-            assert_equal(dp_res.asnumpy(), np_res)
+            assert_equal(dp_res, np_res)
 
             for i in range(1, 3):
                 assert_raises(
@@ -410,7 +403,7 @@ class TestConcatenate:
 
         np_res = numpy.concatenate((np_a, np_a), axis=None)
         dp_res = dpnp.concatenate((dp_a, dp_a), axis=None)
-        assert_equal(dp_res.asnumpy(), np_res)
+        assert_equal(dp_res, np_res)
 
     @pytest.mark.parametrize(
         "dtype", get_all_dtypes(no_bool=True, no_none=True)
@@ -422,7 +415,7 @@ class TestConcatenate:
 
         np_res = numpy.concatenate(np_a, axis=None)
         dp_res = dpnp.concatenate(dp_a, axis=None)
-        assert_array_equal(dp_res.asnumpy(), np_res)
+        assert_array_equal(dp_res, np_res)
 
         # numpy doesn't raise an exception here but probably should
         with pytest.raises(AxisError):
@@ -438,7 +431,7 @@ class TestConcatenate:
 
         np_res = numpy.concatenate((np_r4,))
         dp_res = dpnp.concatenate((dp_r4,))
-        assert_array_equal(dp_res.asnumpy(), np_res)
+        assert_array_equal(dp_res, np_res)
 
         # 1D default concatenation
         r3 = list(range(3))
@@ -447,17 +440,17 @@ class TestConcatenate:
 
         np_res = numpy.concatenate((np_r4, np_r3))
         dp_res = dpnp.concatenate((dp_r4, dp_r3))
-        assert_array_equal(dp_res.asnumpy(), np_res)
+        assert_array_equal(dp_res, np_res)
 
         # Explicit axis specification
         np_res = numpy.concatenate((np_r4, np_r3), axis=0)
         dp_res = dpnp.concatenate((dp_r4, dp_r3), axis=0)
-        assert_array_equal(dp_res.asnumpy(), np_res)
+        assert_array_equal(dp_res, np_res)
 
         # Including negative
         np_res = numpy.concatenate((np_r4, np_r3), axis=-1)
         dp_res = dpnp.concatenate((dp_r4, dp_r3), axis=-1)
-        assert_array_equal(dp_res.asnumpy(), np_res)
+        assert_array_equal(dp_res, np_res)
 
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     def test_concatenate_2d(self, dtype):
@@ -469,16 +462,16 @@ class TestConcatenate:
 
         np_res = numpy.concatenate((np_a23, np_a13))
         dp_res = dpnp.concatenate((dp_a23, dp_a13))
-        assert_array_equal(dp_res.asnumpy(), np_res)
+        assert_array_equal(dp_res, np_res)
 
         np_res = numpy.concatenate((np_a23, np_a13), axis=0)
         dp_res = dpnp.concatenate((dp_a23, dp_a13), axis=0)
-        assert_array_equal(dp_res.asnumpy(), np_res)
+        assert_array_equal(dp_res, np_res)
 
         for axis in [1, -1]:
             np_res = numpy.concatenate((np_a23.T, np_a13.T), axis=axis)
             dp_res = dpnp.concatenate((dp_a23.T, dp_a13.T), axis=axis)
-            assert_array_equal(dp_res.asnumpy(), np_res)
+            assert_array_equal(dp_res, np_res)
 
         # Arrays much match shape
         assert_raises(
@@ -505,11 +498,11 @@ class TestConcatenate:
         for axis in [2, -1]:
             np_res = numpy.concatenate((np_a0, np_a1, np_a2), axis=axis)
             dp_res = dpnp.concatenate((dp_a0, dp_a1, dp_a2), axis=axis)
-            assert_array_equal(dp_res.asnumpy(), np_res)
+            assert_array_equal(dp_res, np_res)
 
         np_res = numpy.concatenate((np_a0.T, np_a1.T, np_a2.T), axis=0)
         dp_res = dpnp.concatenate((dp_a0.T, dp_a1.T, dp_a2.T), axis=0)
-        assert_array_equal(dp_res.asnumpy(), np_res)
+        assert_array_equal(dp_res, np_res)
 
     @pytest.mark.parametrize(
         "dtype", get_all_dtypes(no_bool=True, no_none=True)
@@ -531,8 +524,7 @@ class TestConcatenate:
         dp_res = dpnp.concatenate((dp_a0, dp_a1, dp_a2), axis=2, out=dp_out)
 
         assert dp_out is dp_res
-        assert_array_equal(dp_out.asnumpy(), np_out)
-        assert_array_equal(dp_res.asnumpy(), np_res)
+        assert_array_equal(dp_res, np_res)
 
     @pytest.mark.parametrize(
         "dtype", get_all_dtypes(no_bool=True, no_none=True)
@@ -548,7 +540,7 @@ class TestConcatenate:
         np_res = numpy.concatenate((np_a, np_a), axis=2, casting=casting)
         dp_res = dpnp.concatenate((dp_a, dp_a), axis=2, casting=casting)
 
-        assert_array_equal(dp_res.asnumpy(), np_res)
+        assert_array_equal(dp_res, np_res)
 
     def test_concatenate_out_dtype(self):
         x = dpnp.ones((5, 5))
@@ -576,7 +568,7 @@ class TestDims:
         dp_a = dpnp.array(0, dtype=dt)
         func = lambda xp, a: xp.broadcast_to(a, sh)
 
-        assert_allclose(func(numpy, np_a), func(dpnp, dp_a))
+        assert_array_equal(func(numpy, np_a), func(dpnp, dp_a))
 
     @pytest.mark.parametrize("dt", get_all_dtypes())
     @pytest.mark.parametrize(
@@ -587,7 +579,7 @@ class TestDims:
         dp_a = dpnp.ones(1, dtype=dt)
         func = lambda xp, a: xp.broadcast_to(a, sh)
 
-        assert_allclose(func(numpy, np_a), func(dpnp, dp_a))
+        assert_array_equal(func(numpy, np_a), func(dpnp, dp_a))
 
     @pytest.mark.parametrize("dt", get_all_dtypes(no_bool=True))
     @pytest.mark.parametrize(
@@ -598,7 +590,7 @@ class TestDims:
         dp_a = dpnp.arange(3, dtype=dt)
         func = lambda xp, a: xp.broadcast_to(a, sh)
 
-        assert_allclose(func(numpy, np_a), func(dpnp, dp_a))
+        assert_array_equal(func(numpy, np_a), func(dpnp, dp_a))
 
     @pytest.mark.parametrize("dt", get_all_dtypes())
     @pytest.mark.parametrize(
@@ -614,7 +606,7 @@ class TestDims:
         dp_a = dpnp.ones(sh1, dtype=dt)
         func = lambda xp, a: xp.broadcast_to(a, sh2)
 
-        assert_allclose(func(numpy, np_a), func(dpnp, dp_a))
+        assert_array_equal(func(numpy, np_a), func(dpnp, dp_a))
 
     @pytest.mark.parametrize("dt", get_all_dtypes())
     @pytest.mark.parametrize(
@@ -630,7 +622,7 @@ class TestDims:
         dp_a = dpnp.ones(sh1, dtype=dt)
         func = lambda xp, a: xp.broadcast_to(a, sh2)
 
-        assert_allclose(func(numpy, np_a), func(dpnp, dp_a))
+        assert_array_equal(func(numpy, np_a), func(dpnp, dp_a))
 
     @pytest.mark.parametrize(
         "sh1, sh2",
@@ -681,7 +673,7 @@ class TestDstack:
 
         np_res = numpy.dstack([np_a, np_b])
         dp_res = dpnp.dstack([dp_a, dp_b])
-        assert_array_equal(dp_res.asnumpy(), np_res)
+        assert_array_equal(dp_res, np_res)
 
     def test_generator(self):
         with pytest.raises(TypeError, match="arrays to stack must be"):
@@ -737,7 +729,7 @@ class TestMatrixtranspose:
     @pytest.mark.parametrize(
         "shape",
         [(3, 5), (4, 2), (2, 5, 2), (2, 3, 3, 6)],
-        ids=["(3,5)", "(4,2)", "(2,5,2)", "(2,3,3,6)"],
+        ids=["(3, 5)", "(4, 2)", "(2, 5, 2)", "(2, 3, 3, 6)"],
     )
     def test_matrix_transpose(self, dtype, shape):
         a = numpy.arange(numpy.prod(shape), dtype=dtype).reshape(shape)
@@ -746,7 +738,7 @@ class TestMatrixtranspose:
         expected = numpy.matrix_transpose(a)
         result = dpnp.matrix_transpose(dp_a)
 
-        assert_allclose(result, expected)
+        assert_array_equal(result, expected)
 
     @pytest.mark.parametrize(
         "shape",
@@ -760,7 +752,7 @@ class TestMatrixtranspose:
         expected = numpy.matrix_transpose(a)
         result = dpnp.matrix_transpose(dp_a)
 
-        assert_allclose(result, expected)
+        assert_array_equal(result, expected)
 
     def test_matrix_transpose_errors(self):
         a_dp = dpnp.array([[1, 2], [3, 4]], dtype="float32")
@@ -862,7 +854,7 @@ class TestStack:
 
         np_res = numpy.stack(np_arrays)
         dp_res = dpnp.stack(dp_arrays)
-        assert_array_equal(dp_res.asnumpy(), np_res)
+        assert_array_equal(dp_res, np_res)
 
     @pytest.mark.parametrize("dtype", get_all_dtypes())
     def test_1d_array_input(self, dtype):
@@ -873,19 +865,19 @@ class TestStack:
 
         np_res = numpy.stack((np_a, np_b))
         dp_res = dpnp.stack((dp_a, dp_b))
-        assert_array_equal(dp_res.asnumpy(), np_res)
+        assert_array_equal(dp_res, np_res)
 
         np_res = numpy.stack((np_a, np_b), axis=1)
         dp_res = dpnp.stack((dp_a, dp_b), axis=1)
-        assert_array_equal(dp_res.asnumpy(), np_res)
+        assert_array_equal(dp_res, np_res)
 
         np_res = numpy.stack(list([np_a, np_b]))
         dp_res = dpnp.stack(list([dp_a, dp_b]))
-        assert_array_equal(dp_res.asnumpy(), np_res)
+        assert_array_equal(dp_res, np_res)
 
         np_res = numpy.stack(numpy.array([np_a, np_b]))
         dp_res = dpnp.stack(dpnp.array([dp_a, dp_b]))
-        assert_array_equal(dp_res.asnumpy(), np_res)
+        assert_array_equal(dp_res, np_res)
 
     @pytest.mark.parametrize("axis", [0, 1, -1, -2])
     @pytest.mark.parametrize(
@@ -898,7 +890,7 @@ class TestStack:
 
         np_res = numpy.stack(np_arrays, axis=axis)
         dp_res = dpnp.stack(dp_arrays, axis=axis)
-        assert_array_equal(dp_res.asnumpy(), np_res)
+        assert_array_equal(dp_res, np_res)
 
     @pytest.mark.parametrize("axis", [2, -3])
     @pytest.mark.parametrize(
@@ -923,7 +915,7 @@ class TestStack:
 
         np_res = numpy.stack(np_arrays, axis=axis)
         dp_res = dpnp.stack(dp_arrays, axis=axis)
-        assert_array_equal(dp_res.asnumpy(), np_res)
+        assert_array_equal(dp_res, np_res)
 
     @pytest.mark.parametrize("dtype", get_all_dtypes())
     def test_empty_arrays_input(self, dtype):
@@ -933,11 +925,11 @@ class TestStack:
 
         np_res = numpy.stack(np_arrays)
         dp_res = dpnp.stack(dp_arrays)
-        assert_array_equal(dp_res.asnumpy(), np_res)
+        assert_array_equal(dp_res, np_res)
 
         np_res = numpy.stack(np_arrays, axis=1)
         dp_res = dpnp.stack(dp_arrays, axis=1)
-        assert_array_equal(dp_res.asnumpy(), np_res)
+        assert_array_equal(dp_res, np_res)
 
     @pytest.mark.parametrize("dtype", get_all_dtypes())
     def test_out(self, dtype):
@@ -953,8 +945,7 @@ class TestStack:
         dp_res = dpnp.stack((dp_a, dp_b), out=dp_out)
 
         assert dp_out is dp_res
-        assert_array_equal(dp_out.asnumpy(), np_out)
-        assert_array_equal(dp_res.asnumpy(), np_res)
+        assert_array_equal(dp_res, np_res)
 
     def test_empty_list_input(self):
         with pytest.raises(TypeError):
@@ -1000,7 +991,7 @@ class TestStack:
             (np_a, np_b), axis=1, casting="unsafe", dtype=dtype
         )
         dp_res = dpnp.stack((dp_a, dp_b), axis=1, casting="unsafe", dtype=dtype)
-        assert_array_equal(dp_res.asnumpy(), np_res)
+        assert_array_equal(dp_res, np_res)
 
     @pytest.mark.parametrize("arr_dtype", get_float_complex_dtypes())
     @pytest.mark.parametrize("dtype", [dpnp.bool, dpnp.int32, dpnp.int64])
@@ -1073,7 +1064,7 @@ class TestUnstack:
         dp_res = dpnp.unstack(dp_a)
         assert len(dp_res) == len(np_res)
         for dp_arr, np_arr in zip(dp_res, np_res):
-            assert_array_equal(dp_arr.asnumpy(), np_arr)
+            assert_array_equal(dp_arr, np_arr)
 
     @pytest.mark.parametrize("dtype", get_all_dtypes())
     def test_2d_array(self, dtype):
@@ -1084,7 +1075,7 @@ class TestUnstack:
         dp_res = dpnp.unstack(dp_a, axis=0)
         assert len(dp_res) == len(np_res)
         for dp_arr, np_arr in zip(dp_res, np_res):
-            assert_array_equal(dp_arr.asnumpy(), np_arr)
+            assert_array_equal(dp_arr, np_arr)
 
     @pytest.mark.parametrize("axis", [0, 1, -1])
     @pytest.mark.parametrize("dtype", get_all_dtypes())
@@ -1096,7 +1087,7 @@ class TestUnstack:
         dp_res = dpnp.unstack(dp_a, axis=axis)
         assert len(dp_res) == len(np_res)
         for dp_arr, np_arr in zip(dp_res, np_res):
-            assert_array_equal(dp_arr.asnumpy(), np_arr)
+            assert_array_equal(dp_arr, np_arr)
 
     @pytest.mark.parametrize("axis", [2, -3])
     @pytest.mark.parametrize("dtype", get_all_dtypes())

--- a/dpnp/tests/test_binary_ufuncs.py
+++ b/dpnp/tests/test_binary_ufuncs.py
@@ -806,7 +806,7 @@ class TestPower:
 
     @pytest.mark.parametrize("val_type", ALL_DTYPES)
     @pytest.mark.parametrize("data_type", ALL_DTYPES)
-    @pytest.mark.parametrize("val", [1.5, 1, 3], ids=["1.5", "1", "3"])
+    @pytest.mark.parametrize("val", [1.5, 1, 3])
     @pytest.mark.parametrize(
         "array",
         [

--- a/dpnp/tests/test_copy.py
+++ b/dpnp/tests/test_copy.py
@@ -2,10 +2,7 @@ import copy
 
 import numpy
 import pytest
-from numpy.testing import (
-    assert_allclose,
-    assert_equal,
-)
+from numpy.testing import assert_allclose, assert_equal
 
 import dpnp
 

--- a/dpnp/tests/test_fill.py
+++ b/dpnp/tests/test_fill.py
@@ -1,22 +1,21 @@
 import dpctl
-import numpy as np
 import pytest
 from dpctl.utils import ExecutionPlacementError
 from numpy.testing import assert_array_equal
 
-import dpnp as dnp
+import dpnp
 
 
 @pytest.mark.parametrize(
     "val, error",
     [
-        pytest.param(dnp.ones(2, dtype="i4"), ValueError, id="array"),
+        pytest.param(dpnp.ones(2, dtype="i4"), ValueError, id="array"),
         pytest.param(dict(), TypeError, id="dictionary"),
         pytest.param("0", TypeError, id="string"),
     ],
 )
 def test_fill_non_scalar(val, error):
-    a = dnp.ones(5, dtype="i4")
+    a = dpnp.ones(5, dtype="i4")
     with pytest.raises(error):
         a.fill(val)
 
@@ -25,18 +24,18 @@ def test_fill_compute_follows_data():
     q1 = dpctl.SyclQueue()
     q2 = dpctl.SyclQueue()
 
-    a = dnp.ones(5, dtype="i4", sycl_queue=q1)
-    val = dnp.ones((), dtype=a.dtype, sycl_queue=q2)
+    a = dpnp.ones(5, dtype="i4", sycl_queue=q1)
+    val = dpnp.ones((), dtype=a.dtype, sycl_queue=q2)
 
     with pytest.raises(ExecutionPlacementError):
         a.fill(val)
 
 
 def test_fill_strided_array():
-    a = dnp.zeros(100, dtype="i4")
+    a = dpnp.zeros(100, dtype="i4")
     b = a[::-2]
 
-    expected = dnp.tile(dnp.asarray([0, 1], dtype=a.dtype), 50)
+    expected = dpnp.tile(dpnp.asarray([0, 1], dtype=a.dtype), 50)
 
     b.fill(1)
     assert_array_equal(b, 1)
@@ -45,10 +44,10 @@ def test_fill_strided_array():
 
 @pytest.mark.parametrize("order", ["C", "F"])
 def test_fill_strided_2d_array(order):
-    a = dnp.zeros((10, 10), dtype="i4", order=order)
+    a = dpnp.zeros((10, 10), dtype="i4", order=order)
     b = a[::-2, ::2]
 
-    expected = dnp.copy(a)
+    expected = dpnp.copy(a)
     expected[::-2, ::2] = 1
 
     b.fill(1)
@@ -58,14 +57,14 @@ def test_fill_strided_2d_array(order):
 
 @pytest.mark.parametrize("order", ["C", "F"])
 def test_fill_memset(order):
-    a = dnp.ones((10, 10), dtype="i4", order=order)
+    a = dpnp.ones((10, 10), dtype="i4", order=order)
     a.fill(0)
 
     assert_array_equal(a, 0)
 
 
 def test_fill_float_complex_to_int():
-    a = dnp.ones((10, 10), dtype="i4")
+    a = dpnp.ones((10, 10), dtype="i4")
 
     a.fill(complex(2, 0))
     assert_array_equal(a, 2)
@@ -75,13 +74,13 @@ def test_fill_float_complex_to_int():
 
 
 def test_fill_complex_to_float():
-    a = dnp.ones((10, 10), dtype="f4")
+    a = dpnp.ones((10, 10), dtype="f4")
 
     a.fill(complex(2, 0))
     assert_array_equal(a, 2)
 
 
 def test_fill_bool():
-    a = dnp.full(5, fill_value=7, dtype="i4")
+    a = dpnp.full(5, fill_value=7, dtype="i4")
     a.fill(True)
     assert_array_equal(a, 1)

--- a/dpnp/tests/test_histogram.py
+++ b/dpnp/tests/test_histogram.py
@@ -2,7 +2,6 @@ import dpctl
 import numpy
 import pytest
 from numpy.testing import (
-    assert_,
     assert_allclose,
     assert_array_equal,
     assert_raises,
@@ -407,8 +406,8 @@ class TestHistogram:
 
         # floating-point computations correctly place edge cases
         for x, left, right in zip(v, left_edges, right_edges):
-            assert_(x >= left)
-            assert_(x < right)
+            assert x >= left
+            assert x < right
 
     @pytest.mark.skipif(not has_support_aspect64(), reason="fp64 required")
     def test_last_bin_inclusive_range(self):
@@ -612,7 +611,7 @@ class TestBincount:
 
         expected = numpy.bincount(np_a, minlength=minlength)
         result = dpnp.bincount(dpnp_a, minlength=minlength)
-        assert_allclose(expected, result)
+        assert_allclose(result, expected)
 
     @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     @pytest.mark.parametrize(
@@ -655,7 +654,7 @@ class TestBincount:
 
         expected = numpy.bincount(np_a, weights=np_weights)
         result = dpnp.bincount(dpnp_a, weights=dpnp_weights)
-        assert_allclose(expected, result)
+        assert_allclose(result, expected)
 
     @pytest.mark.parametrize(
         "data",
@@ -1109,5 +1108,5 @@ class TestHistogram2d:
             ix, iy, bins=bins_count
         )
         assert_array_equal(result_hist, expected_hist)
-        assert_allclose(result_edges_x, expected_edges_x, rtol=1e-6)
-        assert_allclose(result_edges_y, expected_edges_y, rtol=1e-6)
+        assert_allclose(result_edges_x, expected_edges_x)
+        assert_allclose(result_edges_y, expected_edges_y)

--- a/dpnp/tests/test_linalg.py
+++ b/dpnp/tests/test_linalg.py
@@ -240,12 +240,12 @@ class TestCholesky:
         # positive strides
         expected = numpy.linalg.cholesky(a_np[::2, ::2])
         result = dpnp.linalg.cholesky(a_dp[::2, ::2])
-        assert_allclose(expected, result, rtol=1e-3, atol=1e-4)
+        assert_allclose(result, expected)
 
         # negative strides
         expected = numpy.linalg.cholesky(a_np[::-2, ::-2])
         result = dpnp.linalg.cholesky(a_dp[::-2, ::-2])
-        assert_allclose(expected, result, rtol=1e-3, atol=1e-4)
+        assert_allclose(result, expected)
 
     @pytest.mark.parametrize(
         "shape",
@@ -257,7 +257,7 @@ class TestCholesky:
         ia = dpnp.array(a)
         result = dpnp.linalg.cholesky(ia)
         expected = numpy.linalg.cholesky(a)
-        assert_array_equal(expected, result)
+        assert_array_equal(result, expected)
 
     def test_cholesky_errors(self):
         a_dp = dpnp.array([[1, 2], [2, 5]], dtype="float32")
@@ -390,7 +390,7 @@ class TestDet:
         ia = dpnp.array(a)
         result = dpnp.linalg.det(ia)
         expected = numpy.linalg.det(a)
-        assert_allclose(expected, result)
+        assert_allclose(result, expected)
 
     def test_det_strides(self):
         a_np = numpy.array(
@@ -408,12 +408,12 @@ class TestDet:
         # positive strides
         expected = numpy.linalg.det(a_np[::2, ::2])
         result = dpnp.linalg.det(a_dp[::2, ::2])
-        assert_allclose(expected, result, rtol=1e-3, atol=1e-4)
+        assert_allclose(result, expected)
 
         # negative strides
         expected = numpy.linalg.det(a_np[::-2, ::-2])
         result = dpnp.linalg.det(a_dp[::-2, ::-2])
-        assert_allclose(expected, result, rtol=1e-3, atol=1e-4)
+        assert_allclose(result, expected)
 
     def test_det_empty(self):
         a = numpy.empty((0, 0, 2, 2), dtype=numpy.float32)
@@ -425,7 +425,7 @@ class TestDet:
         assert dpnp_det.dtype == np_det.dtype
         assert dpnp_det.shape == np_det.shape
 
-        assert_allclose(np_det, dpnp_det)
+        assert_allclose(dpnp_det, np_det)
 
     @pytest.mark.parametrize(
         "matrix",
@@ -453,7 +453,7 @@ class TestDet:
         expected = numpy.linalg.det(a_np)
         result = dpnp.linalg.det(a_dp)
 
-        assert_allclose(expected, result, rtol=1e-3, atol=1e-4)
+        assert_allclose(result, expected)
 
     # TODO: remove skipif when MKLD-13852 is resolved
     # _getrf_batch does not raise an error with singular matrices.
@@ -468,7 +468,7 @@ class TestDet:
         expected = numpy.linalg.det(a_np)
         result = dpnp.linalg.det(a_dp)
 
-        assert_allclose(expected, result, rtol=1e-3, atol=1e-4)
+        assert_allclose(result, expected)
 
     def test_det_errors(self):
         a_dp = dpnp.array([[1, 2], [3, 5]], dtype="float32")
@@ -1456,12 +1456,12 @@ class TestEinsum:
         # Use einsum to compare to not have difference due to sum round-offs:
         result1 = dpnp.einsum(",i->", s_dp, a_dp)
         result2 = dpnp.einsum("i->", s_dp * a_dp)
-        assert_array_equal(result1.asnumpy(), result2.asnumpy())
+        assert_array_equal(result1, result2)
 
         # contig + scalar -> scalar
         # Use einsum to compare to not have difference due to sum round-offs:
         result3 = dpnp.einsum("i,->", a_dp, s_dp)
-        assert_array_equal(result2.asnumpy(), result3.asnumpy())
+        assert_array_equal(result1, result2)
 
         # contig + contig + contig -> scalar
         a = numpy.array([0.5, 0.5, 0.25, 4.5, 3.0], dtype=dtype)
@@ -1709,12 +1709,12 @@ class TestInv:
         # positive strides
         expected = numpy.linalg.inv(a_np[::2, ::2])
         result = dpnp.linalg.inv(a_dp[::2, ::2])
-        assert_allclose(expected, result, rtol=1e-3, atol=1e-4)
+        assert_allclose(result, expected)
 
         # negative strides
         expected = numpy.linalg.inv(a_np[::-2, ::-2])
         result = dpnp.linalg.inv(a_dp[::-2, ::-2])
-        assert_allclose(expected, result, rtol=1e-3, atol=1e-4)
+        assert_allclose(result, expected)
 
     @pytest.mark.parametrize(
         "shape",
@@ -2065,7 +2065,7 @@ def test_matrix_transpose():
     expected = numpy.linalg.matrix_transpose(a)
     result = dpnp.linalg.matrix_transpose(a_dp)
 
-    assert_allclose(expected, result)
+    assert_allclose(result, expected)
 
     with assert_raises_regex(
         ValueError, "array must be at least 2-dimensional"
@@ -2452,9 +2452,9 @@ class TestQr:
                 )
             else:  # mode=="raw"
                 dpnp_q, dpnp_r = dpnp.linalg.qr(ia, mode)
-                assert_allclose(np_q, dpnp_q, atol=1e-4)
+                assert_allclose(dpnp_q, np_q, atol=1e-4)
         if mode in ("raw", "r"):
-            assert_allclose(np_r, dpnp_r, atol=1e-4)
+            assert_allclose(dpnp_r, np_r, atol=1e-4)
 
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
     @pytest.mark.parametrize(
@@ -2553,7 +2553,7 @@ class TestSolve:
         expected = numpy.linalg.solve(a_np, a_np)
         result = dpnp.linalg.solve(a_dp, a_dp)
 
-        assert_allclose(expected, result, rtol=1e-06)
+        assert_allclose(result, expected)
 
     @testing.with_requires("numpy>=2.0")
     @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
@@ -2626,12 +2626,12 @@ class TestSolve:
         # positive strides
         expected = numpy.linalg.solve(a_np[::2, ::2], b_np[::2])
         result = dpnp.linalg.solve(a_dp[::2, ::2], b_dp[::2])
-        assert_allclose(expected, result, rtol=1e-05)
+        assert_allclose(result, expected)
 
         # negative strides
         expected = numpy.linalg.solve(a_np[::-2, ::-2], b_np[::-2])
         result = dpnp.linalg.solve(a_dp[::-2, ::-2], b_dp[::-2])
-        assert_allclose(expected, result, rtol=1e-05)
+        assert_allclose(result, expected)
 
     @pytest.mark.parametrize(
         "matrix, vector",
@@ -2700,8 +2700,8 @@ class TestSlogdet:
         result = dpnp.linalg.slogdet(a_dp)
         sign_result, logdet_result = result.sign, result.logabsdet
 
-        assert_allclose(sign_expected, sign_result)
-        assert_allclose(logdet_expected, logdet_result, rtol=1e-3, atol=1e-4)
+        assert_allclose(sign_result, sign_expected)
+        assert_allclose(logdet_result, logdet_expected)
 
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
     def test_slogdet_3d(self, dtype):
@@ -2719,8 +2719,8 @@ class TestSlogdet:
         result = dpnp.linalg.slogdet(a_dp)
         sign_result, logdet_result = result.sign, result.logabsdet
 
-        assert_allclose(sign_expected, sign_result)
-        assert_allclose(logdet_expected, logdet_result, rtol=1e-3, atol=1e-4)
+        assert_allclose(sign_result, sign_expected)
+        assert_allclose(logdet_result, logdet_expected)
 
     def test_slogdet_strides(self):
         a_np = numpy.array(
@@ -2739,15 +2739,15 @@ class TestSlogdet:
         sign_expected, logdet_expected = numpy.linalg.slogdet(a_np[::2, ::2])
         result = dpnp.linalg.slogdet(a_dp[::2, ::2])
         sign_result, logdet_result = result.sign, result.logabsdet
-        assert_allclose(sign_expected, sign_result)
-        assert_allclose(logdet_expected, logdet_result, rtol=1e-3, atol=1e-4)
+        assert_allclose(sign_result, sign_expected)
+        assert_allclose(logdet_result, logdet_expected)
 
         # negative strides
         sign_expected, logdet_expected = numpy.linalg.slogdet(a_np[::-2, ::-2])
         result = dpnp.linalg.slogdet(a_dp[::-2, ::-2])
         sign_result, logdet_result = result.sign, result.logabsdet
-        assert_allclose(sign_expected, sign_result)
-        assert_allclose(logdet_expected, logdet_result, rtol=1e-3, atol=1e-4)
+        assert_allclose(sign_result, sign_expected)
+        assert_allclose(logdet_result, logdet_expected)
 
     @pytest.mark.parametrize(
         "matrix",
@@ -2776,8 +2776,8 @@ class TestSlogdet:
         result = dpnp.linalg.slogdet(a_dp)
         sign_result, logdet_result = result.sign, result.logabsdet
 
-        assert_allclose(sign_expected, sign_result)
-        assert_allclose(logdet_expected, logdet_result, rtol=1e-3, atol=1e-4)
+        assert_allclose(sign_result, sign_expected)
+        assert_allclose(logdet_result, logdet_expected)
 
     # TODO: remove skipif when MKLD-13852 is resolved
     # _getrf_batch does not raise an error with singular matrices.
@@ -2793,8 +2793,8 @@ class TestSlogdet:
         result = dpnp.linalg.slogdet(a_dp)
         sign_result, logdet_result = result.sign, result.logabsdet
 
-        assert_allclose(sign_expected, sign_result)
-        assert_allclose(logdet_expected, logdet_result, rtol=1e-3, atol=1e-4)
+        assert_allclose(sign_result, sign_expected)
+        assert_allclose(logdet_result, logdet_expected)
 
     def test_slogdet_errors(self):
         a_dp = dpnp.array([[1, 2], [3, 5]], dtype="float32")
@@ -2851,7 +2851,7 @@ class TestSvd:
                 dpnp_diag_s[..., i, i] = dp_s[..., i]
                 reconstructed = dpnp.dot(dp_u, dpnp.dot(dpnp_diag_s, dp_vt))
 
-            assert dpnp.allclose(dp_a, reconstructed, rtol=tol, atol=1e-4)
+            assert_allclose(dp_a, reconstructed, rtol=tol, atol=1e-4)
 
         assert_allclose(dp_s, np_s, rtol=tol, atol=1e-03)
 
@@ -2862,13 +2862,13 @@ class TestSvd:
                     np_vt[..., i, :] = -np_vt[..., i, :]
             for i in range(numpy.count_nonzero(np_s > tol)):
                 assert_allclose(
-                    dpnp.asnumpy(dp_u[..., :, i]),
+                    dp_u[..., :, i],
                     np_u[..., :, i],
                     rtol=tol,
                     atol=tol,
                 )
                 assert_allclose(
-                    dpnp.asnumpy(dp_vt[..., i, :]),
+                    dp_vt[..., i, :],
                     np_vt[..., i, :],
                     rtol=tol,
                     atol=tol,
@@ -3092,18 +3092,15 @@ class TestPinv:
         a = generate_random_numpy_array((5, 5))
         a_dp = dpnp.array(a)
 
-        self.get_tol(a_dp.dtype)
-        tol = self._tol
-
         # positive strides
         B = numpy.linalg.pinv(a[::2, ::2])
         B_dp = dpnp.linalg.pinv(a_dp[::2, ::2])
-        assert_allclose(B_dp, B, rtol=tol, atol=tol)
+        assert_allclose(B_dp, B)
 
         # negative strides
         B = numpy.linalg.pinv(a[::-2, ::-2])
         B_dp = dpnp.linalg.pinv(a_dp[::-2, ::-2])
-        assert_allclose(B_dp, B, rtol=tol, atol=tol)
+        assert_allclose(B_dp, B)
 
     def test_pinv_errors(self):
         a_dp = dpnp.array([[1, 2], [3, 4]], dtype="float32")

--- a/dpnp/tests/test_logic.py
+++ b/dpnp/tests/test_logic.py
@@ -25,8 +25,8 @@ class TestAllAny:
         assert_allclose(result, expected)
 
     @pytest.mark.parametrize("func", ["all", "any"])
-    @pytest.mark.parametrize("a_dtype", get_all_dtypes())
-    @pytest.mark.parametrize("out_dtype", get_all_dtypes())
+    @pytest.mark.parametrize("a_dtype", get_all_dtypes(no_none=True))
+    @pytest.mark.parametrize("out_dtype", get_all_dtypes(no_none=True))
     def test_all_any_out(self, func, a_dtype, out_dtype):
         dp_array = dpnp.array([[0, 1, 2], [3, 4, 0]], dtype=a_dtype)
         np_array = dpnp.asnumpy(dp_array)
@@ -546,7 +546,7 @@ def test_array_equiv(a, b):
     result = dpnp.array_equiv(dpnp.array(a), dpnp.array(b))
     expected = numpy.array_equiv(a, b)
 
-    assert_equal(expected, result)
+    assert_equal(result, expected)
 
 
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True))
@@ -558,12 +558,12 @@ def test_array_equiv_dtype(dtype):
     result = dpnp.array_equiv(dpnp.array(a), dpnp.array(b))
     expected = numpy.array_equiv(a, b)
 
-    assert_equal(expected, result)
+    assert_equal(result, expected)
 
     result = dpnp.array_equiv(dpnp.array(a), dpnp.array(c))
     expected = numpy.array_equiv(a, c)
 
-    assert_equal(expected, result)
+    assert_equal(result, expected)
 
 
 @pytest.mark.parametrize("a", [numpy.array([1, 2]), numpy.array([1, 1])])
@@ -572,7 +572,7 @@ def test_array_equiv_scalar(a):
     result = dpnp.array_equiv(dpnp.array(a), b)
     expected = numpy.array_equiv(a, b)
 
-    assert_equal(expected, result)
+    assert_equal(result, expected)
 
 
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True))
@@ -585,12 +585,12 @@ def test_array_equal_dtype(dtype, equal_nan):
     result = dpnp.array_equal(dpnp.array(a), dpnp.array(b), equal_nan=equal_nan)
     expected = numpy.array_equal(a, b, equal_nan=equal_nan)
 
-    assert_equal(expected, result)
+    assert_equal(result, expected)
 
     result = dpnp.array_equal(dpnp.array(a), dpnp.array(c), equal_nan=equal_nan)
     expected = numpy.array_equal(a, c, equal_nan=equal_nan)
 
-    assert_equal(expected, result)
+    assert_equal(result, expected)
 
 
 @pytest.mark.parametrize(
@@ -605,11 +605,11 @@ def test_array_equal_same_arr(a):
     expected = numpy.array_equal(a, a)
     b = dpnp.array(a)
     result = dpnp.array_equal(b, b)
-    assert_equal(expected, result)
+    assert_equal(result, expected)
 
     expected = numpy.array_equal(a, a, equal_nan=True)
     result = dpnp.array_equal(b, b, equal_nan=True)
-    assert_equal(expected, result)
+    assert_equal(result, expected)
 
 
 @pytest.mark.parametrize(
@@ -625,4 +625,4 @@ def test_array_equal_nan(a):
     b = numpy.array([1.0, 2.0])
     result = dpnp.array_equal(dpnp.array(a), dpnp.array(b), equal_nan=True)
     expected = numpy.array_equal(a, b, equal_nan=True)
-    assert_equal(expected, result)
+    assert_equal(result, expected)

--- a/dpnp/tests/test_nanfunctions.py
+++ b/dpnp/tests/test_nanfunctions.py
@@ -89,7 +89,7 @@ class TestNanArgmaxNanArgmin:
         if numpy.can_cast(out.dtype, numpy.intp, casting="safe"):
             result = getattr(dpnp, func)(ia, out=iout, axis=1)
             expected = getattr(numpy, func)(a, out=out, axis=1)
-            assert_array_equal(expected, result)
+            assert_array_equal(result, expected)
             assert result is iout
         else:
             assert_raises(TypeError, getattr(numpy, func), a, out=out, axis=1)
@@ -283,7 +283,7 @@ class TestNanMaxNanMin:
 
         result = getattr(dpnp, func)(ia, out=iout, axis=1)
         expected = getattr(numpy, func)(a, out=out, axis=1)
-        assert_array_equal(expected, result)
+        assert_array_equal(result, expected)
         assert result is iout
 
     @pytest.mark.parametrize("func", ["nanmax", "nanmin"])
@@ -390,7 +390,7 @@ class TestNanMean:
 
         result = dpnp.nanmean(dp_array)
         expected = numpy.nanmean(np_array)
-        assert_allclose(expected, result)
+        assert_allclose(result, expected)
 
     def test_nanmean_error(self):
         ia = dpnp.arange(5, dtype=dpnp.float32)
@@ -599,7 +599,7 @@ class TestNanProd:
 
         result = dpnp.nanprod(ia, out=iout, dtype=dtype, axis=1)
         expected = numpy.nanprod(a, out=out, dtype=dtype, axis=1)
-        assert_array_equal(expected, result)
+        assert_array_equal(result, expected)
         assert result is iout
 
     def test_nanprod_Error(self):

--- a/dpnp/tests/test_special.py
+++ b/dpnp/tests/test_special.py
@@ -8,9 +8,7 @@ import dpnp
 
 def test_erf():
     a = numpy.linspace(2.0, 3.0, num=10)
-    ia = dpnp.linspace(2.0, 3.0, num=10)
-
-    assert_allclose(a, ia)
+    ia = dpnp.array(a)
 
     expected = numpy.empty_like(a)
     for idx, val in enumerate(a):

--- a/dpnp/tests/test_statistics.py
+++ b/dpnp/tests/test_statistics.py
@@ -498,7 +498,7 @@ class TestCov:
         # unit weights
         expected = numpy.cov(a, fweights=freq, aweights=weights)
         result = dpnp.cov(ia, fweights=ifreq, aweights=iweights)
-        assert_allclose(result, expected)
+        assert_dtype_allclose(result, expected)
 
         a = numpy.array([[0, 2], [1, 1], [2, 0]])
         ia = dpnp.array(a)
@@ -586,7 +586,7 @@ class TestCov:
 
         expected = numpy.cov(a, rowvar=False)
         result = dpnp.cov(ia, rowvar=False)
-        assert_allclose(expected, result)
+        assert_allclose(result, expected)
 
     # numpy 2.2 properly transposes 2d array when rowvar=False
     @with_requires("numpy>=2.2")
@@ -597,7 +597,7 @@ class TestCov:
 
         expected = numpy.cov(a, ddof=0, rowvar=True)
         result = dpnp.cov(ia, ddof=0, rowvar=True)
-        assert_allclose(expected, result)
+        assert_allclose(result, expected)
 
 
 class TestMaxMin:
@@ -658,15 +658,14 @@ class TestMaxMin:
     @pytest.mark.parametrize("arr_dt", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize("out_dt", get_all_dtypes(no_none=True))
     def test_out_dtype(self, func, arr_dt, out_dt):
-        a = numpy.arange(12).reshape(2, 2, 3).astype(arr_dt)
+        low = 0 if dpnp.issubdtype(out_dt, dpnp.unsignedinteger) else -10
+        a = generate_random_numpy_array((2, 2, 3), dtype=arr_dt, low=low)
         out = numpy.zeros_like(a, shape=(2, 3), dtype=out_dt)
-
-        ia = dpnp.array(a)
-        iout = dpnp.array(out)
+        ia, iout = dpnp.array(a), dpnp.array(out)
 
         result = getattr(dpnp, func)(ia, out=iout, axis=1)
         expected = getattr(numpy, func)(a, out=out, axis=1)
-        assert_array_equal(result, expected)
+        assert_dtype_allclose(result, expected)
         assert result is iout
 
     @pytest.mark.parametrize("func", ["max", "min"])

--- a/dpnp/tests/test_sum.py
+++ b/dpnp/tests/test_sum.py
@@ -65,13 +65,13 @@ def test_sum(shape, dtype_in, dtype_out, transpose, keepdims, order):
         assert_dtype_allclose(dpnp_res, numpy_res, factor=16)
 
 
-@pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
+@pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True, no_bool=True))
 def test_sum_empty_out(dtype):
     a = dpnp.empty((1, 2, 0, 4), dtype=dtype)
     out = dpnp.ones((), dtype=dtype)
     res = a.sum(out=out)
-    assert_array_equal(out.asnumpy(), res.asnumpy())
-    assert_array_equal(out.asnumpy(), numpy.array(0, dtype=dtype))
+    assert out is res
+    assert_array_equal(out, numpy.array(0, dtype=dtype))
 
 
 @pytest.mark.parametrize("dtype", get_all_dtypes(no_complex=True, no_bool=True))
@@ -80,7 +80,7 @@ def test_sum_empty(dtype, axis):
     a = numpy.empty((1, 2, 0, 4), dtype=dtype)
     numpy_res = a.sum(axis=axis)
     dpnp_res = dpnp.array(a).sum(axis=axis)
-    assert_array_equal(numpy_res, dpnp_res.asnumpy())
+    assert_array_equal(numpy_res, dpnp_res)
 
 
 @pytest.mark.parametrize("dtype", get_float_dtypes())

--- a/dpnp/tests/test_umath.py
+++ b/dpnp/tests/test_umath.py
@@ -110,10 +110,7 @@ def test_umaths(test_cases):
         ):
             pytest.skip("numpy.ldexp doesn't have a loop for the input types")
 
-    # original
     expected = getattr(numpy, umath)(*args)
-
-    # DPNP
     result = getattr(dpnp, umath)(*iargs)
 
     assert_allclose(result, expected, rtol=1e-6)
@@ -129,7 +126,7 @@ def _get_numpy_arrays_1in_1out(func_name, dtype, range):
     low = range[0]
     high = range[1]
     size = range[2]
-    if dtype == numpy.bool_:
+    if dtype == dpnp.bool:
         np_array = numpy.arange(2, dtype=dtype)
         result = getattr(numpy, func_name)(np_array)
     elif dpnp.issubdtype(dtype, dpnp.complexfloating):
@@ -155,7 +152,7 @@ def _get_numpy_arrays_2in_1out(func_name, dtype, range):
     low = range[0]
     high = range[1]
     size = range[2]
-    if dtype == numpy.bool_:
+    if dtype == dpnp.bool:
         np_array1 = numpy.arange(2, dtype=dtype)
         np_array2 = numpy.arange(2, dtype=dtype)
         result = getattr(numpy, func_name)(np_array1, np_array2)
@@ -472,7 +469,7 @@ class TestLogAddExp2:
 
     @pytest.mark.parametrize(
         "dt",
-        [numpy.bool_, numpy.int32, numpy.int64, numpy.float32, numpy.float64],
+        [dpnp.bool, dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64],
     )
     def test_range(self, dt):
         a = numpy.array([1000000, -1000000, 1000200, -1000200], dtype=dt)
@@ -637,7 +634,7 @@ class TestSquare:
         )
 
         dp_array = dpnp.array(np_array)
-        out_dtype = numpy.int8 if dtype == numpy.bool_ else dtype
+        out_dtype = numpy.int8 if dtype == dpnp.bool else dtype
         dp_out = dpnp.empty(expected.shape, dtype=out_dtype)
         result = dpnp.square(dp_array, out=dp_out)
 


### PR DESCRIPTION
In this PR, `test_search.py`, `test_special.py`, `test_statistics.py`, and `test_umath.py` are updated. In particular, `strict=True` is added to `assert_array_euqal` to compare dtypes and shape of `dpnp` and `numpy` arrays. In addition, `assert_allclose` is replaced with `assert_dtype_allcloe` to compare array dtypes.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
