### PR TITLE
Resolve typos in the job for Clean up anaconda packages

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -675,7 +675,7 @@ jobs:
       - name: Checkout DPNP repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 1
+          fetch-depth: ${{ env.fetch-depth }}
 
       - name: Setup miniconda
         id: setup_miniconda
@@ -685,8 +685,8 @@ jobs:
           miniforge-version: latest
           use-mamba: 'true'
           conda-remove-defaults: 'true'
-          environment-file: ${{ env.upload-conda-pkg-env }}
-          activate-environment: ${{ env.upload-env-name }}
+          environment-file: ${{ env.cleanup-conda-pkg-env }}
+          activate-environment: ${{ env.cleanup-env-name }}
 
       - name: ReSetup miniconda
         if: steps.setup_miniconda.outcome == 'failure'


### PR DESCRIPTION
The PR update GitHub workflow with `Conda package` to resolve typos in `Clean up anaconda packages` job there.
There was empty string passed as a name of env file for miniconda resulting to incomplete environment created.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
