### PR TITLE
Reuse `dpnp.nan_to_num` in `dpnp.nansum` and `dpnp.nanprod`

### DIFF
--- a/dpnp/dpnp_iface_nanfunctions.py
+++ b/dpnp/dpnp_iface_nanfunctions.py
@@ -60,6 +60,31 @@ __all__ = [
 ]
 
 
+def _replace_nan_no_mask(a, val):
+    """
+    Replace NaNs in array `a` with `val`.
+
+    If `a` is of inexact type, make a copy of `a`, replace NaNs with
+    the `val` value, and return the copy together. If `a` is not of
+    inexact type, do nothing and return `a`.
+
+    Parameters
+    ----------
+    a : {dpnp.ndarray, usm_ndarray}
+        Input array.
+    val : float
+        NaN values are set to `val` before doing the operation.
+
+    Returns
+    -------
+    out : {dpnp.ndarray}
+        If `a` is of inexact type, return a copy of `a` with the NaNs
+        replaced by the fill value, otherwise return `a`.
+    """
+
+    return dpnp.nan_to_num(a, nan=val, posinf=dpnp.inf, neginf=-dpnp.inf)
+
+
 def _replace_nan(a, val):
     """
     Replace NaNs in array `a` with `val`.
@@ -315,7 +340,7 @@ def nancumprod(a, axis=None, dtype=None, out=None):
 
     """
 
-    a, _ = _replace_nan(a, 1)
+    a = _replace_nan_no_mask(a, 1.0)
     return dpnp.cumprod(a, axis=axis, dtype=dtype, out=out)
 
 
@@ -385,7 +410,7 @@ def nancumsum(a, axis=None, dtype=None, out=None):
 
     """
 
-    a, _ = _replace_nan(a, 0)
+    a = _replace_nan_no_mask(a, 0.0)
     return dpnp.cumsum(a, axis=axis, dtype=dtype, out=out)
 
 
@@ -884,7 +909,7 @@ def nanprod(
 
     """
 
-    a = dpnp.nan_to_num(a, nan=1.0, posinf=dpnp.inf, neginf=-dpnp.inf)
+    a = _replace_nan_no_mask(a, 1.0)
     return dpnp.prod(
         a,
         axis=axis,
@@ -988,7 +1013,7 @@ def nansum(
 
     """
 
-    a = dpnp.nan_to_num(a, nan=0.0, posinf=dpnp.inf, neginf=-dpnp.inf)
+    a = _replace_nan_no_mask(a, 0.0)
     return dpnp.sum(
         a,
         axis=axis,

--- a/dpnp/dpnp_iface_nanfunctions.py
+++ b/dpnp/dpnp_iface_nanfunctions.py
@@ -144,6 +144,11 @@ def nanargmax(a, axis=None, out=None, *, keepdims=False):
     the user is recommended to filter NaNs themselves and use `dpnp.argmax`
     on the filtered array.
 
+    Warning
+    -------
+    The results cannot be trusted if a slice contains only NaNs
+    and -Infs.
+
     Parameters
     ----------
     a : {dpnp.ndarray, usm_ndarray}
@@ -173,8 +178,6 @@ def nanargmax(a, axis=None, out=None, *, keepdims=False):
         values ignoring NaNs. The returned array must have the default array
         index data type.
         For all-NaN slices ``ValueError`` is raised.
-        Warning: the results cannot be trusted if a slice contains only NaNs
-        and -Infs.
 
     Limitations
     -----------
@@ -225,6 +228,11 @@ def nanargmin(a, axis=None, out=None, *, keepdims=False):
     the user is recommended to filter NaNs themselves and use `dpnp.argmax`
     on the filtered array.
 
+    Warning
+    -------
+    The results cannot be trusted if a slice contains only NaNs
+    and -Infs.
+
     Parameters
     ----------
     a : {dpnp.ndarray, usm_ndarray}
@@ -254,8 +262,6 @@ def nanargmin(a, axis=None, out=None, *, keepdims=False):
         values ignoring NaNs. The returned array must have the default array
         index data type.
         For all-NaN slices ``ValueError`` is raised.
-        Warning: the results cannot be trusted if a slice contains only NaNs
-        and Infs.
 
     Limitations
     -----------

--- a/dpnp/dpnp_iface_nanfunctions.py
+++ b/dpnp/dpnp_iface_nanfunctions.py
@@ -137,6 +137,13 @@ def nanargmax(a, axis=None, out=None, *, keepdims=False):
 
     For full documentation refer to :obj:`numpy.nanargmax`.
 
+    Warning
+    -------
+    This function synchronizes in order to test for all-NaN slices in the array.
+    This may harm performance in some applications. To avoid synchronization,
+    the user is recommended to filter NaNs themselves and use `dpnp.argmax`
+    on the filtered array.
+
     Parameters
     ----------
     a : {dpnp.ndarray, usm_ndarray}
@@ -210,6 +217,13 @@ def nanargmin(a, axis=None, out=None, *, keepdims=False):
     Returns the indices of the minimum values along an axis ignoring NaNs.
 
     For full documentation refer to :obj:`numpy.nanargmin`.
+
+    Warning
+    -------
+    This function synchronizes in order to test for all-NaN slices in the array.
+    This may harm performance in some applications. To avoid synchronization,
+    the user is recommended to filter NaNs themselves and use `dpnp.argmax`
+    on the filtered array.
 
     Parameters
     ----------

--- a/dpnp/dpnp_iface_nanfunctions.py
+++ b/dpnp/dpnp_iface_nanfunctions.py
@@ -884,7 +884,7 @@ def nanprod(
 
     """
 
-    a, _ = _replace_nan(a, 1)
+    a = dpnp.nan_to_num(a, nan=1.0, posinf=dpnp.inf, neginf=-dpnp.inf)
     return dpnp.prod(
         a,
         axis=axis,
@@ -988,7 +988,7 @@ def nansum(
 
     """
 
-    a, _ = _replace_nan(a, 0)
+    a = dpnp.nan_to_num(a, nan=0.0, posinf=dpnp.inf, neginf=-dpnp.inf)
     return dpnp.sum(
         a,
         axis=axis,

--- a/dpnp/dpnp_iface_nanfunctions.py
+++ b/dpnp/dpnp_iface_nanfunctions.py
@@ -65,8 +65,8 @@ def _replace_nan_no_mask(a, val):
     Replace NaNs in array `a` with `val`.
 
     If `a` is of inexact type, make a copy of `a`, replace NaNs with
-    the `val` value, and return the copy together. If `a` is not of
-    inexact type, do nothing and return `a`.
+    the `val` value, and return the copy. If `a` is not of inexact type,
+    do nothing and return `a`.
 
     Parameters
     ----------
@@ -83,7 +83,11 @@ def _replace_nan_no_mask(a, val):
 
     """
 
-    return dpnp.nan_to_num(a, nan=val, posinf=dpnp.inf, neginf=-dpnp.inf)
+    dpnp.check_supported_arrays_type(a)
+    if dpnp.issubdtype(a.dtype, dpnp.inexact):
+        return dpnp.nan_to_num(a, nan=val, posinf=dpnp.inf, neginf=-dpnp.inf)
+
+    return a
 
 
 def _replace_nan(a, val):

--- a/dpnp/dpnp_iface_nanfunctions.py
+++ b/dpnp/dpnp_iface_nanfunctions.py
@@ -77,9 +77,10 @@ def _replace_nan_no_mask(a, val):
 
     Returns
     -------
-    out : {dpnp.ndarray}
+    out : dpnp.ndarray
         If `a` is of inexact type, return a copy of `a` with the NaNs
         replaced by the fill value, otherwise return `a`.
+
     """
 
     return dpnp.nan_to_num(a, nan=val, posinf=dpnp.inf, neginf=-dpnp.inf)


### PR DESCRIPTION
This PR proposes the use of `nan_to_num` over `_replace_nan` in `nansum`, `nanprod`, `nancumsum`, and `nancumprod` using new internal function `_replace_nan_no_mask`.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
