### PR TITLE
get rid of unnecessary template in the backend of dot functions

### DIFF
--- a/dpnp/backend/extensions/blas/blas_py.cpp
+++ b/dpnp/backend/extensions/blas/blas_py.cpp
@@ -62,8 +62,7 @@ PYBIND11_MODULE(_blas_impl, m)
     using event_vecT = std::vector<sycl::event>;
 
     {
-        dot_ns::init_dot_dispatch_vector<dot_impl_fn_ptr_t,
-                                         blas_ns::DotContigFactory>(
+        dot_ns::init_dot_dispatch_vector<blas_ns::DotContigFactory>(
             dot_dispatch_vector);
 
         auto dot_pyapi = [&](sycl::queue &exec_q, const arrayT &src1,
@@ -81,8 +80,7 @@ PYBIND11_MODULE(_blas_impl, m)
     }
 
     {
-        dot_ns::init_dot_dispatch_vector<dot_impl_fn_ptr_t,
-                                         blas_ns::DotcContigFactory>(
+        dot_ns::init_dot_dispatch_vector<blas_ns::DotcContigFactory>(
             dotc_dispatch_vector);
 
         auto dotc_pyapi = [&](sycl::queue &exec_q, const arrayT &src1,
@@ -101,8 +99,7 @@ PYBIND11_MODULE(_blas_impl, m)
     }
 
     {
-        dot_ns::init_dot_dispatch_vector<dot_impl_fn_ptr_t,
-                                         blas_ns::DotuContigFactory>(
+        dot_ns::init_dot_dispatch_vector<blas_ns::DotuContigFactory>(
             dotu_dispatch_vector);
 
         auto dotu_pyapi = [&](sycl::queue &exec_q, const arrayT &src1,

--- a/dpnp/backend/extensions/blas/dot_common.hpp
+++ b/dpnp/backend/extensions/blas/dot_common.hpp
@@ -50,14 +50,13 @@ typedef sycl::event (*dot_impl_fn_ptr_t)(sycl::queue &,
 namespace dpctl_td_ns = dpctl::tensor::type_dispatch;
 namespace py = pybind11;
 
-template <typename dispatchT>
 std::pair<sycl::event, sycl::event>
     dot_func(sycl::queue &exec_q,
              const dpctl::tensor::usm_ndarray &vectorX,
              const dpctl::tensor::usm_ndarray &vectorY,
              const dpctl::tensor::usm_ndarray &result,
              const std::vector<sycl::event> &depends,
-             const dispatchT &dot_dispatch_vector)
+             const dot_impl_fn_ptr_t *dot_dispatch_vector)
 {
     const int vectorX_nd = vectorX.get_ndim();
     const int vectorY_nd = vectorY.get_ndim();
@@ -166,12 +165,10 @@ std::pair<sycl::event, sycl::event>
     return std::make_pair(args_ev, dot_ev);
 }
 
-template <typename dispatchT,
-          template <typename fnT, typename T>
-          typename factoryT>
-void init_dot_dispatch_vector(dispatchT dot_dispatch_vector[])
+template <template <typename fnT, typename T> typename factoryT>
+void init_dot_dispatch_vector(dot_impl_fn_ptr_t dot_dispatch_vector[])
 {
-    dpctl_td_ns::DispatchVectorBuilder<dispatchT, factoryT,
+    dpctl_td_ns::DispatchVectorBuilder<dot_impl_fn_ptr_t, factoryT,
                                        dpctl_td_ns::num_types>
         contig;
     contig.populate_dispatch_vector(dot_dispatch_vector);

--- a/dpnp/backend/extensions/window/common.hpp
+++ b/dpnp/backend/extensions/window/common.hpp
@@ -67,12 +67,11 @@ sycl::event window_impl(sycl::queue &q,
     return window_ev;
 }
 
-template <typename dispatchT>
 std::pair<sycl::event, sycl::event>
     py_window(sycl::queue &exec_q,
               const dpctl::tensor::usm_ndarray &result,
               const std::vector<sycl::event> &depends,
-              const dispatchT &window_dispatch_vector)
+              const window_fn_ptr_t *window_dispatch_vector)
 {
     dpctl::tensor::validation::CheckWritable::throw_if_not_writable(result);
 


### PR DESCRIPTION
In this PR, unnecessary template in the backend of dot functions is removed.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
