### PR TITLE
Update build and install instructions in Quick start guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Extended `dpnp.fft.fftfreq` and `dpnp.fft.rfftfreq` functions to support `dtype` keyword per Python Array API spec 2024.12 [#2384](https://github.com/IntelPython/dpnp/pull/2384)
+* Improved performance of `dpnp.nansum`, `dpnp.nanprod`, `dpnp.nancumsum`, and `dpnp.nancumprod` by reusing `dpnp.nan_to_num` function in implementation of the functions [#2339](https://github.com/IntelPython/dpnp/pull/2339)
 * Allowed input array of `uint64` dtype in `dpnp.bincount` [#2361](https://github.com/IntelPython/dpnp/pull/2361)
 * The vector norms `ord={None, 1, 2, inf}` and the matrix norms `ord={None, 1, 2, inf, "fro", "nuc"}` now consistently return zero for empty arrays, which are arrays with at least one axis of size zero. This change affects `dpnp.linalg.norm`, `dpnp.linalg.vector_norm`, and `dpnp.linalg.matrix_norm`. Previously, dpnp would either raise errors or return zero depending on the parameters provided [#2371](https://github.com/IntelPython/dpnp/pull/2371)
-* Improved performance of `dpnp.nansum`, `dpnp.nanprod`, `dpnp.nancumsum`, and `dpnp.nancumprod` by reusing `dpnp.nan_to_num` function in implementation of the functions [#2339](https://github.com/IntelPython/dpnp/pull/2339)
+* Extended `dpnp.fft.fftfreq` and `dpnp.fft.rfftfreq` functions to support `dtype` keyword per Python Array API spec 2024.12 [#2384](https://github.com/IntelPython/dpnp/pull/2384)
 
 ### Fixed
 
 * Resolved an issue with an incorrect result returned due to missing dependency from the strided kernel on a copy event in `dpnp.erf` [#2378](https://github.com/IntelPython/dpnp/pull/2378)
+* Updated `conda create` commands build and install instructions of `Quick start guide` to avoid a compilation error [#2395](https://github.com/IntelPython/dpnp/pull/2395)
 
 
 ## [0.17.0] - 02/26/2025

--- a/doc/quick_start_guide.rst
+++ b/doc/quick_start_guide.rst
@@ -89,8 +89,8 @@ On Linux:
 .. code-block:: bash
 
     conda create -n build-env dpctl cython dpcpp_linux-64 mkl-devel-dpcpp tbb-devel \
-          onedpl-devel cmake scikit-build ninja pytest -c dppy/label/dev            \
-          -c https://software.repos.intel.com/python/conda/ -c conda-forge
+          onedpl-devel cmake scikit-build ninja pytest intel-gpu-ocl-icd-system     \
+          -c dppy/label/dev -c https://software.repos.intel.com/python/conda/ -c conda-forge
     conda activate build-env
 
 On Windows:
@@ -98,8 +98,8 @@ On Windows:
 .. code-block:: bash
 
     conda create -n build-env dpctl cython dpcpp_win-64 mkl-devel-dpcpp tbb-devel \
-          onedpl-devel cmake scikit-build ninja pytest -c dppy/label/dev          \
-          -c https://software.repos.intel.com/python/conda/ -c conda-forge
+          onedpl-devel cmake scikit-build ninja pytest intel-gpu-ocl-icd-system   \
+          -c dppy/label/dev -c https://software.repos.intel.com/python/conda/ -c conda-forge
     conda activate build-env
 
 To build and install the package on Linux OS, run:

--- a/doc/quick_start_guide.rst
+++ b/doc/quick_start_guide.rst
@@ -88,14 +88,18 @@ On Linux:
 
 .. code-block:: bash
 
-    conda create -n build-env dpctl cython dpcpp_linux-64 mkl-devel-dpcpp tbb-devel onedpl-devel cmake scikit-build ninja pytest -c https://software.repos.intel.com/python/conda/ -c conda-forge
+    conda create -n build-env dpctl cython dpcpp_linux-64 mkl-devel-dpcpp tbb-devel \
+          onedpl-devel cmake scikit-build ninja pytest -c dppy/label/dev            \
+          -c https://software.repos.intel.com/python/conda/ -c conda-forge
     conda activate build-env
 
 On Windows:
 
 .. code-block:: bash
 
-    conda create -n build-env dpctl cython dpcpp_win-64 mkl-devel-dpcpp tbb-devel onedpl-devel cmake scikit-build ninja pytest -c https://software.repos.intel.com/python/conda/ -c conda-forge
+    conda create -n build-env dpctl cython dpcpp_win-64 mkl-devel-dpcpp tbb-devel \
+          onedpl-devel cmake scikit-build ninja pytest -c dppy/label/dev          \
+          -c https://software.repos.intel.com/python/conda/ -c conda-forge
     conda activate build-env
 
 To build and install the package on Linux OS, run:


### PR DESCRIPTION
As reported in #2388 the instruction was not complete and caused compilation error.
The PR proposes to add `dppy/label/dev` channel in `conda create` command to mitigate the issue.

Also the list of conda packages was extended to install `intel-gpu-ocl-icd-system` conda package, because FFT function will fail otherwise.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [x] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
