### PR TITLE
Update GH workflows to work with 2025.1 release

### DIFF
--- a/.github/workflows/check-mkl-interfaces.yaml
+++ b/.github/workflows/check-mkl-interfaces.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Merge conda env files
         run: |
-          conda-merge ${{ env.build-with-oneapi-env }} ${{ env.dpctl-pkg-env }} ${{ env.oneapi-pkgs-env }} > ${{ env.environment-file }}
+          conda-merge ${{ env.dpctl-pkg-env }} ${{ env.oneapi-pkgs-env }} ${{ env.build-with-oneapi-env }} > ${{ env.environment-file }}
           cat ${{ env.environment-file }}
 
       - name: Upload artifact

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -93,13 +93,13 @@ jobs:
         continue-on-error: true
         run: conda build --no-test --python ${{ matrix.python }} --numpy 2.0 ${{ env.channels-list }} conda-recipe
         env:
-          MAX_BUILD_CMPL_MKL_VERSION: '2025.1a0'
+          MAX_BUILD_CMPL_MKL_VERSION: '2025.2a0'
 
       - name: ReBuild conda package
         if: steps.build_conda_pkg.outcome == 'failure'
         run: conda build --no-test --python ${{ matrix.python }} --numpy 2.0 ${{ env.channels-list }} conda-recipe
         env:
-          MAX_BUILD_CMPL_MKL_VERSION: '2025.1a0'
+          MAX_BUILD_CMPL_MKL_VERSION: '2025.2a0'
 
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/dpnp/tests/test_statistics.py
+++ b/dpnp/tests/test_statistics.py
@@ -19,6 +19,7 @@ from .helper import (
     get_float_complex_dtypes,
     get_float_dtypes,
     has_support_aspect64,
+    is_win_platform,
     numpy_version,
 )
 from .third_party.cupy.testing import with_requires
@@ -197,6 +198,7 @@ class TestCorrelate:
     def setup_method(self):
         numpy.random.seed(0)
 
+    # @pytest.mark.skipif(is_win_platform(), reason="SAT-7784")
     @pytest.mark.parametrize(
         "a, v", [([1], [1, 2, 3]), ([1, 2, 3], [1]), ([1, 2, 3], [1, 2])]
     )
@@ -216,6 +218,7 @@ class TestCorrelate:
 
         assert_dtype_allclose(result, expected)
 
+    # @pytest.mark.skipif(is_win_platform(), reason="SAT-7784")
     @pytest.mark.parametrize("a_size", [1, 100, 10000])
     @pytest.mark.parametrize("v_size", [1, 100, 10000])
     @pytest.mark.parametrize("mode", ["full", "valid", "same"])

--- a/dpnp/tests/test_statistics.py
+++ b/dpnp/tests/test_statistics.py
@@ -19,7 +19,6 @@ from .helper import (
     get_float_complex_dtypes,
     get_float_dtypes,
     has_support_aspect64,
-    is_win_platform,
     numpy_version,
 )
 from .third_party.cupy.testing import with_requires
@@ -198,7 +197,6 @@ class TestCorrelate:
     def setup_method(self):
         numpy.random.seed(0)
 
-    # @pytest.mark.skipif(is_win_platform(), reason="SAT-7784")
     @pytest.mark.parametrize(
         "a, v", [([1], [1, 2, 3]), ([1, 2, 3], [1]), ([1, 2, 3], [1, 2])]
     )
@@ -218,7 +216,6 @@ class TestCorrelate:
 
         assert_dtype_allclose(result, expected)
 
-    # @pytest.mark.skipif(is_win_platform(), reason="SAT-7784")
     @pytest.mark.parametrize("a_size", [1, 100, 10000])
     @pytest.mark.parametrize("v_size", [1, 100, 10000])
     @pytest.mark.parametrize("mode", ["full", "valid", "same"])


### PR DESCRIPTION
The PR bumps max versions of DPC++ compiler and Intel MKL used during build of dpnp conda packages.
The workflow `Test oneMKL interfaces` is updated to have a proper channels priority in test conda environments.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
