### PR TITLE
Remove `dpnp.bitwise_count` from a list of miscellaneous mathematical functions

### DIFF
--- a/doc/reference/math.rst
+++ b/doc/reference/math.rst
@@ -232,5 +232,3 @@ Miscellaneous
    dpnp.real_if_close
 
    dpnp.interp
-
-   dpnp.bitwise_count


### PR DESCRIPTION
The PR proposes to remove duplicating reference on `dpnp.bitwise_count` from a list of miscellaneous mathematical functions.
It seems better to have `dpnp.bitwise_count` listed under bit-wise operations only.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
