### PR TITLE
Fix an issue in `conda-package.yml`

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -218,7 +218,7 @@ jobs:
       - name: Run tests
         if: env.rerun-tests-on-failure != 'true'
         run: |
-          if [[ ${{ matrix.python }} == ${{ env.python-ver-test-all-dtypes }} ]]; then
+          if [[ "${{ matrix.python }}" == "${{ env.python-ver-test-all-dtypes }}" ]]; then
             export DPNP_TEST_ALL_INT_TYPES=1
             python -m pytest -ra --pyargs ${{ env.package-name }}.tests
           else
@@ -238,7 +238,7 @@ jobs:
             . $CONDA/etc/profile.d/mamba.sh
             mamba activate ${{ env.test-env-name }}
 
-            if [[ ${{ matrix.python }} == ${{ env.python-ver-test-all-dtypes }} ]]; then
+            if [[ "${{ matrix.python }}" == "${{ env.python-ver-test-all-dtypes }}" ]]; then
               export DPNP_TEST_ALL_INT_TYPES=1
               python -m pytest -ra --pyargs ${{ env.package-name }}.tests
             else
@@ -383,9 +383,10 @@ jobs:
 
       - name: Run tests
         if: env.rerun-tests-on-failure != 'true'
+        shell: pwsh
         run: |
           if (${{ matrix.python }} -eq ${{ env.python-ver-test-all-dtypes }}) {
-            set DPNP_TEST_ALL_INT_TYPES=1
+            $env:DPNP_TEST_ALL_INT_TYPES=1
             python -m pytest -ra --pyargs ${{ env.package-name }}.tests
           } else {
             python -m pytest -n auto -ra --pyargs ${{ env.package-name }}.tests
@@ -399,9 +400,10 @@ jobs:
           timeout_minutes: ${{ env.rerun-tests-timeout }}
           max_attempts: ${{ env.rerun-tests-max-attempts }}
           retry_on: any
+          shell: pwsh
           command: |
             if ( ${{ matrix.python }} -eq ${{ env.python-ver-test-all-dtypes }} ) {
-              set DPNP_TEST_ALL_INT_TYPES=1
+              $env:DPNP_TEST_ALL_INT_TYPES=1
               python -m pytest -ra --pyargs ${{ env.package-name }}.tests
             } else {
               python -m pytest -n auto -ra --pyargs ${{ env.package-name }}.tests

--- a/dpnp/tests/conftest.py
+++ b/dpnp/tests/conftest.py
@@ -32,6 +32,8 @@ import dpctl
 import numpy
 import pytest
 
+from . import config as dtype_config
+
 if numpy.lib.NumpyVersion(numpy.__version__) >= "2.0.0b1":
     from numpy.exceptions import ComplexWarning
 else:
@@ -128,20 +130,25 @@ def pytest_collection_modifyitems(config, items):
 
     dev = dpctl.select_default_device()
     is_cpu = dev.is_cpu
-    is_gpu_no_fp64 = not dev.has_aspect_fp64
+    is_gpu = dev.is_gpu
+    support_fp64 = dev.has_aspect_fp64
     is_cuda = dpnp.is_cuda_backend(dev)
 
     print("")
+    print(
+        f"DPNP Test scope includes all integer dtypes: {bool(dtype_config.all_int_types)}"
+    )
     print(f"DPNP current device is CPU: {is_cpu}")
-    print(f"DPNP current device is GPU without fp64 support: {is_gpu_no_fp64}")
+    print(f"DPNP current device is GPU: {is_gpu}")
+    print(f"DPNP current device supports fp64: {support_fp64}")
     print(f"DPNP current device is GPU with cuda backend: {is_cuda}")
     print(f"DPNP version: {dpnp.__version__}, location: {dpnp}")
     print(f"NumPy version: {numpy.__version__}, location: {numpy}")
     print(f"Python version: {sys.version}")
     print("")
-    if not is_cpu or os.getenv("DPNP_QUEUE_GPU") == "1":
+    if is_gpu or os.getenv("DPNP_QUEUE_GPU") == "1":
         excluded_tests.extend(get_excluded_tests(test_exclude_file_gpu))
-        if is_gpu_no_fp64:
+        if not support_fp64:
             excluded_tests.extend(
                 get_excluded_tests(test_exclude_file_gpu_no_fp64)
             )


### PR DESCRIPTION
In this PR, an issue in `conda-package.yml` file is fixed to properly run tests with all integer dtypes on windows when `DPNP_TEST_ALL_INT_TYPES=1`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
