### PR TITLE
Update docstrings for logic functions

### DIFF
--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -926,7 +926,7 @@ class dpnp_array:
 
         Parameters
         ----------
-        order : {"C", "F", "A", "K"}, optional
+        order : {None, "C", "F", "A", "K"}, optional
             Memory layout of the newly output array.
             Default: ``"C"``.
         device : {None, string, SyclDevice, SyclQueue, Device}, optional

--- a/dpnp/dpnp_iface.py
+++ b/dpnp/dpnp_iface.py
@@ -572,7 +572,7 @@ def get_result_array(a, out=None, casting="safe"):
     ----------
     a : {dpnp.ndarray, usm_ndarray}
         Input array.
-    out : {dpnp.ndarray, usm_ndarray}
+    out : {None, dpnp.ndarray, usm_ndarray}
         If provided, value of `a` array will be copied into it
         according to ``safe`` casting rule.
         It should be of the appropriate shape.
@@ -585,7 +585,7 @@ def get_result_array(a, out=None, casting="safe"):
 
     Returns
     -------
-    out : {dpnp_array}
+    out : dpnp.ndarray
         Return `out` if provided, otherwise return `a`.
 
     """

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -320,7 +320,7 @@ def array(
         (``dtype``, ``order``, etc.). For ``False`` it raises a ``ValueError``
         exception if a copy can not be avoided.
         Default: ``True``.
-    order : {"C", "F", "A", "K"}, optional
+    order : {None, "C", "F", "A", "K"}, optional
         Memory layout of the newly output array.
         Default: ``"K"``.
     ndmin : int, optional
@@ -998,7 +998,7 @@ def copy(
         Input data, in any form that can be converted to an array. This
         includes scalars, lists, lists of tuples, tuples, tuples of tuples,
         tuples of lists, and ndarrays.
-    order : {"C", "F", "A", "K"}, optional
+    order : {None, "C", "F", "A", "K"}, optional
         Memory layout of the newly output array.
         Default: ``"K"``.
     device : {None, string, SyclDevice, SyclQueue, Device}, optional

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -3559,7 +3559,7 @@ def trace(a, offset=0, axis1=0, axis2=1, dtype=None, out=None):
         precision, then the default integer precision is used. Otherwise, the
         precision is the same as that of `a`.
         Default: ``None``.
-    out : {dpnp.ndarray, usm_ndarray}, optional
+    out : {None, dpnp.ndarray, usm_ndarray}, optional
         Array into which the output is placed. Its type is preserved and it
         must be of the right shape to hold the output.
         Default: ``None``.

--- a/dpnp/dpnp_iface_bitwise.py
+++ b/dpnp/dpnp_iface_bitwise.py
@@ -150,7 +150,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -231,7 +231,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -292,7 +292,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -372,7 +372,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -450,7 +450,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -538,7 +538,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -617,7 +617,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.

--- a/dpnp/dpnp_iface_linearalgebra.py
+++ b/dpnp/dpnp_iface_linearalgebra.py
@@ -780,7 +780,7 @@ def matmul(
         Controls what kind of data casting may occur.
 
         Default: ``"same_kind"``.
-    order : {"C", "F", "A", "K", None}, optional
+    order : {None, "C", "F", "A", "K"}, optional
         Memory layout of the newly output array, if parameter `out` is ``None``.
 
         Default: ``"K"``.
@@ -960,7 +960,7 @@ def matvec(
         Controls what kind of data casting may occur.
 
         Default: ``"same_kind"``.
-    order : {"C", "F", "A", "K", None}, optional
+    order : {None, "C", "F", "A", "K"}, optional
         Memory layout of the newly output array, if parameter `out` is ``None``.
 
         Default: ``"K"``.
@@ -1335,7 +1335,7 @@ def vecdot(
         Controls what kind of data casting may occur.
 
         Default: ``"same_kind"``.
-    order : {"C", "F", "A", "K", None}, optional
+    order : {None, "C", "F", "A", "K"}, optional
         Memory layout of the newly output array, if parameter `out` is ``None``.
 
         Default: ``"K"``.
@@ -1463,7 +1463,7 @@ def vecmat(
         Controls what kind of data casting may occur.
 
         Default: ``"same_kind"``.
-    order : {"C", "F", "A", "K", None}, optional
+    order : {None, "C", "F", "A", "K"}, optional
         Memory layout of the newly output array, if parameter `out` is ``None``.
 
         Default: ``"K"``.

--- a/dpnp/dpnp_iface_logic.py
+++ b/dpnp/dpnp_iface_logic.py
@@ -97,11 +97,13 @@ def all(a, /, axis=None, out=None, keepdims=False, *, where=True):
         The default is to perform a logical AND over all the dimensions
         of the input array.`axis` may be negative, in which case it counts
         from the last to the first axis.
+
         Default: ``None``.
     out : {None, dpnp.ndarray, usm_ndarray}, optional
         Alternative output array in which to place the result. It must have
         the same shape as the expected output but the type (of the returned
         values) will be cast if necessary.
+
         Default: ``None``.
     keepdims : {None, bool}, optional
         If ``True``, the reduced axes (dimensions) are included in the result
@@ -109,15 +111,15 @@ def all(a, /, axis=None, out=None, keepdims=False, *, where=True):
         compatible with the input array according to Array Broadcasting
         rules. Otherwise, if ``False``, the reduced axes are not included in
         the returned array.
+
         Default: ``False``.
 
     Returns
     -------
-    out : dpnp.ndarray
-        An array with a data type of `bool`.
-        containing the results of the logical AND reduction is returned
-        unless `out` is specified. Otherwise, a reference to `out` is returned.
-        The result has the same shape as `a` if `axis` is not ``None``
+    out : dpnp.ndarray of bool dtype
+        An array containing the results of the logical AND reduction is
+        returned unless `out` is specified. Otherwise, a reference to `out` is
+        returned. The result has the same shape as `a` if `axis` is not ``None``
         or `a` is a 0-d array.
 
     Limitations
@@ -200,20 +202,23 @@ def allclose(a, b, rtol=1.0e-5, atol=1.0e-8, equal_nan=False):
         Both inputs `a` and `b` can not be scalars at the same time.
     rtol : {dpnp.ndarray, usm_ndarray, scalar}, optional
         The relative tolerance parameter.
+
         Default: ``1e-05``.
     atol : {dpnp.ndarray, usm_ndarray, scalar}, optional
         The absolute tolerance parameter.
+
         Default: ``1e-08``.
     equal_nan : bool
         Whether to compare ``NaNs`` as equal. If ``True``, ``NaNs`` in `a` will
         be considered equal to ``NaNs`` in `b` in the output array.
+
         Default: ``False``.
 
     Returns
     -------
-    out : dpnp.ndarray
-        A 0-dim array with ``True`` value if the two arrays are equal within
-        the given tolerance; with ``False`` otherwise.
+    out : dpnp.ndarray of bool dtype
+        A 0-d array with ``True`` value if the two arrays are equal within the
+        given tolerance; with ``False`` otherwise.
 
     See Also
     --------
@@ -224,8 +229,8 @@ def allclose(a, b, rtol=1.0e-5, atol=1.0e-8, equal_nan=False):
 
     Notes
     -----
-    The comparison of `a` and `b` uses standard broadcasting, which
-    means that `a` and `b` need not have the same shape in order for
+    The comparison of `a` and `b` uses standard broadcasting, which means that
+    `a` and `b` need not have the same shape in order for
     ``dpnp.allclose(a, b)`` to evaluate to ``True``.
     The same is true for :obj:`dpnp.equal` but not :obj:`dpnp.array_equal`.
 
@@ -269,11 +274,13 @@ def any(a, /, axis=None, out=None, keepdims=False, *, where=True):
         The default is to perform a logical OR over all the dimensions
         of the input array.`axis` may be negative, in which case it counts
         from the last to the first axis.
+
         Default: ``None``.
     out : {None, dpnp.ndarray, usm_ndarray}, optional
         Alternative output array in which to place the result. It must have
         the same shape as the expected output but the type (of the returned
         values) will be cast if necessary.
+
         Default: ``None``.
     keepdims : {None, bool}, optional
         If ``True``, the reduced axes (dimensions) are included in the result
@@ -281,16 +288,16 @@ def any(a, /, axis=None, out=None, keepdims=False, *, where=True):
         compatible with the input array according to Array Broadcasting
         rules. Otherwise, if ``False``, the reduced axes are not included in
         the returned array.
+
         Default: ``False``.
 
     Returns
     -------
-    out : dpnp.ndarray
-        An array with a data type of `bool`.
-        containing the results of the logical OR reduction is returned
+    out : dpnp.ndarray of bool dtype
+        An array containing the results of the logical OR reduction is returned
         unless `out` is specified. Otherwise, a reference to `out` is returned.
-        The result has the same shape as `a` if `axis` is not ``None``
-        or `a` is a 0-d array.
+        The result has the same shape as `a` if `axis` is not ``None`` or `a`
+        is a 0-d array.
 
     Limitations
     -----------
@@ -366,13 +373,13 @@ def array_equal(a1, a2, equal_nan=False):
         Whether to compare ``NaNs`` as equal. If the dtype of `a1` and `a2` is
         complex, values will be considered equal if either the real or the
         imaginary component of a given value is ``NaN``.
+
         Default: ``False``.
 
     Returns
     -------
-    b : dpnp.ndarray
-        An array with a data type of `bool`.
-        Returns ``True`` if the arrays are equal.
+    out : dpnp.ndarray of bool dtype
+        A 0-d array with ``True`` value if the arrays are equal.
 
     See Also
     --------
@@ -490,9 +497,9 @@ def array_equiv(a1, a2):
 
     Returns
     -------
-    out : dpnp.ndarray
-        An array with a data type of `bool`.
-        ``True`` if equivalent, ``False`` otherwise.
+    out : dpnp.ndarray of bool dtype
+        A 0-d array with ``True`` value if the arrays are equivalent, ``False``
+        otherwise.
 
     Examples
     --------
@@ -551,15 +558,17 @@ x2 : {dpnp.ndarray, usm_ndarray, scalar}
 out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array have the correct shape and the expected data type.
+
+    Default: ``None``.
 order : {"C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
+
     Default: ``"K"``.
 
 Returns
 -------
-out : dpnp.ndarray
+out : dpnp.ndarray of bool dtype
     An array containing the result of element-wise equality comparison.
-    The returned array has a data type of `bool`.
 
 Limitations
 -----------
@@ -595,6 +604,7 @@ The ``==`` operator can be used as a shorthand for ``equal`` on
 >>> b = np.array([2, 4, 2])
 >>> a == b
 array([ True,  True, False])
+
 """
 
 equal = DPNPBinaryFunc(
@@ -624,16 +634,17 @@ x2 : {dpnp.ndarray, usm_ndarray, scalar}
 out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
+
     Default: ``None``.
 order : {"C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
+
     Default: ``"K"``.
 
 Returns
 -------
-out : dpnp.ndarray
+out : dpnp.ndarray of bool dtype
     An array containing the result of element-wise greater-than comparison.
-    The returned array has a data type of `bool`.
 
 Limitations
 -----------
@@ -663,6 +674,7 @@ The ``>`` operator can be used as a shorthand for ``greater`` on
 >>> b = np.array([2, 2])
 >>> a > b
 array([ True, False])
+
 """
 
 greater = DPNPBinaryFunc(
@@ -692,17 +704,18 @@ x2 : {dpnp.ndarray, usm_ndarray, scalar}
 out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
+
     Default: ``None``.
 order : {"C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
+
     Default: ``"K"``.
 
 Returns
 -------
-out : dpnp.ndarray
+out : dpnp.ndarray of bool dtype
     An array containing the result of element-wise greater-than or equal-to
     comparison.
-    The returned array has a data type of `bool`.
 
 Limitations
 -----------
@@ -732,6 +745,7 @@ The ``>=`` operator can be used as a shorthand for ``greater_equal`` on
 >>> b = np.array([2, 2, 2])
 >>> a >= b
 array([ True,  True, False])
+
 """
 
 greater_equal = DPNPBinaryFunc(
@@ -768,18 +782,21 @@ def isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
         Both inputs `a` and `b` can not be scalars at the same time.
     rtol : {dpnp.ndarray, usm_ndarray, scalar}, optional
         The relative tolerance parameter.
+
         Default: ``1e-05``.
     atol : {dpnp.ndarray, usm_ndarray, scalar}, optional
         The absolute tolerance parameter.
+
         Default: ``1e-08``.
     equal_nan : bool
         Whether to compare ``NaNs`` as equal. If ``True``, ``NaNs`` in `a` will
         be considered equal to ``NaNs`` in `b` in the output array.
+
         Default: ``False``.
 
     Returns
     -------
-    out : dpnp.ndarray
+    out : dpnp.ndarray of bool dtype
         Returns a boolean array of where `a` and `b` are equal within the given
         tolerance.
 
@@ -880,7 +897,7 @@ def iscomplex(x):
 
     Returns
     -------
-    out : dpnp.ndarray
+    out : dpnp.ndarray of bool dtype
         Output array.
 
     See Also
@@ -898,6 +915,7 @@ def iscomplex(x):
     array([ True, False, False, False, False,  True])
 
     """
+
     dpnp.check_supported_arrays_type(x)
     if dpnp.issubdtype(x.dtype, dpnp.complexfloating):
         return x.imag != 0
@@ -945,6 +963,7 @@ def iscomplexobj(x):
     True
 
     """
+
     return numpy.iscomplexobj(x)
 
 
@@ -960,17 +979,18 @@ x : {dpnp.ndarray, usm_ndarray}
 out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
+
     Default: ``None``.
 order : {"C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
+
     Default: ``"K"``.
 
 Returns
 -------
-out : dpnp.ndarray
+out : dpnp.ndarray of bool dtype
     An array which is True where `x` is not positive infinity,
     negative infinity, or ``NaN``, False otherwise.
-    The data type of the returned array is `bool`.
 
 Limitations
 -----------
@@ -998,6 +1018,7 @@ Examples
 >>> x = np.array([-np.inf, 0., np.inf])
 >>> np.isfinite(x)
 array([False,  True, False])
+
 """
 
 isfinite = DPNPUnaryFunc(
@@ -1074,7 +1095,6 @@ def isfortran(a):
     """
 
     dpnp.check_supported_arrays_type(a)
-
     return a.flags.fnc
 
 
@@ -1090,16 +1110,18 @@ x : {dpnp.ndarray, usm_ndarray}
 out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
+
     Default: ``None``.
 order : {"C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
+
     Default: ``"K"``.
 
 Returns
 -------
-out : dpnp.ndarray
+out : dpnp.ndarray of bool dtype
     An array which is True where `x` is positive or negative infinity,
-    False otherwise. The data type of the returned array is `bool`.
+    False otherwise.
 
 Limitations
 -----------
@@ -1122,6 +1144,7 @@ Examples
 >>> x = np.array([-np.inf, 0., np.inf])
 >>> np.isinf(x)
 array([ True, False,  True])
+
 """
 
 isinf = DPNPUnaryFunc(
@@ -1144,16 +1167,17 @@ x : {dpnp.ndarray, usm_ndarray}
 out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
+
     Default: ``None``.
 order : {"C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
+
     Default: ``"K"``.
 
 Returns
 -------
-out : dpnp.ndarray
+out : dpnp.ndarray of bool dtype
     An array which is True where `x` is ``NaN``, False otherwise.
-    The data type of the returned array is `bool`.
 
 Limitations
 -----------
@@ -1175,6 +1199,7 @@ Examples
 >>> x = np.array([np.inf, 0., np.nan])
 >>> np.isnan(x)
 array([False, False,  True])
+
 """
 
 isnan = DPNPUnaryFunc(
@@ -1200,12 +1225,19 @@ def isneginf(x, out=None):
         shape that the input broadcasts to and a boolean data type.
         If not provided or ``None``, a freshly-allocated boolean array
         is returned.
+
         Default: ``None``.
 
     Returns
     -------
-    out : dpnp.ndarray
-        Boolean array of same shape as ``x``.
+    out : dpnp.ndarray of bool dtype
+        An array with the same shape as `x`.
+        If `out` is ``None`` then an array is returned with values ``True``
+        where the corresponding element of the input is negative infinity
+        and values ``False`` where the element of the input is not negative
+        infinity.
+        If `out` is not ``None`` then the result is stored there and `out` is
+        a reference to that array.
 
     See Also
     --------
@@ -1272,12 +1304,19 @@ def isposinf(x, out=None):
         shape that the input broadcasts to and a boolean data type.
         If not provided or ``None``, a freshly-allocated boolean array
         is returned.
+
         Default: ``None``.
 
     Returns
     -------
-    out : dpnp.ndarray
-        Boolean array of same shape as ``x``.
+    out : dpnp.ndarray of bool dtype
+        An array with the same shape as `x`.
+        If `out` is ``None`` then an array is returned with values ``True``
+        where the corresponding element of the input is positive infinity
+        and values ``False`` where the element of the input is not positive
+        infinity.
+        If `out` is not ``None`` then the result is stored there and `out` is
+        a reference to that array.
 
     See Also
     --------
@@ -1345,8 +1384,8 @@ def isreal(x):
 
     Returns
     -------
-    out : : dpnp.ndarray
-        Boolean array of same shape as `x`.
+    out : dpnp.ndarray of bool dtype
+        An array of same shape as `x`.
 
     See Also
     --------
@@ -1362,6 +1401,7 @@ def isreal(x):
     array([False,  True,  True,  True,  True, False])
 
     """
+
     dpnp.check_supported_arrays_type(x)
     if dpnp.issubdtype(x.dtype, dpnp.complexfloating):
         return x.imag == 0
@@ -1410,6 +1450,7 @@ def isrealobj(x):
     False
 
     """
+
     return not iscomplexobj(x)
 
 
@@ -1442,7 +1483,9 @@ def isscalar(element):
     True
     >>> np.isscalar("dpnp")
     True
+
     """
+
     return numpy.isscalar(element)
 
 
@@ -1465,16 +1508,17 @@ x2 : {dpnp.ndarray, usm_ndarray, scalar}
 out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
+
     Default: ``None``.
 order : {"C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
+
     Default: ``"K"``.
 
 Returns
 -------
-out : dpnp.ndarray
+out : dpnp.ndarray of bool dtype
     An array containing the result of element-wise less-than comparison.
-    The returned array has a data type of `bool`.
 
 Limitations
 -----------
@@ -1504,6 +1548,7 @@ The ``<`` operator can be used as a shorthand for ``less`` on
 >>> b = np.array([2, 2])
 >>> a < b
 array([ True, False])
+
 """
 
 less = DPNPBinaryFunc(
@@ -1533,16 +1578,17 @@ x2 : {dpnp.ndarray, usm_ndarray, scalar}
 out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
+
     Default: ``None``.
 order : {"C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
+
     Default: ``"K"``.
 
 Returns
 -------
-out : dpnp.ndarray
+out : dpnp.ndarray of bool dtype
     An array containing the result of element-wise less-than or equal-to
-    comparison. The returned array has a data type of `bool`.
 
 Limitations
 -----------
@@ -1572,6 +1618,7 @@ The ``<=`` operator can be used as a shorthand for ``less_equal`` on
 >>> b = np.array([2, 2, 2])
 >>> a <= b
 array([False,  True,  True])
+
 """
 
 less_equal = DPNPBinaryFunc(
@@ -1601,16 +1648,17 @@ x2 : {dpnp.ndarray, usm_ndarray, scalar}
 out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
+
     Default: ``None``.
 order : {"C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
+
     Default: ``"K"``.
 
 Returns
 -------
-out : dpnp.ndarray
+out : dpnp.ndarray of bool dtype
     An array containing the element-wise logical AND results.
-    The shape is determined by broadcasting.
 
 Limitations
 -----------
@@ -1643,6 +1691,7 @@ boolean :class:`dpnp.ndarray`.
 >>> b = np.array([False, False])
 >>> a & b
 array([False, False])
+
 """
 
 logical_and = DPNPBinaryFunc(
@@ -1665,14 +1714,16 @@ x : {dpnp.ndarray, usm_ndarray}
 out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
+
     Default: ``None``.
 order : {"C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
+
     Default: ``"K"``.
 
 Returns
 -------
-out : dpnp.ndarray
+out : dpnp.ndarray of bool dtype
     An array containing the element-wise logical NOT results.
 
 Limitations
@@ -1696,6 +1747,7 @@ array([False,  True,  True, False])
 >>> x = np.arange(5)
 >>> np.logical_not(x < 3)
 array([False, False, False,  True,  True])
+
 """
 
 logical_not = DPNPUnaryFunc(
@@ -1725,16 +1777,17 @@ x2 : {dpnp.ndarray, usm_ndarray, scalar}
 out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
+
     Default: ``None``.
 order : {"C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
+
     Default: ``"K"``.
 
 Returns
 -------
-out : dpnp.ndarray
+out : dpnp.ndarray of bool dtype
     An array containing the element-wise logical OR results.
-    The shape is determined by broadcasting.
 
 Limitations
 -----------
@@ -1767,6 +1820,7 @@ boolean :class:`dpnp.ndarray`.
 >>> b = np.array([False, False])
 >>> a | b
 array([ True, False])
+
 """
 
 logical_or = DPNPBinaryFunc(
@@ -1796,16 +1850,17 @@ x2 : {dpnp.ndarray, usm_ndarray, scalar}
 out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
+
     Default: ``None``.
 order : {"C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
+
     Default: ``"K"``.
 
 Returns
 -------
-out : dpnp.ndarray
+out : dpnp.ndarray of bool dtype
     An array containing the element-wise logical XOR results.
-    The shape is determined by broadcasting.
 
 Limitations
 -----------
@@ -1836,6 +1891,7 @@ Simple example showing support of broadcasting
 >>> np.logical_xor(0, np.eye(2))
 array([[ True, False],
        [False,  True]])
+
 """
 
 logical_xor = DPNPBinaryFunc(
@@ -1865,16 +1921,17 @@ x2 : {dpnp.ndarray, usm_ndarray, scalar}
 out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
+
     Default: ``None``.
 order : {"C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
+
     Default: ``"K"``.
 
 Returns
 -------
-out : dpnp.ndarray
+out : dpnp.ndarray of bool dtype
     An array containing the result of element-wise inequality comparison.
-    The returned array has a data type of `bool`.
 
 Limitations
 -----------
@@ -1904,6 +1961,7 @@ The ``!=`` operator can be used as a shorthand for ``not_equal`` on
 >>> b = np.array([1., 3.])
 >>> a != b
 array([False,  True])
+
 """
 
 not_equal = DPNPBinaryFunc(

--- a/dpnp/dpnp_iface_logic.py
+++ b/dpnp/dpnp_iface_logic.py
@@ -43,7 +43,7 @@ it contains:
 
 
 import dpctl.tensor as dpt
-import dpctl.tensor._tensor_elementwise_impl as tei
+import dpctl.tensor._tensor_elementwise_impl as ti
 import numpy
 
 import dpnp
@@ -599,8 +599,8 @@ array([ True,  True, False])
 
 equal = DPNPBinaryFunc(
     "equal",
-    tei._equal_result_type,
-    tei._equal,
+    ti._equal_result_type,
+    ti._equal,
     _EQUAL_DOCSTRING,
 )
 
@@ -667,8 +667,8 @@ array([ True, False])
 
 greater = DPNPBinaryFunc(
     "greater",
-    tei._greater_result_type,
-    tei._greater,
+    ti._greater_result_type,
+    ti._greater,
     _GREATER_DOCSTRING,
 )
 
@@ -736,8 +736,8 @@ array([ True,  True, False])
 
 greater_equal = DPNPBinaryFunc(
     "greater",
-    tei._greater_equal_result_type,
-    tei._greater_equal,
+    ti._greater_equal_result_type,
+    ti._greater_equal,
     _GREATER_EQUAL_DOCSTRING,
 )
 
@@ -1002,8 +1002,8 @@ array([False,  True, False])
 
 isfinite = DPNPUnaryFunc(
     "isfinite",
-    tei._isfinite_result_type,
-    tei._isfinite,
+    ti._isfinite_result_type,
+    ti._isfinite,
     _ISFINITE_DOCSTRING,
 )
 
@@ -1126,8 +1126,8 @@ array([ True, False,  True])
 
 isinf = DPNPUnaryFunc(
     "isinf",
-    tei._isinf_result_type,
-    tei._isinf,
+    ti._isinf_result_type,
+    ti._isinf,
     _ISINF_DOCSTRING,
 )
 
@@ -1179,8 +1179,8 @@ array([False, False,  True])
 
 isnan = DPNPUnaryFunc(
     "isnan",
-    tei._isnan_result_type,
-    tei._isnan,
+    ti._isnan_result_type,
+    ti._isnan,
     _ISNAN_DOCSTRING,
 )
 
@@ -1508,8 +1508,8 @@ array([ True, False])
 
 less = DPNPBinaryFunc(
     "less",
-    tei._less_result_type,
-    tei._less,
+    ti._less_result_type,
+    ti._less,
     _LESS_DOCSTRING,
 )
 
@@ -1576,8 +1576,8 @@ array([False,  True,  True])
 
 less_equal = DPNPBinaryFunc(
     "less_equal",
-    tei._less_equal_result_type,
-    tei._less_equal,
+    ti._less_equal_result_type,
+    ti._less_equal,
     _LESS_EQUAL_DOCSTRING,
 )
 
@@ -1647,8 +1647,8 @@ array([False, False])
 
 logical_and = DPNPBinaryFunc(
     "logical_and",
-    tei._logical_and_result_type,
-    tei._logical_and,
+    ti._logical_and_result_type,
+    ti._logical_and,
     _LOGICAL_AND_DOCSTRING,
 )
 
@@ -1700,8 +1700,8 @@ array([False, False, False,  True,  True])
 
 logical_not = DPNPUnaryFunc(
     "logical_not",
-    tei._logical_not_result_type,
-    tei._logical_not,
+    ti._logical_not_result_type,
+    ti._logical_not,
     _LOGICAL_NOT_DOCSTRING,
 )
 
@@ -1771,8 +1771,8 @@ array([ True, False])
 
 logical_or = DPNPBinaryFunc(
     "logical_or",
-    tei._logical_or_result_type,
-    tei._logical_or,
+    ti._logical_or_result_type,
+    ti._logical_or,
     _LOGICAL_OR_DOCSTRING,
 )
 
@@ -1840,8 +1840,8 @@ array([[ True, False],
 
 logical_xor = DPNPBinaryFunc(
     "logical_xor",
-    tei._logical_xor_result_type,
-    tei._logical_xor,
+    ti._logical_xor_result_type,
+    ti._logical_xor,
     _LOGICAL_XOR_DOCSTRING,
 )
 
@@ -1908,7 +1908,7 @@ array([False,  True])
 
 not_equal = DPNPBinaryFunc(
     "not_equal",
-    tei._not_equal_result_type,
-    tei._not_equal,
+    ti._not_equal_result_type,
+    ti._not_equal,
     _NOT_EQUAL_DOCSTRING,
 )

--- a/dpnp/dpnp_iface_logic.py
+++ b/dpnp/dpnp_iface_logic.py
@@ -103,7 +103,7 @@ def all(a, /, axis=None, out=None, keepdims=False, *, where=True):
         the same shape as the expected output but the type (of the returned
         values) will be cast if necessary.
         Default: ``None``.
-    keepdims : bool, optional
+    keepdims : {None, bool}, optional
         If ``True``, the reduced axes (dimensions) are included in the result
         as singleton dimensions, so that the returned array remains
         compatible with the input array according to Array Broadcasting
@@ -275,7 +275,7 @@ def any(a, /, axis=None, out=None, keepdims=False, *, where=True):
         the same shape as the expected output but the type (of the returned
         values) will be cast if necessary.
         Default: ``None``.
-    keepdims : bool, optional
+    keepdims : {None, bool}, optional
         If ``True``, the reduced axes (dimensions) are included in the result
         as singleton dimensions, so that the returned array remains
         compatible with the input array according to Array Broadcasting

--- a/dpnp/dpnp_iface_logic.py
+++ b/dpnp/dpnp_iface_logic.py
@@ -560,7 +560,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -636,7 +636,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -706,7 +706,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -981,7 +981,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -1112,7 +1112,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -1169,7 +1169,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -1510,7 +1510,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -1580,7 +1580,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -1650,7 +1650,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -1716,7 +1716,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -1779,7 +1779,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -1852,7 +1852,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -1923,7 +1923,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -362,7 +362,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -437,7 +437,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -513,7 +513,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -617,7 +617,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -681,7 +681,7 @@ def clip(a, /, min=None, max=None, *, out=None, order="K", **kwargs):
         output. Its type is preserved.
 
         Default : ``None``.
-    order : {"C", "F", "A", "K", None}, optional
+    order : {None, "C", "F", "A", "K"}, optional
         Memory layout of the newly output array, if parameter `out` is ``None``.
         If `order` is ``None``, the default value ``"K"`` will be used.
 
@@ -753,7 +753,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -831,7 +831,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -1513,7 +1513,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -1683,7 +1683,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -1741,7 +1741,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -1820,7 +1820,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -1909,7 +1909,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -1977,7 +1977,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -2055,7 +2055,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -2144,7 +2144,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -2230,7 +2230,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -2303,7 +2303,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -2572,7 +2572,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -2622,7 +2622,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -2666,7 +2666,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -2732,7 +2732,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -2793,7 +2793,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -2862,7 +2862,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -2946,7 +2946,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -3063,7 +3063,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -3272,7 +3272,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -3336,7 +3336,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -3392,7 +3392,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -3463,7 +3463,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -3652,7 +3652,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -3705,7 +3705,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -3837,7 +3837,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -3915,7 +3915,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -4038,7 +4038,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -4095,7 +4095,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -4152,7 +4152,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -4214,7 +4214,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -4278,7 +4278,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.
@@ -4580,7 +4580,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Array must have the correct shape and the expected data type.
 
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
 
     Default: ``"K"``.

--- a/dpnp/dpnp_iface_nanfunctions.py
+++ b/dpnp/dpnp_iface_nanfunctions.py
@@ -682,7 +682,7 @@ def nanmedian(a, axis=None, out=None, overwrite_input=False, keepdims=False):
        but it will probably be fully or partially sorted.
 
        Default: ``False``.
-    keepdims : bool, optional
+    keepdims : {None, bool}, optional
         If ``True``, the reduced axes (dimensions) are included in the result
         as singleton dimensions, so that the returned array remains
         compatible with the input array according to Array Broadcasting

--- a/dpnp/dpnp_iface_searching.py
+++ b/dpnp/dpnp_iface_searching.py
@@ -400,7 +400,7 @@ def where(condition, x=None, y=None, /, *, order="K", out=None):
         broadcastable to some shape.
 
         Default: ``None``.
-    order : {"K", "C", "F", "A"}, optional
+    order : {None, "C", "F", "A", "K"}, optional
         Memory layout of the new output array, if keyword `out` is ``None``.
 
         Default: ``"K"``.

--- a/dpnp/dpnp_iface_statistics.py
+++ b/dpnp/dpnp_iface_statistics.py
@@ -1125,7 +1125,7 @@ def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
        but it will probably be fully or partially sorted.
 
        Default: ``False``.
-    keepdims : bool, optional
+    keepdims : {None, bool}, optional
         If ``True``, the reduced axes (dimensions) are included in the result
         as singleton dimensions, so that the returned array remains
         compatible with the input array according to Array Broadcasting

--- a/dpnp/dpnp_iface_trigonometric.py
+++ b/dpnp/dpnp_iface_trigonometric.py
@@ -124,7 +124,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -200,7 +200,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -277,7 +277,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -356,7 +356,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -433,7 +433,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -522,7 +522,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -595,7 +595,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -668,7 +668,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -720,7 +720,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -774,7 +774,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -916,7 +916,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -971,7 +971,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -1029,7 +1029,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -1082,7 +1082,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -1138,7 +1138,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -1205,7 +1205,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -1266,7 +1266,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -1321,7 +1321,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -1381,7 +1381,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -1441,7 +1441,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -1512,7 +1512,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -1586,7 +1586,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -1727,7 +1727,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -1782,7 +1782,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -1841,7 +1841,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -1967,11 +1967,11 @@ Parameters
 ----------
 x : {dpnp.ndarray, usm_ndarray}
     Input array, expected to have a real floating-point data type.
-out : ({None, dpnp.ndarray, usm_ndarray}, optional):
+out : {None, dpnp.ndarray, usm_ndarray}, optional:
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : ({'C', 'F', 'A', 'K'}, optional):
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is `None`.
     Default: ``"K"``
 
@@ -2022,7 +2022,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -2076,7 +2076,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -2129,7 +2129,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -2185,7 +2185,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -2240,7 +2240,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 
@@ -2294,7 +2294,7 @@ out : {None, dpnp.ndarray, usm_ndarray}, optional
     Output array to populate.
     Array must have the correct shape and the expected data type.
     Default: ``None``.
-order : {"C", "F", "A", "K"}, optional
+order : {None, "C", "F", "A", "K"}, optional
     Memory layout of the newly output array, if parameter `out` is ``None``.
     Default: ``"K"``.
 

--- a/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
+++ b/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
@@ -66,7 +66,7 @@ def _compute_res_dtype(*arrays, sycl_queue, dtype=None, out=None, casting="no"):
         Input arrays.
     dtype : dtype
         If not ``None`` and `out` is not defined, data type of the output array.
-    out : {out, dpnp.ndarray, usm_ndarray}
+    out : {None, dpnp.ndarray, usm_ndarray}
         If not ``None``, data type of the output array.
     casting : {"no", "equiv", "safe", "same_kind", "unsafe"}, optional
         Controls what kind of data casting may occur.

--- a/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
+++ b/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
@@ -66,7 +66,7 @@ def _compute_res_dtype(*arrays, sycl_queue, dtype=None, out=None, casting="no"):
         Input arrays.
     dtype : dtype
         If not ``None`` and `out` is not defined, data type of the output array.
-    out : {dpnp.ndarray, usm_ndarray}
+    out : {out, dpnp.ndarray, usm_ndarray}
         If not ``None``, data type of the output array.
     casting : {"no", "equiv", "safe", "same_kind", "unsafe"}, optional
         Controls what kind of data casting may occur.
@@ -75,7 +75,7 @@ def _compute_res_dtype(*arrays, sycl_queue, dtype=None, out=None, casting="no"):
 
     Returns
     -------
-    res_dtype :
+    res_dtype : dtype
         `res_dtype` is the output data type. When the result is obtained,
         it is cast to `res_dtype`.
 

--- a/dpnp/linalg/dpnp_iface_linalg.py
+++ b/dpnp/linalg/dpnp_iface_linalg.py
@@ -962,7 +962,7 @@ def matrix_norm(x, /, *, keepdims=False, ord="fro"):
     x : {dpnp.ndarray, usm_ndarray}
         Input array having shape (..., M, N) and whose two innermost
         dimensions form ``MxN`` matrices.
-    keepdims : bool, optional
+    keepdims : {None, bool}, optional
         If this is set to ``True``, the axes which are normed over are left in
         the result as dimensions with size one. With this option the result
         will broadcast correctly against the original `x`.
@@ -1290,7 +1290,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
         `x` is 1-D) or a matrix norm (when `x` is 2-D) is returned.
 
         Default: ``None``.
-    keepdims : bool, optional
+    keepdims : {None, bool}, optional
         If this is set to ``True``, the axes which are normed over are left in
         the result as dimensions with size one. With this option the result
         will broadcast correctly against the original `x`.
@@ -2336,7 +2336,7 @@ def vector_norm(x, /, *, axis=None, keepdims=False, ord=2):
         equivalent to computing the vector norm of a flattened array).
 
         Default: ``None``.
-    keepdims : bool, optional
+    keepdims : {None, bool}, optional
         If this is set to ``True``, the axes which are normed over are left in
         the result as dimensions with size one. With this option the result
         will broadcast correctly against the original `x`.


### PR DESCRIPTION
The PR updates docstrings for logic functions to have a blank line prior `Default` value.
Additionally it proposes to align description of `order`, `out` `keepdims` keywords.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [x] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
