### PR TITLE
Bump `conda-build` and `anaconda-client` versions

### DIFF
--- a/environments/build_conda_pkg.yml
+++ b/environments/build_conda_pkg.yml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - python=3.12 # conda-build does not support python 3.13
-  - conda-build=25.1.2
+  - conda-build=25.3.1

--- a/environments/upload_cleanup_conda_pkg.yml
+++ b/environments/upload_cleanup_conda_pkg.yml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - python=3.13
-  - anaconda-client=1.12.3
+  - anaconda-client=1.13.0


### PR DESCRIPTION
This PR bumps `conda-build` version from 25.1.2 to 25.3.1 and `anaconda-client` version from 1.12.3 to 1.13.0.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
