### PR TITLE
Install dpctl via pip manager in coverage and docs workflows

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -135,11 +135,26 @@ jobs:
           environment-file: ${{ env.environment-file }}
           activate-environment: 'docs'
 
-      - name: Conda info
-        run: mamba info
+      # We can't install dpctl as a conda package when the environment is created through
+      # installing of Intel OneAPI packages because the dpctl conda package has a runtime
+      # dependency on DPC++ RT one. Whereas the DPC++ RT package has been already installed
+      # by the apt command above and its version has been matched with the DPC++ compiler.
+      # In case where we install the DPC++ compiler with the apt (including DPC++ RT) and
+      # install the DPC++ RT conda package while resolving dependencies, this can lead
+      # to a versioning error, i.e. compatibility issue as the DPC++ compiler only guarantees
+      # backwards compatibility, not forward compatibility (DPC++ RT may not run a binary built
+      # with a newer version of the DPC++ compiler).
+      # Installing dpctl via the pip manager has no such limitation, as the package has no
+      # run dependency on the DPC++ RT pip package, so this is why the step is necessary here.
+      - name: Install dpctl
+        if: env.oneapi-pkgs-env == ''
+        run: |
+          pip install -i https://pypi.anaconda.org/dppy/label/dev/simple dpctl
 
-      - name: Conda list
-        run: mamba list
+      - name: Conda info
+        run: |
+          mamba info
+          mamba list
 
       - name: Build library
         run: |

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Install dpctl
         if: env.oneapi-pkgs-env == ''
         run: |
-          pip install -i https://pypi.anaconda.org/dppy/label/dev/simple dpctl
+          pip install -i https://pypi.anaconda.org/dppy/label/dev/simple dpctl==0.20.0dev0
 
       - name: Conda info
         run: |

--- a/.github/workflows/check-mkl-interfaces.yaml
+++ b/.github/workflows/check-mkl-interfaces.yaml
@@ -13,6 +13,7 @@ env:
   environment-file-name: 'environment.yml'
   environment-file-loc: '${{ github.workspace }}/environments'
   build-with-oneapi-env: 'environments/build_with_oneapi.yml'
+  dpctl-pkg-env: 'environments/dpctl_pkg.yml'
   oneapi-pkgs-env: 'environments/oneapi_pkgs.yml'
   test-env-name: 'test_onemkl_interfaces'
   rerun-tests-on-failure: 'true'
@@ -47,7 +48,8 @@ jobs:
 
       - name: Merge conda env files
         run: |
-          conda-merge ${{ env.build-with-oneapi-env }} ${{ env.oneapi-pkgs-env }} > ${{ env.environment-file }}
+          conda-merge ${{ env.build-with-oneapi-env }} ${{ env.dpctl-pkg-env }} ${{ env.oneapi-pkgs-env }} > ${{ env.environment-file }}
+          cat ${{ env.environment-file }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -94,6 +94,22 @@ jobs:
           environment-file: ${{ env.environment-file }}
           activate-environment: 'coverage'
 
+      # We can't install dpctl as a conda package when the environment is created through
+      # installing of Intel OneAPI packages because the dpctl conda package has a runtime
+      # dependency on DPC++ RT one. Whereas the DPC++ RT package has beedn already installed
+      # by the apt command above and its version has been matched with the DPC++ compiler.
+      # In case where we install the DPC++ compiler with the apt (including DPC++ RT) and
+      # install the DPC++ RT conda package while resolving dependencies, this can lead
+      # to a versioning error, i.e. compatibility issue as the DPC++ compiler only guarantees
+      # backwards compatibility, not forward compatibility (DPC++ RT may not run a binary built
+      # with a newer version of the DPC++ compiler).
+      # Installing dpctl via the pip manager has no such limitation, as the package has no
+      # run dependency on the DPC++ RT pip package, so this is why the step is necessary here.
+      - name: Install dpctl
+        if: env.oneapi-pkgs-env == ''
+        run: |
+          pip install -i https://pypi.anaconda.org/dppy/label/dev/simple dpctl
+
       - name: Conda info
         run: |
           mamba info

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -108,7 +108,7 @@ jobs:
       - name: Install dpctl
         if: env.oneapi-pkgs-env == ''
         run: |
-          pip install -i https://pypi.anaconda.org/dppy/label/dev/simple dpctl
+          pip install -i https://pypi.anaconda.org/dppy/label/dev/simple dpctl==0.20.0dev0
 
       - name: Conda info
         run: |

--- a/environments/build_with_oneapi.yml
+++ b/environments/build_with_oneapi.yml
@@ -1,11 +1,9 @@
 name: Packages to build DPNP with OneAPI env activated
 channels:
-  - dppy/label/dev
   - conda-forge
 dependencies:
   - cmake
   - cython
-  - dpctl>=0.19.0dev0
   - ninja
   - numpy
   - pytest

--- a/environments/dpctl_pkg.yml
+++ b/environments/dpctl_pkg.yml
@@ -1,0 +1,5 @@
+name: Install dpctl package
+channels:
+  - dppy/label/dev
+dependencies:
+  - dpctl>=0.20.0dev0


### PR DESCRIPTION
This PR resolves issue with `coverage` and `docs` GitHub workflows observing since 2025.1 release is published.

The reason of the proposed changes is that it isn't possible to install dpctl there as a conda package when the environment is created through installing of Intel OneAPI packages because the dpctl conda package has a runtime dependency on DPC++ RT one. Whereas the DPC++ RT package has been already installed by the apt command above and its version has been matched with the DPC++ compiler.
In case where we install the DPC++ compiler with the apt (including DPC++ RT) and install the DPC++ RT conda package while resolving dependencies, this can lead to a versioning error, i.e. compatibility issue as the DPC++ compiler only guarantees backwards compatibility, not forward compatibility (DPC++ RT may not run a binary built with a newer version of the DPC++ compiler).

Installing dpctl via the pip manager has no such limitation, as the package has no run dependency on the DPC++ RT pip package, so this is why the new step is proposed to be added to the workflows.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
