### PR TITLE
Add w/a for oneMath to fix test oneMKL interfaces action

### DIFF
--- a/dpnp/backend/extensions/lapack/gesv.cpp
+++ b/dpnp/backend/extensions/lapack/gesv.cpp
@@ -144,6 +144,16 @@ static sycl::event gesv_impl(sycl::queue &exec_q,
         is_exception_caught = true;
         gesv_utils::handle_lapack_exc(exec_q, lda, a, scratchpad_size,
                                       scratchpad, ipiv, e, error_msg);
+    } catch (oneapi::mkl::computation_error const &e) {
+        // TODO: remove this catch when gh-642(oneMath) is fixed
+        // Workaround for oneMath interfaces
+        // oneapi::mkl::computation_error is thrown instead of
+        // oneapi::mkl::lapack::computation_error.
+        if (scratchpad != nullptr)
+            sycl_free_noexcept(scratchpad, exec_q);
+        if (ipiv != nullptr)
+            sycl_free_noexcept(ipiv, exec_q);
+        throw LinAlgError("The input coefficient matrix is singular.");
     } catch (sycl::exception const &e) {
         is_exception_caught = true;
         error_msg << "Unexpected SYCL exception caught during getrf() or "

--- a/dpnp/backend/extensions/lapack/getrf.cpp
+++ b/dpnp/backend/extensions/lapack/getrf.cpp
@@ -120,6 +120,15 @@ static sycl::event getrf_impl(sycl::queue &exec_q,
                          "call:\nreason: "
                       << e.what() << "\ninfo: " << e.info();
         }
+    } catch (oneapi::mkl::computation_error const &e) {
+        // TODO: remove this catch when gh-642(oneMath) is fixed
+        // Workaround for oneMath interfaces
+        // oneapi::mkl::computation_error is thrown instead of
+        // oneapi::mkl::lapack::computation_error.
+        is_exception_caught = false;
+        // computation_error means the input matrix is singular
+        // dev_info must be set to any positive value.
+        dev_info[0] = 2;
     } catch (sycl::exception const &e) {
         is_exception_caught = true;
         error_msg << "Unexpected SYCL exception caught during getrf() call:\n"


### PR DESCRIPTION
This PR suggests adding a temporary workaround to a problem in oneMath [#642 ](https://github.com/uxlfoundation/oneMath/issues/642) where exceptions are no longer thrown in `lapack` namespace for `getrf` function as expected.

In oneMath develop branch `oneapi::mkl::lapack::computation_error` is not thrown. 
Instead, `oneapi::mkl::computation_error` from `mkl` namespace is used so existing catch block `mkl_lapack::exception` does not handle singular matrix errors.

A workaround has been added to explicitly catch `oneapi::mkl::computation_error` and update `dev_info`  ensuring that singular matrices are handled correctly.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
