### PR TITLE
Enable clip test from `array-api-tests` scope

### DIFF
--- a/.github/workflows/array-api-skips.txt
+++ b/.github/workflows/array-api-skips.txt
@@ -1,8 +1,5 @@
 # array API tests to be skipped
 
-# hypothesis found failures
-array_api_tests/test_operators_and_elementwise_functions.py::test_clip
-
 # unexpected result is returned - unmute when dpctl-1986 is resolved
 array_api_tests/test_operators_and_elementwise_functions.py::test_asin
 array_api_tests/test_operators_and_elementwise_functions.py::test_asinh


### PR DESCRIPTION
There were few fixes implemented in `array-api-tests` around clip tests.
The PR proposes to enable `test_clip` test from `array-api-tests` scope.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
