### PR TITLE
get rid of explicit instantiation in fft backend

### DIFF
--- a/dpnp/backend/extensions/fft/CMakeLists.txt
+++ b/dpnp/backend/extensions/fft/CMakeLists.txt
@@ -27,8 +27,6 @@
 set(python_module_name _fft_impl)
 set(_module_src
     ${CMAKE_CURRENT_SOURCE_DIR}/fft_py.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/in_place.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/out_of_place.cpp
 )
 
 pybind11_add_module(${python_module_name} MODULE ${_module_src})

--- a/dpnp/backend/extensions/fft/in_place.hpp
+++ b/dpnp/backend/extensions/fft/in_place.hpp
@@ -42,3 +42,5 @@ std::pair<sycl::event, sycl::event>
                          const std::vector<sycl::event> &depends);
 
 } // namespace dpnp::extensions::fft
+
+#include "in_place.tpp" // Include template definition

--- a/dpnp/backend/extensions/fft/in_place.tpp
+++ b/dpnp/backend/extensions/fft/in_place.tpp
@@ -23,6 +23,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //*****************************************************************************
 
+#pragma once
 #include <stdexcept>
 
 #include <oneapi/mkl.hpp>
@@ -32,7 +33,6 @@
 
 #include "common.hpp"
 #include "fft_utils.hpp"
-#include "in_place.hpp"
 // dpctl tensor headers
 #include "utils/output_validation.hpp"
 
@@ -106,22 +106,5 @@ std::pair<sycl::event, sycl::event>
 
     return std::make_pair(fft_event, args_ev);
 }
-
-// Explicit instantiations
-// single precision c2c FFT
-template std::pair<sycl::event, sycl::event> compute_fft_in_place(
-    DescriptorWrapper<mkl_dft::precision::SINGLE, mkl_dft::domain::COMPLEX>
-        &descr,
-    const dpctl::tensor::usm_ndarray &in_out,
-    const bool is_forward,
-    const std::vector<sycl::event> &depends);
-
-// double precision c2c FFT
-template std::pair<sycl::event, sycl::event> compute_fft_in_place(
-    DescriptorWrapper<mkl_dft::precision::DOUBLE, mkl_dft::domain::COMPLEX>
-        &descr,
-    const dpctl::tensor::usm_ndarray &in_out,
-    const bool is_forward,
-    const std::vector<sycl::event> &depends);
 
 } // namespace dpnp::extensions::fft

--- a/dpnp/backend/extensions/fft/out_of_place.hpp
+++ b/dpnp/backend/extensions/fft/out_of_place.hpp
@@ -43,3 +43,5 @@ std::pair<sycl::event, sycl::event>
                              const std::vector<sycl::event> &depends);
 
 } // namespace dpnp::extensions::fft
+
+#include "out_of_place.tpp" // Include template definition

--- a/dpnp/backend/extensions/fft/out_of_place.tpp
+++ b/dpnp/backend/extensions/fft/out_of_place.tpp
@@ -23,6 +23,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //*****************************************************************************
 
+#pragma once
 #include <stdexcept>
 
 #include <oneapi/mkl.hpp>
@@ -32,7 +33,6 @@
 
 #include "common.hpp"
 #include "fft_utils.hpp"
-#include "out_of_place.hpp"
 // dpctl tensor headers
 #include "utils/memory_overlap.hpp"
 #include "utils/output_validation.hpp"
@@ -167,38 +167,4 @@ std::pair<sycl::event, sycl::event>
     return std::make_pair(fft_event, args_ev);
 }
 
-// Explicit instantiations
-// single precision c2c FFT
-template std::pair<sycl::event, sycl::event> compute_fft_out_of_place(
-    DescriptorWrapper<mkl_dft::precision::SINGLE, mkl_dft::domain::COMPLEX>
-        &descr,
-    const dpctl::tensor::usm_ndarray &in,
-    const dpctl::tensor::usm_ndarray &out,
-    const bool is_forward,
-    const std::vector<sycl::event> &depends);
-
-// double precision c2c FFT
-template std::pair<sycl::event, sycl::event> compute_fft_out_of_place(
-    DescriptorWrapper<mkl_dft::precision::DOUBLE, mkl_dft::domain::COMPLEX>
-        &descr,
-    const dpctl::tensor::usm_ndarray &in,
-    const dpctl::tensor::usm_ndarray &out,
-    const bool is_forward,
-    const std::vector<sycl::event> &depends);
-
-// single precision r2c/c2r FFT
-template std::pair<sycl::event, sycl::event> compute_fft_out_of_place(
-    DescriptorWrapper<mkl_dft::precision::SINGLE, mkl_dft::domain::REAL> &descr,
-    const dpctl::tensor::usm_ndarray &in,
-    const dpctl::tensor::usm_ndarray &out,
-    const bool is_forward,
-    const std::vector<sycl::event> &depends);
-
-// double precision r2c/c2r FFT
-template std::pair<sycl::event, sycl::event> compute_fft_out_of_place(
-    DescriptorWrapper<mkl_dft::precision::DOUBLE, mkl_dft::domain::REAL> &descr,
-    const dpctl::tensor::usm_ndarray &in,
-    const dpctl::tensor::usm_ndarray &out,
-    const bool is_forward,
-    const std::vector<sycl::event> &depends);
 } // namespace dpnp::extensions::fft


### PR DESCRIPTION
In this PR, explicit instantiation of `compute_fft_in_place` and `compute_fft_out_of_place` functions in the backend is replaced with including a template definition.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
