### PR TITLE
Add support of `uint64` dtype in `dpnp.bincount`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Allowed input array of `uint64` dtype in `dpnp.bincount` [#2361](https://github.com/IntelPython/dpnp/pull/2361)
+
 ### Fixed
 
 

--- a/dpnp/backend/extensions/statistics/bincount.cpp
+++ b/dpnp/backend/extensions/statistics/bincount.cpp
@@ -72,7 +72,7 @@ struct BincountEdges
     template <typename dT>
     bool in_bounds(const dT *val, const boundsT &bounds) const
     {
-        return check_in_bounds(val[0], std::get<0>(bounds),
+        return check_in_bounds(static_cast<T>(val[0]), std::get<0>(bounds),
                                std::get<1>(bounds));
     }
 
@@ -81,13 +81,15 @@ private:
     T max;
 };
 
-template <typename T, typename HistType = size_t>
+using DefaultHistType = int64_t;
+
+template <typename T, typename HistType = DefaultHistType>
 struct BincountF
 {
     static sycl::event impl(sycl::queue &exec_q,
                             const void *vin,
-                            const int64_t min,
-                            const int64_t max,
+                            const uint64_t min,
+                            const uint64_t max,
                             const void *vweights,
                             void *vout,
                             const size_t,
@@ -145,9 +147,12 @@ struct BincountF
     }
 };
 
-using SupportedTypes = std::tuple<std::tuple<int64_t, int64_t>,
+using SupportedTypes = std::tuple<std::tuple<int64_t, DefaultHistType>,
+                                  std::tuple<uint64_t, DefaultHistType>,
                                   std::tuple<int64_t, float>,
-                                  std::tuple<int64_t, double>>;
+                                  std::tuple<uint64_t, float>,
+                                  std::tuple<int64_t, double>,
+                                  std::tuple<uint64_t, double>>;
 
 } // namespace
 
@@ -158,8 +163,8 @@ Bincount::Bincount() : dispatch_table("sample", "histogram")
 
 std::tuple<sycl::event, sycl::event> Bincount::call(
     const dpctl::tensor::usm_ndarray &sample,
-    const int64_t min,
-    const int64_t max,
+    const uint64_t min,
+    const uint64_t max,
     const std::optional<const dpctl::tensor::usm_ndarray> &weights,
     dpctl::tensor::usm_ndarray &histogram,
     const std::vector<sycl::event> &depends)

--- a/dpnp/backend/extensions/statistics/bincount.cpp
+++ b/dpnp/backend/extensions/statistics/bincount.cpp
@@ -92,7 +92,6 @@ struct BincountF
                             const uint64_t max,
                             const void *vweights,
                             void *vout,
-                            const size_t,
                             const size_t size,
                             const std::vector<sycl::event> &depends)
     {
@@ -186,9 +185,9 @@ std::tuple<sycl::event, sycl::event> Bincount::call(
     void *weights_ptr =
         weights.has_value() ? weights.value().get_data() : nullptr;
 
-    auto ev = bincount_func(exec_q, sample.get_data(), min, max, weights_ptr,
-                            histogram.get_data(), histogram.get_shape(0),
-                            sample.get_shape(0), depends);
+    auto ev =
+        bincount_func(exec_q, sample.get_data(), min, max, weights_ptr,
+                      histogram.get_data(), histogram.get_size(), depends);
 
     sycl::event args_ev;
     if (weights.has_value()) {

--- a/dpnp/backend/extensions/statistics/bincount.cpp
+++ b/dpnp/backend/extensions/statistics/bincount.cpp
@@ -185,9 +185,8 @@ std::tuple<sycl::event, sycl::event> Bincount::call(
     void *weights_ptr =
         weights.has_value() ? weights.value().get_data() : nullptr;
 
-    auto ev =
-        bincount_func(exec_q, sample.get_data(), min, max, weights_ptr,
-                      histogram.get_data(), histogram.get_size(), depends);
+    auto ev = bincount_func(exec_q, sample.get_data(), min, max, weights_ptr,
+                            histogram.get_data(), sample.get_size(), depends);
 
     sycl::event args_ev;
     if (weights.has_value()) {

--- a/dpnp/backend/extensions/statistics/bincount.hpp
+++ b/dpnp/backend/extensions/statistics/bincount.hpp
@@ -39,8 +39,8 @@ struct Bincount
 {
     using FnT = sycl::event (*)(sycl::queue &,
                                 const void *,
-                                const int64_t,
-                                const int64_t,
+                                const uint64_t,
+                                const uint64_t,
                                 const void *,
                                 void *,
                                 const size_t,
@@ -53,8 +53,8 @@ struct Bincount
 
     std::tuple<sycl::event, sycl::event>
         call(const dpctl::tensor::usm_ndarray &input,
-             const int64_t min,
-             const int64_t max,
+             const uint64_t min,
+             const uint64_t max,
              const std::optional<const dpctl::tensor::usm_ndarray> &weights,
              dpctl::tensor::usm_ndarray &output,
              const std::vector<sycl::event> &depends);

--- a/dpnp/backend/extensions/statistics/bincount.hpp
+++ b/dpnp/backend/extensions/statistics/bincount.hpp
@@ -44,7 +44,6 @@ struct Bincount
                                 const void *,
                                 void *,
                                 const size_t,
-                                const size_t,
                                 const std::vector<sycl::event> &);
 
     common::DispatchTable2<FnT> dispatch_table;

--- a/dpnp/backend/extensions/statistics/histogram.cpp
+++ b/dpnp/backend/extensions/statistics/histogram.cpp
@@ -106,7 +106,9 @@ using CachedEdges = HistogramEdges<T, CachedData<const T, 1>>;
 template <typename T>
 using UncachedEdges = HistogramEdges<T, UncachedData<const T, 1>>;
 
-template <typename T, typename BinsT, typename HistType = size_t>
+using DefaultHistType = int64_t;
+
+template <typename T, typename BinsT, typename HistType = DefaultHistType>
 struct HistogramF
 {
     static sycl::event impl(sycl::queue &exec_q,
@@ -186,26 +188,27 @@ using HistogramF_ = HistogramF<SampleType, SampleType, HistType>;
 
 } // namespace
 
-using SupportedTypes = std::tuple<std::tuple<uint64_t, int64_t>,
-                                  std::tuple<int64_t, int64_t>,
-                                  std::tuple<uint64_t, float>,
-                                  std::tuple<int64_t, float>,
-                                  std::tuple<uint64_t, double>,
-                                  std::tuple<int64_t, double>,
-                                  std::tuple<uint64_t, std::complex<float>>,
-                                  std::tuple<int64_t, std::complex<float>>,
-                                  std::tuple<uint64_t, std::complex<double>>,
-                                  std::tuple<int64_t, std::complex<double>>,
-                                  std::tuple<float, int64_t>,
-                                  std::tuple<double, int64_t>,
-                                  std::tuple<float, float>,
-                                  std::tuple<double, double>,
-                                  std::tuple<float, std::complex<float>>,
-                                  std::tuple<double, std::complex<double>>,
-                                  std::tuple<std::complex<float>, int64_t>,
-                                  std::tuple<std::complex<double>, int64_t>,
-                                  std::tuple<std::complex<float>, float>,
-                                  std::tuple<std::complex<double>, double>>;
+using SupportedTypes =
+    std::tuple<std::tuple<uint64_t, DefaultHistType>,
+               std::tuple<int64_t, DefaultHistType>,
+               std::tuple<uint64_t, float>,
+               std::tuple<int64_t, float>,
+               std::tuple<uint64_t, double>,
+               std::tuple<int64_t, double>,
+               std::tuple<uint64_t, std::complex<float>>,
+               std::tuple<int64_t, std::complex<float>>,
+               std::tuple<uint64_t, std::complex<double>>,
+               std::tuple<int64_t, std::complex<double>>,
+               std::tuple<float, DefaultHistType>,
+               std::tuple<double, DefaultHistType>,
+               std::tuple<float, float>,
+               std::tuple<double, double>,
+               std::tuple<float, std::complex<float>>,
+               std::tuple<double, std::complex<double>>,
+               std::tuple<std::complex<float>, DefaultHistType>,
+               std::tuple<std::complex<double>, DefaultHistType>,
+               std::tuple<std::complex<float>, float>,
+               std::tuple<std::complex<double>, double>>;
 
 Histogram::Histogram() : dispatch_table("sample", "histogram")
 {

--- a/dpnp/dpnp_iface_histograms.py
+++ b/dpnp/dpnp_iface_histograms.py
@@ -293,8 +293,8 @@ def _bincount_run_native(
 
     mem_ev, bc_ev = statistics_ext.bincount(
         x_usm,
-        min_v,
-        max_v,
+        min_v.item(),
+        max_v.item(),
         weights_usm,
         n_usm,
         depends=_manager.submitted_events,

--- a/dpnp/dpnp_iface_histograms.py
+++ b/dpnp/dpnp_iface_histograms.py
@@ -391,10 +391,8 @@ def bincount(x, weights=None, minlength=0):
 
     if x_casted_dtype is None or ntype_casted is None:  # pragma: no cover
         raise ValueError(
-            f"function '{bincount}' does not support input types "
-            f"({x.dtype}, {ntype}), "
-            "and the inputs could not be coerced to any "
-            "supported types"
+            f"Input types ({x.dtype}, {ntype}) are not supported, "
+            "and the inputs could not be coerced to any supported types"
         )
 
     x_casted = dpnp.asarray(x, dtype=x_casted_dtype, order="C")
@@ -611,9 +609,8 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
 
     if a_bin_dtype is None or hist_dtype is None:  # pragma: no cover
         raise ValueError(
-            f"function '{histogram}' does not support input types "
-            f"({a.dtype}, {bin_edges.dtype}, {ntype}), "
-            "and the inputs could not be coerced to any "
+            f"Input types ({a.dtype}, {bin_edges.dtype}, {ntype}) "
+            "are not supported, and the inputs could not be coerced to any "
             "supported types"
         )
 

--- a/dpnp/dpnp_iface_histograms.py
+++ b/dpnp/dpnp_iface_histograms.py
@@ -313,6 +313,11 @@ def bincount(x, weights=None, minlength=0):
 
     For full documentation refer to :obj:`numpy.bincount`.
 
+    Warning
+    -------
+    This function synchronizes in order to calculate binning edges.
+    This may harm performance in some applications.
+
     Parameters
     ----------
     x : {dpnp.ndarray, usm_ndarray}
@@ -506,6 +511,11 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
 
     For full documentation refer to :obj:`numpy.histogram`.
 
+    Warning
+    -------
+    This function may synchronize in order to check a monotonically increasing
+    array of bin edges. This may harm performance in some applications.
+
     Parameters
     ----------
     a : {dpnp.ndarray, usm_ndarray}
@@ -672,6 +682,11 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
 
     For full documentation refer to :obj:`numpy.histogram_bin_edges`.
 
+    Warning
+    -------
+    This function may synchronize in order to check a monotonically increasing
+    array of bin edges. This may harm performance in some applications.
+
     Parameters
     ----------
     a : {dpnp.ndarray, usm_ndarray}
@@ -756,6 +771,13 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
 def histogram2d(x, y, bins=10, range=None, density=None, weights=None):
     """
     Compute the bi-dimensional histogram of two data samples.
+
+    For full documentation refer to :obj:`numpy.histogram2d`.
+
+    Warning
+    -------
+    This function may synchronize in order to check a monotonically increasing
+    array of bin edges. This may harm performance in some applications.
 
     Parameters
     ----------
@@ -1084,6 +1106,11 @@ def histogramdd(sample, bins=10, range=None, density=None, weights=None):
     Compute the multidimensional histogram of some data.
 
     For full documentation refer to :obj:`numpy.histogramdd`.
+
+    Warning
+    -------
+    This function may synchronize in order to check a monotonically increasing
+    array of bin edges. This may harm performance in some applications.
 
     Parameters
     ----------

--- a/dpnp/tests/third_party/cupy/statistics_tests/test_histogram.py
+++ b/dpnp/tests/third_party/cupy/statistics_tests/test_histogram.py
@@ -9,7 +9,7 @@ from dpnp.tests.helper import has_support_aspect64, numpy_version
 from dpnp.tests.third_party.cupy import testing
 
 # Note that numpy.bincount does not support uint64 on 64-bit environment
-# as it casts an input array to intp.
+# as it casts an input array to intp (planned to support since 2.2.4).
 # And it does not support uint32, int64 and uint64 on 32-bit environment.
 _all_types = (
     numpy.float16,
@@ -27,6 +27,9 @@ _signed_types = (numpy.int8, numpy.int16, numpy.int32, numpy.bool_)
 if sys.maxsize > 2**32:
     _all_types = _all_types + (numpy.int64, numpy.uint32)
     _signed_types = _signed_types + (numpy.int64,)
+
+if numpy_version() > "2.2.3":
+    _all_types = _all_types + (numpy.uint64,)
 
 
 def for_all_dtypes_bincount(name="dtype"):

--- a/dpnp/tests/third_party/cupy/statistics_tests/test_histogram.py
+++ b/dpnp/tests/third_party/cupy/statistics_tests/test_histogram.py
@@ -337,9 +337,107 @@ class TestHistogram(unittest.TestCase):
                 xp.bincount(x, minlength=-1)
 
 
-# TODO(leofang): we temporarily remove CUB histogram support for now,
-# see cupy/cupy#7698. When it's ready, revert the commit that checked
-# in this comment to restore the support.
+# This class compares CUB results against NumPy's
+@unittest.skipUnless(False, "The CUB routine is not enabled")
+class TestCubHistogram(unittest.TestCase):
+
+    def setUp(self):
+        self.old_accelerators = _accelerator.get_routine_accelerators()
+        _accelerator.set_routine_accelerators(["cub"])
+
+    def tearDown(self):
+        _accelerator.set_routine_accelerators(self.old_accelerators)
+
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_histogram(self, xp, dtype):
+        x = testing.shaped_arange((10,), xp, dtype)
+
+        if xp is numpy:
+            return xp.histogram(x)
+
+        # xp is cupy, first ensure we really use CUB
+        cub_func = "cupy._statistics.histogram.cub.device_histogram"
+        with testing.AssertFunctionIsCalled(cub_func):
+            xp.histogram(x)
+        # ...then perform the actual computation
+        return xp.histogram(x)
+
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_histogram_range_float(self, xp, dtype):
+        a = testing.shaped_arange((10,), xp, dtype)
+        h, b = xp.histogram(a, testing.shaped_arange((10,), xp, numpy.float64))
+        assert int(h.sum()) == 10
+        return h, b
+
+    @testing.for_all_dtypes_combination(
+        ["dtype_a", "dtype_b"], no_bool=True, no_complex=True
+    )
+    @testing.numpy_cupy_array_equal()
+    def test_histogram_with_bins(self, xp, dtype_a, dtype_b):
+        x = testing.shaped_arange((10,), xp, dtype_a)
+        bins = testing.shaped_arange((4,), xp, dtype_b)
+
+        if xp is numpy:
+            return xp.histogram(x, bins)[0]
+
+        # xp is cupy, first ensure we really use CUB
+        cub_func = "cupy._statistics.histogram.cub.device_histogram"
+        with testing.AssertFunctionIsCalled(cub_func):
+            xp.histogram(x, bins)
+        # ...then perform the actual computation
+        return xp.histogram(x, bins)[0]
+
+    @testing.for_all_dtypes_combination(
+        ["dtype_a", "dtype_b"], no_bool=True, no_complex=True
+    )
+    @testing.numpy_cupy_array_equal()
+    def test_histogram_with_bins2(self, xp, dtype_a, dtype_b):
+        x = testing.shaped_arange((10,), xp, dtype_a)
+        bins = testing.shaped_arange((4,), xp, dtype_b)
+
+        if xp is numpy:
+            return xp.histogram(x, bins)[1]
+
+        # xp is cupy, first ensure we really use CUB
+        cub_func = "cupy._statistics.histogram.cub.device_histogram"
+        with testing.AssertFunctionIsCalled(cub_func):
+            xp.histogram(x, bins)
+        # ...then perform the actual computation
+        return xp.histogram(x, bins)[1]
+
+    @testing.slow
+    @testing.numpy_cupy_array_equal()
+    def test_no_oom(self, xp):
+        # ensure the workaround for NVIDIA/cub#613 kicks in
+        amax = 28854312
+        A = xp.linspace(
+            0, amax, num=amax, endpoint=True, retstep=False, dtype=xp.int32
+        )
+        out = xp.histogram(A, bins=amax, range=[0, amax])
+        return out
+
+    @testing.for_int_dtypes("dtype", no_bool=True)
+    @testing.numpy_cupy_array_equal()
+    def test_bincount_gh7698(self, xp, dtype):
+        dtype = xp.dtype(dtype)
+        max_val = xp.iinfo(dtype).max if dtype.itemsize < 4 else 65536
+        if dtype == xp.uint64:
+            pytest.skip("only numpy raises exception on uint64 input")
+
+        # https://github.com/cupy/cupy/issues/7698
+        x = xp.arange(max_val, dtype=dtype)
+
+        if xp is numpy:
+            return xp.bincount(x)
+
+        # xp is cupy, first ensure we really use CUB
+        cub_func = "cupy._statistics.histogram.cub.device_histogram"
+        with testing.AssertFunctionIsCalled(cub_func):
+            xp.bincount(x)
+        # ...then perform the actual computation
+        return xp.bincount(x)
 
 
 @testing.parameterize(
@@ -560,7 +658,7 @@ class TestHistogramddErrors(unittest.TestCase):
     *testing.product(
         {
             "weights": [None, 1, 2],
-            "weights_dtype": [numpy.int32, numpy.float32],
+            "weights_dtype": [numpy.int32, cupy.default_float_type()],
             "density": [True, False],
             "bins": [10, (8, 16), (16, 8), "array_list", "array"],
             "range": [None, ((20, 50), (10, 100))],


### PR DESCRIPTION
Previously NumPy prohibits `uint64` dtype of input array in `numpy.bincount`. But that is going to be changed since `2.2.4` release (fixed in numpy#28355 and backported to 2.2.x branch in numpy#28420).

This PR proposes to align with upcoming changes and to allow `uint64` dtype of input array in `dpnp.bincount`.
Additionally, it extends the docstring of histogram-like functions to clearly notify with a warning about possible synchronization impact.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
