### PR TITLE
Add `dtype` keyword argument to `dpnp.fft.fftfreq` and `dpnp.fft.rfftfreq`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Extended `dpnp.fft.fftfreq` and `dpnp.fft.rfftfreq` functions to support `dtype` keyword per Python Array API spec 2024.12 [#2384](https://github.com/IntelPython/dpnp/pull/2384)
 * Allowed input array of `uint64` dtype in `dpnp.bincount` [#2361](https://github.com/IntelPython/dpnp/pull/2361)
 * The vector norms `ord={None, 1, 2, inf}` and the matrix norms `ord={None, 1, 2, inf, "fro", "nuc"}` now consistently return zero for empty arrays, which are arrays with at least one axis of size zero. This change affects `dpnp.linalg.norm`, `dpnp.linalg.vector_norm`, and `dpnp.linalg.matrix_norm`. Previously, dpnp would either raise errors or return zero depending on the parameters provided [#2371](https://github.com/IntelPython/dpnp/pull/2371)
 

--- a/dpnp/fft/dpnp_iface_fft.py
+++ b/dpnp/fft/dpnp_iface_fft.py
@@ -102,19 +102,24 @@ def fft(a, n=None, axis=-1, norm=None, out=None):
         If `n` is smaller than the length of the input, the input is cropped.
         If it is larger, the input is padded with zeros. If `n` is not given,
         the length of the input along the axis specified by `axis` is used.
+
         Default: ``None``.
     axis : int, optional
         Axis over which to compute the FFT. If not given, the last axis is
-        used. Default: ``-1``.
+        used.
+
+        Default: ``-1``.
     norm : {None, "backward", "ortho", "forward"}, optional
         Normalization mode (see :obj:`dpnp.fft`).
         Indicates which direction of the forward/backward pair of transforms
         is scaled and with what normalization factor. ``None`` is an alias of
         the default option ``"backward"``.
+
         Default: ``"backward"``.
     out : {None, dpnp.ndarray or usm_ndarray of complex dtype}, optional
         If provided, the result will be placed in this array. It should be of
         the appropriate shape (consistent with the choice of `n`) and dtype.
+
         Default: ``None``.
 
     Returns
@@ -184,7 +189,9 @@ def fft2(a, s=None, axes=(-2, -1), norm=None, out=None):
         If it is ``-1``, the whole input is used (no padding/trimming).
         If `s` is not given, the shape of the input along the axes specified
         by `axes` is used. If `s` is not ``None``, `axes` must not be ``None``
-        either. Default: ``None``.
+        either.
+
+        Default: ``None``.
     axes : {None, sequence of ints}, optional
         Axes over which to compute the FFT. If not given, the last two axes are
         used. A repeated index in `axes` means the transform over that axis is
@@ -192,16 +199,19 @@ def fft2(a, s=None, axes=(-2, -1), norm=None, out=None):
         to be transformed must be explicitly specified too. A one-element
         sequence means that a one-dimensional FFT is performed. An empty
         sequence means that no FFT is performed.
+
         Default: ``(-2, -1)``.
     norm : {None, "backward", "ortho", "forward"}, optional
         Normalization mode (see :obj:`dpnp.fft`).
         Indicates which direction of the forward/backward pair of transforms
         is scaled and with what normalization factor. ``None`` is an alias of
         the default option ``"backward"``.
+
         Default: ``"backward"``.
     out : {None, dpnp.ndarray or usm_ndarray of complex dtype}, optional
         If provided, the result will be placed in this array. It should be of
         the appropriate shape (consistent with the choice of `s`) and dtype.
+
         Default: ``None``.
 
     Returns
@@ -281,6 +291,7 @@ def fftfreq(
         Window length.
     d : scalar, optional
         Sample spacing (inverse of the sampling rate).
+
         Default: ``1.0``.
     dtype : {None, str, dtype object}, optional
         The output array data type. Must be a real-valued floating-point data
@@ -299,12 +310,14 @@ def fftfreq(
         Default: ``None``.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
+
         Default: ``None``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying. The
         `sycl_queue` can be passed as ``None`` (the default), which means
         to get the SYCL queue from `device` keyword if present or to use
         a default queue.
+
         Default: ``None``.
 
     Returns
@@ -389,7 +402,9 @@ def fftn(a, s=None, axes=None, norm=None, out=None):
         If it is ``-1``, the whole input is used (no padding/trimming).
         If `s` is not given, the shape of the input along the axes specified
         by `axes` is used. If `s` is not ``None``, `axes` must not be ``None``
-        either. Default: ``None``.
+        either.
+
+        Default: ``None``.
     axes : {None, sequence of ints}, optional
         Axes over which to compute the FFT. If not given, the last ``len(s)``
         axes are used, or all axes if `s` is also not specified.
@@ -398,16 +413,19 @@ def fftn(a, s=None, axes=None, norm=None, out=None):
         to be transformed must be explicitly specified too. A one-element
         sequence means that a one-dimensional FFT is performed. An empty
         sequence means that no FFT is performed.
+
         Default: ``None``.
     norm : {None, "backward", "ortho", "forward"}, optional
         Normalization mode (see :obj:`dpnp.fft`).
         Indicates which direction of the forward/backward pair of transforms
         is scaled and with what normalization factor. ``None`` is an alias of
         the default option ``"backward"``.
+
         Default: ``"backward"``.
     out : {None, dpnp.ndarray or usm_ndarray of complex dtype}, optional
         If provided, the result will be placed in this array. It should be of
         the appropriate shape (consistent with the choice of `s`) and dtype.
+
         Default: ``None``.
 
     Returns
@@ -481,8 +499,9 @@ def fftshift(x, axes=None):
     x : {dpnp.ndarray, usm_ndarray}
         Input array.
     axes : {None, int, list or tuple of ints}, optional
-        Axes over which to shift.
-        Default is ``None``, which shifts all axes.
+        Axes over which to shift. By default, it shifts over all axes.
+
+        Default: ``None``.
 
     Returns
     -------
@@ -546,19 +565,25 @@ def hfft(a, n=None, axis=-1, norm=None, out=None):
         input is longer than this, it is cropped. If it is shorter than this,
         it is padded with zeros. If `n` is not given, it is taken to be
         ``2*(m-1)`` where `m` is the length of the input along the axis
-        specified by `axis`. Default: ``None``.
+        specified by `axis`.
+
+        Default: ``None``.
     axis : int, optional
         Axis over which to compute the FFT. If not given, the last axis is
-        used. Default: ``-1``.
+        used.
+
+        Default: ``-1``.
     norm : {None, "backward", "ortho", "forward"}, optional
         Normalization mode (see :obj:`dpnp.fft`).
         Indicates which direction of the forward/backward pair of transforms
         is scaled and with what normalization factor. ``None`` is an alias of
         the default option ``"backward"``.
+
         Default: ``"backward"``.
     out : {None, dpnp.ndarray, usm_ndarray}, optional
         If provided, the result will be placed in this array. It should be
         of the appropriate shape and dtype.
+
         Default: ``None``.
 
     Returns
@@ -656,19 +681,24 @@ def ifft(a, n=None, axis=-1, norm=None, out=None):
         If `n` is smaller than the length of the input, the input is cropped.
         If it is larger, the input is padded with zeros. If `n` is not given,
         the length of the input along the axis specified by `axis` is used.
+
         Default: ``None``.
     axis : int, optional
         Axis over which to compute the inverse FFT. If not given, the last
-        axis is used. Default: ``-1``.
-    norm : {"backward", "ortho", "forward"}, optional
+        axis is used.
+
+        Default: ``-1``.
+    norm : {None, "backward", "ortho", "forward"}, optional
         Normalization mode (see :obj:`dpnp.fft`).
         Indicates which direction of the forward/backward pair of transforms
         is scaled and with what normalization factor. ``None`` is an alias of
         the default option ``"backward"``.
+
         Default: ``"backward"``.
     out : {None, dpnp.ndarray or usm_ndarray of complex dtype}, optional
         If provided, the result will be placed in this array. It should be of
         the appropriate shape (consistent with the choice of `n`) and dtype.
+
         Default: ``None``.
 
     Returns
@@ -741,7 +771,9 @@ def ifft2(a, s=None, axes=(-2, -1), norm=None, out=None):
         If `s` is not given, the shape of the input along the axes specified
         by `axes` is used. See notes for issue on :obj:`dpnp.fft.ifft`
         zero padding. If `s` is not ``None``, `axes` must not be ``None``
-        either. Default: ``None``.
+        either.
+
+        Default: ``None``.
     axes : {None, sequence of ints}, optional
         Axes over which to compute the inverse FFT. If not given, the last two
         axes are used. A repeated index in `axes` means the transform over that
@@ -749,16 +781,19 @@ def ifft2(a, s=None, axes=(-2, -1), norm=None, out=None):
         corresponding `axes` to be transformed must be explicitly specified
         too. A one-element sequence means that a one-dimensional FFT is
         performed. An empty sequence means that no FFT is performed.
+
         Default: ``(-2, -1)``.
     norm : {None, "backward", "ortho", "forward"}, optional
         Normalization mode (see :obj:`dpnp.fft`).
         Indicates which direction of the forward/backward pair of transforms
         is scaled and with what normalization factor. ``None`` is an alias of
         the default option ``"backward"``.
+
         Default: ``"backward"``.
     out : {None, dpnp.ndarray or usm_ndarray of complex dtype}, optional
         If provided, the result will be placed in this array. It should be of
         the appropriate shape (consistent with the choice of `s`) and dtype.
+
         Default: ``None``.
 
     Returns
@@ -839,7 +874,9 @@ def ifftn(a, s=None, axes=None, norm=None, out=None):
         If it is ``-1``, the whole input is used (no padding/trimming).
         if `s` is not given, the shape of the input along the axes specified
         by `axes` is used. If `s` is not ``None``, `axes` must not be ``None``
-        either. Default: ``None``.
+        either.
+
+        Default: ``None``.
     axes : {None, sequence of ints}, optional
         Axes over which to compute the inverse FFT. If not given, the last
         ``len(s)`` axes are used, or all axes if `s` is also not specified.
@@ -848,16 +885,19 @@ def ifftn(a, s=None, axes=None, norm=None, out=None):
         to be transformed must be explicitly specified too. A one-element
         sequence means that a one-dimensional FFT is performed. An empty
         sequence means that no FFT is performed.
+
         Default: ``None``.
     norm : {None, "backward", "ortho", "forward"}, optional
         Normalization mode (see :obj:`dpnp.fft`).
         Indicates which direction of the forward/backward pair of transforms
         is scaled and with what normalization factor. ``None`` is an alias of
         the default option ``"backward"``.
+
         Default: ``"backward"``.
     out : {None, dpnp.ndarray or usm_ndarray of complex dtype}, optional
         If provided, the result will be placed in this array. It should be of
         the appropriate shape (consistent with the choice of `s`) and dtype.
+
         Default: ``None``.
 
     Returns
@@ -919,8 +959,9 @@ def ifftshift(x, axes=None):
     x : {dpnp.ndarray, usm_ndarray}
         Input array.
     axes : {None, int, list or tuple of ints}, optional
-        Axes over which to calculate.
-        Defaults to ``None``, which shifts all axes.
+        Axes over which to shift. By default, it shifts over all axes.
+
+        Default: ``None``.
 
     Returns
     -------
@@ -976,19 +1017,24 @@ def ihfft(a, n=None, axis=-1, norm=None, out=None):
         the length of the input, the input is cropped. If it is larger,
         the input is padded with zeros. If `n` is not given, the length of
         the input along the axis specified by `axis` is used.
+
         Default: ``None``.
     axis : int, optional
         Axis over which to compute the FFT. If not given, the last axis is
-        used. Default: ``-1``.
+        used.
+
+        Default: ``-1``.
     norm : {None, "backward", "ortho", "forward"}, optional
         Normalization mode (see :obj:`dpnp.fft`).
         Indicates which direction of the forward/backward pair of transforms
         is scaled and with what normalization factor. ``None`` is an alias of
         the default option ``"backward"``.
+
         Default: ``"backward"``.
     out : {None, dpnp.ndarray or usm_ndarray of complex dtype}, optional
         If provided, the result will be placed in this array. It should be
         of the appropriate shape and dtype.
+
         Default: ``None``.
 
     Returns
@@ -1060,19 +1106,25 @@ def irfft(a, n=None, axis=-1, norm=None, out=None):
         input is longer than this, it is cropped. If it is shorter than this,
         it is padded with zeros. If `n` is not given, it is taken to be
         ``2*(m-1)`` where `m` is the length of the input along the axis
-        specified by `axis`. Default: ``None``.
+        specified by `axis`.
+
+        Default: ``None``.
     axis : int, optional
         Axis over which to compute the FFT. If not given, the last axis is
-        used. Default: ``-1``.
+        used.
+
+        Default: ``-1``.
     norm : {None, "backward", "ortho", "forward"}, optional
         Normalization mode (see :obj:`dpnp.fft`).
         Indicates which direction of the forward/backward pair of transforms
         is scaled and with what normalization factor. ``None`` is an alias of
         the default option ``"backward"``.
+
         Default: ``"backward"``.
     out : {None, dpnp.ndarray, usm_ndarray}, optional
         If provided, the result will be placed in this array. It should be
         of the appropriate shape and dtype.
+
         Default: ``None``.
 
     Returns
@@ -1158,7 +1210,8 @@ def irfft2(a, s=None, axes=(-2, -1), norm=None, out=None):
         If `s` is not given, the shape of the input along the axes
         specified by `axes` is used. Except for the last axis which is taken to
         be ``2*(m-1)`` where `m` is the length of the input along that axis.
-        If `s` is not ``None``, `axes` must not be ``None``
+        If `s` is not ``None``, `axes` must not be ``None`` either.
+
         Default: ``None``.
     axes : {None, sequence of ints}, optional
         Axes over which to compute the inverse FFT. If not given, the last
@@ -1168,17 +1221,20 @@ def irfft2(a, s=None, axes=(-2, -1), norm=None, out=None):
         to be transformed must be explicitly specified too. A one-element
         sequence means that a one-dimensional FFT is performed. An empty
         sequence means that no FFT is performed.
+
         Default: ``(-2, -1)``.
     norm : {None, "backward", "ortho", "forward"}, optional
         Normalization mode (see :obj:`dpnp.fft`).
         Indicates which direction of the forward/backward pair of transforms
         is scaled and with what normalization factor. ``None`` is an alias of
         the default option ``"backward"``.
+
         Default: ``"backward"``.
-    out : {None, dpnp.ndarray or usm_ndarray}, optional
+    out : {None, dpnp.ndarray, usm_ndarray}, optional
         If provided, the result will be placed in this array. It should be of
         the appropriate dtype and shape for the last transformation
         (consistent with the choice of `s`).
+
         Default: ``None``.
 
     Returns
@@ -1255,9 +1311,10 @@ def irfftn(a, s=None, axes=None, norm=None, out=None):
         the input is cropped. If it is larger, the input is padded with zeros.
         If it is ``-1``, the whole input is used (no padding/trimming).
         If `s` is not given, the shape of the input along the axes
-        specified by axes is used. Except for the last axis which is taken to
+        specified by `axes` is used. Except for the last axis which is taken to
         be ``2*(m-1)`` where `m` is the length of the input along that axis.
-        If `s` is not ``None``, `axes` must not be ``None``
+        If `s` is not ``None``, `axes` must not be ``None`` either.
+
         Default: ``None``.
     axes : {None, sequence of ints}, optional
         Axes over which to compute the inverse FFT. If not given, the last
@@ -1267,17 +1324,20 @@ def irfftn(a, s=None, axes=None, norm=None, out=None):
         to be transformed must be explicitly specified too. A one-element
         sequence means that a one-dimensional FFT is performed. An empty
         sequence means that no FFT is performed.
+
         Default: ``None``.
     norm : {None, "backward", "ortho", "forward"}, optional
         Normalization mode (see :obj:`dpnp.fft`).
         Indicates which direction of the forward/backward pair of transforms
         is scaled and with what normalization factor. ``None`` is an alias of
         the default option ``"backward"``.
+
         Default: ``"backward"``.
-    out : {None, dpnp.ndarray or usm_ndarray}, optional
+    out : {None, dpnp.ndarray, usm_ndarray}, optional
         If provided, the result will be placed in this array. It should be of
         the appropriate dtype and shape for the last transformation
         (consistent with the choice of `s`).
+
         Default: ``None``.
 
     Returns
@@ -1361,19 +1421,24 @@ def rfft(a, n=None, axis=-1, norm=None, out=None):
         If `n` is smaller than the length of the input, the input is cropped.
         If it is larger, the input is padded with zeros. If `n` is not given,
         the length of the input along the axis specified by `axis` is used.
+
         Default: ``None``.
     axis : int, optional
         Axis over which to compute the FFT. If not given, the last axis is
-        used. Default: ``-1``.
+        used.
+
+        Default: ``-1``.
     norm : {None, "backward", "ortho", "forward"}, optional
         Normalization mode (see :obj:`dpnp.fft`).
         Indicates which direction of the forward/backward pair of transforms
         is scaled and with what normalization factor. ``None`` is an alias of
         the default option ``"backward"``.
+
         Default: ``"backward"``.
     out : {None, dpnp.ndarray or usm_ndarray of complex dtype}, optional
         If provided, the result will be placed in this array. It should be
         of the appropriate shape and dtype.
+
         Default: ``None``.
 
     Returns
@@ -1453,7 +1518,9 @@ def rfft2(a, s=None, axes=(-2, -1), norm=None, out=None):
         If it is ``-1``, the whole input is used (no padding/trimming).
         If `s` is not given, the shape of the input along the axes specified
         by `axes` is used. If `s` is not ``None``, `axes` must not be ``None``
-        either. Default: ``None``.
+        either.
+
+        Default: ``None``.
     axes : {None, sequence of ints}, optional
         Axes over which to compute the FFT. If not given, the last two axes are
         used. A repeated index in `axes` means the transform over that axis is
@@ -1461,17 +1528,20 @@ def rfft2(a, s=None, axes=(-2, -1), norm=None, out=None):
         to be transformed must be explicitly specified too. A one-element
         sequence means that a one-dimensional FFT is performed. An empty
         sequence means that no FFT is performed.
+
         Default: ``(-2, -1)``.
     norm : {None, "backward", "ortho", "forward"}, optional
         Normalization mode (see :obj:`dpnp.fft`).
         Indicates which direction of the forward/backward pair of transforms
         is scaled and with what normalization factor. ``None`` is an alias of
         the default option ``"backward"``.
+
         Default: ``"backward"``.
     out : {None, dpnp.ndarray or usm_ndarray of complex dtype}, optional
         If provided, the result will be placed in this array. It should be of
         the appropriate dtype and shape for the last transformation
         (consistent with the choice of `s`).
+
         Default: ``None``.
 
     Returns
@@ -1539,6 +1609,7 @@ def rfftfreq(
         Window length.
     d : scalar, optional
         Sample spacing (inverse of the sampling rate).
+
         Default: ``1.0``.
     dtype : {None, str, dtype object}, optional
         The output array data type. Must be a real-valued floating-point data
@@ -1557,12 +1628,14 @@ def rfftfreq(
         Default: ``None``.
     usm_type : {None, "device", "shared", "host"}, optional
         The type of SYCL USM allocation for the output array.
+
         Default: ``None``.
     sycl_queue : {None, SyclQueue}, optional
         A SYCL queue to use for output array allocation and copying. The
         `sycl_queue` can be passed as ``None`` (the default), which means
         to get the SYCL queue from `device` keyword if present or to use
         a default queue.
+
         Default: ``None``.
 
     Returns
@@ -1657,7 +1730,9 @@ def rfftn(a, s=None, axes=None, norm=None, out=None):
         If it is ``-1``, the whole input is used (no padding/trimming).
         If `s` is not given, the shape of the input along the axes specified
         by `axes` is used. If `s` is not ``None``, `axes` must not be ``None``
-        either. Default: ``None``.
+        either.
+
+        Default: ``None``.
     axes : {None, sequence of ints}, optional
         Axes over which to compute the FFT. If not given, the last ``len(s)``
         axes are used, or all axes if `s` is also not specified.
@@ -1666,17 +1741,20 @@ def rfftn(a, s=None, axes=None, norm=None, out=None):
         to be transformed must be explicitly specified too. A one-element
         sequence means that a one-dimensional FFT is performed. An empty
         sequence means that no FFT is performed.
+
         Default: ``None``.
     norm : {None, "backward", "ortho", "forward"}, optional
         Normalization mode (see :obj:`dpnp.fft`).
         Indicates which direction of the forward/backward pair of transforms
         is scaled and with what normalization factor. ``None`` is an alias of
         the default option ``"backward"``.
+
         Default: ``"backward"``.
     out : {None, dpnp.ndarray or usm_ndarray of complex dtype}, optional
         If provided, the result will be placed in this array. It should be of
         the appropriate dtype and shape for the last transformation
         (consistent with the choice of `s`).
+
         Default: ``None``.
 
     Returns

--- a/dpnp/fft/dpnp_iface_fft.py
+++ b/dpnp/fft/dpnp_iface_fft.py
@@ -269,7 +269,7 @@ def fft2(a, s=None, axes=(-2, -1), norm=None, out=None):
 
 
 def fftfreq(
-    n, /, *, d=1.0, dtype=None, device=None, usm_type=None, sycl_queue=None
+    n, /, d=1.0, *, dtype=None, device=None, usm_type=None, sycl_queue=None
 ):
     """
     Return the Discrete Fourier Transform sample frequencies.
@@ -1583,7 +1583,7 @@ def rfft2(a, s=None, axes=(-2, -1), norm=None, out=None):
 
 
 def rfftfreq(
-    n, /, *, d=1.0, dtype=None, device=None, usm_type=None, sycl_queue=None
+    n, /, d=1.0, *, dtype=None, device=None, usm_type=None, sycl_queue=None
 ):
     """
     Return the Discrete Fourier Transform sample frequencies

--- a/dpnp/fft/dpnp_utils_fft.py
+++ b/dpnp/fft/dpnp_utils_fft.py
@@ -60,6 +60,7 @@ from ..dpnp_utils.dpnp_utils_linearalgebra import (
 __all__ = [
     "dpnp_fft",
     "dpnp_fftn",
+    "dpnp_fillfreq",
 ]
 
 
@@ -698,3 +699,18 @@ def dpnp_fftn(a, forward, real, s=None, axes=None, norm=None, out=None):
     return _complex_nd_fft(
         a, s, norm, out, forward, in_place, c2c, axes, a.ndim != len_axes
     )
+
+
+def dpnp_fillfreq(a, m, n, val):
+    """Fill an array with the sample frequencies"""
+
+    exec_q = a.sycl_queue
+    _manager = dpctl.utils.SequentialOrderManager[exec_q]
+
+    # it's assumed there is no dependent events to fill the array
+    ht_lin_ev, lin_ev = ti._linspace_step(0, m, a[:m].get_array(), exec_q)
+    _manager.add_event_pair(ht_lin_ev, lin_ev)
+
+    ht_lin_ev, lin_ev = ti._linspace_step(m - n, 0, a[m:].get_array(), exec_q)
+    _manager.add_event_pair(ht_lin_ev, lin_ev)
+    return a * val

--- a/dpnp/fft/dpnp_utils_fft.py
+++ b/dpnp/fft/dpnp_utils_fft.py
@@ -708,9 +708,9 @@ def dpnp_fillfreq(a, m, n, val):
     _manager = dpctl.utils.SequentialOrderManager[exec_q]
 
     # it's assumed there is no dependent events to fill the array
-    ht_lin_ev, lin_ev = ti._linspace_step(0, m, a[:m].get_array(), exec_q)
+    ht_lin_ev, lin_ev = ti._linspace_step(0, 1, a[:m].get_array(), exec_q)
     _manager.add_event_pair(ht_lin_ev, lin_ev)
 
-    ht_lin_ev, lin_ev = ti._linspace_step(m - n, 0, a[m:].get_array(), exec_q)
+    ht_lin_ev, lin_ev = ti._linspace_step(m - n, 1, a[m:].get_array(), exec_q)
     _manager.add_event_pair(ht_lin_ev, lin_ev)
     return a * val

--- a/dpnp/fft/dpnp_utils_fft.py
+++ b/dpnp/fft/dpnp_utils_fft.py
@@ -707,7 +707,7 @@ def dpnp_fillfreq(a, m, n, val):
     exec_q = a.sycl_queue
     _manager = dpctl.utils.SequentialOrderManager[exec_q]
 
-    # it's assumed there is no dependent events to fill the array
+    # it's assumed there are no dependent events to populate the array
     ht_lin_ev, lin_ev = ti._linspace_step(0, 1, a[:m].get_array(), exec_q)
     _manager.add_event_pair(ht_lin_ev, lin_ev)
 

--- a/dpnp/tests/test_fft.py
+++ b/dpnp/tests/test_fft.py
@@ -411,22 +411,35 @@ class TestFft2:
         assert_raises(IndexError, xp.fft.fft2, a)
 
 
+@pytest.mark.parametrize("func", ["fftfreq", "rfftfreq"])
 class TestFftfreq:
-    @pytest.mark.parametrize("func", ["fftfreq", "rfftfreq"])
     @pytest.mark.parametrize("n", [10, 20])
     @pytest.mark.parametrize("d", [0.5, 2])
     def test_fftfreq(self, func, n, d):
-        expected = getattr(dpnp.fft, func)(n, d)
-        result = getattr(numpy.fft, func)(n, d)
-        assert_dtype_allclose(expected, result)
+        result = getattr(dpnp.fft, func)(n, d)
+        expected = getattr(numpy.fft, func)(n, d)
+        assert_dtype_allclose(result, expected)
 
-    @pytest.mark.parametrize("func", ["fftfreq", "rfftfreq"])
+    @pytest.mark.parametrize("dt", [None] + get_float_dtypes())
+    def test_dtype(self, func, dt):
+        n = 15
+        result = getattr(dpnp.fft, func)(n, dtype=dt)
+        expected = getattr(numpy.fft, func)(n).astype(dt)
+        assert_dtype_allclose(result, expected)
+
     def test_error(self, func):
-        # n should be an integer
-        assert_raises(ValueError, getattr(dpnp.fft, func), 10.0)
+        func = getattr(dpnp.fft, func)
+        # n must be an integer
+        assert_raises(ValueError, func, 10.0)
 
-        # d should be an scalar
-        assert_raises(ValueError, getattr(dpnp.fft, func), 10, (2,))
+        # d must be an scalar
+        assert_raises(ValueError, func, 10, (2,))
+
+        # dtype must be None or a real-valued floating-point dtype
+        # which is passed as a keyword argument only
+        assert_raises(TypeError, func, 10, 2, None)
+        assert_raises(ValueError, func, 10, 2, dtype=dpnp.intp)
+        assert_raises(ValueError, func, 10, 2, dtype=dpnp.complex64)
 
 
 class TestFftn:


### PR DESCRIPTION
The PR proposes to align `dpnp.fft.fftfreq` and `dpnp.fft.rfftfreq` functions with [2024.12](https://data-apis.org/array-api/2024.12/extensions/generated/array_api.fft.fftfreq.html) revision of Python array API spec where `dtype` keyword was specified for the functions.

Additionally, implementation of `dpnp.fft.fftfreq` was reworked a bit to consume less memory and to avoid allocating temporary arrays.
Also docstrings of FFT functions were improved to add blank lines prior defaults values.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [x] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
