### PR TITLE
Remove Python 3.13 from the metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3.10
 Programming Language :: Python :: 3.11
 Programming Language :: Python :: 3.12
-Programming Language :: Python :: 3.13
 Programming Language :: Python :: Implementation :: CPython
 Topic :: Software Development
 Topic :: Scientific/Engineering


### PR DESCRIPTION
Python 3.13 is not officially supported yet.
Thus this PR removes it from the metadata for upcoming `0.17.0` release.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
