### PR TITLE
Add a missing event dependency for the strided kernel of erf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Resolved an issue with an incorrect result returned due to missing dependency from the strided kernel on a copy event in `dpnp.erf` [#2378](https://github.com/IntelPython/dpnp/pull/2378)
+
 
 ## [0.17.0] - 02/26/2025
 

--- a/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_elemwise.cpp
@@ -148,6 +148,7 @@ constexpr T dispatch_erf_op(T elem)
                 }                                                              \
             };                                                                 \
             auto kernel_func = [&](sycl::handler &cgh) {                       \
+                cgh.depends_on(copy_strides_ev);                               \
                 cgh.parallel_for<class __name__##_strides_kernel<_DataType>>(  \
                     gws, kernel_parallel_for_func);                            \
             };                                                                 \


### PR DESCRIPTION
The PR proposes to resolve a sporadic failure due to mismatch with the expected data in `test_strides.py::test_erf`.
The issue looks caused by missing dependency from strided erf kernel on a copy event (produced by copy kernel to transfer the strides of input array from host to device memory).

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
