### PR TITLE
Resolve failures in tests while running with numpy 2.0

### DIFF
--- a/dpnp/tests/test_manipulation.py
+++ b/dpnp/tests/test_manipulation.py
@@ -1105,7 +1105,7 @@ class TestReshape:
         result = ia.reshape((2, 5))
         assert_array_equal(result, expected)
 
-    @testing.with_requires("numpy>=2.0")
+    @testing.with_requires("numpy>=2.1")
     def test_copy(self):
         a = numpy.arange(10).reshape(2, 5)
         ia = dpnp.array(a)

--- a/dpnp/tests/test_mathematical.py
+++ b/dpnp/tests/test_mathematical.py
@@ -2445,10 +2445,10 @@ class TestRoundingFuncs:
 
         assert result is dp_out
         # numpy.ceil, numpy.floor, numpy.trunc always return float dtype for
-        # NumPy < 2.0.0 while output has the dtype of input for NumPy >= 2.0.0
+        # NumPy < 2.1.0 while output has the dtype of input for NumPy >= 2.1.0
         # (dpnp follows the latter behavior except for boolean dtype where it
         # returns int8)
-        if numpy_version() < "2.0.0" or dtype == numpy.bool:
+        if numpy_version() < "2.1.0" or dtype == numpy.bool:
             check_type = False
         else:
             check_type = True

--- a/dpnp/tests/test_strides.py
+++ b/dpnp/tests/test_strides.py
@@ -101,9 +101,10 @@ def test_1arg(func, dtype, stride):
     result = getattr(dpnp, func)(ia)
     expected = getattr(numpy, func)(a)
 
-    # numpy.ceil, numpy.floor, numpy.trunc always return float dtype for NumPy < 2.0.0
-    # while for NumPy >= 2.0.0, output has the dtype of input (dpnp follows this behavior)
-    if numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0":
+    # numpy.ceil, numpy.floor, numpy.trunc always return float dtype for
+    # NumPy < 2.1.0 while for NumPy >= 2.1.0, output has the dtype of input
+    # (dpnp follows this behavior)
+    if numpy_version() < "2.1.0":
         check_type = False
     else:
         check_type = True


### PR DESCRIPTION
The PR proposes to resolve faults in dpnp tests when running towards numpy 2.0.
The affected tests assume numpy fixes released in 2.1 version, so the tests logic has to be updated to align with expected numpy behavior depending on the version used.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
