### PR TITLE
Update docstrings for sorting functions

### DIFF
--- a/dpnp/dpnp_iface_sorting.py
+++ b/dpnp/dpnp_iface_sorting.py
@@ -110,22 +110,26 @@ def argsort(
     axis : {None, int}, optional
         Axis along which to sort. If ``None``, the array is flattened before
         sorting. The default is ``-1``, which sorts along the last axis.
+
         Default: ``-1``.
     kind : {None, "stable", "mergesort", "radixsort"}, optional
         Sorting algorithm. The default is ``None``, which uses parallel
         merge-sort or parallel radix-sort algorithms depending on the array
         data type.
+
         Default: ``None``.
     descending : bool, optional
         Sort order. If ``True``, the array must be sorted in descending order
         (by value). If ``False``, the array must be sorted in ascending order
         (by value).
+
         Default: ``False``.
     stable : {None, bool}, optional
         Sort stability. If ``True``, the returned array will maintain the
         relative order of `a` values which compare as equal. The same behavior
         applies when set to ``False`` or ``None``.
         Internally, this option selects ``kind="stable"``.
+
         Default: ``None``.
 
     Returns
@@ -251,22 +255,26 @@ def sort(a, axis=-1, kind=None, order=None, *, descending=False, stable=None):
     axis : {None, int}, optional
         Axis along which to sort. If ``None``, the array is flattened before
         sorting. The default is ``-1``, which sorts along the last axis.
+
         Default: ``-1``.
     kind : {None, "stable", "mergesort", "radixsort"}, optional
         Sorting algorithm. The default is ``None``, which uses parallel
         merge-sort or parallel radix-sort algorithms depending on the array
         data type.
+
         Default: ``None``.
     descending : bool, optional
         Sort order. If ``True``, the array must be sorted in descending order
         (by value). If ``False``, the array must be sorted in ascending order
         (by value).
+
         Default: ``False``.
     stable : {None, bool}, optional
         Sort stability. If ``True``, the returned array will maintain the
         relative order of `a` values which compare as equal. The same behavior
         applies when set to ``False`` or ``None``.
         Internally, this option selects ``kind="stable"``.
+
         Default: ``None``.
 
     Returns

--- a/dpnp/dpnp_iface_statistics.py
+++ b/dpnp/dpnp_iface_statistics.py
@@ -837,7 +837,7 @@ def cov(
     >>> import dpnp as np
     >>> x = np.array([[0, 2], [1, 1], [2, 0]]).T
 
-    Consider two variables, :math:`x_0` and  :math:`x_1`, which correlate
+    Consider two variables, :math:`x_0` and :math:`x_1`, which correlate
     perfectly, but in opposite directions:
 
     >>> x


### PR DESCRIPTION
The PR updates docstrings for sorting functions to have a blank line prior `Default` value.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
