### PR TITLE
update `test_usm_type.py`

### DIFF
--- a/dpnp/tests/test_nanfunctions.py
+++ b/dpnp/tests/test_nanfunctions.py
@@ -25,12 +25,11 @@ from .helper import (
     has_support_aspect64,
     numpy_version,
 )
-from .third_party.cupy import testing
 from .third_party.cupy.testing import with_requires
 
 
+@pytest.mark.parametrize("func", ["nanargmin", "nanargmax"])
 class TestNanArgmaxNanArgmin:
-    @pytest.mark.parametrize("func", ["nanargmin", "nanargmax"])
     @pytest.mark.parametrize("axis", [None, 0, 1, -1, 2, -2])
     @pytest.mark.parametrize("keepdims", [False, True])
     @pytest.mark.parametrize("dtype", get_float_dtypes())
@@ -43,7 +42,6 @@ class TestNanArgmaxNanArgmin:
         dpnp_res = getattr(dpnp, func)(ia, axis=axis, keepdims=keepdims)
         assert_dtype_allclose(dpnp_res, np_res)
 
-    @pytest.mark.parametrize("func", ["nanargmin", "nanargmax"])
     def test_out(self, func):
         a = numpy.arange(12, dtype=numpy.float32).reshape((2, 2, 3))
         a[1, 0, 2] = numpy.nan
@@ -72,19 +70,12 @@ class TestNanArgmaxNanArgmin:
         with pytest.raises(ValueError):
             getattr(dpnp, func)(ia, axis=0, out=dpnp_res)
 
-    @pytest.mark.parametrize("func", ["nanargmin", "nanargmax"])
-    @pytest.mark.parametrize("arr_dt", get_all_dtypes(no_none=True))
+    @pytest.mark.parametrize("in_dt", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize("out_dt", get_all_dtypes(no_none=True))
-    def test_out_dtype(self, func, arr_dt, out_dt):
-        a = (
-            numpy.arange(12, dtype=numpy.float32)
-            .reshape((2, 2, 3))
-            .astype(dtype=arr_dt)
-        )
+    def test_out_dtype(self, func, in_dt, out_dt):
+        a = generate_random_numpy_array((2, 2, 3), dtype=in_dt)
         out = numpy.zeros_like(a, shape=(2, 3), dtype=out_dt)
-
-        ia = dpnp.array(a)
-        iout = dpnp.array(out)
+        ia, iout = dpnp.array(a), dpnp.array(out)
 
         if numpy.can_cast(out.dtype, numpy.intp, casting="safe"):
             result = getattr(dpnp, func)(ia, out=iout, axis=1)
@@ -95,7 +86,6 @@ class TestNanArgmaxNanArgmin:
             assert_raises(TypeError, getattr(numpy, func), a, out=out, axis=1)
             assert_raises(TypeError, getattr(dpnp, func), ia, out=iout, axis=1)
 
-    @pytest.mark.parametrize("func", ["nanargmin", "nanargmax"])
     def test_error(self, func):
         ia = dpnp.arange(12, dtype=dpnp.float32).reshape((2, 2, 3))
         ia[:, :, 2] = dpnp.nan
@@ -105,13 +95,7 @@ class TestNanArgmaxNanArgmin:
             getattr(dpnp, func)(ia, axis=0)
 
 
-@testing.parameterize(
-    *testing.product(
-        {
-            "func": ("nancumsum", "nancumprod"),
-        }
-    )
-)
+@pytest.mark.parametrize("func", ["nancumsum", "nancumprod"])
 class TestNanCumSumProd:
     @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
     @pytest.mark.parametrize(
@@ -119,48 +103,48 @@ class TestNanCumSumProd:
         [numpy.array(numpy.nan), numpy.full((3, 3), numpy.nan)],
         ids=["0d", "2d"],
     )
-    def test_allnans(self, dtype, array):
+    def test_allnans(self, func, dtype, array):
         a = numpy.array(array, dtype=dtype)
         ia = dpnp.array(a, dtype=dtype)
 
-        result = getattr(dpnp, self.func)(ia)
-        expected = getattr(numpy, self.func)(a)
+        result = getattr(dpnp, func)(ia)
+        expected = getattr(numpy, func)(a)
         assert_dtype_allclose(result, expected)
 
     @pytest.mark.parametrize("axis", [None, 0, 1])
-    def test_empty(self, axis):
+    def test_empty(self, func, axis):
         a = numpy.zeros((0, 3))
         ia = dpnp.array(a)
 
-        result = getattr(dpnp, self.func)(ia, axis=axis)
-        expected = getattr(numpy, self.func)(a, axis=axis)
+        result = getattr(dpnp, func)(ia, axis=axis)
+        expected = getattr(numpy, func)(a, axis=axis)
         assert_equal(result, expected)
 
     @pytest.mark.parametrize("axis", [None, 0, 1])
-    def test_keepdims(self, axis):
+    def test_keepdims(self, func, axis):
         a = numpy.eye(3)
         ia = dpnp.array(a)
 
-        result = getattr(dpnp, self.func)(ia, axis=axis, out=None)
-        expected = getattr(numpy, self.func)(a, axis=axis, out=None)
+        result = getattr(dpnp, func)(ia, axis=axis, out=None)
+        expected = getattr(numpy, func)(a, axis=axis, out=None)
         assert_equal(result, expected)
         assert result.ndim == expected.ndim
 
     @pytest.mark.parametrize("axis", [None] + list(range(4)))
-    def test_keepdims_random(self, axis):
+    def test_keepdims_random(self, func, axis):
         a = numpy.ones((3, 5, 7, 11))
         # Randomly set some elements to NaN:
         rs = numpy.random.RandomState(0)
         a[rs.rand(*a.shape) < 0.5] = numpy.nan
         ia = dpnp.array(a)
 
-        result = getattr(dpnp, self.func)(ia, axis=axis)
-        expected = getattr(numpy, self.func)(a, axis=axis)
+        result = getattr(dpnp, func)(ia, axis=axis)
+        expected = getattr(numpy, func)(a, axis=axis)
         assert_equal(result, expected)
 
     @pytest.mark.parametrize("axis", [-2, -1, 0, 1, None])
     @pytest.mark.parametrize("dtype", get_float_dtypes())
-    def test_ndat_ones(self, axis, dtype):
+    def test_ndat_ones(self, func, axis, dtype):
         a = numpy.array(
             [
                 [0.6244, 1.0, 0.2692, 0.0116, 1.0, 0.1170],
@@ -172,13 +156,13 @@ class TestNanCumSumProd:
         a = a.astype(dtype=dtype)
         ia = dpnp.array(a)
 
-        result = getattr(dpnp, self.func)(ia, axis=axis)
-        expected = getattr(numpy, self.func)(a, axis=axis)
+        result = getattr(dpnp, func)(ia, axis=axis)
+        expected = getattr(numpy, func)(a, axis=axis)
         assert_dtype_allclose(result, expected)
 
     @pytest.mark.parametrize("axis", [-2, -1, 0, 1, None])
     @pytest.mark.parametrize("dtype", get_float_dtypes())
-    def test_ndat_zeros(self, axis, dtype):
+    def test_ndat_zeros(self, func, axis, dtype):
         a = numpy.array(
             [
                 [0.6244, 0.0, 0.2692, 0.0116, 0.0, 0.1170],
@@ -190,26 +174,26 @@ class TestNanCumSumProd:
         a = a.astype(dtype=dtype)
         ia = dpnp.array(a)
 
-        result = getattr(dpnp, self.func)(ia, axis=axis)
-        expected = getattr(numpy, self.func)(a, axis=axis)
+        result = getattr(dpnp, func)(ia, axis=axis)
+        expected = getattr(numpy, func)(a, axis=axis)
         assert_dtype_allclose(result, expected)
 
     @pytest.mark.parametrize("axis", [-2, -1, 0, 1])
-    def test_out(self, axis):
+    def test_out(self, func, axis):
         a = numpy.eye(3)
         out = numpy.eye(3)
 
         ia = dpnp.array(a)
         iout = dpnp.array(out)
 
-        result = getattr(dpnp, self.func)(ia, axis=axis, out=iout)
-        expected = getattr(numpy, self.func)(a, axis=axis, out=out)
+        result = getattr(dpnp, func)(ia, axis=axis, out=iout)
+        expected = getattr(numpy, func)(a, axis=axis, out=out)
         assert_almost_equal(result, expected)
         assert result is iout
 
 
+@pytest.mark.parametrize("func", ["nanmax", "nanmin"])
 class TestNanMaxNanMin:
-    @pytest.mark.parametrize("func", ["nanmax", "nanmin"])
     @pytest.mark.parametrize("axis", [None, 0, 1, -1, 2, -2, (1, 2), (0, -2)])
     @pytest.mark.parametrize("keepdims", [False, True])
     @pytest.mark.parametrize("dtype", get_float_dtypes())
@@ -222,7 +206,6 @@ class TestNanMaxNanMin:
         dpnp_res = getattr(dpnp, func)(ia, axis=axis, keepdims=keepdims)
         assert_dtype_allclose(dpnp_res, np_res)
 
-    @pytest.mark.parametrize("func", ["nanmax", "nanmin"])
     @pytest.mark.parametrize("dtype", get_float_dtypes())
     def test_max_min_strided(self, func, dtype):
         a = numpy.arange(20, dtype=dtype)
@@ -237,7 +220,6 @@ class TestNanMaxNanMin:
         dpnp_res = getattr(dpnp, func)(ia[::2])
         assert_dtype_allclose(dpnp_res, np_res)
 
-    @pytest.mark.parametrize("func", ["nanmax", "nanmin"])
     def test_out(self, func):
         a = numpy.arange(12, dtype=numpy.float32).reshape((2, 2, 3))
         a[1, 0, 2] = numpy.nan
@@ -267,26 +249,18 @@ class TestNanMaxNanMin:
             getattr(dpnp, func)(ia, axis=0, out=dpnp_res)
 
     @pytest.mark.usefixtures("suppress_complex_warning")
-    @pytest.mark.parametrize("func", ["nanmax", "nanmin"])
-    @pytest.mark.parametrize("arr_dt", get_all_dtypes(no_none=True))
+    @pytest.mark.parametrize("in_dt", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize("out_dt", get_all_dtypes(no_none=True))
-    def test_out_dtype(self, func, arr_dt, out_dt):
-        a = (
-            numpy.arange(12, dtype=numpy.float32)
-            .reshape((2, 2, 3))
-            .astype(dtype=arr_dt)
-        )
+    def test_out_dtype(self, func, in_dt, out_dt):
+        a = generate_random_numpy_array((2, 2, 3), dtype=in_dt)
         out = numpy.zeros_like(a, shape=(2, 3), dtype=out_dt)
-
-        ia = dpnp.array(a)
-        iout = dpnp.array(out)
+        ia, iout = dpnp.array(a), dpnp.array(out)
 
         result = getattr(dpnp, func)(ia, out=iout, axis=1)
         expected = getattr(numpy, func)(a, out=out, axis=1)
         assert_array_equal(result, expected)
         assert result is iout
 
-    @pytest.mark.parametrize("func", ["nanmax", "nanmin"])
     def test_error(self, func):
         ia = dpnp.arange(5)
         # where is not supported
@@ -297,7 +271,6 @@ class TestNanMaxNanMin:
         with pytest.raises(NotImplementedError):
             getattr(dpnp, func)(ia, initial=6)
 
-    @pytest.mark.parametrize("func", ["nanmax", "nanmin"])
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
     def test_nanmax_nanmin_no_NaN(self, func, dtype):
         a = numpy.arange(768, dtype=dtype).reshape((4, 4, 6, 8))
@@ -307,7 +280,6 @@ class TestNanMaxNanMin:
         dpnp_res = getattr(dpnp, func)(ia, axis=0)
         assert_dtype_allclose(dpnp_res, np_res)
 
-    @pytest.mark.parametrize("func", ["nanmax", "nanmin"])
     def test_nanmax_nanmin_all_NaN(self, recwarn, func):
         a = numpy.arange(12, dtype=numpy.float32).reshape((2, 2, 3))
         a[:, :, 2] = numpy.nan
@@ -609,13 +581,7 @@ class TestNanProd:
             dpnp.nanprod(dpnp.asnumpy(ia))
 
 
-@testing.parameterize(
-    *testing.product(
-        {
-            "func": ("nanstd", "nanvar"),
-        }
-    )
-)
+@pytest.mark.parametrize("func", ["nanstd", "nanvar"])
 class TestNanStdVar:
     @pytest.mark.parametrize(
         "array",
@@ -658,7 +624,7 @@ class TestNanStdVar:
     @pytest.mark.parametrize(
         "dtype", get_all_dtypes(no_none=True, no_bool=True)
     )
-    def test_basic(self, array, dtype):
+    def test_basic(self, func, array, dtype):
         try:
             a = get_abs_array(array, dtype=dtype)
         except:
@@ -666,18 +632,18 @@ class TestNanStdVar:
         ia = dpnp.array(a)
 
         for ddof in range(a.ndim):
-            expected = getattr(numpy, self.func)(a, ddof=ddof)
-            result = getattr(dpnp, self.func)(ia, ddof=ddof)
+            expected = getattr(numpy, func)(a, ddof=ddof)
+            result = getattr(dpnp, func)(ia, ddof=ddof)
             assert_dtype_allclose(result, expected)
 
     @pytest.mark.parametrize("dtype", get_complex_dtypes())
-    def test_complex_dtype(self, dtype):
+    def test_complex(self, func, dtype):
         a = generate_random_numpy_array(10, dtype=dtype)
         a[::3] = numpy.nan
         ia = dpnp.array(a)
 
-        expected = getattr(numpy, self.func)(a)
-        result = getattr(dpnp, self.func)(ia)
+        expected = getattr(numpy, func)(a)
+        result = getattr(dpnp, func)(ia)
         assert_dtype_allclose(result, expected)
 
     @pytest.mark.usefixtures("suppress_dof_numpy_warnings")
@@ -685,13 +651,13 @@ class TestNanStdVar:
     @pytest.mark.parametrize("axis", [None, 0, 1, 2, (0, 1), (1, 2)])
     @pytest.mark.parametrize("keepdims", [True, False])
     @pytest.mark.parametrize("ddof", [0, 0.5, 1, 1.5, 2, 3])
-    def test_out_keyword(self, dtype, axis, keepdims, ddof):
+    def test_out(self, func, dtype, axis, keepdims, ddof):
         a = numpy.arange(4 * 3 * 5, dtype=dtype)
         a[::2] = numpy.nan
         a = a.reshape(4, 3, 5)
         ia = dpnp.array(a)
 
-        expected = getattr(numpy, self.func)(
+        expected = getattr(numpy, func)(
             a, axis=axis, ddof=ddof, keepdims=keepdims
         )
         if has_support_aspect64():
@@ -699,43 +665,43 @@ class TestNanStdVar:
         else:
             res_dtype = dpnp.default_float_type(ia.device)
         out = dpnp.empty(expected.shape, dtype=res_dtype)
-        result = getattr(dpnp, self.func)(
+        result = getattr(dpnp, func)(
             ia, out=out, axis=axis, ddof=ddof, keepdims=keepdims
         )
         assert result is out
         assert_dtype_allclose(result, expected)
 
     @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
-    def test_strided_array(self, dtype):
+    def test_strided_array(self, func, dtype):
         a = numpy.arange(20, dtype=dtype)
         a[::3] = numpy.nan
         ia = dpnp.array(a)
 
-        result = getattr(dpnp, self.func)(ia[::-1])
-        expected = getattr(numpy, self.func)(a[::-1])
+        result = getattr(dpnp, func)(ia[::-1])
+        expected = getattr(numpy, func)(a[::-1])
         assert_dtype_allclose(result, expected)
 
-        result = getattr(dpnp, self.func)(ia[::2])
-        expected = getattr(numpy, self.func)(a[::2])
+        result = getattr(dpnp, func)(ia[::2])
+        expected = getattr(numpy, func)(a[::2])
         assert_dtype_allclose(result, expected)
 
     @pytest.mark.usefixtures("suppress_complex_warning")
     @pytest.mark.parametrize("dt_in", get_float_complex_dtypes())
     @pytest.mark.parametrize("dt_out", get_float_complex_dtypes())
-    def test_dtype_keyword(self, dt_in, dt_out):
+    def test_dtype(self, func, dt_in, dt_out):
         a = numpy.arange(4 * 3 * 5, dtype=dt_in)
         a[::2] = numpy.nan
         a = a.reshape(4, 3, 5)
         ia = dpnp.array(a)
 
-        expected = getattr(numpy, self.func)(a, dtype=dt_out)
-        result = getattr(dpnp, self.func)(ia, dtype=dt_out)
+        expected = getattr(numpy, func)(a, dtype=dt_out)
+        result = getattr(dpnp, func)(ia, dtype=dt_out)
         assert_dtype_allclose(result, expected)
 
     @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
     @pytest.mark.parametrize("axis", [1, (0, 2), None])
     @pytest.mark.parametrize("keepdims", [True, False])
-    def test_mean_keyword(self, dtype, axis, keepdims):
+    def test_mean_keyword(self, func, dtype, axis, keepdims):
         a = generate_random_numpy_array((10, 20, 5), dtype)
         mask = numpy.random.choice([True, False], size=a.size, p=[0.3, 0.7])
         numpy.place(a, mask, numpy.nan)
@@ -745,56 +711,56 @@ class TestNanStdVar:
         imean = dpnp.nanmean(ia, axis=axis, keepdims=True)
 
         mean_kw = {"mean": mean} if numpy_version() >= "2.0.0" else {}
-        expected = getattr(numpy, self.func)(
+        expected = getattr(numpy, func)(
             a, axis=axis, keepdims=keepdims, **mean_kw
         )
-        result = getattr(dpnp, self.func)(
+        result = getattr(dpnp, func)(
             ia, axis=axis, keepdims=keepdims, mean=imean
         )
         assert_dtype_allclose(result, expected)
 
     @with_requires("numpy>=2.0")
-    def test_correction(self):
+    def test_correction(self, func):
         a = numpy.array([127, numpy.nan, numpy.nan, 39, 93, 87, numpy.nan, 46])
         ia = dpnp.array(a)
 
-        expected = getattr(numpy, self.func)(a, correction=0.5)
-        result = getattr(dpnp, self.func)(ia, correction=0.5)
+        expected = getattr(numpy, func)(a, correction=0.5)
+        result = getattr(dpnp, func)(ia, correction=0.5)
         assert_dtype_allclose(result, expected)
 
     @with_requires("numpy>=2.0")
     @pytest.mark.parametrize("xp", [dpnp, numpy])
-    def test_both_ddof_correction_are_set(self, xp):
+    def test_both_ddof_correction_are_set(self, func, xp):
         a = xp.array([5, xp.nan, -2])
 
         err_msg = "ddof and correction can't be provided simultaneously."
 
         with assert_raises_regex(ValueError, err_msg):
-            getattr(xp, self.func)(a, ddof=0.5, correction=0.5)
+            getattr(xp, func)(a, ddof=0.5, correction=0.5)
 
         with assert_raises_regex(ValueError, err_msg):
-            getattr(xp, self.func)(a, ddof=1, correction=0)
+            getattr(xp, func)(a, ddof=1, correction=0)
 
-    def test_error(self):
+    def test_error(self, func):
         ia = dpnp.arange(5, dtype=dpnp.float32)
         ia[0] = dpnp.nan
 
         # where keyword is not implemented
         with pytest.raises(NotImplementedError):
-            getattr(dpnp, self.func)(ia, where=False)
+            getattr(dpnp, func)(ia, where=False)
 
         # dtype should be floating
         with pytest.raises(TypeError):
-            getattr(dpnp, self.func)(ia, dtype=dpnp.int32)
+            getattr(dpnp, func)(ia, dtype=dpnp.int32)
 
         # out dtype should be inexact
         res = dpnp.empty((1,), dtype=dpnp.int32)
         with pytest.raises(TypeError):
-            getattr(dpnp, self.func)(ia, out=res)
+            getattr(dpnp, func)(ia, out=res)
 
         # ddof should be an integer or float
         with pytest.raises(TypeError):
-            getattr(dpnp, self.func)(ia, ddof="1")
+            getattr(dpnp, func)(ia, ddof="1")
 
 
 class TestNanSum:

--- a/dpnp/tests/test_nanfunctions.py
+++ b/dpnp/tests/test_nanfunctions.py
@@ -252,7 +252,12 @@ class TestNanMaxNanMin:
     @pytest.mark.parametrize("in_dt", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize("out_dt", get_all_dtypes(no_none=True))
     def test_out_dtype(self, func, in_dt, out_dt):
-        a = generate_random_numpy_array((2, 2, 3), dtype=in_dt)
+        # TODO: update to use generate_random_numpy_array
+        a = (
+            numpy.arange(12, dtype=numpy.float32)
+            .reshape((2, 2, 3))
+            .astype(dtype=in_dt)
+        )
         out = numpy.zeros_like(a, shape=(2, 3), dtype=out_dt)
         ia, iout = dpnp.array(a), dpnp.array(out)
 

--- a/dpnp/tests/test_statistics.py
+++ b/dpnp/tests/test_statistics.py
@@ -21,7 +21,6 @@ from .helper import (
     has_support_aspect64,
     numpy_version,
 )
-from .third_party.cupy import testing
 from .third_party.cupy.testing import with_requires
 
 
@@ -590,7 +589,6 @@ class TestCov:
 
     # numpy 2.2 properly transposes 2d array when rowvar=False
     @with_requires("numpy>=2.2")
-    @pytest.mark.usefixtures("allow_fall_back_on_numpy")
     def test_true_rowvar(self):
         a = numpy.ones((3, 1))
         ia = dpnp.array(a)
@@ -600,87 +598,81 @@ class TestCov:
         assert_allclose(result, expected)
 
 
-@testing.parameterize(
-    *testing.product(
-        {
-            "func": ("max", "min"),
-        }
-    )
-)
+@pytest.mark.parametrize("func", ["max", "min"])
 class TestMaxMin:
     @pytest.mark.parametrize("axis", [None, 0, 1, -1, 2, -2, (1, 2), (0, -2)])
     @pytest.mark.parametrize("keepdims", [False, True])
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
-    def test_func(self, axis, keepdims, dtype):
+    def test_func(self, func, axis, keepdims, dtype):
         a = numpy.arange(768, dtype=dtype).reshape((4, 4, 6, 8))
         ia = dpnp.array(a)
 
-        expected = getattr(numpy, self.func)(a, axis=axis, keepdims=keepdims)
-        result = getattr(dpnp, self.func)(ia, axis=axis, keepdims=keepdims)
+        expected = getattr(numpy, func)(a, axis=axis, keepdims=keepdims)
+        result = getattr(dpnp, func)(ia, axis=axis, keepdims=keepdims)
         assert_dtype_allclose(result, expected)
 
     @pytest.mark.parametrize("axis", [None, 0, 1, -1])
     @pytest.mark.parametrize("keepdims", [False, True])
-    def test_bool(self, axis, keepdims):
+    def test_bool(self, func, axis, keepdims):
         a = numpy.arange(2, dtype=numpy.bool_)
         a = numpy.tile(a, (2, 2))
         ia = dpnp.array(a)
 
-        expected = getattr(numpy, self.func)(a, axis=axis, keepdims=keepdims)
-        result = getattr(dpnp, self.func)(ia, axis=axis, keepdims=keepdims)
+        expected = getattr(numpy, func)(a, axis=axis, keepdims=keepdims)
+        result = getattr(dpnp, func)(ia, axis=axis, keepdims=keepdims)
         assert_dtype_allclose(result, expected)
 
-    def test_out(self):
+    def test_out(self, func):
         a = numpy.arange(12, dtype=numpy.float32).reshape((2, 2, 3))
         ia = dpnp.array(a)
 
         # out is dpnp_array
-        expected = getattr(numpy, self.func)(a, axis=0)
+        expected = getattr(numpy, func)(a, axis=0)
         dpnp_out = dpnp.empty(expected.shape, dtype=expected.dtype)
-        result = getattr(dpnp, self.func)(ia, axis=0, out=dpnp_out)
+        result = getattr(dpnp, func)(ia, axis=0, out=dpnp_out)
         assert dpnp_out is result
         assert_allclose(result, expected)
 
         # out is usm_ndarray
         dpt_out = dpt.empty(expected.shape, dtype=expected.dtype)
-        result = getattr(dpnp, self.func)(ia, axis=0, out=dpt_out)
+        result = getattr(dpnp, func)(ia, axis=0, out=dpt_out)
         assert dpt_out is result.get_array()
         assert_allclose(result, expected)
 
         # output is numpy array -> Error
         result = numpy.empty_like(expected)
         with pytest.raises(TypeError):
-            getattr(dpnp, self.func)(ia, axis=0, out=result)
+            getattr(dpnp, func)(ia, axis=0, out=result)
 
         # output has incorrect shape -> Error
         result = dpnp.array(numpy.zeros((4, 2)))
         with pytest.raises(ValueError):
-            getattr(dpnp, self.func)(ia, axis=0, out=result)
+            getattr(dpnp, func)(ia, axis=0, out=result)
 
     @pytest.mark.usefixtures("suppress_complex_warning")
     @pytest.mark.parametrize("arr_dt", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize("out_dt", get_all_dtypes(no_none=True))
-    def test_out_dtype(self, arr_dt, out_dt):
+    def test_out_dtype(self, func, arr_dt, out_dt):
         # if out_dt is unsigned, input cannot be signed otherwise overflow occurs
         low = 0 if dpnp.issubdtype(out_dt, dpnp.unsignedinteger) else -10
         a = generate_random_numpy_array((2, 2, 3), dtype=arr_dt, low=low)
         out = numpy.zeros_like(a, shape=(2, 3), dtype=out_dt)
         ia, iout = dpnp.array(a), dpnp.array(out)
 
-        result = getattr(dpnp, self.func)(ia, out=iout, axis=1)
-        expected = getattr(numpy, self.func)(a, out=out, axis=1)
+        result = getattr(dpnp, func)(ia, out=iout, axis=1)
+        expected = getattr(numpy, func)(a, out=out, axis=1)
         assert_dtype_allclose(result, expected)
         assert result is iout
 
-    def test_error(self):
+    def test_error(self, func):
         ia = dpnp.arange(5)
         # where is not supported
         with pytest.raises(NotImplementedError):
-            getattr(dpnp, self.func)(ia, where=False)
+            getattr(dpnp, func)(ia, where=False)
 
         # initial is not supported
         with pytest.raises(NotImplementedError):
-            getattr(dpnp, self.func)(ia, initial=6)
+            getattr(dpnp, func)(ia, initial=6)
 
 
 class TestMean:
@@ -894,13 +886,7 @@ class TestPtp:
         assert_array_equal(result, expected)
 
 
-@testing.parameterize(
-    *testing.product(
-        {
-            "func": ("std", "var"),
-        }
-    )
-)
+@pytest.mark.parametrize("func", ["std", "var"])
 class TestStdVar:
     @pytest.mark.usefixtures(
         "suppress_divide_invalid_numpy_warnings", "suppress_dof_numpy_warnings"
@@ -909,14 +895,14 @@ class TestStdVar:
     @pytest.mark.parametrize("axis", [0, 1, (0, 1)])
     @pytest.mark.parametrize("keepdims", [True, False])
     @pytest.mark.parametrize("ddof", [0, 0.5, 1, 1.5, 2])
-    def test_basic(self, dtype, axis, keepdims, ddof):
+    def test_basic(self, func, dtype, axis, keepdims, ddof):
         a = generate_random_numpy_array((2, 3), dtype)
         ia = dpnp.array(a)
 
-        expected = getattr(numpy, self.func)(
+        expected = getattr(numpy, func)(
             a, axis=axis, keepdims=keepdims, ddof=ddof
         )
-        result = getattr(dpnp, self.func)(
+        result = getattr(dpnp, func)(
             ia, axis=axis, keepdims=keepdims, ddof=ddof
         )
         if axis == 0 and ddof == 2:
@@ -930,18 +916,18 @@ class TestStdVar:
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize("axis", [0, 1])
     @pytest.mark.parametrize("ddof", [0, 1])
-    def test_out_keyword(self, dtype, axis, ddof):
+    def test_out(self, func, dtype, axis, ddof):
         a = generate_random_numpy_array((2, 3), dtype)
         ia = dpnp.array(a)
 
-        expected = getattr(numpy, self.func)(a, axis=axis, ddof=ddof)
+        expected = getattr(numpy, func)(a, axis=axis, ddof=ddof)
         if has_support_aspect64():
             res_dtype = expected.dtype
         else:
             res_dtype = dpnp.default_float_type(ia.device)
 
         out = dpnp.empty(expected.shape, dtype=res_dtype)
-        result = getattr(dpnp, self.func)(ia, axis=axis, out=out, ddof=ddof)
+        result = getattr(dpnp, func)(ia, axis=axis, out=out, ddof=ddof)
         assert result is out
         assert_dtype_allclose(result, expected)
 
@@ -950,30 +936,30 @@ class TestStdVar:
     )
     @pytest.mark.parametrize("axis", [None, 0, 1, (0, 1)])
     @pytest.mark.parametrize("shape", [(2, 3), (2, 0), (0, 3)])
-    def test_empty_array(self, axis, shape):
+    def test_empty(self, func, axis, shape):
         ia = dpnp.empty(shape, dtype=dpnp.int64)
         a = dpnp.asnumpy(ia)
 
-        expected = getattr(numpy, self.func)(a, axis=axis)
-        result = getattr(dpnp, self.func)(ia, axis=axis)
+        expected = getattr(numpy, func)(a, axis=axis)
+        result = getattr(dpnp, func)(ia, axis=axis)
         assert_dtype_allclose(result, expected)
 
     @pytest.mark.usefixtures("suppress_complex_warning")
     @pytest.mark.parametrize("dt_in", get_all_dtypes(no_bool=True))
     @pytest.mark.parametrize("dt_out", get_float_complex_dtypes())
-    def test_dtype_keyword(self, dt_in, dt_out):
+    def test_dtype(self, func, dt_in, dt_out):
         ia = dpnp.array([[0, 1, 2], [3, 4, 0]], dtype=dt_in)
         a = dpnp.asnumpy(ia)
 
-        expected = getattr(numpy, self.func)(a, dtype=dt_out)
-        result = getattr(dpnp, self.func)(ia, dtype=dt_out)
+        expected = getattr(numpy, func)(a, dtype=dt_out)
+        result = getattr(dpnp, func)(ia, dtype=dt_out)
         assert expected.dtype == result.dtype
         assert_allclose(result, expected, rtol=1e-6)
 
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize("axis", [1, (0, 2), None])
     @pytest.mark.parametrize("keepdims", [True, False])
-    def test_mean_keyword(self, dtype, axis, keepdims):
+    def test_mean_keyword(self, func, dtype, axis, keepdims):
         a = generate_random_numpy_array((10, 20, 5), dtype)
         ia = dpnp.array(a)
 
@@ -981,51 +967,47 @@ class TestStdVar:
         imean = dpnp.mean(ia, axis=axis, keepdims=True)
 
         mean_kw = {"mean": mean} if numpy_version() >= "2.0.0" else {}
-        expected = getattr(a, self.func)(
-            axis=axis, keepdims=keepdims, **mean_kw
-        )
-        result = getattr(ia, self.func)(
-            axis=axis, keepdims=keepdims, mean=imean
-        )
+        expected = getattr(a, func)(axis=axis, keepdims=keepdims, **mean_kw)
+        result = getattr(ia, func)(axis=axis, keepdims=keepdims, mean=imean)
         assert_dtype_allclose(result, expected)
 
-    def test_scalar(self):
+    def test_scalar(self, func):
         ia = dpnp.array(5)
         a = dpnp.asnumpy(ia)
 
-        expected = getattr(a, self.func)()
-        result = getattr(ia, self.func)()
+        expected = getattr(a, func)()
+        result = getattr(ia, func)()
         assert_dtype_allclose(result, expected)
 
     @with_requires("numpy>=2.0")
-    def test_correction(self):
+    def test_correction(self, func):
         a = numpy.array([1, -1, 1, -1])
         ia = dpnp.array(a)
 
         # numpy doesn't support `correction` keyword in std/var methods
-        expected = getattr(numpy, self.func)(a, correction=1)
-        result = getattr(ia, self.func)(correction=1)
+        expected = getattr(numpy, func)(a, correction=1)
+        result = getattr(ia, func)(correction=1)
         assert_dtype_allclose(result, expected)
 
     @with_requires("numpy>=2.0")
     @pytest.mark.parametrize("xp", [dpnp, numpy])
-    def test_both_ddof_correction_are_set(self, xp):
+    def test_both_ddof_correction_are_set(self, func, xp):
         a = xp.array([1, -1, 1, -1])
 
         err_msg = "ddof and correction can't be provided simultaneously."
 
         with assert_raises_regex(ValueError, err_msg):
-            getattr(xp, self.func)(a, ddof=1, correction=0)
+            getattr(xp, func)(a, ddof=1, correction=0)
 
         with assert_raises_regex(ValueError, err_msg):
-            getattr(xp, self.func)(a, ddof=1, correction=1)
+            getattr(xp, func)(a, ddof=1, correction=1)
 
-    def test_error(self):
+    def test_error(self, func):
         ia = dpnp.arange(5)
         # where keyword is not implemented
         with pytest.raises(NotImplementedError):
-            getattr(dpnp, self.func)(ia, where=False)
+            getattr(dpnp, func)(ia, where=False)
 
         # ddof should be an integer or float
         with pytest.raises(TypeError):
-            getattr(dpnp, self.func)(ia, ddof="1")
+            getattr(dpnp, func)(ia, ddof="1")

--- a/dpnp/tests/test_sycl_queue.py
+++ b/dpnp/tests/test_sycl_queue.py
@@ -1424,6 +1424,7 @@ def test_choose(device):
     assert_sycl_queue_equal(result.sycl_queue, chc.sycl_queue)
 
 
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 class TestLinAlgebra:
     @pytest.mark.parametrize(
         "data, is_empty",
@@ -1435,7 +1436,6 @@ class TestLinAlgebra:
         ],
         ids=["2D", "3D", "Empty_2D", "Empty_3D"],
     )
-    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_cholesky(self, data, is_empty, device):
         if is_empty:
             x = dpnp.empty(data, device=device)
@@ -1446,7 +1446,6 @@ class TestLinAlgebra:
         result = dpnp.linalg.cholesky(x)
         assert_sycl_queue_equal(result.sycl_queue, x.sycl_queue)
 
-    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     @pytest.mark.parametrize(
         "p", [None, -dpnp.inf, -2, -1, 1, 2, dpnp.inf, "fro"]
     )
@@ -1456,7 +1455,6 @@ class TestLinAlgebra:
         result = dpnp.linalg.cond(ia, p=p)
         assert_sycl_queue_equal(result.sycl_queue, ia.sycl_queue)
 
-    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_det(self, device):
         data = [[[1, 2], [3, 4]], [[1, 2], [2, 1]], [[1, 3], [3, 1]]]
         x = dpnp.array(data, device=device)
@@ -1469,7 +1467,6 @@ class TestLinAlgebra:
         [(4, 4), (0, 0), (2, 3, 3), (0, 2, 2), (1, 0, 0)],
         ids=["(4, 4)", "(0, 0)", "(2, 3, 3)", "(0, 2, 2)", "(1, 0, 0)"],
     )
-    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_eigenvalue(self, func, shape, device):
         dtype = dpnp.default_float_type(device)
         # Set a `hermitian` flag for generate_random_numpy_array() to
@@ -1498,7 +1495,6 @@ class TestLinAlgebra:
         ],
         ids=["(2, 2)", "(3, 2, 2)", "(0, 0)", "(0, 2, 2)"],
     )
-    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_inv(self, shape, is_empty, device):
         if is_empty:
             x = dpnp.empty(shape, device=device)
@@ -1512,7 +1508,6 @@ class TestLinAlgebra:
         result = dpnp.linalg.inv(x)
         assert_sycl_queue_equal(result.sycl_queue, x.sycl_queue)
 
-    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     @pytest.mark.parametrize(
         ["m", "n", "nrhs"],
         [(4, 2, 2), (4, 0, 1), (4, 2, 0), (0, 0, 0)],
@@ -1530,7 +1525,6 @@ class TestLinAlgebra:
             assert_sycl_queue_equal(param_queue, b.sycl_queue)
 
     @pytest.mark.parametrize("n", [-1, 0, 1, 2, 3])
-    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_matrix_power(self, n, device):
         x = dpnp.array([[1.0, 2.0], [3.0, 5.0]], device=device)
         result = dpnp.linalg.matrix_power(x, n)
@@ -1541,13 +1535,11 @@ class TestLinAlgebra:
         [([1, 2], None), ([[1, 2], [3, 4]], None), ([[1, 2], [3, 4]], 1e-06)],
         ids=["1-D array", "2-D array no tol", "2_d array with tol"],
     )
-    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_matrix_rank(self, data, tol, device):
         x = dpnp.array(data, device=device)
         result = dpnp.linalg.matrix_rank(x, tol=tol)
         assert_sycl_queue_equal(result.sycl_queue, x.sycl_queue)
 
-    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_multi_dot(self, device):
         array_list = []
         for num_array in [3, 5]:  # number of arrays in multi_dot
@@ -1559,7 +1551,6 @@ class TestLinAlgebra:
             _, exec_q = get_usm_allocations(array_list)
             assert_sycl_queue_equal(result.sycl_queue, exec_q)
 
-    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_multi_dot_out(self, device):
         array_list = []
         for num_array in [3, 5]:  # number of arrays in multi_dot
@@ -1573,7 +1564,6 @@ class TestLinAlgebra:
             _, exec_q = get_usm_allocations(array_list)
             assert_sycl_queue_equal(result.sycl_queue, exec_q)
 
-    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     @pytest.mark.parametrize(
         "ord", [None, -dpnp.inf, -2, -1, 1, 2, 3, dpnp.inf, "fro", "nuc"]
     )
@@ -1619,7 +1609,6 @@ class TestLinAlgebra:
             "(1, 0, 3)",
         ],
     )
-    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_pinv(self, shape, hermitian, rcond_as_array, device):
         dtype = dpnp.default_float_type(device)
         a = generate_random_numpy_array(shape, dtype, hermitian=hermitian)
@@ -1640,7 +1629,6 @@ class TestLinAlgebra:
         ids=["(4, 4)", "(2, 0)", "(2, 2, 3)", "(0, 2, 3)", "(1, 0, 3)"],
     )
     @pytest.mark.parametrize("mode", ["r", "raw", "complete", "reduced"])
-    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_qr(self, shape, mode, device):
         dtype = dpnp.default_float_type(device)
         count_elems = numpy.prod(shape)
@@ -1667,7 +1655,6 @@ class TestLinAlgebra:
         ],
         ids=["(2, 2)", "(3, 2, 2)", "(0, 0)", "(0, 2, 2)"],
     )
-    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_slogdet(self, shape, is_empty, device):
         if is_empty:
             x = dpnp.empty(shape, device=device)
@@ -1683,7 +1670,6 @@ class TestLinAlgebra:
         assert_sycl_queue_equal(sign_result.sycl_queue, x.sycl_queue)
         assert_sycl_queue_equal(logdet_result.sycl_queue, x.sycl_queue)
 
-    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     @pytest.mark.parametrize(
         "matrix, rhs",
         [
@@ -1710,7 +1696,6 @@ class TestLinAlgebra:
         assert_sycl_queue_equal(result.sycl_queue, a.sycl_queue)
         assert_sycl_queue_equal(result.sycl_queue, b.sycl_queue)
 
-    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     @pytest.mark.parametrize("full_matrices", [True, False])
     @pytest.mark.parametrize("compute_uv", [True, False])
     @pytest.mark.parametrize(
@@ -1759,13 +1744,11 @@ class TestLinAlgebra:
             )
             assert_sycl_queue_equal(dpnp_s.sycl_queue, expected_queue)
 
-    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_tensorinv(self, device):
         a = dpnp.eye(12, device=device).reshape(12, 4, 3)
         result = dpnp.linalg.tensorinv(a, ind=1)
         assert_sycl_queue_equal(result.sycl_queue, a.sycl_queue)
 
-    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_tensorsolve(self, device):
         a = dpnp.random.randn(3, 2, 6, device=device)
         b = dpnp.ones(a.shape[:2], device=device)

--- a/dpnp/tests/test_sycl_queue.py
+++ b/dpnp/tests/test_sycl_queue.py
@@ -520,17 +520,8 @@ def test_logic_op_2in(op, device):
     x2 = dpnp.array(
         [dpnp.inf, 1.0, 0.0, -1.0, -dpnp.inf, dpnp.nan], device=device
     )
-    # Remove NaN value from input arrays because numpy raises RuntimeWarning
-    if op in [
-        "greater",
-        "greater_equal",
-        "less",
-        "less_equal",
-    ]:
-        x1 = x1[:-1]
-        x2 = x2[:-1]
-    result = getattr(dpnp, op)(x1, x2)
 
+    result = getattr(dpnp, op)(x1, x2)
     assert_sycl_queue_equal(result.sycl_queue, x1.sycl_queue)
     assert_sycl_queue_equal(result.sycl_queue, x2.sycl_queue)
 
@@ -1020,7 +1011,6 @@ def test_from_dlpack(arr_dtype, shape, device):
         assert V.strides == W.strides
 
 
-@pytest.mark.usefixtures("suppress_invalid_numpy_warnings")
 @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 @pytest.mark.parametrize("arr_dtype", get_all_dtypes(no_float16=True))
 def test_from_dlpack_with_dpt(arr_dtype, device):
@@ -1583,7 +1573,6 @@ class TestLinAlgebra:
             _, exec_q = get_usm_allocations(array_list)
             assert_sycl_queue_equal(result.sycl_queue, exec_q)
 
-    @pytest.mark.usefixtures("suppress_divide_numpy_warnings")
     @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     @pytest.mark.parametrize(
         "ord", [None, -dpnp.inf, -2, -1, 1, 2, 3, dpnp.inf, "fro", "nuc"]

--- a/dpnp/tests/test_sycl_queue.py
+++ b/dpnp/tests/test_sycl_queue.py
@@ -977,29 +977,12 @@ def test_det(device):
 
 @pytest.mark.parametrize(
     "func",
-    [
-        "eig",
-        "eigvals",
-        "eigh",
-        "eigvalsh",
-    ],
+    ["eig", "eigvals", "eigh", "eigvalsh"],
 )
 @pytest.mark.parametrize(
     "shape",
-    [
-        (4, 4),
-        (0, 0),
-        (2, 3, 3),
-        (0, 2, 2),
-        (1, 0, 0),
-    ],
-    ids=[
-        "(4, 4)",
-        "(0, 0)",
-        "(2, 3, 3)",
-        "(0, 2, 2)",
-        "(1, 0, 0)",
-    ],
+    [(4, 4), (0, 0), (2, 3, 3), (0, 2, 2), (1, 0, 0)],
+    ids=["(4, 4)", "(0, 0)", "(2, 3, 3)", "(0, 2, 2)", "(1, 0, 0)"],
 )
 @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_eigenvalue(func, shape, device):
@@ -1023,18 +1006,8 @@ def test_eigenvalue(func, shape, device):
 
 @pytest.mark.parametrize(
     "shape, is_empty",
-    [
-        ((2, 2), False),
-        ((3, 2, 2), False),
-        ((0, 0), True),
-        ((0, 2, 2), True),
-    ],
-    ids=[
-        "(2, 2)",
-        "(3, 2, 2)",
-        "(0, 0)",
-        "(0, 2, 2)",
-    ],
+    [((2, 2), False), ((3, 2, 2), False), ((0, 0), True), ((0, 2, 2), True)],
+    ids=["(2, 2)", "(3, 2, 2)", "(0, 0)", "(0, 2, 2)"],
 )
 @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_inv(shape, is_empty, device):

--- a/dpnp/tests/test_sycl_queue.py
+++ b/dpnp/tests/test_sycl_queue.py
@@ -1044,19 +1044,18 @@ def test_concat_stack(func, data1, data2, device):
     assert_sycl_queue_equal(result.sycl_queue, x2.sycl_queue)
 
 
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 class TestDelete:
     @pytest.mark.parametrize(
         "obj",
         [slice(None, None, 2), 3, [2, 3]],
         ids=["slice", "scalar", "list"],
     )
-    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_delete(self, obj, device):
         x = dpnp.arange(5, device=device)
         result = dpnp.delete(x, obj)
         assert_sycl_queue_equal(result.sycl_queue, x.sycl_queue)
 
-    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_obj_ndarray(self, device):
         x = dpnp.arange(5, device=device)
         y = dpnp.array([1, 4], device=device)
@@ -1066,13 +1065,13 @@ class TestDelete:
         assert_sycl_queue_equal(result.sycl_queue, y.sycl_queue)
 
 
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 class TestInsert:
     @pytest.mark.parametrize(
         "obj",
         [slice(None, None, 2), 3, [2, 3]],
         ids=["slice", "scalar", "list"],
     )
-    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_basic(self, obj, device):
         x = dpnp.arange(5, device=device)
         result = dpnp.insert(x, obj, 3)
@@ -1083,7 +1082,6 @@ class TestInsert:
         [slice(None, None, 3), 3, [2, 3]],
         ids=["slice", "scalar", "list"],
     )
-    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_values_ndarray(self, obj, device):
         x = dpnp.arange(5, device=device)
         y = dpnp.array([1, 4], device=device)
@@ -1093,7 +1091,6 @@ class TestInsert:
         assert_sycl_queue_equal(result.sycl_queue, y.sycl_queue)
 
     @pytest.mark.parametrize("values", [-2, [-1, -2]], ids=["scalar", "list"])
-    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_obj_ndarray(self, values, device):
         x = dpnp.arange(5, device=device)
         y = dpnp.array([1, 4], device=device)
@@ -1102,7 +1099,6 @@ class TestInsert:
         assert_sycl_queue_equal(result.sycl_queue, x.sycl_queue)
         assert_sycl_queue_equal(result.sycl_queue, y.sycl_queue)
 
-    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_obj_values_ndarray(self, device):
         x = dpnp.arange(5, device=device)
         y = dpnp.array([1, 4], device=device)

--- a/dpnp/tests/test_sycl_queue.py
+++ b/dpnp/tests/test_sycl_queue.py
@@ -36,6 +36,8 @@ for device in available_devices:
     else:
         valid_dev.append(device)
 
+dev_ids = [device.filter_string for device in valid_dev]
+
 
 def assert_sycl_queue_equal(result, expected):
     assert result.backend == expected.backend
@@ -75,11 +77,7 @@ def assert_sycl_queue_equal(result, expected):
         pytest.param("zeros", [(2, 2)], {}),
     ],
 )
-@pytest.mark.parametrize(
-    "device",
-    valid_dev + [None],
-    ids=[dev.filter_string for dev in valid_dev] + [None],
-)
+@pytest.mark.parametrize("device", valid_dev + [None], ids=dev_ids + [None])
 def test_array_creation(func, arg, kwargs, device):
     kwargs = dict(kwargs)
     kwargs["device"] = device
@@ -113,9 +111,7 @@ def test_array_creation(func, arg, kwargs, device):
         pytest.param("zeros_like", ["x0"], {}),
     ],
 )
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_array_creation_follow_device(func, args, kwargs, device):
     x = dpnp.array([1, 2, 3, 4], device=device)
     dpnp_args = [eval(val, {"x0": x}) for val in args]
@@ -123,9 +119,7 @@ def test_array_creation_follow_device(func, args, kwargs, device):
     assert_sycl_queue_equal(y.sycl_queue, x.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_array_creation_follow_device_logspace_base(device):
     x = dpnp.array([1, 2, 3, 4], device=device)
     y = dpnp.logspace(0, 8, 4, base=x[1:3])
@@ -139,9 +133,7 @@ def test_array_creation_follow_device_logspace_base(device):
         pytest.param("diagflat", ["x0"], {}),
     ],
 )
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_array_creation_follow_device_2d_array(func, args, kwargs, device):
     x = dpnp.arange(9, device=device).reshape(3, 3)
     dpnp_args = [eval(val, {"x0": x}) for val in args]
@@ -164,12 +156,8 @@ def test_array_creation_follow_device_2d_array(func, args, kwargs, device):
         pytest.param("vander", ["x0"], {}),
     ],
 )
-@pytest.mark.parametrize(
-    "device_x", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
-@pytest.mark.parametrize(
-    "device_y", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device_x", valid_dev, ids=dev_ids)
+@pytest.mark.parametrize("device_y", valid_dev, ids=dev_ids)
 def test_array_creation_cross_device(func, args, kwargs, device_x, device_y):
     if func == "linspace" and is_win_platform():
         pytest.skip("CPU driver experiences an instability on Windows.")
@@ -193,12 +181,8 @@ def test_array_creation_cross_device(func, args, kwargs, device_x, device_y):
         pytest.param("diagflat", ["x0"], {}),
     ],
 )
-@pytest.mark.parametrize(
-    "device_x", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
-@pytest.mark.parametrize(
-    "device_y", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device_x", valid_dev, ids=dev_ids)
+@pytest.mark.parametrize("device_y", valid_dev, ids=dev_ids)
 def test_array_creation_cross_device_2d_array(
     func, args, kwargs, device_x, device_y
 ):
@@ -217,11 +201,7 @@ def test_array_creation_cross_device_2d_array(
     assert_sycl_queue_equal(y.sycl_queue, x.to_device(device_y).sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device",
-    valid_dev + [None],
-    ids=[dev.filter_string for dev in valid_dev] + [None],
-)
+@pytest.mark.parametrize("device", valid_dev + [None], ids=dev_ids + [None])
 def test_array_creation_from_file(device):
     with tempfile.TemporaryFile() as fh:
         fh.write(b"\x00\x01\x02\x03\x04\x05\x06\x07\x08")
@@ -236,11 +216,7 @@ def test_array_creation_from_file(device):
     assert x.sycl_device == device
 
 
-@pytest.mark.parametrize(
-    "device",
-    valid_dev + [None],
-    ids=[dev.filter_string for dev in valid_dev] + [None],
-)
+@pytest.mark.parametrize("device", valid_dev + [None], ids=dev_ids + [None])
 def test_array_creation_load_txt(device):
     with tempfile.TemporaryFile() as fh:
         fh.write(b"1 2 3 4")
@@ -255,12 +231,8 @@ def test_array_creation_load_txt(device):
     assert x.sycl_device == device
 
 
-@pytest.mark.parametrize(
-    "device_x", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
-@pytest.mark.parametrize(
-    "device_y", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device_x", valid_dev, ids=dev_ids)
+@pytest.mark.parametrize("device_y", valid_dev, ids=dev_ids)
 def test_copy_method(device_x, device_y):
     x = dpnp.array([[1, 2, 3], [4, 5, 6]], device=device_x)
     y = x.copy()
@@ -271,18 +243,14 @@ def test_copy_method(device_x, device_y):
     assert_sycl_queue_equal(y.sycl_queue, q)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_copy_operation(device):
     x = dpnp.array([[1, 2, 3], [4, 5, 6]], device=device)
     y = copy.copy(x)
     assert_sycl_queue_equal(y.sycl_queue, x.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_extract(device):
     x = dpnp.arange(3, device=device)
     y = dpnp.array([True, False, True], device=device)
@@ -292,9 +260,7 @@ def test_extract(device):
     assert_sycl_queue_equal(result.sycl_queue, y.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_meshgrid(device):
     x = dpnp.arange(100, device=device)
     y = dpnp.arange(100, device=device)
@@ -422,9 +388,7 @@ def test_meshgrid(device):
         pytest.param("var", [1.0, 2.0, 4.0, 7.0]),
     ],
 )
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_1in_1out(func, data, device):
     x = dpnp.array(data, device=device)
     result = getattr(dpnp, func)(x)
@@ -564,9 +528,7 @@ def test_1in_1out(func, data, device):
         pytest.param("vdot", [3 + 2j, 4 + 1j, 5], [1, 2 + 3j, 3]),
     ],
 )
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_2in_1out(func, data1, data2, device):
     x1 = dpnp.array(data1, device=device)
     x2 = dpnp.array(data2, device=device)
@@ -598,9 +560,7 @@ def test_2in_1out(func, data1, data2, device):
         "logical_not",
     ],
 )
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_logic_op_1in(op, device):
     x = dpnp.array(
         [-dpnp.inf, -1.0, 0.0, 1.0, dpnp.inf, dpnp.nan], device=device
@@ -626,9 +586,7 @@ def test_logic_op_1in(op, device):
         "not_equal",
     ],
 )
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_logic_op_2in(op, device):
     x1 = dpnp.array(
         [-dpnp.inf, -1.0, 0.0, 1.0, dpnp.inf, dpnp.nan], device=device
@@ -657,9 +615,7 @@ def test_logic_op_2in(op, device):
         pytest.param("searchsorted", [11, 12, 13, 14, 15], 13),
     ],
 )
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_2in_with_scalar_1out(func, data, scalar, device):
     x1 = dpnp.array(data, device=device)
     result = getattr(dpnp, func)(x1, scalar)
@@ -691,9 +647,7 @@ def test_2in_with_scalar_1out(func, data, scalar, device):
         ),
     ],
 )
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_2in_broadcasting(func, data1, data2, device):
     x1 = dpnp.array(data1, device=device)
     x2 = dpnp.array(data2, device=device)
@@ -719,9 +673,7 @@ def test_2in_broadcasting(func, data1, data2, device):
         "subtract",
     ],
 )
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_2in_1out_diff_queue_but_equal_context(func, device):
     x1 = dpnp.arange(10)
     x2 = dpnp.arange(10, sycl_queue=dpctl.SyclQueue(device))[::-1]
@@ -729,9 +681,7 @@ def test_2in_1out_diff_queue_but_equal_context(func, device):
         getattr(dpnp, func)(x1, x2)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 @pytest.mark.parametrize(
     "shape1, shape2",
     [
@@ -767,9 +717,7 @@ def test_matmul(device, shape1, shape2):
     assert_sycl_queue_equal(result_queue, b.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 @pytest.mark.parametrize(
     "shape1, shape2",
     [
@@ -790,9 +738,7 @@ def test_matvec(device, shape1, shape2):
     assert_sycl_queue_equal(result_queue, b.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 @pytest.mark.parametrize(
     "shape1, shape2",
     [
@@ -813,9 +759,7 @@ def test_vecdot(device, shape1, shape2):
     assert_sycl_queue_equal(result_queue, b.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 @pytest.mark.parametrize(
     "shape1, shape2",
     [
@@ -860,9 +804,7 @@ def test_vecmat(device, shape1, shape2):
         ),
     ],
 )
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 @pytest.mark.parametrize("usm_type", ["host", "device", "shared"])
 def test_random(func, args, kwargs, device, usm_type):
     kwargs = {**kwargs, "device": device, "usm_type": usm_type}
@@ -903,9 +845,7 @@ def test_random(func, args, kwargs, device, usm_type):
         ),
     ],
 )
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 @pytest.mark.parametrize("usm_type", ["host", "device", "shared"])
 def test_random_state(func, args, kwargs, device, usm_type):
     kwargs = {**kwargs, "usm_type": usm_type}
@@ -929,9 +869,7 @@ def test_random_state(func, args, kwargs, device, usm_type):
     assert_sycl_queue_equal(res_array.sycl_queue, sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_modf(device):
     x = dpnp.array([0, 3.5], device=device)
     result1, result2 = dpnp.modf(x)
@@ -941,9 +879,7 @@ def test_modf(device):
     assert_sycl_queue_equal(result2.sycl_queue, expected_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_multi_dot(device):
     array_list = []
     for num_array in [3, 5]:  # number of arrays in multi_dot
@@ -956,9 +892,7 @@ def test_multi_dot(device):
         assert_sycl_queue_equal(result.sycl_queue, exec_q)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_einsum(device):
     array_list = []
     for _ in range(3):  # create arrays one by one
@@ -970,9 +904,7 @@ def test_einsum(device):
     assert_sycl_queue_equal(result.sycl_queue, exec_q)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_out_multi_dot(device):
     array_list = []
     for num_array in [3, 5]:  # number of arrays in multi_dot
@@ -987,9 +919,7 @@ def test_out_multi_dot(device):
         assert_sycl_queue_equal(result.sycl_queue, exec_q)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_pad(device):
     all_modes = [
         "constant",
@@ -1010,9 +940,7 @@ def test_pad(device):
         assert_sycl_queue_equal(result.sycl_queue, x.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_require(device):
     x = dpnp.arange(10, device=device).reshape(2, 5)
     result = dpnp.require(x, dtype="f4", requirements=["F"])
@@ -1023,9 +951,7 @@ def test_require(device):
     assert_sycl_queue_equal(result.sycl_queue, x.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_resize(device):
     x = dpnp.arange(10, device=device)
     result = dpnp.resize(x, (2, 5))
@@ -1036,18 +962,14 @@ class TestFft:
     @pytest.mark.parametrize(
         "func", ["fft", "ifft", "rfft", "irfft", "hfft", "ihfft"]
     )
-    @pytest.mark.parametrize(
-        "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-    )
+    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_fft(self, func, device):
         dtype = dpnp.float32 if func in ["rfft", "ihfft"] else dpnp.complex64
         x = dpnp.arange(20, dtype=dtype, device=device)
         result = getattr(dpnp.fft, func)(x)
         assert_sycl_queue_equal(result.sycl_queue, x.sycl_queue)
 
-    @pytest.mark.parametrize(
-        "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-    )
+    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_fftn(self, device):
         x = dpnp.arange(24, dtype=dpnp.complex64, device=device)
         x = x.reshape(2, 3, 4)
@@ -1058,9 +980,7 @@ class TestFft:
         result = dpnp.fft.ifftn(result)
         assert_sycl_queue_equal(result.sycl_queue, x.sycl_queue)
 
-    @pytest.mark.parametrize(
-        "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-    )
+    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_rfftn(self, device):
         x = dpnp.arange(24, dtype=dpnp.float32, device=device)
         x = x.reshape(2, 3, 4)
@@ -1072,11 +992,7 @@ class TestFft:
         assert_sycl_queue_equal(result.sycl_queue, x.sycl_queue)
 
     @pytest.mark.parametrize("func", ["fftfreq", "rfftfreq"])
-    @pytest.mark.parametrize(
-        "device",
-        valid_dev + [None],
-        ids=[dev.filter_string for dev in valid_dev] + [None],
-    )
+    @pytest.mark.parametrize("device", valid_dev + [None], ids=dev_ids + [None])
     def test_fftfreq(self, func, device):
         result = getattr(dpnp.fft, func)(10, 0.5, device=device)
 
@@ -1086,9 +1002,7 @@ class TestFft:
         assert result.sycl_device == device
 
     @pytest.mark.parametrize("func", ["fftshift", "ifftshift"])
-    @pytest.mark.parametrize(
-        "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-    )
+    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_fftshift(self, func, device):
         x = dpnp.fft.fftfreq(10, 0.5, device=device)
         result = getattr(dpnp.fft, func)(x)
@@ -1105,9 +1019,7 @@ class TestFft:
     ],
     ids=["2D", "3D", "Empty_2D", "Empty_3D"],
 )
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_cholesky(data, is_empty, device):
     if is_empty:
         x = dpnp.empty(data, device=device)
@@ -1119,9 +1031,7 @@ def test_cholesky(data, is_empty, device):
     assert_sycl_queue_equal(result.sycl_queue, x.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 @pytest.mark.parametrize("p", [None, -dpnp.inf, -2, -1, 1, 2, dpnp.inf, "fro"])
 def test_cond(device, p):
     a = generate_random_numpy_array((2, 4, 4))
@@ -1130,9 +1040,7 @@ def test_cond(device, p):
     assert_sycl_queue_equal(result.sycl_queue, ia.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_det(device):
     data = [[[1, 2], [3, 4]], [[1, 2], [2, 1]], [[1, 3], [3, 1]]]
     x = dpnp.array(data, device=device)
@@ -1166,9 +1074,7 @@ def test_det(device):
         "(1, 0, 0)",
     ],
 )
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_eigenvalue(func, shape, device):
     dtype = dpnp.default_float_type(device)
     # Set a `hermitian` flag for generate_random_numpy_array() to
@@ -1203,9 +1109,7 @@ def test_eigenvalue(func, shape, device):
         "(0, 2, 2)",
     ],
 )
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_inv(shape, is_empty, device):
     if is_empty:
         x = dpnp.empty(shape, device=device)
@@ -1221,9 +1125,7 @@ def test_inv(shape, is_empty, device):
 
 
 @pytest.mark.parametrize("n", [-1, 0, 1, 2, 3])
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_matrix_power(n, device):
     x = dpnp.array([[1.0, 2.0], [3.0, 5.0]], device=device)
     result = dpnp.linalg.matrix_power(x, n)
@@ -1243,9 +1145,7 @@ def test_matrix_power(n, device):
         "2_d array with tol",
     ],
 )
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_matrix_rank(data, tol, device):
     x = dpnp.array(data, device=device)
     result = dpnp.linalg.matrix_rank(x, tol=tol)
@@ -1253,9 +1153,7 @@ def test_matrix_rank(data, tol, device):
 
 
 @pytest.mark.usefixtures("suppress_divide_numpy_warnings")
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 @pytest.mark.parametrize(
     "ord", [None, -dpnp.inf, -2, -1, 1, 2, 3, dpnp.inf, "fro", "nuc"]
 )
@@ -1295,9 +1193,7 @@ def test_norm(device, ord, axis):
     ],
 )
 @pytest.mark.parametrize("mode", ["r", "raw", "complete", "reduced"])
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_qr(shape, mode, device):
     dtype = dpnp.default_float_type(device)
     count_elems = numpy.prod(shape)
@@ -1315,9 +1211,7 @@ def test_qr(shape, mode, device):
         assert_sycl_queue_equal(dp_r.sycl_queue, expected_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 @pytest.mark.parametrize("full_matrices", [True, False])
 @pytest.mark.parametrize("compute_uv", [True, False])
 @pytest.mark.parametrize(
@@ -1368,12 +1262,8 @@ def test_svd(shape, full_matrices, compute_uv, device):
 
 
 class TestToDevice:
-    @pytest.mark.parametrize(
-        "device_from", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-    )
-    @pytest.mark.parametrize(
-        "device_to", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-    )
+    @pytest.mark.parametrize("device_from", valid_dev, ids=dev_ids)
+    @pytest.mark.parametrize("device_to", valid_dev, ids=dev_ids)
     def test_basic(self, device_from, device_to):
         data = [1.0, 1.0, 1.0, 1.0, 1.0]
         x = dpnp.array(data, dtype=dpnp.float32, device=device_from)
@@ -1425,9 +1315,7 @@ class TestToDevice:
         assert_raises(TypeError, x.to_device, q_prof, stream=stream)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 @pytest.mark.parametrize(
     "func",
     [
@@ -1460,9 +1348,7 @@ def test_array_copy(device, func, device_param, queue_param):
 
 
 @pytest.mark.parametrize("copy", [True, False, None])
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_array_creation_from_dpctl(copy, device):
     dpt_data = dpt.ones((3, 3), device=device)
 
@@ -1472,9 +1358,7 @@ def test_array_creation_from_dpctl(copy, device):
     assert isinstance(result, dpnp_array)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 @pytest.mark.parametrize("arr_dtype", get_all_dtypes(no_float16=True))
 @pytest.mark.parametrize("shape", [tuple(), (2,), (3, 0, 1), (2, 2, 2)])
 def test_from_dlpack(arr_dtype, shape, device):
@@ -1491,9 +1375,7 @@ def test_from_dlpack(arr_dtype, shape, device):
 
 
 @pytest.mark.usefixtures("suppress_invalid_numpy_warnings")
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 @pytest.mark.parametrize("arr_dtype", get_all_dtypes(no_float16=True))
 def test_from_dlpack_with_dpt(arr_dtype, device):
     X = dpctl.tensor.empty((64,), dtype=arr_dtype, device=device)
@@ -1505,9 +1387,7 @@ def test_from_dlpack_with_dpt(arr_dtype, device):
     assert_sycl_queue_equal(X.sycl_queue, Y.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_broadcast_to(device):
     x = dpnp.arange(5, device=device)
     y = dpnp.broadcast_to(x, (3, 5))
@@ -1525,9 +1405,7 @@ def test_broadcast_to(device):
         pytest.param("vstack", [0, 1, 2, 3], [4, 5, 6, 7]),
     ],
 )
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_concat_stack(func, data1, data2, device):
     x1 = dpnp.array(data1, device=device)
     x2 = dpnp.array(data2, device=device)
@@ -1543,17 +1421,13 @@ class TestDelete:
         [slice(None, None, 2), 3, [2, 3]],
         ids=["slice", "scalar", "list"],
     )
-    @pytest.mark.parametrize(
-        "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-    )
+    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_delete(self, obj, device):
         x = dpnp.arange(5, device=device)
         result = dpnp.delete(x, obj)
         assert_sycl_queue_equal(result.sycl_queue, x.sycl_queue)
 
-    @pytest.mark.parametrize(
-        "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-    )
+    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_obj_ndarray(self, device):
         x = dpnp.arange(5, device=device)
         y = dpnp.array([1, 4], device=device)
@@ -1569,9 +1443,7 @@ class TestInsert:
         [slice(None, None, 2), 3, [2, 3]],
         ids=["slice", "scalar", "list"],
     )
-    @pytest.mark.parametrize(
-        "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-    )
+    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_basic(self, obj, device):
         x = dpnp.arange(5, device=device)
         result = dpnp.insert(x, obj, 3)
@@ -1582,9 +1454,7 @@ class TestInsert:
         [slice(None, None, 3), 3, [2, 3]],
         ids=["slice", "scalar", "list"],
     )
-    @pytest.mark.parametrize(
-        "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-    )
+    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_values_ndarray(self, obj, device):
         x = dpnp.arange(5, device=device)
         y = dpnp.array([1, 4], device=device)
@@ -1594,9 +1464,7 @@ class TestInsert:
         assert_sycl_queue_equal(result.sycl_queue, y.sycl_queue)
 
     @pytest.mark.parametrize("values", [-2, [-1, -2]], ids=["scalar", "list"])
-    @pytest.mark.parametrize(
-        "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-    )
+    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_obj_ndarray(self, values, device):
         x = dpnp.arange(5, device=device)
         y = dpnp.array([1, 4], device=device)
@@ -1605,9 +1473,7 @@ class TestInsert:
         assert_sycl_queue_equal(result.sycl_queue, x.sycl_queue)
         assert_sycl_queue_equal(result.sycl_queue, y.sycl_queue)
 
-    @pytest.mark.parametrize(
-        "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-    )
+    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
     def test_obj_values_ndarray(self, device):
         x = dpnp.arange(5, device=device)
         y = dpnp.array([1, 4], device=device)
@@ -1632,9 +1498,7 @@ class TestInsert:
         pytest.param("vsplit", [[1, 2, 3, 4], [1, 2, 3, 4]]),
     ],
 )
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_split(func, data1, device):
     x1 = dpnp.array(data1, device=device)
     result = getattr(dpnp, func)(x1, 2)
@@ -1642,39 +1506,29 @@ def test_split(func, data1, device):
     assert_sycl_queue_equal(result[1].sycl_queue, x1.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_apply_along_axis(device):
     x = dpnp.arange(9, device=device).reshape(3, 3)
     result = dpnp.apply_along_axis(dpnp.sum, 0, x)
     assert_sycl_queue_equal(result.sycl_queue, x.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_apply_over_axes(device):
     x = dpnp.arange(18, device=device).reshape(2, 3, 3)
     result = dpnp.apply_over_axes(dpnp.sum, x, [0, 1])
     assert_sycl_queue_equal(result.sycl_queue, x.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device_x", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
-@pytest.mark.parametrize(
-    "device_y", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device_x", valid_dev, ids=dev_ids)
+@pytest.mark.parametrize("device_y", valid_dev, ids=dev_ids)
 def test_asarray(device_x, device_y):
     x = dpnp.array([1, 2, 3], device=device_x)
     y = dpnp.asarray([x, x, x], device=device_y)
     assert_sycl_queue_equal(y.sycl_queue, x.to_device(device_y).sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 @pytest.mark.parametrize(
     "kwargs",
     [
@@ -1690,18 +1544,14 @@ def test_diff_scalar_append(device, kwargs):
     assert_sycl_queue_equal(result.sycl_queue, x.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_clip(device):
     x = dpnp.arange(10, device=device)
     y = dpnp.clip(x, 3, 7)
     assert_sycl_queue_equal(x.sycl_queue, y.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_take(device):
     x = dpnp.arange(5, device=device)
     ind = dpnp.array([0, 2, 4], device=device)
@@ -1720,9 +1570,7 @@ def test_take(device):
         ),
     ],
 )
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_take_along_axis(data, ind, axis, device):
     x = dpnp.array(data, device=device)
     ind = dpnp.array(ind, device=device)
@@ -1731,9 +1579,7 @@ def test_take_along_axis(data, ind, axis, device):
     assert_sycl_queue_equal(result.sycl_queue, x.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 @pytest.mark.parametrize("sparse", [True, False])
 def test_indices(device, sparse):
     sycl_queue = dpctl.SyclQueue(device)
@@ -1742,9 +1588,7 @@ def test_indices(device, sparse):
         assert_sycl_queue_equal(dpnp_array.sycl_queue, sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_nonzero(device):
     a = dpnp.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], device=device)
     x = dpnp.nonzero(a)
@@ -1752,19 +1596,18 @@ def test_nonzero(device):
         assert_sycl_queue_equal(x_el.sycl_queue, a.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev + [None], ids=dev_ids + [None])
 @pytest.mark.parametrize("func", ["mgrid", "ogrid"])
 def test_grid(device, func):
-    sycl_queue = dpctl.SyclQueue(device)
-    x = getattr(dpnp, func)(sycl_queue=sycl_queue)[0:4]
-    assert_sycl_queue_equal(x.sycl_queue, sycl_queue)
+    result = getattr(dpnp, func)(device=device)[0:4]
+
+    if device is None:
+        # assert against default device
+        device = dpctl.select_default_device()
+    assert result.sycl_device == device
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_where(device):
     ia = dpnp.array([[0, 1, 2], [0, 2, 4], [0, 3, 6]], device=device)
     result = dpnp.where(ia < 4, ia, -1)
@@ -1772,9 +1615,7 @@ def test_where(device):
     assert_sycl_queue_equal(result.sycl_queue, ia.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 @pytest.mark.parametrize(
     "matrix, rhs",
     [
@@ -1821,9 +1662,7 @@ def test_solve(matrix, rhs, device):
         "(0, 2, 2)",
     ],
 )
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_slogdet(shape, is_empty, device):
     if is_empty:
         x = dpnp.empty(shape, device=device)
@@ -1865,9 +1704,7 @@ def test_slogdet(shape, is_empty, device):
         "(1, 0, 3)",
     ],
 )
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_pinv(shape, hermitian, rcond_as_array, device):
     dtype = dpnp.default_float_type(device)
     a = generate_random_numpy_array(shape, dtype, hermitian=hermitian)
@@ -1883,18 +1720,14 @@ def test_pinv(shape, hermitian, rcond_as_array, device):
     assert_sycl_queue_equal(result.sycl_queue, ia.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_tensorinv(device):
     a = dpnp.eye(12, device=device).reshape(12, 4, 3)
     result = dpnp.linalg.tensorinv(a, ind=1)
     assert_sycl_queue_equal(result.sycl_queue, a.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_tensorsolve(device):
     a = dpnp.random.randn(3, 2, 6, device=device)
     b = dpnp.ones(a.shape[:2], device=device)
@@ -1902,9 +1735,7 @@ def test_tensorsolve(device):
     assert_sycl_queue_equal(result.sycl_queue, a.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 @pytest.mark.parametrize(
     ["m", "n", "nrhs"],
     [
@@ -1928,9 +1759,7 @@ def test_lstsq(m, n, nrhs, device):
 
 
 @pytest.mark.parametrize("wgt", [None, numpy.arange(7, 12)])
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_bincount(wgt, device):
     iv = dpnp.arange(5, device=device)
     iw = None if wgt is None else dpnp.array(wgt, sycl_queue=iv.sycl_queue)
@@ -1939,9 +1768,7 @@ def test_bincount(wgt, device):
 
 
 @pytest.mark.parametrize("wgt", [None, numpy.arange(7, 12)])
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_histogram(wgt, device):
     iv = dpnp.arange(5, device=device)
     iw = None if wgt is None else dpnp.array(wgt, sycl_queue=iv.sycl_queue)
@@ -1952,9 +1779,7 @@ def test_histogram(wgt, device):
 
 
 @pytest.mark.parametrize("wgt", [None, numpy.arange(7, 12)])
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_histogram2d(wgt, device):
     ix = dpnp.arange(5, device=device)
     iy = dpnp.arange(5, device=device)
@@ -1969,9 +1794,7 @@ def test_histogram2d(wgt, device):
 
 
 @pytest.mark.parametrize("wgt", [None, numpy.arange(7, 12)])
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_histogramdd(wgt, device):
     iv = dpnp.arange(5, device=device)
     iw = None if wgt is None else dpnp.array(wgt, sycl_queue=iv.sycl_queue)
@@ -1985,9 +1808,7 @@ def test_histogramdd(wgt, device):
 @pytest.mark.parametrize(
     "func", ["tril_indices_from", "triu_indices_from", "diag_indices_from"]
 )
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_tri_diag_indices_from(func, device):
     a = dpnp.ones((3, 3), device=device)
     res = getattr(dpnp, func)(a)
@@ -1998,9 +1819,7 @@ def test_tri_diag_indices_from(func, device):
 @pytest.mark.parametrize(
     "func", ["tril_indices", "triu_indices", "diag_indices"]
 )
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_tri_diag_indices(func, device):
     sycl_queue = dpctl.SyclQueue(device)
     res = getattr(dpnp, func)(4, sycl_queue=sycl_queue)
@@ -2009,9 +1828,7 @@ def test_tri_diag_indices(func, device):
 
 
 @pytest.mark.parametrize("mask_func", ["tril", "triu"])
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_mask_indices(mask_func, device):
     sycl_queue = dpctl.SyclQueue(device)
     res = dpnp.mask_indices(4, getattr(dpnp, mask_func), sycl_queue=sycl_queue)
@@ -2020,9 +1837,7 @@ def test_mask_indices(mask_func, device):
 
 
 @pytest.mark.parametrize("wgt", [None, numpy.arange(7, 12)])
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_histogram_bin_edges(wgt, device):
     iv = dpnp.arange(5, device=device)
     iw = None if wgt is None else dpnp.array(wgt, sycl_queue=iv.sycl_queue)
@@ -2030,12 +1845,8 @@ def test_histogram_bin_edges(wgt, device):
     assert_sycl_queue_equal(result_edges.sycl_queue, iv.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device_x", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
-@pytest.mark.parametrize(
-    "device_y", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device_x", valid_dev, ids=dev_ids)
+@pytest.mark.parametrize("device_y", valid_dev, ids=dev_ids)
 def test_astype(device_x, device_y):
     x = dpnp.array([1, 2, 3], dtype="i4", device=device_x)
     y = dpnp.astype(x, "f4")
@@ -2046,9 +1857,7 @@ def test_astype(device_x, device_y):
     assert_sycl_queue_equal(y.sycl_queue, sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_select(device):
     condlist = [dpnp.array([True, False], device=device)]
     choicelist = [dpnp.array([1, 2], device=device)]
@@ -2057,9 +1866,7 @@ def test_select(device):
 
 
 @pytest.mark.parametrize("axis", [None, 0, -1])
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_unique(axis, device):
     ia = dpnp.array([[1, 1], [2, 3]], device=device)
     result = dpnp.unique(ia, True, True, True, axis=axis)
@@ -2068,9 +1875,7 @@ def test_unique(axis, device):
 
 
 @pytest.mark.parametrize("copy", [True, False])
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_nan_to_num(copy, device):
     a = dpnp.array([-dpnp.nan, -1, 0, 1, dpnp.nan], device=device)
     result = dpnp.nan_to_num(a, copy=copy)
@@ -2079,9 +1884,7 @@ def test_nan_to_num(copy, device):
     assert copy == (result is not a)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 @pytest.mark.parametrize(
     ["to_end", "to_begin"],
     [
@@ -2102,9 +1905,7 @@ def test_ediff1d(device, to_end, to_begin):
     assert_sycl_queue_equal(res.sycl_queue, x.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_unravel_index(device):
     x = dpnp.array(2, device=device)
     result = dpnp.unravel_index(x, shape=(2, 2))
@@ -2112,21 +1913,15 @@ def test_unravel_index(device):
         assert_sycl_queue_equal(res.sycl_queue, x.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_ravel_index(device):
     x = dpnp.array([1, 0], device=device)
     result = dpnp.ravel_multi_index(x, (2, 2))
     assert_sycl_queue_equal(result.sycl_queue, x.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device_0", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
-@pytest.mark.parametrize(
-    "device_1", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device_0", valid_dev, ids=dev_ids)
+@pytest.mark.parametrize("device_1", valid_dev, ids=dev_ids)
 def test_ix(device_0, device_1):
     x0 = dpnp.array([0, 1], device=device_0)
     x1 = dpnp.array([2, 4], device=device_1)
@@ -2135,9 +1930,7 @@ def test_ix(device_0, device_1):
     assert_sycl_queue_equal(ixgrid[1].sycl_queue, x1.sycl_queue)
 
 
-@pytest.mark.parametrize(
-    "device", valid_dev, ids=[dev.filter_string for dev in valid_dev]
-)
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_choose(device):
     chc = dpnp.arange(5, dtype="i4", device=device)
     inds = dpnp.array([0, 1, 3], dtype="i4", device=device)

--- a/dpnp/tests/test_usm_type.py
+++ b/dpnp/tests/test_usm_type.py
@@ -788,13 +788,13 @@ def test_split(func, data1, usm_type):
     assert y[1].usm_type == usm_type
 
 
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 class TestDelete:
     @pytest.mark.parametrize(
         "obj",
         [slice(None, None, 2), 3, [2, 3]],
         ids=["slice", "scalar", "list"],
     )
-    @pytest.mark.parametrize("usm_type", list_of_usm_types)
     def test_delete(self, obj, usm_type):
         x = dpnp.arange(5, usm_type=usm_type)
         result = dpnp.delete(x, obj)
@@ -802,16 +802,15 @@ class TestDelete:
         assert x.usm_type == usm_type
         assert result.usm_type == usm_type
 
-    @pytest.mark.parametrize("usm_type_x", list_of_usm_types)
-    @pytest.mark.parametrize("usm_type_y", list_of_usm_types)
-    def test_obj_ndarray(self, usm_type_x, usm_type_y):
-        x = dpnp.arange(5, usm_type=usm_type_x)
-        y = dpnp.array([1, 4], usm_type=usm_type_y)
+    @pytest.mark.parametrize("usm_type_other", list_of_usm_types)
+    def test_obj_ndarray(self, usm_type, usm_type_other):
+        x = dpnp.arange(5, usm_type=usm_type)
+        y = dpnp.array([1, 4], usm_type=usm_type_other)
         z = dpnp.delete(x, y)
 
-        assert x.usm_type == usm_type_x
-        assert y.usm_type == usm_type_y
-        assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
+        assert x.usm_type == usm_type
+        assert y.usm_type == usm_type_other
+        assert z.usm_type == du.get_coerced_usm_type([usm_type, usm_type_other])
 
 
 @pytest.mark.parametrize("usm_type", list_of_usm_types)
@@ -829,8 +828,8 @@ def test_einsum(usm_type):
     assert result.usm_type == usm_type
 
 
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 class TestInsert:
-    @pytest.mark.parametrize("usm_type", list_of_usm_types)
     @pytest.mark.parametrize(
         "obj",
         [slice(None, None, 2), 3, [2, 3]],
@@ -848,43 +847,40 @@ class TestInsert:
         [slice(None, None, 3), 3, [2, 3]],
         ids=["slice", "scalar", "list"],
     )
-    @pytest.mark.parametrize("usm_type_x", list_of_usm_types)
-    @pytest.mark.parametrize("usm_type_y", list_of_usm_types)
-    def test_values_ndarray(self, obj, usm_type_x, usm_type_y):
-        x = dpnp.arange(5, usm_type=usm_type_x)
-        y = dpnp.array([1, 4], usm_type=usm_type_y)
+    @pytest.mark.parametrize("usm_type_other", list_of_usm_types)
+    def test_values_ndarray(self, obj, usm_type, usm_type_other):
+        x = dpnp.arange(5, usm_type=usm_type)
+        y = dpnp.array([1, 4], usm_type=usm_type_other)
         z = dpnp.insert(x, obj, y)
 
-        assert x.usm_type == usm_type_x
-        assert y.usm_type == usm_type_y
-        assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
+        assert x.usm_type == usm_type
+        assert y.usm_type == usm_type_other
+        assert z.usm_type == du.get_coerced_usm_type([usm_type, usm_type_other])
 
     @pytest.mark.parametrize("values", [-2, [-1, -2]], ids=["scalar", "list"])
-    @pytest.mark.parametrize("usm_type_x", list_of_usm_types)
-    @pytest.mark.parametrize("usm_type_y", list_of_usm_types)
-    def test_obj_ndarray(self, values, usm_type_x, usm_type_y):
-        x = dpnp.arange(5, usm_type=usm_type_x)
-        y = dpnp.array([1, 4], usm_type=usm_type_y)
+    @pytest.mark.parametrize("usm_type_other", list_of_usm_types)
+    def test_obj_ndarray(self, values, usm_type, usm_type_other):
+        x = dpnp.arange(5, usm_type=usm_type)
+        y = dpnp.array([1, 4], usm_type=usm_type_other)
         z = dpnp.insert(x, y, values)
 
-        assert x.usm_type == usm_type_x
-        assert y.usm_type == usm_type_y
-        assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
+        assert x.usm_type == usm_type
+        assert y.usm_type == usm_type_other
+        assert z.usm_type == du.get_coerced_usm_type([usm_type, usm_type_other])
 
-    @pytest.mark.parametrize("usm_type_x", list_of_usm_types)
     @pytest.mark.parametrize("usm_type_y", list_of_usm_types)
     @pytest.mark.parametrize("usm_type_z", list_of_usm_types)
-    def test_obj_values_ndarray(self, usm_type_x, usm_type_y, usm_type_z):
-        x = dpnp.arange(5, usm_type=usm_type_x)
+    def test_obj_values_ndarray(self, usm_type, usm_type_y, usm_type_z):
+        x = dpnp.arange(5, usm_type=usm_type)
         y = dpnp.array([1, 4], usm_type=usm_type_y)
         z = dpnp.array([-1, -3], usm_type=usm_type_z)
         res = dpnp.insert(x, y, z)
 
-        assert x.usm_type == usm_type_x
+        assert x.usm_type == usm_type
         assert y.usm_type == usm_type_y
         assert z.usm_type == usm_type_z
         assert res.usm_type == du.get_coerced_usm_type(
-            [usm_type_x, usm_type_y, usm_type_z]
+            [usm_type, usm_type_y, usm_type_z]
         )
 
 
@@ -1258,6 +1254,7 @@ def test_choose(usm_type_x, usm_type_ind):
     assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_ind])
 
 
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 class TestLinAlgebra:
     @pytest.mark.parametrize(
         "data, is_empty",
@@ -1269,7 +1266,6 @@ class TestLinAlgebra:
         ],
         ids=["2D", "3D", "Empty_2D", "Empty_3D"],
     )
-    @pytest.mark.parametrize("usm_type", list_of_usm_types)
     def test_cholesky(self, data, is_empty, usm_type):
         dtype = dpnp.default_float_type()
         if is_empty:
@@ -1280,7 +1276,6 @@ class TestLinAlgebra:
         result = dpnp.linalg.cholesky(x)
         assert x.usm_type == result.usm_type
 
-    @pytest.mark.parametrize("usm_type", list_of_usm_types)
     @pytest.mark.parametrize(
         "p", [None, -dpnp.inf, -2, -1, 1, 2, dpnp.inf, "fro"]
     )
@@ -1292,7 +1287,6 @@ class TestLinAlgebra:
         assert ia.usm_type == usm_type
         assert result.usm_type == usm_type
 
-    @pytest.mark.parametrize("usm_type", list_of_usm_types)
     @pytest.mark.parametrize(
         "shape, is_empty",
         [
@@ -1328,7 +1322,6 @@ class TestLinAlgebra:
         [(4, 4), (0, 0), (2, 3, 3), (0, 2, 2), (1, 0, 0)],
         ids=["(4, 4)", "(0, 0)", "(2, 3, 3)", "(0, 2, 2)", "(1, 0, 0)"],
     )
-    @pytest.mark.parametrize("usm_type", list_of_usm_types)
     def test_eigenvalue(self, func, shape, usm_type):
         # Set a `hermitian` flag for generate_random_numpy_array() to
         # get a symmetric array for eigh() and eigvalsh() or
@@ -1346,7 +1339,6 @@ class TestLinAlgebra:
 
         assert a.usm_type == dp_val.usm_type
 
-    @pytest.mark.parametrize("usm_type", list_of_usm_types)
     @pytest.mark.parametrize(
         "shape, is_empty",
         [
@@ -1371,26 +1363,24 @@ class TestLinAlgebra:
 
         assert x.usm_type == result.usm_type
 
-    @pytest.mark.parametrize("usm_type_a", list_of_usm_types)
-    @pytest.mark.parametrize("usm_type_b", list_of_usm_types)
+    @pytest.mark.parametrize("usm_type_other", list_of_usm_types)
     @pytest.mark.parametrize(
         ["m", "n", "nrhs"],
         [(4, 2, 2), (4, 0, 1), (4, 2, 0), (0, 0, 0)],
     )
-    def test_lstsq(self, m, n, nrhs, usm_type_a, usm_type_b):
-        a = dpnp.arange(m * n, usm_type=usm_type_a).reshape(m, n)
-        b = dpnp.ones((m, nrhs), usm_type=usm_type_b)
+    def test_lstsq(self, m, n, nrhs, usm_type, usm_type_other):
+        a = dpnp.arange(m * n, usm_type=usm_type).reshape(m, n)
+        b = dpnp.ones((m, nrhs), usm_type=usm_type_other)
         result = dpnp.linalg.lstsq(a, b)
 
-        assert a.usm_type == usm_type_a
-        assert b.usm_type == usm_type_b
+        assert a.usm_type == usm_type
+        assert b.usm_type == usm_type_other
         for param in result:
             assert param.usm_type == du.get_coerced_usm_type(
-                [usm_type_a, usm_type_b]
+                [usm_type, usm_type_other]
             )
 
     @pytest.mark.parametrize("n", [-1, 0, 1, 2, 3])
-    @pytest.mark.parametrize("usm_type", list_of_usm_types)
     def test_matrix_power(self, n, usm_type):
         a = dpnp.array([[1, 2], [3, 5]], usm_type=usm_type)
 
@@ -1406,14 +1396,12 @@ class TestLinAlgebra:
         ],
         ids=["1-D array", "2-D array no tol", "2_d array with tol"],
     )
-    @pytest.mark.parametrize("usm_type", list_of_usm_types)
     def test_matrix_rank(self, data, tol, usm_type):
         a = dpnp.array(data, usm_type=usm_type)
 
         result = dpnp.linalg.matrix_rank(a, tol=tol)
         assert a.usm_type == result.usm_type
 
-    @pytest.mark.parametrize("usm_type", list_of_usm_types)
     def test_multi_dot(self, usm_type):
         array_list = []
         for num_array in [3, 5]:  # number of arrays in multi_dot
@@ -1427,7 +1415,6 @@ class TestLinAlgebra:
             assert input_usm_type == usm_type
             assert result.usm_type == usm_type
 
-    @pytest.mark.parametrize("usm_type", list_of_usm_types)
     @pytest.mark.parametrize(
         "ord", [None, -dpnp.inf, -2, -1, 1, 2, 3, dpnp.inf, "fro", "nuc"]
     )
@@ -1449,7 +1436,6 @@ class TestLinAlgebra:
             assert ia.usm_type == usm_type
             assert result.usm_type == usm_type
 
-    @pytest.mark.parametrize("usm_type", list_of_usm_types)
     @pytest.mark.parametrize(
         "shape, hermitian",
         [
@@ -1476,7 +1462,6 @@ class TestLinAlgebra:
         result = dpnp.linalg.pinv(a, hermitian=hermitian)
         assert a.usm_type == result.usm_type
 
-    @pytest.mark.parametrize("usm_type", list_of_usm_types)
     @pytest.mark.parametrize(
         "shape",
         [(4, 4), (2, 0), (2, 2, 3), (0, 2, 3), (1, 0, 3)],
@@ -1496,7 +1481,6 @@ class TestLinAlgebra:
             assert a.usm_type == dp_q.usm_type
             assert a.usm_type == dp_r.usm_type
 
-    @pytest.mark.parametrize("usm_type", list_of_usm_types)
     @pytest.mark.parametrize(
         "shape, is_empty",
         [
@@ -1522,7 +1506,6 @@ class TestLinAlgebra:
         assert x.usm_type == sign.usm_type
         assert x.usm_type == logdet.usm_type
 
-    @pytest.mark.parametrize("usm_type_matrix", list_of_usm_types)
     @pytest.mark.parametrize("usm_type_rhs", list_of_usm_types)
     @pytest.mark.parametrize(
         "matrix, rhs",
@@ -1546,18 +1529,15 @@ class TestLinAlgebra:
             "3D_Matrix_and_3D_RHS",
         ],
     )
-    def test_solve(self, matrix, rhs, usm_type_matrix, usm_type_rhs):
-        x = dpnp.array(matrix, usm_type=usm_type_matrix)
+    def test_solve(self, matrix, rhs, usm_type, usm_type_rhs):
+        x = dpnp.array(matrix, usm_type=usm_type)
         y = dpnp.array(rhs, usm_type=usm_type_rhs)
         z = dpnp.linalg.solve(x, y)
 
-        assert x.usm_type == usm_type_matrix
+        assert x.usm_type == usm_type
         assert y.usm_type == usm_type_rhs
-        assert z.usm_type == du.get_coerced_usm_type(
-            [usm_type_matrix, usm_type_rhs]
-        )
+        assert z.usm_type == du.get_coerced_usm_type([usm_type, usm_type_rhs])
 
-    @pytest.mark.parametrize("usm_type", list_of_usm_types)
     @pytest.mark.parametrize("full_matrices_param", [True, False])
     @pytest.mark.parametrize("compute_uv_param", [True, False])
     @pytest.mark.parametrize(
@@ -1606,24 +1586,22 @@ class TestLinAlgebra:
 
         assert x.usm_type == s.usm_type
 
-    @pytest.mark.parametrize("usm_type", list_of_usm_types)
     def test_tensorinv(self, usm_type):
         a = dpnp.eye(12, usm_type=usm_type).reshape(12, 4, 3)
         ainv = dpnp.linalg.tensorinv(a, ind=1)
 
         assert a.usm_type == ainv.usm_type
 
-    @pytest.mark.parametrize("usm_type_a", list_of_usm_types)
-    @pytest.mark.parametrize("usm_type_b", list_of_usm_types)
-    def test_tensorsolve(self, usm_type_a, usm_type_b):
+    @pytest.mark.parametrize("usm_type_other", list_of_usm_types)
+    def test_tensorsolve(self, usm_type, usm_type_other):
         data = numpy.random.randn(3, 2, 6)
-        a = dpnp.array(data, usm_type=usm_type_a)
-        b = dpnp.ones(a.shape[:2], dtype=a.dtype, usm_type=usm_type_b)
+        a = dpnp.array(data, usm_type=usm_type)
+        b = dpnp.ones(a.shape[:2], dtype=a.dtype, usm_type=usm_type_other)
 
         result = dpnp.linalg.tensorsolve(a, b)
 
-        assert a.usm_type == usm_type_a
-        assert b.usm_type == usm_type_b
+        assert a.usm_type == usm_type
+        assert b.usm_type == usm_type_other
         assert result.usm_type == du.get_coerced_usm_type(
-            [usm_type_a, usm_type_b]
+            [usm_type, usm_type_other]
         )

--- a/dpnp/tests/test_usm_type.py
+++ b/dpnp/tests/test_usm_type.py
@@ -17,7 +17,7 @@ list_of_usm_types = ["device", "shared", "host"]
 
 @pytest.mark.parametrize("usm_type_x", list_of_usm_types)
 @pytest.mark.parametrize("usm_type_y", list_of_usm_types)
-def test_coerced_usm_types_add(usm_type_x, usm_type_y):
+def test_add(usm_type_x, usm_type_y):
     x = dpnp.arange(1000, usm_type=usm_type_x)
     y = dpnp.arange(1000, usm_type=usm_type_y)
 
@@ -34,7 +34,7 @@ def test_coerced_usm_types_add(usm_type_x, usm_type_y):
 
 @pytest.mark.parametrize("usm_type_x", list_of_usm_types)
 @pytest.mark.parametrize("usm_type_y", list_of_usm_types)
-def test_coerced_usm_types_mul(usm_type_x, usm_type_y):
+def test_multiply(usm_type_x, usm_type_y):
     x = dpnp.arange(10, usm_type=usm_type_x)
     y = dpnp.arange(10, usm_type=usm_type_y)
 
@@ -51,7 +51,7 @@ def test_coerced_usm_types_mul(usm_type_x, usm_type_y):
 
 @pytest.mark.parametrize("usm_type_x", list_of_usm_types)
 @pytest.mark.parametrize("usm_type_y", list_of_usm_types)
-def test_coerced_usm_types_subtract(usm_type_x, usm_type_y):
+def test_subtract(usm_type_x, usm_type_y):
     x = dpnp.arange(50, usm_type=usm_type_x)
     y = dpnp.arange(50, usm_type=usm_type_y)
 
@@ -68,7 +68,7 @@ def test_coerced_usm_types_subtract(usm_type_x, usm_type_y):
 
 @pytest.mark.parametrize("usm_type_x", list_of_usm_types)
 @pytest.mark.parametrize("usm_type_y", list_of_usm_types)
-def test_coerced_usm_types_divide(usm_type_x, usm_type_y):
+def test_divide(usm_type_x, usm_type_y):
     x = dpnp.arange(120, usm_type=usm_type_x)
     y = dpnp.arange(120, usm_type=usm_type_y)
 
@@ -85,7 +85,7 @@ def test_coerced_usm_types_divide(usm_type_x, usm_type_y):
 
 @pytest.mark.parametrize("usm_type_x", list_of_usm_types)
 @pytest.mark.parametrize("usm_type_y", list_of_usm_types)
-def test_coerced_usm_types_remainder(usm_type_x, usm_type_y):
+def test_remainder(usm_type_x, usm_type_y):
     x = dpnp.arange(100, usm_type=usm_type_x).reshape(10, 10)
     y = dpnp.arange(100, usm_type=usm_type_y).reshape(10, 10)
     y = y.T + 1
@@ -105,7 +105,7 @@ def test_coerced_usm_types_remainder(usm_type_x, usm_type_y):
 
 @pytest.mark.parametrize("usm_type_x", list_of_usm_types)
 @pytest.mark.parametrize("usm_type_y", list_of_usm_types)
-def test_coerced_usm_types_floor_divide(usm_type_x, usm_type_y):
+def test_floor_divide(usm_type_x, usm_type_y):
     x = dpnp.arange(100, usm_type=usm_type_x).reshape(10, 10)
     y = dpnp.arange(100, usm_type=usm_type_y).reshape(10, 10)
     x = x + 1.5
@@ -126,7 +126,7 @@ def test_coerced_usm_types_floor_divide(usm_type_x, usm_type_y):
 
 @pytest.mark.parametrize("usm_type_x", list_of_usm_types)
 @pytest.mark.parametrize("usm_type_y", list_of_usm_types)
-def test_coerced_usm_types_power(usm_type_x, usm_type_y):
+def test_power(usm_type_x, usm_type_y):
     x = dpnp.arange(70, usm_type=usm_type_x).reshape((7, 5, 2))
     y = dpnp.arange(70, usm_type=usm_type_y).reshape((7, 5, 2))
 
@@ -144,6 +144,8 @@ def test_coerced_usm_types_power(usm_type_x, usm_type_y):
     [
         pytest.param("copy", ["x0"]),
         pytest.param("diag", ["x0"]),
+        pytest.param("diag", ["x0.reshape((3,3))"]),
+        pytest.param("diagflat", ["x0.reshape((3,3))"]),
         pytest.param("empty_like", ["x0"]),
         pytest.param("full", ["10", "x0[3]"]),
         pytest.param("full_like", ["x0", "4"]),
@@ -160,32 +162,12 @@ def test_coerced_usm_types_power(usm_type_x, usm_type_y):
 )
 @pytest.mark.parametrize("usm_type_x", list_of_usm_types)
 @pytest.mark.parametrize("usm_type_y", list_of_usm_types)
-def test_array_creation_from_1d_array(func, args, usm_type_x, usm_type_y):
-    x0 = dpnp.full(10, 3, usm_type=usm_type_x)
-    new_args = [eval(val, {"x0": x0}) for val in args]
+def test_array_creation_from_array(func, args, usm_type_x, usm_type_y):
+    x0 = dpnp.full(9, 3, usm_type=usm_type_x)
+    args = [eval(val, {"x0": x0}) for val in args]
 
-    x = getattr(dpnp, func)(*new_args)
-    y = getattr(dpnp, func)(*new_args, usm_type=usm_type_y)
-
-    assert x.usm_type == usm_type_x
-    assert y.usm_type == usm_type_y
-
-
-@pytest.mark.parametrize(
-    "func, args",
-    [
-        pytest.param("diag", ["x0"]),
-        pytest.param("diagflat", ["x0"]),
-    ],
-)
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
-def test_array_creation_from_2d_array(func, args, usm_type_x, usm_type_y):
-    x0 = dpnp.arange(25, usm_type=usm_type_x).reshape(5, 5)
-    new_args = [eval(val, {"x0": x0}) for val in args]
-
-    x = getattr(dpnp, func)(*new_args)
-    y = getattr(dpnp, func)(*new_args, usm_type=usm_type_y)
+    x = getattr(dpnp, func)(*args)
+    y = getattr(dpnp, func)(*args, usm_type=usm_type_y)
 
     assert x.usm_type == usm_type_x
     assert y.usm_type == usm_type_y
@@ -213,6 +195,7 @@ def test_array_creation_from_2d_array(func, args, usm_type_x, usm_type_y):
         pytest.param("identity", [4], {}),
         pytest.param("linspace", [0, 4, 8], {}),
         pytest.param("logspace", [0, 4, 8], {}),
+        pytest.param("logspace", [0, 4, 8], {"base": [10]}),
         pytest.param("ones", [(2, 2)], {}),
         pytest.param("tri", [3, 5, 2], {}),
         pytest.param("zeros", [(2, 2)], {}),
@@ -228,6 +211,18 @@ def test_array_creation_from_scratch(func, arg, kwargs, usm_type):
         # assert against default USM type
         usm_type = "device"
     assert result.usm_type == usm_type
+
+
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
+def test_array_creation_logspace_base(usm_type_x, usm_type_y):
+    x0 = dpnp.full(10, 2, usm_type=usm_type_x)
+
+    x = dpnp.logspace([2, 2], 8, 4, base=x0[3:5])
+    y = dpnp.logspace([2, 2], 8, 4, base=x0[3:5], usm_type=usm_type_y)
+
+    assert x.usm_type == usm_type_x
+    assert y.usm_type == usm_type_y
 
 
 @pytest.mark.parametrize("usm_type", list_of_usm_types + [None])
@@ -279,18 +274,6 @@ def test_copy_operation(usm_type):
     assert x.usm_type == y.usm_type == usm_type
 
 
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
-def test_logspace_base(usm_type_x, usm_type_y):
-    x0 = dpnp.full(10, 2, usm_type=usm_type_x)
-
-    x = dpnp.logspace([2, 2], 8, 4, base=x0[3:5])
-    y = dpnp.logspace([2, 2], 8, 4, base=x0[3:5], usm_type=usm_type_y)
-
-    assert x.usm_type == usm_type_x
-    assert y.usm_type == usm_type_y
-
-
 @pytest.mark.parametrize(
     "func",
     [
@@ -306,9 +289,6 @@ def test_logspace_base(usm_type_x, usm_type_y):
 @pytest.mark.parametrize("usm_type_x", list_of_usm_types)
 @pytest.mark.parametrize("usm_type_y", list_of_usm_types)
 def test_array_copy(func, usm_type_x, usm_type_y):
-    if numpy.lib.NumpyVersion(numpy.__version__) >= "2.0.0":
-        pytest.skip("numpy.asfarray was removed")
-
     sh = (3, 7, 5)
     x = dpnp.arange(1, prod(sh) + 1, 1, usm_type=usm_type_x).reshape(sh)
 
@@ -330,20 +310,12 @@ def test_array_creation_from_dpctl(copy, usm_type_x):
 @pytest.mark.parametrize("usm_type_start", list_of_usm_types)
 @pytest.mark.parametrize("usm_type_stop", list_of_usm_types)
 def test_linspace_arrays(usm_type_start, usm_type_stop):
-    start = dpnp.asarray([0, 0], usm_type=usm_type_start)
-    stop = dpnp.asarray([2, 4], usm_type=usm_type_stop)
+    start = dpnp.array([0, 0], usm_type=usm_type_start)
+    stop = dpnp.array([2, 4], usm_type=usm_type_stop)
     res = dpnp.linspace(start, stop, 4)
     assert res.usm_type == du.get_coerced_usm_type(
         [usm_type_start, usm_type_stop]
     )
-
-
-@pytest.mark.parametrize("func", ["tril", "triu"])
-@pytest.mark.parametrize("usm_type", list_of_usm_types)
-def test_tril_triu(func, usm_type):
-    x0 = dpnp.ones((3, 3), usm_type=usm_type)
-    x = getattr(dpnp, func)(x0)
-    assert x.usm_type == usm_type
 
 
 @pytest.mark.parametrize(
@@ -360,7 +332,7 @@ def test_tril_triu(func, usm_type):
     ],
 )
 @pytest.mark.parametrize("usm_type_x", list_of_usm_types)
-def test_coerced_usm_types_logic_op_1in(op, usm_type_x):
+def test_logic_op_1in(op, usm_type_x):
     x = dpnp.arange(-10, 10, usm_type=usm_type_x)
     res = getattr(dpnp, op)(x)
 
@@ -386,7 +358,7 @@ def test_coerced_usm_types_logic_op_1in(op, usm_type_x):
 )
 @pytest.mark.parametrize("usm_type_x", list_of_usm_types)
 @pytest.mark.parametrize("usm_type_y", list_of_usm_types)
-def test_coerced_usm_types_logic_op_2in(op, usm_type_x, usm_type_y):
+def test_logic_op_2in(op, usm_type_x, usm_type_y):
     x = dpnp.arange(100, usm_type=usm_type_x)
     y = dpnp.arange(100, usm_type=usm_type_y)[::-1]
 
@@ -405,7 +377,7 @@ def test_coerced_usm_types_logic_op_2in(op, usm_type_x, usm_type_y):
 )
 @pytest.mark.parametrize("usm_type_x", list_of_usm_types)
 @pytest.mark.parametrize("usm_type_y", list_of_usm_types)
-def test_coerced_usm_types_bitwise_op(op, usm_type_x, usm_type_y):
+def test_bitwise_op(op, usm_type_x, usm_type_y):
     x = dpnp.arange(25, usm_type=usm_type_x)
     y = dpnp.arange(25, usm_type=usm_type_y)[::-1]
 
@@ -659,9 +631,9 @@ def test_norm(usm_type, ord, axis):
             "tan", [-dpnp.pi / 2, -dpnp.pi / 4, 0.0, dpnp.pi / 4, dpnp.pi / 2]
         ),
         pytest.param("tanh", [-5.0, -3.5, 0.0, 3.5, 5.0]),
-        pytest.param(
-            "trace", [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
-        ),
+        pytest.param("trace", numpy.eye(3)),
+        pytest.param("tril", numpy.ones((3, 3))),
+        pytest.param("triu", numpy.ones((3, 3))),
         pytest.param("trapezoid", [1, 2, 3]),
         pytest.param("trim_zeros", [0, 0, 0, 1, 2, 3, 0, 2, 1, 0]),
         pytest.param("trunc", [-1.7, -1.5, -0.2, 0.2, 1.5, 1.7, 2.0]),
@@ -673,8 +645,7 @@ def test_norm(usm_type, ord, axis):
 def test_1in_1out(func, data, usm_type):
     x = dpnp.array(data, usm_type=usm_type)
     res = getattr(dpnp, func)(x)
-    assert x.usm_type == usm_type
-    assert res.usm_type == usm_type
+    assert x.usm_type == usm_type == res.usm_type
 
 
 @pytest.mark.parametrize(
@@ -705,39 +676,23 @@ def test_1in_1out(func, data, usm_type):
         pytest.param("dot", [3 + 2j, 4 + 1j, 5], [1, 2 + 3j, 3]),
         pytest.param("extract", [False, True, True, False], [0, 1, 2, 3]),
         pytest.param(
-            "float_power",
-            [0, 1, 2, 3, 4, 5],
-            [1.0, 2.0, 3.0, 3.0, 2.0, 1.0],
+            "float_power", [0, 1, 2, 3, 4, 5], [1.0, 2.0, 3.0, 3.0, 2.0, 1.0]
         ),
         pytest.param("fmax", [0.0, 1.0, 2.0], [3.0, 4.0, 5.0]),
         pytest.param("fmin", [0.0, 1.0, 2.0], [3.0, 4.0, 5.0]),
         pytest.param("fmod", [5, 3], [2, 2.0]),
-        pytest.param(
-            "gcd",
-            [0, 1, 2, 3, 4, 5],
-            [20, 20, 20, 20, 20, 20],
-        ),
+        pytest.param("gcd", [0, 1, 2, 3, 4, 5], [20, 20, 20, 20, 20, 20]),
         pytest.param(
             "gradient", [1, 2, 4, 7, 11, 16], [0.0, 1.0, 1.5, 3.5, 4.0, 6.0]
         ),
         pytest.param("heaviside", [-1.5, 0, 2.0], [1]),
-        pytest.param(
-            "hypot", [[1.0, 2.0, 3.0, 4.0]], [[-1.0, -2.0, -4.0, -5.0]]
-        ),
+        pytest.param("hypot", [1.0, 2.0, 3.0, 4.0], [-1.0, -2.0, -4.0, -5.0]),
         pytest.param("inner", [1.0, 2.0, 3.0], [4.0, 5.0, 6.0]),
         pytest.param("kron", [3.0, 4.0, 5.0], [1.0, 2.0]),
-        pytest.param(
-            "lcm",
-            [0, 1, 2, 3, 4, 5],
-            [20, 20, 20, 20, 20, 20],
-        ),
-        pytest.param(
-            "ldexp",
-            [5, 5, 5, 5, 5],
-            [0, 1, 2, 3, 4],
-        ),
-        pytest.param("logaddexp", [[-1, 2, 5, 9]], [[4, -3, 2, -8]]),
-        pytest.param("logaddexp2", [[-1, 2, 5, 9]], [[4, -3, 2, -8]]),
+        pytest.param("lcm", [0, 1, 2, 3, 4, 5], [20, 20, 20, 20, 20, 20]),
+        pytest.param("ldexp", [5, 5, 5, 5, 5], [0, 1, 2, 3, 4]),
+        pytest.param("logaddexp", [-1, 2, 5, 9], [4, -3, 2, -8]),
+        pytest.param("logaddexp2", [-1, 2, 5, 9], [4, -3, 2, -8]),
         pytest.param("maximum", [0.0, 1.0, 2.0], [3.0, 4.0, 5.0]),
         pytest.param("minimum", [0.0, 1.0, 2.0], [3.0, 4.0, 5.0]),
         pytest.param("nextafter", [1, 2], [2, 1]),
@@ -772,6 +727,7 @@ def test_2in_1out(func, data1, data2, usm_type_x, usm_type_y):
     "func, data, scalar",
     [
         pytest.param("searchsorted", [11, 12, 13, 14, 15], 13),
+        pytest.param("broadcast_to", numpy.ones(7), (2, 7)),
     ],
 )
 @pytest.mark.parametrize("usm_type", list_of_usm_types)
@@ -794,13 +750,6 @@ def test_apply_over_axes(usm_type):
     x = dpnp.arange(18, usm_type=usm_type).reshape(2, 3, 3)
     y = dpnp.apply_over_axes(dpnp.sum, x, [0, 1])
 
-    assert x.usm_type == y.usm_type
-
-
-@pytest.mark.parametrize("usm_type", list_of_usm_types)
-def test_broadcast_to(usm_type):
-    x = dpnp.ones(7, usm_type=usm_type)
-    y = dpnp.broadcast_to(x, (2, 7))
     assert x.usm_type == y.usm_type
 
 

--- a/dpnp/tests/test_usm_type.py
+++ b/dpnp/tests/test_usm_type.py
@@ -996,12 +996,6 @@ def test_cholesky(data, is_empty, usm_type):
     assert x.usm_type == result.usm_type
 
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types)
-def test_indices(usm_type):
-    x = dpnp.indices((2,), usm_type=usm_type)
-    assert x.usm_type == usm_type
-
-
 @pytest.mark.parametrize("usm_type", list_of_usm_types + [None])
 @pytest.mark.parametrize("func", ["mgrid", "ogrid"])
 def test_grid(usm_type, func):
@@ -1015,7 +1009,7 @@ def test_grid(usm_type, func):
 
 @pytest.mark.parametrize("usm_type", list_of_usm_types)
 @pytest.mark.parametrize("sparse", [True, False])
-def test_indices_sparse(usm_type, sparse):
+def test_indices(usm_type, sparse):
     x = dpnp.indices((2, 3), sparse=sparse, usm_type=usm_type)
     for i in x:
         assert i.usm_type == usm_type
@@ -1045,29 +1039,12 @@ def test_where(usm_type):
 
 @pytest.mark.parametrize(
     "func",
-    [
-        "eig",
-        "eigvals",
-        "eigh",
-        "eigvalsh",
-    ],
+    ["eig", "eigvals", "eigh", "eigvalsh"],
 )
 @pytest.mark.parametrize(
     "shape",
-    [
-        (4, 4),
-        (0, 0),
-        (2, 3, 3),
-        (0, 2, 2),
-        (1, 0, 0),
-    ],
-    ids=[
-        "(4, 4)",
-        "(0, 0)",
-        "(2, 3, 3)",
-        "(0, 2, 2)",
-        "(1, 0, 0)",
-    ],
+    [(4, 4), (0, 0), (2, 3, 3), (0, 2, 2), (1, 0, 0)],
+    ids=["(4, 4)", "(0, 0)", "(2, 3, 3)", "(0, 2, 2)", "(1, 0, 0)"],
 )
 @pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_eigenvalue(func, shape, usm_type):

--- a/dpnp/tests/test_usm_type.py
+++ b/dpnp/tests/test_usm_type.py
@@ -7,23 +7,19 @@ import dpctl.utils as du
 import numpy
 import pytest
 
-import dpnp as dp
+import dpnp
 from dpnp.dpnp_utils import get_usm_allocations
 
-from .helper import (
-    assert_dtype_allclose,
-    generate_random_numpy_array,
-    is_win_platform,
-)
+from .helper import generate_random_numpy_array, is_win_platform
 
 list_of_usm_types = ["device", "shared", "host"]
 
 
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
 def test_coerced_usm_types_add(usm_type_x, usm_type_y):
-    x = dp.arange(1000, usm_type=usm_type_x)
-    y = dp.arange(1000, usm_type=usm_type_y)
+    x = dpnp.arange(1000, usm_type=usm_type_x)
+    y = dpnp.arange(1000, usm_type=usm_type_y)
 
     z = 1.3 + x + y + 2
 
@@ -36,11 +32,11 @@ def test_coerced_usm_types_add(usm_type_x, usm_type_y):
     assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
 
 
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
 def test_coerced_usm_types_mul(usm_type_x, usm_type_y):
-    x = dp.arange(10, usm_type=usm_type_x)
-    y = dp.arange(10, usm_type=usm_type_y)
+    x = dpnp.arange(10, usm_type=usm_type_x)
+    y = dpnp.arange(10, usm_type=usm_type_y)
 
     z = 3 * x * y * 1.5
 
@@ -53,11 +49,11 @@ def test_coerced_usm_types_mul(usm_type_x, usm_type_y):
     assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
 
 
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
 def test_coerced_usm_types_subtract(usm_type_x, usm_type_y):
-    x = dp.arange(50, usm_type=usm_type_x)
-    y = dp.arange(50, usm_type=usm_type_y)
+    x = dpnp.arange(50, usm_type=usm_type_x)
+    y = dpnp.arange(50, usm_type=usm_type_y)
 
     z = 20 - x - y - 7.4
 
@@ -70,11 +66,11 @@ def test_coerced_usm_types_subtract(usm_type_x, usm_type_y):
     assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
 
 
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
 def test_coerced_usm_types_divide(usm_type_x, usm_type_y):
-    x = dp.arange(120, usm_type=usm_type_x)
-    y = dp.arange(120, usm_type=usm_type_y)
+    x = dpnp.arange(120, usm_type=usm_type_x)
+    y = dpnp.arange(120, usm_type=usm_type_y)
 
     z = 2 / x / y / 1.5
 
@@ -87,11 +83,11 @@ def test_coerced_usm_types_divide(usm_type_x, usm_type_y):
     assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
 
 
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
 def test_coerced_usm_types_remainder(usm_type_x, usm_type_y):
-    x = dp.arange(100, usm_type=usm_type_x).reshape(10, 10)
-    y = dp.arange(100, usm_type=usm_type_y).reshape(10, 10)
+    x = dpnp.arange(100, usm_type=usm_type_x).reshape(10, 10)
+    y = dpnp.arange(100, usm_type=usm_type_y).reshape(10, 10)
     y = y.T + 1
 
     z = 100 % y
@@ -107,11 +103,11 @@ def test_coerced_usm_types_remainder(usm_type_x, usm_type_y):
     assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
 
 
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
 def test_coerced_usm_types_floor_divide(usm_type_x, usm_type_y):
-    x = dp.arange(100, usm_type=usm_type_x).reshape(10, 10)
-    y = dp.arange(100, usm_type=usm_type_y).reshape(10, 10)
+    x = dpnp.arange(100, usm_type=usm_type_x).reshape(10, 10)
+    y = dpnp.arange(100, usm_type=usm_type_y).reshape(10, 10)
     x = x + 1.5
     y = y.T + 0.5
 
@@ -128,11 +124,11 @@ def test_coerced_usm_types_floor_divide(usm_type_x, usm_type_y):
     assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
 
 
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
 def test_coerced_usm_types_power(usm_type_x, usm_type_y):
-    x = dp.arange(70, usm_type=usm_type_x).reshape((7, 5, 2))
-    y = dp.arange(70, usm_type=usm_type_y).reshape((7, 5, 2))
+    x = dpnp.arange(70, usm_type=usm_type_x).reshape((7, 5, 2))
+    y = dpnp.arange(70, usm_type=usm_type_y).reshape((7, 5, 2))
 
     z = 2**x**y**1.5
     z **= x
@@ -162,14 +158,14 @@ def test_coerced_usm_types_power(usm_type_x, usm_type_y):
         pytest.param("zeros_like", ["x0"]),
     ],
 )
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
 def test_array_creation_from_1d_array(func, args, usm_type_x, usm_type_y):
-    x0 = dp.full(10, 3, usm_type=usm_type_x)
+    x0 = dpnp.full(10, 3, usm_type=usm_type_x)
     new_args = [eval(val, {"x0": x0}) for val in args]
 
-    x = getattr(dp, func)(*new_args)
-    y = getattr(dp, func)(*new_args, usm_type=usm_type_y)
+    x = getattr(dpnp, func)(*new_args)
+    y = getattr(dpnp, func)(*new_args, usm_type=usm_type_y)
 
     assert x.usm_type == usm_type_x
     assert y.usm_type == usm_type_y
@@ -182,14 +178,14 @@ def test_array_creation_from_1d_array(func, args, usm_type_x, usm_type_y):
         pytest.param("diagflat", ["x0"]),
     ],
 )
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
 def test_array_creation_from_2d_array(func, args, usm_type_x, usm_type_y):
-    x0 = dp.arange(25, usm_type=usm_type_x).reshape(5, 5)
+    x0 = dpnp.arange(25, usm_type=usm_type_x).reshape(5, 5)
     new_args = [eval(val, {"x0": x0}) for val in args]
 
-    x = getattr(dp, func)(*new_args)
-    y = getattr(dp, func)(*new_args, usm_type=usm_type_y)
+    x = getattr(dpnp, func)(*new_args)
+    y = getattr(dpnp, func)(*new_args, usm_type=usm_type_y)
 
     assert x.usm_type == usm_type_x
     assert y.usm_type == usm_type_y
@@ -199,15 +195,21 @@ def test_array_creation_from_2d_array(func, args, usm_type_x, usm_type_y):
     "func, arg, kwargs",
     [
         pytest.param("arange", [-25.7], {"stop": 10**8, "step": 15}),
-        pytest.param("frombuffer", [b"\x01\x02\x03\x04"], {"dtype": dp.int32}),
+        pytest.param("eye", [4, 2], {}),
+        pytest.param("empty", [(3, 4)], {}),
         pytest.param(
-            "fromfunction", [(lambda i, j: i + j), (3, 3)], {"dtype": dp.int32}
+            "frombuffer", [b"\x01\x02\x03\x04"], {"dtype": dpnp.int32}
         ),
-        pytest.param("fromiter", [[1, 2, 3, 4]], {"dtype": dp.int64}),
+        pytest.param(
+            "fromfunction",
+            [(lambda i, j: i + j), (3, 3)],
+            {"dtype": dpnp.int32},
+        ),
+        pytest.param("fromiter", [[1, 2, 3, 4]], {"dtype": dpnp.int64}),
         pytest.param("fromstring", ["1 2"], {"dtype": int, "sep": " "}),
         pytest.param("full", [(2, 2)], {"fill_value": 5}),
-        pytest.param("eye", [4, 2], {}),
         pytest.param("geomspace", [1, 4, 8], {}),
+        pytest.param("hamming", [10], {}),
         pytest.param("identity", [4], {}),
         pytest.param("linspace", [0, 4, 8], {}),
         pytest.param("logspace", [0, 4, 8], {}),
@@ -218,34 +220,14 @@ def test_array_creation_from_2d_array(func, args, usm_type_x, usm_type_y):
 )
 @pytest.mark.parametrize("usm_type", list_of_usm_types + [None])
 def test_array_creation_from_scratch(func, arg, kwargs, usm_type):
-    dpnp_kwargs = dict(kwargs)
-    dpnp_kwargs["usm_type"] = usm_type
-    dpnp_array = getattr(dp, func)(*arg, **dpnp_kwargs)
-
-    numpy_kwargs = dict(kwargs)
-    numpy_kwargs["dtype"] = dpnp_array.dtype
-    numpy_array = getattr(numpy, func)(*arg, **numpy_kwargs)
+    kwargs = dict(kwargs)
+    kwargs["usm_type"] = usm_type
+    result = getattr(dpnp, func)(*arg, **kwargs)
 
     if usm_type is None:
         # assert against default USM type
         usm_type = "device"
-
-    assert_dtype_allclose(dpnp_array, numpy_array)
-    assert dpnp_array.shape == numpy_array.shape
-    assert dpnp_array.usm_type == usm_type
-
-
-@pytest.mark.parametrize("usm_type", list_of_usm_types + [None])
-def test_array_creation_empty(usm_type):
-    dpnp_array = dp.empty((3, 4), usm_type=usm_type)
-    numpy_array = numpy.empty((3, 4))
-
-    if usm_type is None:
-        # assert against default USM type
-        usm_type = "device"
-
-    assert dpnp_array.shape == numpy_array.shape
-    assert dpnp_array.usm_type == usm_type
+    assert result.usm_type == usm_type
 
 
 @pytest.mark.parametrize("usm_type", list_of_usm_types + [None])
@@ -255,18 +237,12 @@ def test_array_creation_from_file(usm_type):
         fh.flush()
 
         fh.seek(0)
-        numpy_array = numpy.fromfile(fh)
-
-        fh.seek(0)
-        dpnp_array = dp.fromfile(fh, usm_type=usm_type)
+        result = dpnp.fromfile(fh, usm_type=usm_type)
 
     if usm_type is None:
         # assert against default USM type
         usm_type = "device"
-
-    assert_dtype_allclose(dpnp_array, numpy_array)
-    assert dpnp_array.shape == numpy_array.shape
-    assert dpnp_array.usm_type == usm_type
+    assert result.usm_type == usm_type
 
 
 @pytest.mark.parametrize("usm_type", list_of_usm_types + [None])
@@ -276,24 +252,18 @@ def test_array_creation_load_txt(usm_type):
         fh.flush()
 
         fh.seek(0)
-        numpy_array = numpy.loadtxt(fh)
-
-        fh.seek(0)
-        dpnp_array = dp.loadtxt(fh, usm_type=usm_type)
+        result = dpnp.loadtxt(fh, usm_type=usm_type)
 
     if usm_type is None:
         # assert against default USM type
         usm_type = "device"
-
-    assert_dtype_allclose(dpnp_array, numpy_array)
-    assert dpnp_array.shape == numpy_array.shape
-    assert dpnp_array.usm_type == usm_type
+    assert result.usm_type == usm_type
 
 
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
 def test_copy_method(usm_type_x, usm_type_y):
-    x = dp.array([[1, 2, 3], [4, 5, 6]], usm_type=usm_type_x)
+    x = dpnp.array([[1, 2, 3], [4, 5, 6]], usm_type=usm_type_x)
 
     y = x.copy()
     assert x.usm_type == y.usm_type == usm_type_x
@@ -302,20 +272,20 @@ def test_copy_method(usm_type_x, usm_type_y):
     assert y.usm_type == usm_type_y
 
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_copy_operation(usm_type):
-    x = dp.array([[1, 2, 3], [4, 5, 6]], usm_type=usm_type)
+    x = dpnp.array([[1, 2, 3], [4, 5, 6]], usm_type=usm_type)
     y = copy.copy(x)
     assert x.usm_type == y.usm_type == usm_type
 
 
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
 def test_logspace_base(usm_type_x, usm_type_y):
-    x0 = dp.full(10, 2, usm_type=usm_type_x)
+    x0 = dpnp.full(10, 2, usm_type=usm_type_x)
 
-    x = dp.logspace([2, 2], 8, 4, base=x0[3:5])
-    y = dp.logspace([2, 2], 8, 4, base=x0[3:5], usm_type=usm_type_y)
+    x = dpnp.logspace([2, 2], 8, 4, base=x0[3:5])
+    y = dpnp.logspace([2, 2], 8, 4, base=x0[3:5], usm_type=usm_type_y)
 
     assert x.usm_type == usm_type_x
     assert y.usm_type == usm_type_y
@@ -333,50 +303,46 @@ def test_logspace_base(usm_type_x, usm_type_y):
         "asfortranarray",
     ],
 )
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
 def test_array_copy(func, usm_type_x, usm_type_y):
     if numpy.lib.NumpyVersion(numpy.__version__) >= "2.0.0":
         pytest.skip("numpy.asfarray was removed")
 
     sh = (3, 7, 5)
-    x = dp.arange(1, prod(sh) + 1, 1, usm_type=usm_type_x).reshape(sh)
+    x = dpnp.arange(1, prod(sh) + 1, 1, usm_type=usm_type_x).reshape(sh)
 
-    y = getattr(dp, func)(x, usm_type=usm_type_y)
+    y = getattr(dpnp, func)(x, usm_type=usm_type_y)
 
     assert x.usm_type == usm_type_x
     assert y.usm_type == usm_type_y
 
 
 @pytest.mark.parametrize("copy", [True, False, None])
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
 def test_array_creation_from_dpctl(copy, usm_type_x):
     x = dpt.ones((3, 3), usm_type=usm_type_x)
-    y = dp.array(x, copy=copy)
+    y = dpnp.array(x, copy=copy)
 
     assert y.usm_type == usm_type_x
 
 
-@pytest.mark.parametrize(
-    "usm_type_start", list_of_usm_types, ids=list_of_usm_types
-)
-@pytest.mark.parametrize(
-    "usm_type_stop", list_of_usm_types, ids=list_of_usm_types
-)
+@pytest.mark.parametrize("usm_type_start", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_stop", list_of_usm_types)
 def test_linspace_arrays(usm_type_start, usm_type_stop):
-    start = dp.asarray([0, 0], usm_type=usm_type_start)
-    stop = dp.asarray([2, 4], usm_type=usm_type_stop)
-    res = dp.linspace(start, stop, 4)
+    start = dpnp.asarray([0, 0], usm_type=usm_type_start)
+    stop = dpnp.asarray([2, 4], usm_type=usm_type_stop)
+    res = dpnp.linspace(start, stop, 4)
     assert res.usm_type == du.get_coerced_usm_type(
         [usm_type_start, usm_type_stop]
     )
 
 
-@pytest.mark.parametrize("func", ["tril", "triu"], ids=["tril", "triu"])
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("func", ["tril", "triu"])
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_tril_triu(func, usm_type):
-    x0 = dp.ones((3, 3), usm_type=usm_type)
-    x = getattr(dp, func)(x0)
+    x0 = dpnp.ones((3, 3), usm_type=usm_type)
+    x = getattr(dpnp, func)(x0)
     assert x.usm_type == usm_type
 
 
@@ -393,10 +359,10 @@ def test_tril_triu(func, usm_type):
         "logical_not",
     ],
 )
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
 def test_coerced_usm_types_logic_op_1in(op, usm_type_x):
-    x = dp.arange(-10, 10, usm_type=usm_type_x)
-    res = getattr(dp, op)(x)
+    x = dpnp.arange(-10, 10, usm_type=usm_type_x)
+    res = getattr(dpnp, op)(x)
 
     assert x.usm_type == res.usm_type == usm_type_x
 
@@ -418,15 +384,15 @@ def test_coerced_usm_types_logic_op_1in(op, usm_type_x):
         "not_equal",
     ],
 )
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
 def test_coerced_usm_types_logic_op_2in(op, usm_type_x, usm_type_y):
-    x = dp.arange(100, usm_type=usm_type_x)
-    y = dp.arange(100, usm_type=usm_type_y)[::-1]
+    x = dpnp.arange(100, usm_type=usm_type_x)
+    y = dpnp.arange(100, usm_type=usm_type_y)[::-1]
 
-    z = getattr(dp, op)(x, y)
-    zx = getattr(dp, op)(x, 50)
-    zy = getattr(dp, op)(30, y)
+    z = getattr(dpnp, op)(x, y)
+    zx = getattr(dpnp, op)(x, 50)
+    zy = getattr(dpnp, op)(30, y)
 
     assert x.usm_type == zx.usm_type == usm_type_x
     assert y.usm_type == zy.usm_type == usm_type_y
@@ -436,31 +402,24 @@ def test_coerced_usm_types_logic_op_2in(op, usm_type_x, usm_type_y):
 @pytest.mark.parametrize(
     "op",
     ["bitwise_and", "bitwise_or", "bitwise_xor", "left_shift", "right_shift"],
-    ids=[
-        "bitwise_and",
-        "bitwise_or",
-        "bitwise_xor",
-        "left_shift",
-        "right_shift",
-    ],
 )
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
 def test_coerced_usm_types_bitwise_op(op, usm_type_x, usm_type_y):
-    x = dp.arange(25, usm_type=usm_type_x)
-    y = dp.arange(25, usm_type=usm_type_y)[::-1]
+    x = dpnp.arange(25, usm_type=usm_type_x)
+    y = dpnp.arange(25, usm_type=usm_type_y)[::-1]
 
-    z = getattr(dp, op)(x, y)
-    zx = getattr(dp, op)(x, 7)
-    zy = getattr(dp, op)(12, y)
+    z = getattr(dpnp, op)(x, y)
+    zx = getattr(dpnp, op)(x, 7)
+    zy = getattr(dpnp, op)(12, y)
 
     assert x.usm_type == zx.usm_type == usm_type_x
     assert y.usm_type == zy.usm_type == usm_type_y
     assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
 
 
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
 @pytest.mark.parametrize(
     "shape1, shape2",
     [
@@ -487,17 +446,17 @@ def test_coerced_usm_types_bitwise_op(op, usm_type_x, usm_type_y):
     ],
 )
 def test_matmul(usm_type_x, usm_type_y, shape1, shape2):
-    x = dp.arange(numpy.prod(shape1), usm_type=usm_type_x).reshape(shape1)
-    y = dp.arange(numpy.prod(shape2), usm_type=usm_type_y).reshape(shape2)
-    z = dp.matmul(x, y)
+    x = dpnp.arange(numpy.prod(shape1), usm_type=usm_type_x).reshape(shape1)
+    y = dpnp.arange(numpy.prod(shape2), usm_type=usm_type_y).reshape(shape2)
+    z = dpnp.matmul(x, y)
 
     assert x.usm_type == usm_type_x
     assert y.usm_type == usm_type_y
     assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
 
 
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
 @pytest.mark.parametrize(
     "shape1, shape2",
     [
@@ -509,17 +468,17 @@ def test_matmul(usm_type_x, usm_type_y, shape1, shape2):
     ],
 )
 def test_matvec(usm_type_x, usm_type_y, shape1, shape2):
-    x = dp.arange(numpy.prod(shape1), usm_type=usm_type_x).reshape(shape1)
-    y = dp.arange(numpy.prod(shape2), usm_type=usm_type_y).reshape(shape2)
-    z = dp.matvec(x, y)
+    x = dpnp.arange(numpy.prod(shape1), usm_type=usm_type_x).reshape(shape1)
+    y = dpnp.arange(numpy.prod(shape2), usm_type=usm_type_y).reshape(shape2)
+    z = dpnp.matvec(x, y)
 
     assert x.usm_type == usm_type_x
     assert y.usm_type == usm_type_y
     assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
 
 
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
 @pytest.mark.parametrize(
     "shape1, shape2",
     [
@@ -531,17 +490,17 @@ def test_matvec(usm_type_x, usm_type_y, shape1, shape2):
     ],
 )
 def test_vecdot(usm_type_x, usm_type_y, shape1, shape2):
-    x = dp.arange(numpy.prod(shape1), usm_type=usm_type_x).reshape(shape1)
-    y = dp.arange(numpy.prod(shape2), usm_type=usm_type_y).reshape(shape2)
-    z = dp.vecdot(x, y)
+    x = dpnp.arange(numpy.prod(shape1), usm_type=usm_type_x).reshape(shape1)
+    y = dpnp.arange(numpy.prod(shape2), usm_type=usm_type_y).reshape(shape2)
+    z = dpnp.vecdot(x, y)
 
     assert x.usm_type == usm_type_x
     assert y.usm_type == usm_type_y
     assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
 
 
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
 @pytest.mark.parametrize(
     "shape1, shape2",
     [
@@ -553,28 +512,28 @@ def test_vecdot(usm_type_x, usm_type_y, shape1, shape2):
     ],
 )
 def test_vecmat(usm_type_x, usm_type_y, shape1, shape2):
-    x = dp.arange(numpy.prod(shape1), usm_type=usm_type_x).reshape(shape1)
-    y = dp.arange(numpy.prod(shape2), usm_type=usm_type_y).reshape(shape2)
-    z = dp.vecmat(x, y)
+    x = dpnp.arange(numpy.prod(shape1), usm_type=usm_type_x).reshape(shape1)
+    y = dpnp.arange(numpy.prod(shape2), usm_type=usm_type_y).reshape(shape2)
+    z = dpnp.vecmat(x, y)
 
     assert x.usm_type == usm_type_x
     assert y.usm_type == usm_type_y
     assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
 
 
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
 def test_meshgrid(usm_type_x, usm_type_y):
-    x = dp.arange(100, usm_type=usm_type_x)
-    y = dp.arange(100, usm_type=usm_type_y)
-    z = dp.meshgrid(x, y)
+    x = dpnp.arange(100, usm_type=usm_type_x)
+    y = dpnp.arange(100, usm_type=usm_type_y)
+    z = dpnp.meshgrid(x, y)
     assert z[0].usm_type == usm_type_x
     assert z[1].usm_type == usm_type_y
 
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 @pytest.mark.parametrize(
-    "ord", [None, -dp.inf, -2, -1, 1, 2, 3, dp.inf, "fro", "nuc"]
+    "ord", [None, -dpnp.inf, -2, -1, 1, 2, 3, dpnp.inf, "fro", "nuc"]
 )
 @pytest.mark.parametrize(
     "axis",
@@ -582,7 +541,7 @@ def test_meshgrid(usm_type_x, usm_type_y):
     ids=["-1", "0", "1", "(0, 1)", "(-2, -1)", "None"],
 )
 def test_norm(usm_type, ord, axis):
-    ia = dp.arange(120, usm_type=usm_type).reshape(2, 3, 4, 5)
+    ia = dpnp.arange(120, usm_type=usm_type).reshape(2, 3, 4, 5)
     if (axis in [-1, 0, 1] and ord in ["nuc", "fro"]) or (
         isinstance(axis, tuple) and ord == 3
     ):
@@ -590,7 +549,7 @@ def test_norm(usm_type, ord, axis):
     elif axis is None and ord is not None:
         pytest.skip("Improper number of dimensions to norm")
     else:
-        result = dp.linalg.norm(ia, ord=ord, axis=axis)
+        result = dpnp.linalg.norm(ia, ord=ord, axis=axis)
         assert ia.usm_type == usm_type
         assert result.usm_type == usm_type
 
@@ -618,7 +577,7 @@ def test_norm(usm_type, ord, axis):
         pytest.param("conjugate", [[1.0 + 1.0j, 0.0], [0.0, 1.0 + 1.0j]]),
         pytest.param("corrcoef", [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]),
         pytest.param(
-            "cos", [-dp.pi / 2, -dp.pi / 4, 0.0, dp.pi / 4, dp.pi / 2]
+            "cos", [-dpnp.pi / 2, -dpnp.pi / 4, 0.0, dpnp.pi / 4, dpnp.pi / 2]
         ),
         pytest.param("cosh", [-5.0, -3.5, 0.0, 3.5, 5.0]),
         pytest.param("cov", [[0, 1, 2], [2, 1, 0]]),
@@ -656,22 +615,22 @@ def test_norm(usm_type, ord, axis):
         pytest.param("mean", [1.0, 2.0, 4.0, 7.0]),
         pytest.param("median", [1.0, 2.0, 4.0, 7.0]),
         pytest.param("min", [1.0, 2.0, 4.0, 7.0]),
-        pytest.param("nanargmax", [1.0, 2.0, 4.0, dp.nan]),
-        pytest.param("nanargmin", [1.0, 2.0, 4.0, dp.nan]),
-        pytest.param("nancumprod", [3.0, dp.nan]),
-        pytest.param("nancumsum", [3.0, dp.nan]),
-        pytest.param("nanmax", [1.0, 2.0, 4.0, dp.nan]),
-        pytest.param("nanmean", [1.0, 2.0, 4.0, dp.nan]),
-        pytest.param("nanmedian", [1.0, 2.0, 4.0, dp.nan]),
-        pytest.param("nanmin", [1.0, 2.0, 4.0, dp.nan]),
-        pytest.param("nanprod", [1.0, 2.0, dp.nan]),
-        pytest.param("nanstd", [1.0, 2.0, 4.0, dp.nan]),
-        pytest.param("nansum", [1.0, 2.0, 4.0, dp.nan]),
-        pytest.param("nanvar", [1.0, 2.0, 4.0, dp.nan]),
+        pytest.param("nanargmax", [1.0, 2.0, 4.0, dpnp.nan]),
+        pytest.param("nanargmin", [1.0, 2.0, 4.0, dpnp.nan]),
+        pytest.param("nancumprod", [3.0, dpnp.nan]),
+        pytest.param("nancumsum", [3.0, dpnp.nan]),
+        pytest.param("nanmax", [1.0, 2.0, 4.0, dpnp.nan]),
+        pytest.param("nanmean", [1.0, 2.0, 4.0, dpnp.nan]),
+        pytest.param("nanmedian", [1.0, 2.0, 4.0, dpnp.nan]),
+        pytest.param("nanmin", [1.0, 2.0, 4.0, dpnp.nan]),
+        pytest.param("nanprod", [1.0, 2.0, dpnp.nan]),
+        pytest.param("nanstd", [1.0, 2.0, 4.0, dpnp.nan]),
+        pytest.param("nansum", [1.0, 2.0, 4.0, dpnp.nan]),
+        pytest.param("nanvar", [1.0, 2.0, 4.0, dpnp.nan]),
         pytest.param("negative", [1.0, 0.0, -1.0]),
         pytest.param("positive", [1.0, 0.0, -1.0]),
         pytest.param("prod", [1.0, 2.0]),
-        pytest.param("proj", [complex(1.0, 2.0), complex(dp.inf, -1.0)]),
+        pytest.param("proj", [complex(1.0, 2.0), complex(dpnp.inf, -1.0)]),
         pytest.param("ptp", [1.0, 2.0, 4.0, 7.0]),
         pytest.param("radians", [180, 90, 45, 0]),
         pytest.param(
@@ -685,7 +644,7 @@ def test_norm(usm_type, ord, axis):
         pytest.param("sign", [-5.0, 0.0, 4.5]),
         pytest.param("signbit", [-5.0, 0.0, 4.5]),
         pytest.param(
-            "sin", [-dp.pi / 2, -dp.pi / 4, 0.0, dp.pi / 4, dp.pi / 2]
+            "sin", [-dpnp.pi / 2, -dpnp.pi / 4, 0.0, dpnp.pi / 4, dpnp.pi / 2]
         ),
         pytest.param("sinc", [-5.0, -3.5, 0.0, 2.5, 4.3]),
         pytest.param("sinh", [-5.0, -3.5, 0.0, 3.5, 5.0]),
@@ -697,7 +656,7 @@ def test_norm(usm_type, ord, axis):
         pytest.param("std", [1.0, 2.0, 4.0, 7.0]),
         pytest.param("sum", [1.0, 2.0]),
         pytest.param(
-            "tan", [-dp.pi / 2, -dp.pi / 4, 0.0, dp.pi / 4, dp.pi / 2]
+            "tan", [-dpnp.pi / 2, -dpnp.pi / 4, 0.0, dpnp.pi / 4, dpnp.pi / 2]
         ),
         pytest.param("tanh", [-5.0, -3.5, 0.0, 3.5, 5.0]),
         pytest.param(
@@ -710,10 +669,10 @@ def test_norm(usm_type, ord, axis):
         pytest.param("var", [1.0, 2.0, 4.0, 7.0]),
     ],
 )
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_1in_1out(func, data, usm_type):
-    x = dp.array(data, usm_type=usm_type)
-    res = getattr(dp, func)(x)
+    x = dpnp.array(data, usm_type=usm_type)
+    res = getattr(dpnp, func)(x)
     assert x.usm_type == usm_type
     assert res.usm_type == usm_type
 
@@ -797,12 +756,12 @@ def test_1in_1out(func, data, usm_type):
         pytest.param("vdot", [3 + 2j, 4 + 1j, 5], [1, 2 + 3j, 3]),
     ],
 )
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
 def test_2in_1out(func, data1, data2, usm_type_x, usm_type_y):
-    x = dp.array(data1, usm_type=usm_type_x)
-    y = dp.array(data2, usm_type=usm_type_y)
-    z = getattr(dp, func)(x, y)
+    x = dpnp.array(data1, usm_type=usm_type_x)
+    y = dpnp.array(data2, usm_type=usm_type_y)
+    z = getattr(dpnp, func)(x, y)
 
     assert x.usm_type == usm_type_x
     assert y.usm_type == usm_type_y
@@ -815,33 +774,33 @@ def test_2in_1out(func, data1, data2, usm_type_x, usm_type_y):
         pytest.param("searchsorted", [11, 12, 13, 14, 15], 13),
     ],
 )
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_2in_with_scalar_1out(func, data, scalar, usm_type):
-    x = dp.array(data, usm_type=usm_type)
-    z = getattr(dp, func)(x, scalar)
+    x = dpnp.array(data, usm_type=usm_type)
+    z = getattr(dpnp, func)(x, scalar)
     assert z.usm_type == usm_type
 
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_apply_along_axis(usm_type):
-    x = dp.arange(9, usm_type=usm_type).reshape(3, 3)
-    y = dp.apply_along_axis(dp.sum, 0, x)
+    x = dpnp.arange(9, usm_type=usm_type).reshape(3, 3)
+    y = dpnp.apply_along_axis(dpnp.sum, 0, x)
 
     assert x.usm_type == y.usm_type
 
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_apply_over_axes(usm_type):
-    x = dp.arange(18, usm_type=usm_type).reshape(2, 3, 3)
-    y = dp.apply_over_axes(dp.sum, x, [0, 1])
+    x = dpnp.arange(18, usm_type=usm_type).reshape(2, 3, 3)
+    y = dpnp.apply_over_axes(dpnp.sum, x, [0, 1])
 
     assert x.usm_type == y.usm_type
 
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_broadcast_to(usm_type):
-    x = dp.ones(7, usm_type=usm_type)
-    y = dp.broadcast_to(x, (2, 7))
+    x = dpnp.ones(7, usm_type=usm_type)
+    y = dpnp.broadcast_to(x, (2, 7))
     assert x.usm_type == y.usm_type
 
 
@@ -856,24 +815,24 @@ def test_broadcast_to(usm_type):
         pytest.param("vstack", [0, 1, 2, 3], [4, 5, 6, 7]),
     ],
 )
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
 def test_concat_stack(func, data1, data2, usm_type_x, usm_type_y):
-    x = dp.array(data1, usm_type=usm_type_x)
-    y = dp.array(data2, usm_type=usm_type_y)
-    z = getattr(dp, func)((x, y))
+    x = dpnp.array(data1, usm_type=usm_type_x)
+    y = dpnp.array(data2, usm_type=usm_type_y)
+    z = getattr(dpnp, func)((x, y))
 
     assert x.usm_type == usm_type_x
     assert y.usm_type == usm_type_y
     assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
 
 
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
 def test_extract(usm_type_x, usm_type_y):
-    x = dp.arange(3, usm_type=usm_type_x)
-    y = dp.array([True, False, True], usm_type=usm_type_y)
-    z = dp.extract(y, x)
+    x = dpnp.arange(3, usm_type=usm_type_x)
+    y = dpnp.array([True, False, True], usm_type=usm_type_y)
+    z = dpnp.extract(y, x)
 
     assert x.usm_type == usm_type_x
     assert y.usm_type == usm_type_y
@@ -893,23 +852,23 @@ def test_extract(usm_type_x, usm_type_y):
         pytest.param("vsplit", [[1, 2, 3, 4], [1, 2, 3, 4]]),
     ],
 )
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_split(func, data1, usm_type):
-    x = dp.array(data1, usm_type=usm_type)
-    y = getattr(dp, func)(x, 2)
+    x = dpnp.array(data1, usm_type=usm_type)
+    y = getattr(dpnp, func)(x, 2)
 
     assert x.usm_type == usm_type
     assert y[0].usm_type == usm_type
     assert y[1].usm_type == usm_type
 
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("p", [None, -dp.inf, -2, -1, 1, 2, dp.inf, "fro"])
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
+@pytest.mark.parametrize("p", [None, -dpnp.inf, -2, -1, 1, 2, dpnp.inf, "fro"])
 def test_cond(usm_type, p):
     a = generate_random_numpy_array((2, 4, 4), seed_value=42)
-    ia = dp.array(a, usm_type=usm_type)
+    ia = dpnp.array(a, usm_type=usm_type)
 
-    result = dp.linalg.cond(ia, p=p)
+    result = dpnp.linalg.cond(ia, p=p)
     assert ia.usm_type == usm_type
     assert result.usm_type == usm_type
 
@@ -920,85 +879,66 @@ class TestDelete:
         [slice(None, None, 2), 3, [2, 3]],
         ids=["slice", "scalar", "list"],
     )
-    @pytest.mark.parametrize(
-        "usm_type", list_of_usm_types, ids=list_of_usm_types
-    )
+    @pytest.mark.parametrize("usm_type", list_of_usm_types)
     def test_delete(self, obj, usm_type):
-        x = dp.arange(5, usm_type=usm_type)
-        result = dp.delete(x, obj)
+        x = dpnp.arange(5, usm_type=usm_type)
+        result = dpnp.delete(x, obj)
 
         assert x.usm_type == usm_type
         assert result.usm_type == usm_type
 
-    @pytest.mark.parametrize(
-        "usm_type_x", list_of_usm_types, ids=list_of_usm_types
-    )
-    @pytest.mark.parametrize(
-        "usm_type_y", list_of_usm_types, ids=list_of_usm_types
-    )
+    @pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+    @pytest.mark.parametrize("usm_type_y", list_of_usm_types)
     def test_obj_ndarray(self, usm_type_x, usm_type_y):
-        x = dp.arange(5, usm_type=usm_type_x)
-        y = dp.array([1, 4], usm_type=usm_type_y)
-        z = dp.delete(x, y)
+        x = dpnp.arange(5, usm_type=usm_type_x)
+        y = dpnp.array([1, 4], usm_type=usm_type_y)
+        z = dpnp.delete(x, y)
 
         assert x.usm_type == usm_type_x
         assert y.usm_type == usm_type_y
         assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
 
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_multi_dot(usm_type):
-    numpy_array_list = []
-    dpnp_array_list = []
+    array_list = []
     for num_array in [3, 5]:  # number of arrays in multi_dot
-        for _ in range(num_array):  # creat arrays one by one
-            a = numpy.random.rand(10, 10)
-            b = dp.array(a, usm_type=usm_type)
+        for _ in range(num_array):  # create arrays one by one
+            a = dpnp.random.rand(10, 10, usm_type=usm_type)
+            array_list.append(a)
 
-            numpy_array_list.append(a)
-            dpnp_array_list.append(b)
+        result = dpnp.linalg.multi_dot(array_list)
 
-        result = dp.linalg.multi_dot(dpnp_array_list)
-        expected = numpy.linalg.multi_dot(numpy_array_list)
-        assert_dtype_allclose(result, expected)
-
-        input_usm_type, _ = get_usm_allocations(dpnp_array_list)
+        input_usm_type, _ = get_usm_allocations(array_list)
         assert input_usm_type == usm_type
         assert result.usm_type == usm_type
 
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_einsum(usm_type):
-    numpy_array_list = []
-    dpnp_array_list = []
-    for _ in range(3):  # creat arrays one by one
-        a = numpy.random.rand(10, 10)
-        b = dp.array(a, usm_type=usm_type)
+    array_list = []
+    for _ in range(3):  # create arrays one by one
+        a = dpnp.random.rand(10, 10)
+        a = dpnp.array(a, usm_type=usm_type)
+        array_list.append(a)
 
-        numpy_array_list.append(a)
-        dpnp_array_list.append(b)
+    result = dpnp.einsum("ij,jk,kl->il", *array_list)
 
-    result = dp.einsum("ij,jk,kl->il", *dpnp_array_list)
-    expected = numpy.einsum("ij,jk,kl->il", *numpy_array_list)
-    assert_dtype_allclose(result, expected)
-
-    input_usm_type, _ = get_usm_allocations(dpnp_array_list)
+    input_usm_type, _ = get_usm_allocations(array_list)
     assert input_usm_type == usm_type
     assert result.usm_type == usm_type
 
 
 class TestInsert:
-    @pytest.mark.parametrize(
-        "usm_type", list_of_usm_types, ids=list_of_usm_types
-    )
+    @pytest.mark.parametrize("usm_type", list_of_usm_types)
     @pytest.mark.parametrize(
         "obj",
         [slice(None, None, 2), 3, [2, 3]],
         ids=["slice", "scalar", "list"],
     )
     def test_bacis(self, usm_type, obj):
-        x = dp.arange(5, usm_type=usm_type)
-        result = dp.insert(x, obj, 3)
+        x = dpnp.arange(5, usm_type=usm_type)
+        result = dpnp.insert(x, obj, 3)
 
         assert x.usm_type == usm_type
         assert result.usm_type == usm_type
@@ -1008,51 +948,37 @@ class TestInsert:
         [slice(None, None, 3), 3, [2, 3]],
         ids=["slice", "scalar", "list"],
     )
-    @pytest.mark.parametrize(
-        "usm_type_x", list_of_usm_types, ids=list_of_usm_types
-    )
-    @pytest.mark.parametrize(
-        "usm_type_y", list_of_usm_types, ids=list_of_usm_types
-    )
+    @pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+    @pytest.mark.parametrize("usm_type_y", list_of_usm_types)
     def test_values_ndarray(self, obj, usm_type_x, usm_type_y):
-        x = dp.arange(5, usm_type=usm_type_x)
-        y = dp.array([1, 4], usm_type=usm_type_y)
-        z = dp.insert(x, obj, y)
+        x = dpnp.arange(5, usm_type=usm_type_x)
+        y = dpnp.array([1, 4], usm_type=usm_type_y)
+        z = dpnp.insert(x, obj, y)
 
         assert x.usm_type == usm_type_x
         assert y.usm_type == usm_type_y
         assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
 
     @pytest.mark.parametrize("values", [-2, [-1, -2]], ids=["scalar", "list"])
-    @pytest.mark.parametrize(
-        "usm_type_x", list_of_usm_types, ids=list_of_usm_types
-    )
-    @pytest.mark.parametrize(
-        "usm_type_y", list_of_usm_types, ids=list_of_usm_types
-    )
+    @pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+    @pytest.mark.parametrize("usm_type_y", list_of_usm_types)
     def test_obj_ndarray(self, values, usm_type_x, usm_type_y):
-        x = dp.arange(5, usm_type=usm_type_x)
-        y = dp.array([1, 4], usm_type=usm_type_y)
-        z = dp.insert(x, y, values)
+        x = dpnp.arange(5, usm_type=usm_type_x)
+        y = dpnp.array([1, 4], usm_type=usm_type_y)
+        z = dpnp.insert(x, y, values)
 
         assert x.usm_type == usm_type_x
         assert y.usm_type == usm_type_y
         assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
 
-    @pytest.mark.parametrize(
-        "usm_type_x", list_of_usm_types, ids=list_of_usm_types
-    )
-    @pytest.mark.parametrize(
-        "usm_type_y", list_of_usm_types, ids=list_of_usm_types
-    )
-    @pytest.mark.parametrize(
-        "usm_type_z", list_of_usm_types, ids=list_of_usm_types
-    )
+    @pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+    @pytest.mark.parametrize("usm_type_y", list_of_usm_types)
+    @pytest.mark.parametrize("usm_type_z", list_of_usm_types)
     def test_obj_values_ndarray(self, usm_type_x, usm_type_y, usm_type_z):
-        x = dp.arange(5, usm_type=usm_type_x)
-        y = dp.array([1, 4], usm_type=usm_type_y)
-        z = dp.array([-1, -3], usm_type=usm_type_z)
-        res = dp.insert(x, y, z)
+        x = dpnp.arange(5, usm_type=usm_type_x)
+        y = dpnp.array([1, 4], usm_type=usm_type_y)
+        z = dpnp.array([-1, -3], usm_type=usm_type_z)
+        res = dpnp.insert(x, y, z)
 
         assert x.usm_type == usm_type_x
         assert y.usm_type == usm_type_y
@@ -1063,14 +989,12 @@ class TestInsert:
 
 
 @pytest.mark.parametrize("func", ["take", "take_along_axis"])
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize(
-    "usm_type_ind", list_of_usm_types, ids=list_of_usm_types
-)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_ind", list_of_usm_types)
 def test_take(func, usm_type_x, usm_type_ind):
-    x = dp.arange(5, usm_type=usm_type_x)
-    ind = dp.array([0, 2, 4], usm_type=usm_type_ind)
-    z = getattr(dp, func)(x, ind, axis=None)
+    x = dpnp.arange(5, usm_type=usm_type_x)
+    ind = dpnp.array([0, 2, 4], usm_type=usm_type_ind)
+    z = getattr(dpnp, func)(x, ind, axis=None)
 
     assert x.usm_type == usm_type_x
     assert ind.usm_type == usm_type_ind
@@ -1088,15 +1012,13 @@ def test_take(func, usm_type_x, usm_type_ind):
         ),
     ],
 )
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize(
-    "usm_type_ind", list_of_usm_types, ids=list_of_usm_types
-)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_ind", list_of_usm_types)
 def test_take_along_axis(data, ind, axis, usm_type_x, usm_type_ind):
-    x = dp.array(data, usm_type=usm_type_x)
-    ind = dp.array(ind, usm_type=usm_type_ind)
+    x = dpnp.array(data, usm_type=usm_type_x)
+    ind = dpnp.array(ind, usm_type=usm_type_ind)
 
-    z = dp.take_along_axis(x, ind, axis=axis)
+    z = dpnp.take_along_axis(x, ind, axis=axis)
 
     assert x.usm_type == usm_type_x
     assert ind.usm_type == usm_type_ind
@@ -1113,61 +1035,62 @@ def test_take_along_axis(data, ind, axis, usm_type_x, usm_type_ind):
     ],
     ids=["2D", "3D", "Empty_2D", "Empty_3D"],
 )
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_cholesky(data, is_empty, usm_type):
+    dtype = dpnp.default_float_type()
     if is_empty:
-        x = dp.empty(data, dtype=dp.default_float_type(), usm_type=usm_type)
+        x = dpnp.empty(data, dtype=dtype, usm_type=usm_type)
     else:
-        x = dp.array(data, dtype=dp.default_float_type(), usm_type=usm_type)
+        x = dpnp.array(data, dtype=dtype, usm_type=usm_type)
 
-    result = dp.linalg.cholesky(x)
-
+    result = dpnp.linalg.cholesky(x)
     assert x.usm_type == result.usm_type
 
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_indices(usm_type):
-    x = dp.indices((2,), usm_type=usm_type)
+    x = dpnp.indices((2,), usm_type=usm_type)
     assert x.usm_type == usm_type
 
 
 @pytest.mark.parametrize("usm_type", list_of_usm_types + [None])
 @pytest.mark.parametrize("func", ["mgrid", "ogrid"])
 def test_grid(usm_type, func):
+    result = getattr(dpnp, func)(usm_type=usm_type)[0:4]
+
     if usm_type is None:
         # assert against default USM type
-        assert getattr(dp, func)(usm_type=usm_type)[0:4].usm_type == "device"
-    else:
-        assert getattr(dp, func)(usm_type=usm_type)[0:4].usm_type == usm_type
+        usm_type = "device"
+    assert result.usm_type == usm_type
 
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("sparse", [True, False], ids=["True", "False"])
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
+@pytest.mark.parametrize("sparse", [True, False])
 def test_indices_sparse(usm_type, sparse):
-    x = dp.indices((2, 3), sparse=sparse, usm_type=usm_type)
+    x = dpnp.indices((2, 3), sparse=sparse, usm_type=usm_type)
     for i in x:
         assert i.usm_type == usm_type
 
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_nonzero(usm_type):
-    a = dp.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], usm_type=usm_type)
-    x = dp.nonzero(a)
+    a = dpnp.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], usm_type=usm_type)
+    x = dpnp.nonzero(a)
     for x_el in x:
         assert x_el.usm_type == usm_type
 
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_clip(usm_type):
-    x = dp.arange(10, usm_type=usm_type)
-    y = dp.clip(x, 2, 7)
+    x = dpnp.arange(10, usm_type=usm_type)
+    y = dpnp.clip(x, 2, 7)
     assert x.usm_type == y.usm_type
 
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_where(usm_type):
-    a = dp.array([[0, 1, 2], [0, 2, 4], [0, 3, 6]], usm_type=usm_type)
-    result = dp.where(a < 4, a, -1)
+    a = dpnp.array([[0, 1, 2], [0, 2, 4], [0, 3, 6]], usm_type=usm_type)
+    result = dpnp.where(a < 4, a, -1)
     assert result.usm_type == usm_type
 
 
@@ -1197,26 +1120,26 @@ def test_where(usm_type):
         "(1, 0, 0)",
     ],
 )
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_eigenvalue(func, shape, usm_type):
     # Set a `hermitian` flag for generate_random_numpy_array() to
     # get a symmetric array for eigh() and eigvalsh() or
     # non-symmetric for eig() and eigvals()
     is_hermitian = func in ("eigh, eigvalsh")
     a_np = generate_random_numpy_array(shape, hermitian=is_hermitian)
-    a = dp.array(a_np, usm_type=usm_type)
+    a = dpnp.array(a_np, usm_type=usm_type)
 
     if func in ("eig", "eigh"):
-        dp_val, dp_vec = getattr(dp.linalg, func)(a)
+        dp_val, dp_vec = getattr(dpnp.linalg, func)(a)
         assert a.usm_type == dp_vec.usm_type
 
     else:  # eighvals or eigvalsh
-        dp_val = getattr(dp.linalg, func)(a)
+        dp_val = getattr(dpnp.linalg, func)(a)
 
     assert a.usm_type == dp_val.usm_type
 
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_pad(usm_type):
     all_modes = [
         "constant",
@@ -1231,32 +1154,32 @@ def test_pad(usm_type):
         "wrap",
         "empty",
     ]
-    dpnp_data = dp.arange(100, usm_type=usm_type)
-    assert dpnp_data.usm_type == usm_type
+    data = dpnp.arange(100, usm_type=usm_type)
+    assert data.usm_type == usm_type
     for mode in all_modes:
-        result = dp.pad(dpnp_data, (25, 20), mode=mode)
+        result = dpnp.pad(data, (25, 20), mode=mode)
         assert result.usm_type == usm_type
 
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_require(usm_type):
-    dpnp_data = dp.arange(10, usm_type=usm_type).reshape(2, 5)
-    result = dp.require(dpnp_data, dtype="f4", requirements=["F"])
-    assert dpnp_data.usm_type == usm_type
+    data = dpnp.arange(10, usm_type=usm_type).reshape(2, 5)
+    result = dpnp.require(data, dtype="f4", requirements=["F"])
+    assert data.usm_type == usm_type
     assert result.usm_type == usm_type
 
     # No requirements
-    result = dp.require(dpnp_data, dtype="f4")
-    assert dpnp_data.usm_type == usm_type
+    result = dpnp.require(data, dtype="f4")
+    assert data.usm_type == usm_type
     assert result.usm_type == usm_type
 
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_resize(usm_type):
-    dpnp_data = dp.arange(10, usm_type=usm_type)
-    result = dp.resize(dpnp_data, (2, 5))
+    data = dpnp.arange(10, usm_type=usm_type)
+    result = dpnp.resize(data, (2, 5))
 
-    assert dpnp_data.usm_type == usm_type
+    assert data.usm_type == usm_type
     assert result.usm_type == usm_type
 
 
@@ -1264,74 +1187,59 @@ class TestFft:
     @pytest.mark.parametrize(
         "func", ["fft", "ifft", "rfft", "irfft", "hfft", "ihfft"]
     )
-    @pytest.mark.parametrize(
-        "usm_type", list_of_usm_types, ids=list_of_usm_types
-    )
+    @pytest.mark.parametrize("usm_type", list_of_usm_types)
     def test_fft(self, func, usm_type):
-        dtype = dp.float32 if func in ["rfft", "ihfft"] else dp.complex64
-        dpnp_data = dp.arange(100, usm_type=usm_type, dtype=dtype)
-        result = getattr(dp.fft, func)(dpnp_data)
+        dtype = dpnp.float32 if func in ["rfft", "ihfft"] else dpnp.complex64
+        data = dpnp.arange(100, usm_type=usm_type, dtype=dtype)
+        result = getattr(dpnp.fft, func)(data)
 
-        assert dpnp_data.usm_type == usm_type
+        assert data.usm_type == usm_type
         assert result.usm_type == usm_type
 
-    @pytest.mark.parametrize(
-        "usm_type", list_of_usm_types, ids=list_of_usm_types
-    )
+    @pytest.mark.parametrize("usm_type", list_of_usm_types)
     def test_fftn(self, usm_type):
-        dpnp_data = dp.arange(24, usm_type=usm_type).reshape(2, 3, 4)
-        assert dpnp_data.usm_type == usm_type
+        data = dpnp.arange(24, usm_type=usm_type).reshape(2, 3, 4)
+        assert data.usm_type == usm_type
 
-        result = dp.fft.fftn(dpnp_data)
+        result = dpnp.fft.fftn(data)
         assert result.usm_type == usm_type
 
-        result = dp.fft.ifftn(result)
+        result = dpnp.fft.ifftn(result)
         assert result.usm_type == usm_type
 
-    @pytest.mark.parametrize(
-        "usm_type", list_of_usm_types, ids=list_of_usm_types
-    )
+    @pytest.mark.parametrize("usm_type", list_of_usm_types)
     def test_rfftn(self, usm_type):
-        dpnp_data = dp.arange(24, usm_type=usm_type).reshape(2, 3, 4)
-        assert dpnp_data.usm_type == usm_type
+        data = dpnp.arange(24, usm_type=usm_type).reshape(2, 3, 4)
+        assert data.usm_type == usm_type
 
-        result = dp.fft.rfftn(dpnp_data)
+        result = dpnp.fft.rfftn(data)
         assert result.usm_type == usm_type
 
-        result = dp.fft.irfftn(result)
+        result = dpnp.fft.irfftn(result)
         assert result.usm_type == usm_type
 
     @pytest.mark.parametrize("func", ["fftfreq", "rfftfreq"])
     @pytest.mark.parametrize("usm_type", list_of_usm_types + [None])
     def test_fftfreq(self, func, usm_type):
-        result = getattr(dp.fft, func)(10, 0.5, usm_type=usm_type)
-        expected = getattr(numpy.fft, func)(10, 0.5)
+        result = getattr(dpnp.fft, func)(10, 0.5, usm_type=usm_type)
 
         if usm_type is None:
             # assert against default USM type
             usm_type = "device"
-
-        assert_dtype_allclose(result, expected)
         assert result.usm_type == usm_type
 
     @pytest.mark.parametrize("func", ["fftshift", "ifftshift"])
-    @pytest.mark.parametrize(
-        "usm_type", list_of_usm_types, ids=list_of_usm_types
-    )
+    @pytest.mark.parametrize("usm_type", list_of_usm_types)
     def test_fftshift(self, func, usm_type):
-        dpnp_data = dp.fft.fftfreq(10, 0.5, usm_type=usm_type)
-        result = getattr(dp.fft, func)(dpnp_data)
+        data = dpnp.fft.fftfreq(10, 0.5, usm_type=usm_type)
+        result = getattr(dpnp.fft, func)(data)
 
-        assert dpnp_data.usm_type == usm_type
+        assert data.usm_type == usm_type
         assert result.usm_type == usm_type
 
 
-@pytest.mark.parametrize(
-    "usm_type_matrix", list_of_usm_types, ids=list_of_usm_types
-)
-@pytest.mark.parametrize(
-    "usm_type_rhs", list_of_usm_types, ids=list_of_usm_types
-)
+@pytest.mark.parametrize("usm_type_matrix", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_rhs", list_of_usm_types)
 @pytest.mark.parametrize(
     "matrix, rhs",
     [
@@ -1355,9 +1263,9 @@ class TestFft:
     ],
 )
 def test_solve(matrix, rhs, usm_type_matrix, usm_type_rhs):
-    x = dp.array(matrix, usm_type=usm_type_matrix)
-    y = dp.array(rhs, usm_type=usm_type_rhs)
-    z = dp.linalg.solve(x, y)
+    x = dpnp.array(matrix, usm_type=usm_type_matrix)
+    y = dpnp.array(rhs, usm_type=usm_type_rhs)
+    z = dpnp.linalg.solve(x, y)
 
     assert x.usm_type == usm_type_matrix
     assert y.usm_type == usm_type_rhs
@@ -1366,7 +1274,7 @@ def test_solve(matrix, rhs, usm_type_matrix, usm_type_rhs):
     )
 
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 @pytest.mark.parametrize(
     "shape, is_empty",
     [
@@ -1383,21 +1291,22 @@ def test_solve(matrix, rhs, usm_type_matrix, usm_type_rhs):
     ],
 )
 def test_slogdet(shape, is_empty, usm_type):
+    dtype = dpnp.default_float_type()
     if is_empty:
-        x = dp.empty(shape, dtype=dp.default_float_type(), usm_type=usm_type)
+        x = dpnp.empty(shape, dtype=dtype, usm_type=usm_type)
     else:
         count_elem = numpy.prod(shape)
-        x = dp.arange(
-            1, count_elem + 1, dtype=dp.default_float_type(), usm_type=usm_type
+        x = dpnp.arange(
+            1, count_elem + 1, dtype=dtype, usm_type=usm_type
         ).reshape(shape)
 
-    sign, logdet = dp.linalg.slogdet(x)
+    sign, logdet = dpnp.linalg.slogdet(x)
 
     assert x.usm_type == sign.usm_type
     assert x.usm_type == logdet.usm_type
 
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 @pytest.mark.parametrize(
     "shape, is_empty",
     [
@@ -1414,20 +1323,21 @@ def test_slogdet(shape, is_empty, usm_type):
     ],
 )
 def test_det(shape, is_empty, usm_type):
+    dtype = dpnp.default_float_type()
     if is_empty:
-        x = dp.empty(shape, dtype=dp.default_float_type(), usm_type=usm_type)
+        x = dpnp.empty(shape, dtype=dtype, usm_type=usm_type)
     else:
         count_elem = numpy.prod(shape)
-        x = dp.arange(
-            1, count_elem + 1, dtype=dp.default_float_type(), usm_type=usm_type
+        x = dpnp.arange(
+            1, count_elem + 1, dtype=dtype, usm_type=usm_type
         ).reshape(shape)
 
-    det = dp.linalg.det(x)
+    det = dpnp.linalg.det(x)
 
     assert x.usm_type == det.usm_type
 
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 @pytest.mark.parametrize(
     "shape, is_empty",
     [
@@ -1444,26 +1354,23 @@ def test_det(shape, is_empty, usm_type):
     ],
 )
 def test_inv(shape, is_empty, usm_type):
+    dtype = dpnp.default_float_type()
     if is_empty:
-        x = dp.empty(shape, dtype=dp.default_float_type(), usm_type=usm_type)
+        x = dpnp.empty(shape, dtype=dtype, usm_type=usm_type)
     else:
         count_elem = numpy.prod(shape)
-        x = dp.arange(
-            1, count_elem + 1, dtype=dp.default_float_type(), usm_type=usm_type
+        x = dpnp.arange(
+            1, count_elem + 1, dtype=dtype, usm_type=usm_type
         ).reshape(shape)
 
-    result = dp.linalg.inv(x)
+    result = dpnp.linalg.inv(x)
 
     assert x.usm_type == result.usm_type
 
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize(
-    "full_matrices_param", [True, False], ids=["True", "False"]
-)
-@pytest.mark.parametrize(
-    "compute_uv_param", [True, False], ids=["True", "False"]
-)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
+@pytest.mark.parametrize("full_matrices_param", [True, False])
+@pytest.mark.parametrize("compute_uv_param", [True, False])
 @pytest.mark.parametrize(
     "shape",
     [
@@ -1490,17 +1397,17 @@ def test_inv(shape, is_empty, usm_type):
     ],
 )
 def test_svd(usm_type, shape, full_matrices_param, compute_uv_param):
-    x = dp.ones(shape, usm_type=usm_type)
+    x = dpnp.ones(shape, usm_type=usm_type)
 
     if compute_uv_param:
-        u, s, vt = dp.linalg.svd(
+        u, s, vt = dpnp.linalg.svd(
             x, full_matrices=full_matrices_param, compute_uv=compute_uv_param
         )
 
         assert x.usm_type == u.usm_type
         assert x.usm_type == vt.usm_type
     else:
-        s = dp.linalg.svd(
+        s = dpnp.linalg.svd(
             x, full_matrices=full_matrices_param, compute_uv=compute_uv_param
         )
 
@@ -1508,12 +1415,12 @@ def test_svd(usm_type, shape, full_matrices_param, compute_uv_param):
 
 
 @pytest.mark.parametrize("n", [-1, 0, 1, 2, 3])
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_matrix_power(n, usm_type):
-    a = dp.array([[1, 2], [3, 5]], usm_type=usm_type)
+    a = dpnp.array([[1, 2], [3, 5]], usm_type=usm_type)
 
-    dp_res = dp.linalg.matrix_power(a, n)
-    assert a.usm_type == dp_res.usm_type
+    result = dpnp.linalg.matrix_power(a, n)
+    assert a.usm_type == result.usm_type
 
 
 @pytest.mark.parametrize(
@@ -1529,15 +1436,15 @@ def test_matrix_power(n, usm_type):
         "2_d array with tol",
     ],
 )
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_matrix_rank(data, tol, usm_type):
-    a = dp.array(data, usm_type=usm_type)
+    a = dpnp.array(data, usm_type=usm_type)
 
-    dp_res = dp.linalg.matrix_rank(a, tol=tol)
-    assert a.usm_type == dp_res.usm_type
+    result = dpnp.linalg.matrix_rank(a, tol=tol)
+    assert a.usm_type == result.usm_type
 
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 @pytest.mark.parametrize(
     "shape, hermitian",
     [
@@ -1559,14 +1466,13 @@ def test_matrix_rank(data, tol, usm_type):
 )
 def test_pinv(shape, hermitian, usm_type):
     a_np = generate_random_numpy_array(shape, hermitian=hermitian)
-    a = dp.array(a_np, usm_type=usm_type)
+    a = dpnp.array(a_np, usm_type=usm_type)
 
-    B = dp.linalg.pinv(a, hermitian=hermitian)
+    result = dpnp.linalg.pinv(a, hermitian=hermitian)
+    assert a.usm_type == result.usm_type
 
-    assert a.usm_type == B.usm_type
 
-
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 @pytest.mark.parametrize(
     "shape",
     [
@@ -1584,49 +1490,45 @@ def test_pinv(shape, hermitian, usm_type):
         "(1, 0, 3)",
     ],
 )
-@pytest.mark.parametrize(
-    "mode",
-    ["r", "raw", "complete", "reduced"],
-    ids=["r", "raw", "complete", "reduced"],
-)
+@pytest.mark.parametrize("mode", ["r", "raw", "complete", "reduced"])
 def test_qr(shape, mode, usm_type):
     count_elems = numpy.prod(shape)
-    a = dp.arange(count_elems, usm_type=usm_type).reshape(shape)
+    a = dpnp.arange(count_elems, usm_type=usm_type).reshape(shape)
 
     if mode == "r":
-        dp_r = dp.linalg.qr(a, mode=mode)
+        dp_r = dpnp.linalg.qr(a, mode=mode)
         assert a.usm_type == dp_r.usm_type
     else:
-        dp_q, dp_r = dp.linalg.qr(a, mode=mode)
+        dp_q, dp_r = dpnp.linalg.qr(a, mode=mode)
 
         assert a.usm_type == dp_q.usm_type
         assert a.usm_type == dp_r.usm_type
 
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_tensorinv(usm_type):
-    a = dp.eye(12, usm_type=usm_type).reshape(12, 4, 3)
-    ainv = dp.linalg.tensorinv(a, ind=1)
+    a = dpnp.eye(12, usm_type=usm_type).reshape(12, 4, 3)
+    ainv = dpnp.linalg.tensorinv(a, ind=1)
 
     assert a.usm_type == ainv.usm_type
 
 
-@pytest.mark.parametrize("usm_type_a", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_b", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_a", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_b", list_of_usm_types)
 def test_tensorsolve(usm_type_a, usm_type_b):
     data = numpy.random.randn(3, 2, 6)
-    a = dp.array(data, usm_type=usm_type_a)
-    b = dp.ones(a.shape[:2], dtype=a.dtype, usm_type=usm_type_b)
+    a = dpnp.array(data, usm_type=usm_type_a)
+    b = dpnp.ones(a.shape[:2], dtype=a.dtype, usm_type=usm_type_b)
 
-    result = dp.linalg.tensorsolve(a, b)
+    result = dpnp.linalg.tensorsolve(a, b)
 
     assert a.usm_type == usm_type_a
     assert b.usm_type == usm_type_b
     assert result.usm_type == du.get_coerced_usm_type([usm_type_a, usm_type_b])
 
 
-@pytest.mark.parametrize("usm_type_a", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_b", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_a", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_b", list_of_usm_types)
 @pytest.mark.parametrize(
     ["m", "n", "nrhs"],
     [
@@ -1637,10 +1539,9 @@ def test_tensorsolve(usm_type_a, usm_type_b):
     ],
 )
 def test_lstsq(m, n, nrhs, usm_type_a, usm_type_b):
-    a = dp.arange(m * n, usm_type=usm_type_a).reshape(m, n)
-    b = dp.ones((m, nrhs), usm_type=usm_type_b)
-
-    result = dp.linalg.lstsq(a, b)
+    a = dpnp.arange(m * n, usm_type=usm_type_a).reshape(m, n)
+    b = dpnp.ones((m, nrhs), usm_type=usm_type_b)
+    result = dpnp.linalg.lstsq(a, b)
 
     assert a.usm_type == usm_type_a
     assert b.usm_type == usm_type_b
@@ -1650,28 +1551,28 @@ def test_lstsq(m, n, nrhs, usm_type_a, usm_type_b):
         )
 
 
-@pytest.mark.parametrize("usm_type_v", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_w", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_v", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_w", list_of_usm_types)
 def test_histogram(usm_type_v, usm_type_w):
-    v = dp.arange(5, usm_type=usm_type_v)
-    w = dp.arange(7, 12, usm_type=usm_type_w)
+    v = dpnp.arange(5, usm_type=usm_type_v)
+    w = dpnp.arange(7, 12, usm_type=usm_type_w)
 
-    hist, edges = dp.histogram(v, weights=w)
+    hist, edges = dpnp.histogram(v, weights=w)
     assert v.usm_type == usm_type_v
     assert w.usm_type == usm_type_w
     assert hist.usm_type == du.get_coerced_usm_type([usm_type_v, usm_type_w])
     assert edges.usm_type == du.get_coerced_usm_type([usm_type_v, usm_type_w])
 
 
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_w", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_w", list_of_usm_types)
 def test_histogram2d(usm_type_x, usm_type_y, usm_type_w):
-    x = dp.arange(5, usm_type=usm_type_x)
-    y = dp.arange(5, usm_type=usm_type_y)
-    w = dp.arange(7, 12, usm_type=usm_type_w)
+    x = dpnp.arange(5, usm_type=usm_type_x)
+    y = dpnp.arange(5, usm_type=usm_type_y)
+    w = dpnp.arange(7, 12, usm_type=usm_type_w)
 
-    hist, edges_x, edges_y = dp.histogram2d(x, y, weights=w)
+    hist, edges_x, edges_y = dpnp.histogram2d(x, y, weights=w)
     assert x.usm_type == usm_type_x
     assert y.usm_type == usm_type_y
     assert w.usm_type == usm_type_w
@@ -1686,25 +1587,25 @@ def test_histogram2d(usm_type_x, usm_type_y, usm_type_w):
     )
 
 
-@pytest.mark.parametrize("usm_type_v", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_w", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_v", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_w", list_of_usm_types)
 def test_bincount(usm_type_v, usm_type_w):
-    v = dp.arange(5, usm_type=usm_type_v)
-    w = dp.arange(7, 12, usm_type=usm_type_w)
+    v = dpnp.arange(5, usm_type=usm_type_v)
+    w = dpnp.arange(7, 12, usm_type=usm_type_w)
 
-    hist = dp.bincount(v, weights=w)
+    hist = dpnp.bincount(v, weights=w)
     assert v.usm_type == usm_type_v
     assert w.usm_type == usm_type_w
     assert hist.usm_type == du.get_coerced_usm_type([usm_type_v, usm_type_w])
 
 
-@pytest.mark.parametrize("usm_type_v", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_w", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_v", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_w", list_of_usm_types)
 def test_histogramdd(usm_type_v, usm_type_w):
-    v = dp.arange(5, usm_type=usm_type_v)
-    w = dp.arange(7, 12, usm_type=usm_type_w)
+    v = dpnp.arange(5, usm_type=usm_type_v)
+    w = dpnp.arange(7, 12, usm_type=usm_type_w)
 
-    hist, edges = dp.histogramdd(v, weights=w)
+    hist, edges = dpnp.histogramdd(v, weights=w)
     assert v.usm_type == usm_type_v
     assert w.usm_type == usm_type_w
     assert hist.usm_type == du.get_coerced_usm_type([usm_type_v, usm_type_w])
@@ -1715,10 +1616,10 @@ def test_histogramdd(usm_type_v, usm_type_w):
 @pytest.mark.parametrize(
     "func", ["tril_indices_from", "triu_indices_from", "diag_indices_from"]
 )
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_tri_diag_indices_from(func, usm_type):
-    arr = dp.ones((3, 3), usm_type=usm_type)
-    res = getattr(dp, func)(arr)
+    arr = dpnp.ones((3, 3), usm_type=usm_type)
+    res = getattr(dpnp, func)(arr)
     for x in res:
         assert x.usm_type == usm_type
 
@@ -1726,65 +1627,63 @@ def test_tri_diag_indices_from(func, usm_type):
 @pytest.mark.parametrize(
     "func", ["tril_indices", "triu_indices", "diag_indices"]
 )
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_tri_diag_indices(func, usm_type):
-    res = getattr(dp, func)(4, usm_type=usm_type)
+    res = getattr(dpnp, func)(4, usm_type=usm_type)
     for x in res:
         assert x.usm_type == usm_type
 
 
 @pytest.mark.parametrize("mask_func", ["tril", "triu"])
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_mask_indices(mask_func, usm_type):
-    res = dp.mask_indices(4, getattr(dp, mask_func), usm_type=usm_type)
+    res = dpnp.mask_indices(4, getattr(dpnp, mask_func), usm_type=usm_type)
     for x in res:
         assert x.usm_type == usm_type
 
 
-@pytest.mark.parametrize("usm_type_v", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_w", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_v", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_w", list_of_usm_types)
 def test_histogram_bin_edges(usm_type_v, usm_type_w):
-    v = dp.arange(5, usm_type=usm_type_v)
-    w = dp.arange(7, 12, usm_type=usm_type_w)
+    v = dpnp.arange(5, usm_type=usm_type_v)
+    w = dpnp.arange(7, 12, usm_type=usm_type_w)
 
-    edges = dp.histogram_bin_edges(v, weights=w)
+    edges = dpnp.histogram_bin_edges(v, weights=w)
     assert v.usm_type == usm_type_v
     assert w.usm_type == usm_type_w
     assert edges.usm_type == du.get_coerced_usm_type([usm_type_v, usm_type_w])
 
 
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
 def test_select(usm_type_x, usm_type_y):
-    condlist = [dp.array([True, False], usm_type=usm_type_x)]
-    choicelist = [dp.array([1, 2], usm_type=usm_type_y)]
-    res = dp.select(condlist, choicelist)
+    condlist = [dpnp.array([True, False], usm_type=usm_type_x)]
+    choicelist = [dpnp.array([1, 2], usm_type=usm_type_y)]
+    res = dpnp.select(condlist, choicelist)
     assert res.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
 
 
 @pytest.mark.parametrize("axis", [None, 0, -1])
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_unique(axis, usm_type):
-    a = dp.array([[1, 1], [2, 3]], usm_type=usm_type)
-    res = dp.unique(a, True, True, True, axis=axis)
+    a = dpnp.array([[1, 1], [2, 3]], usm_type=usm_type)
+    res = dpnp.unique(a, True, True, True, axis=axis)
     for x in res:
         assert x.usm_type == usm_type
 
 
-@pytest.mark.parametrize("copy", [True, False], ids=["True", "False"])
-@pytest.mark.parametrize("usm_type_a", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("copy", [True, False])
+@pytest.mark.parametrize("usm_type_a", list_of_usm_types)
 def test_nan_to_num(copy, usm_type_a):
-    a = dp.array([-dp.nan, -1, 0, 1, dp.nan], usm_type=usm_type_a)
-    result = dp.nan_to_num(a, copy=copy)
+    a = dpnp.array([-dpnp.nan, -1, 0, 1, dpnp.nan], usm_type=usm_type_a)
+    result = dpnp.nan_to_num(a, copy=copy)
 
     assert result.usm_type == usm_type_a
     assert copy == (result is not a)
 
 
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize(
-    "usm_type_args", list_of_usm_types, ids=list_of_usm_types
-)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_args", list_of_usm_types)
 @pytest.mark.parametrize(
     ["to_end", "to_begin"],
     [
@@ -1796,64 +1695,50 @@ def test_nan_to_num(copy, usm_type_a):
 def test_ediff1d(usm_type_x, usm_type_args, to_end, to_begin):
     data = [1, 3, 5, 7]
 
-    x = dp.array(data, usm_type=usm_type_x)
+    x = dpnp.array(data, usm_type=usm_type_x)
     if to_end:
-        to_end = dp.array(to_end, usm_type=usm_type_args)
+        to_end = dpnp.array(to_end, usm_type=usm_type_args)
 
     if to_begin:
-        to_begin = dp.array(to_begin, usm_type=usm_type_args)
+        to_begin = dpnp.array(to_begin, usm_type=usm_type_args)
 
-    res = dp.ediff1d(x, to_end=to_end, to_begin=to_begin)
+    res = dpnp.ediff1d(x, to_end=to_end, to_begin=to_begin)
 
     assert res.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_args])
 
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_unravel_index(usm_type):
-    x = dp.array(2, usm_type=usm_type)
-    result = dp.unravel_index(x, shape=(2, 2))
+    x = dpnp.array(2, usm_type=usm_type)
+    result = dpnp.unravel_index(x, shape=(2, 2))
     for res in result:
         assert res.usm_type == x.usm_type
 
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
 def test_ravel_index(usm_type):
-    x = dp.array([1, 0], usm_type=usm_type)
-    result = dp.ravel_multi_index(x, (2, 2))
+    x = dpnp.array([1, 0], usm_type=usm_type)
+    result = dpnp.ravel_multi_index(x, (2, 2))
     assert result.usm_type == x.usm_type
 
 
-@pytest.mark.parametrize("usm_type_0", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize("usm_type_1", list_of_usm_types, ids=list_of_usm_types)
+@pytest.mark.parametrize("usm_type_0", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_1", list_of_usm_types)
 def test_ix(usm_type_0, usm_type_1):
-    x0 = dp.array([0, 1], usm_type=usm_type_0)
-    x1 = dp.array([2, 4], usm_type=usm_type_1)
-    ixgrid = dp.ix_(x0, x1)
+    x0 = dpnp.array([0, 1], usm_type=usm_type_0)
+    x1 = dpnp.array([2, 4], usm_type=usm_type_1)
+    ixgrid = dpnp.ix_(x0, x1)
     assert ixgrid[0].usm_type == x0.usm_type
     assert ixgrid[1].usm_type == x1.usm_type
 
 
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types, ids=list_of_usm_types)
-@pytest.mark.parametrize(
-    "usm_type_ind", list_of_usm_types, ids=list_of_usm_types
-)
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_ind", list_of_usm_types)
 def test_choose(usm_type_x, usm_type_ind):
-    chc = dp.arange(5, usm_type=usm_type_x)
-    ind = dp.array([0, 2, 4], usm_type=usm_type_ind)
-    z = dp.choose(ind, chc)
+    chc = dpnp.arange(5, usm_type=usm_type_x)
+    ind = dpnp.array([0, 2, 4], usm_type=usm_type_ind)
+    z = dpnp.choose(ind, chc)
 
     assert chc.usm_type == usm_type_x
     assert ind.usm_type == usm_type_ind
     assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_ind])
-
-
-# TODO: add it as part of `test_array_creation_from_scratch` function
-@pytest.mark.parametrize("func", ["hamming"])
-@pytest.mark.parametrize("usm_type", list_of_usm_types + [None])
-def test_window(func, usm_type):
-    result = getattr(dp, func)(10, usm_type=usm_type)
-    if usm_type is None:
-        # assert against default USM type
-        assert result.usm_type == "device"
-    else:
-        assert result.usm_type == usm_type


### PR DESCRIPTION
In this PR, `test_usm_type.py` to get rid of comparison with numpy results. The correctness of dpnp functions is separately validated in other tests. In this file, only compute-follow-data paradigm should be validated.
In addition, passing redundant ids into test is removed in this file and ids for test in `test_sycl_queue.py` is simplified.
 

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
