### PR TITLE
define a new helper function for tests called `get_integer_float_dtypes`

### DIFF
--- a/dpnp/tests/helper.py
+++ b/dpnp/tests/helper.py
@@ -198,6 +198,8 @@ def get_all_dtypes(
     no_float16=True,
     no_complex=False,
     no_none=False,
+    xfail_dtypes=None,
+    exclude=None,
     no_unsigned=False,
     device=None,
 ):
@@ -225,6 +227,17 @@ def get_all_dtypes(
     if not no_none:
         dtypes.append(None)
 
+    def mark_xfail(dtype):
+        if xfail_dtypes is not None and dtype in xfail_dtypes:
+            return pytest.param(dtype, marks=pytest.mark.xfail)
+        return dtype
+
+    def not_excluded(dtype):
+        if exclude is None:
+            return True
+        return dtype not in exclude
+
+    dtypes = [mark_xfail(dtype) for dtype in dtypes if not_excluded(dtype)]
     return dtypes
 
 

--- a/dpnp/tests/helper.py
+++ b/dpnp/tests/helper.py
@@ -198,8 +198,6 @@ def get_all_dtypes(
     no_float16=True,
     no_complex=False,
     no_none=False,
-    xfail_dtypes=None,
-    exclude=None,
     no_unsigned=False,
     device=None,
 ):
@@ -227,17 +225,6 @@ def get_all_dtypes(
     if not no_none:
         dtypes.append(None)
 
-    def mark_xfail(dtype):
-        if xfail_dtypes is not None and dtype in xfail_dtypes:
-            return pytest.param(dtype, marks=pytest.mark.xfail)
-        return dtype
-
-    def not_excluded(dtype):
-        if exclude is None:
-            return True
-        return dtype not in exclude
-
-    dtypes = [mark_xfail(dtype) for dtype in dtypes if not_excluded(dtype)]
     return dtypes
 
 
@@ -309,6 +296,36 @@ def get_integer_dtypes(all_int_types=False, no_unsigned=False):
         if not no_unsigned:
             dtypes += [dpnp.uint8, dpnp.uint16, dpnp.uint32, dpnp.uint64]
 
+    return dtypes
+
+
+def get_integer_float_dtypes(
+    all_int_types=False,
+    no_unsigned=False,
+    no_float16=True,
+    device=None,
+    xfail_dtypes=None,
+    exclude=None,
+):
+    """
+    Build a list of integer and float types supported by DPNP.
+    """
+    dtypes = get_integer_dtypes(
+        all_int_types=all_int_types, no_unsigned=no_unsigned
+    )
+    dtypes += get_float_dtypes(no_float16=no_float16, device=device)
+
+    def mark_xfail(dtype):
+        if xfail_dtypes is not None and dtype in xfail_dtypes:
+            return pytest.param(dtype, marks=pytest.mark.xfail)
+        return dtype
+
+    def not_excluded(dtype):
+        if exclude is None:
+            return True
+        return dtype not in exclude
+
+    dtypes = [mark_xfail(dtype) for dtype in dtypes if not_excluded(dtype)]
     return dtypes
 
 

--- a/dpnp/tests/test_binary_ufuncs.py
+++ b/dpnp/tests/test_binary_ufuncs.py
@@ -20,6 +20,7 @@ from .helper import (
     get_float_complex_dtypes,
     get_float_dtypes,
     get_integer_dtypes,
+    get_integer_float_dtypes,
     has_support_aspect16,
     numpy_version,
 )
@@ -141,7 +142,7 @@ class TestAdd:
 @pytest.mark.parametrize("func", ["fmax", "fmin", "maximum", "minimum"])
 class TestBoundFuncs:
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
-    def test_out(self, func, dtype):
+    def test_basic(self, func, dtype):
         a = generate_random_numpy_array(10, dtype)
         b = generate_random_numpy_array(10, dtype)
         expected = getattr(numpy, func)(a, b)
@@ -278,7 +279,7 @@ class TestDivide:
 
 @pytest.mark.parametrize("func", ["floor_divide", "remainder"])
 class TestFloorDivideRemainder:
-    ALL_DTYPES = get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
+    ALL_DTYPES = get_integer_float_dtypes()
 
     def do_inplace_op(self, base, other, func):
         if func == "floor_divide":

--- a/dpnp/tests/test_histogram.py
+++ b/dpnp/tests/test_histogram.py
@@ -25,9 +25,7 @@ from .helper import (
 
 
 class TestDigitize:
-    @pytest.mark.parametrize(
-        "dtype", get_all_dtypes(no_bool=True, no_complex=True)
-    )
+    @pytest.mark.parametrize("dtype", get_integer_float_dtypes())
     @pytest.mark.parametrize("right", [True, False])
     @pytest.mark.parametrize(
         "x, bins",
@@ -73,12 +71,8 @@ class TestDigitize:
         expected = numpy.digitize(x, bins, right=right)
         assert_dtype_allclose(result, expected)
 
-    @pytest.mark.parametrize(
-        "dtype_x", get_all_dtypes(no_bool=True, no_complex=True)
-    )
-    @pytest.mark.parametrize(
-        "dtype_bins", get_all_dtypes(no_bool=True, no_complex=True)
-    )
+    @pytest.mark.parametrize("dtype_x", get_integer_float_dtypes())
+    @pytest.mark.parametrize("dtype_bins", get_integer_float_dtypes())
     @pytest.mark.parametrize("right", [True, False])
     def test_digitize_diff_types(self, dtype_x, dtype_bins, right):
         x = numpy.array([1, 2, 3, 4, 5], dtype=dtype_x)
@@ -90,9 +84,7 @@ class TestDigitize:
         expected = numpy.digitize(x, bins, right=right)
         assert_dtype_allclose(result, expected)
 
-    @pytest.mark.parametrize(
-        "dtype", get_all_dtypes(no_bool=True, no_complex=True)
-    )
+    @pytest.mark.parametrize("dtype", get_integer_float_dtypes())
     @pytest.mark.parametrize(
         "x, bins",
         [

--- a/dpnp/tests/test_histogram.py
+++ b/dpnp/tests/test_histogram.py
@@ -19,6 +19,7 @@ from .helper import (
     get_float_complex_dtypes,
     get_float_dtypes,
     get_integer_dtypes,
+    get_integer_float_dtypes,
     has_support_aspect64,
     numpy_version,
 )

--- a/dpnp/tests/test_linalg.py
+++ b/dpnp/tests/test_linalg.py
@@ -22,6 +22,7 @@ from .helper import (
     get_all_dtypes,
     get_complex_dtypes,
     get_float_complex_dtypes,
+    get_integer_float_dtypes,
     has_support_aspect64,
     is_cpu_device,
     is_cuda_device,

--- a/dpnp/tests/test_linalg.py
+++ b/dpnp/tests/test_linalg.py
@@ -1409,9 +1409,7 @@ class TestEinsum:
         result = dpnp.einsum("ijij->", tensor_dp)
         assert_dtype_allclose(result, expected)
 
-    @pytest.mark.parametrize(
-        "dtype", get_all_dtypes(no_bool=True, no_complex=True, no_none=True)
-    )
+    @pytest.mark.parametrize("dtype", get_integer_float_dtypes())
     def test_different_paths(self, dtype):
         # Simple test, designed to exercise most specialized code paths,
         # note the +0.5 for floats.  This makes sure we use a float value

--- a/dpnp/tests/test_logic.py
+++ b/dpnp/tests/test_logic.py
@@ -83,7 +83,7 @@ class TestAllAny:
         check_raises(func, TypeError, [0, 1, 2, 3])
 
 
-@pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True))
+@pytest.mark.parametrize("dtype", get_integer_float_dtypes())
 def test_allclose(dtype):
     a = numpy.random.rand(10)
     b = a + numpy.random.rand(10) * 1e-8
@@ -508,7 +508,7 @@ def test_infinity_sign_errors(func):
         getattr(dpnp, func)(x, out=out)
 
 
-@pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True))
+@pytest.mark.parametrize("dtype", get_integer_float_dtypes())
 @pytest.mark.parametrize(
     "rtol", [1e-05, dpnp.array(1e-05), dpnp.full(10, 1e-05)]
 )
@@ -549,7 +549,7 @@ def test_array_equiv(a, b):
     assert_equal(result, expected)
 
 
-@pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True))
+@pytest.mark.parametrize("dtype", get_integer_float_dtypes())
 def test_array_equiv_dtype(dtype):
     a = numpy.array([1, 2], dtype=dtype)
     b = numpy.array([1, 2], dtype=dtype)
@@ -575,7 +575,7 @@ def test_array_equiv_scalar(a):
     assert_equal(result, expected)
 
 
-@pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True, no_complex=True))
+@pytest.mark.parametrize("dtype", get_integer_float_dtypes())
 @pytest.mark.parametrize("equal_nan", [True, False])
 def test_array_equal_dtype(dtype, equal_nan):
     a = numpy.array([1, 2], dtype=dtype)

--- a/dpnp/tests/test_logic.py
+++ b/dpnp/tests/test_logic.py
@@ -8,6 +8,7 @@ from .helper import (
     get_all_dtypes,
     get_float_complex_dtypes,
     get_float_dtypes,
+    get_integer_float_dtypes,
 )
 
 

--- a/dpnp/tests/test_manipulation.py
+++ b/dpnp/tests/test_manipulation.py
@@ -20,6 +20,7 @@ from .helper import (
     get_float_complex_dtypes,
     get_float_dtypes,
     get_integer_dtypes,
+    get_integer_float_dtypes,
     has_support_aspect64,
     numpy_version,
 )
@@ -325,9 +326,7 @@ class TestCopyTo:
     ]
     testdata += [
         ([1, -1, 0], dtype)
-        for dtype in get_all_dtypes(
-            no_none=True, no_bool=True, no_complex=True, no_unsigned=True
-        )
+        for dtype in get_integer_float_dtypes(no_unsigned=True)
     ]
     testdata += [([0.1, 0.0, -0.1], dtype) for dtype in get_float_dtypes()]
     testdata += [([1j, -1j, 1 - 2j], dtype) for dtype in get_complex_dtypes()]

--- a/dpnp/tests/test_mathematical.py
+++ b/dpnp/tests/test_mathematical.py
@@ -2403,7 +2403,7 @@ class TestReduceHypot:
 
         assert_dtype_allclose(res, exp)
 
-    @pytest.mark.parametrize("in_dtype", get_integer_float_dtypes())
+    @pytest.mark.parametrize("in_dt", get_integer_float_dtypes())
     @pytest.mark.parametrize("dt", get_all_dtypes(no_bool=True))
     def test_dtype(self, in_dt, dt):
         a = dpnp.ones(99, dtype=in_dt)

--- a/dpnp/tests/test_mathematical.py
+++ b/dpnp/tests/test_mathematical.py
@@ -1848,12 +1848,7 @@ class TestUnwrap:
         assert_array_equal(result, expected)
         assert_array_equal(result, isimple_seq)
 
-    @pytest.mark.parametrize(
-        "dt",
-        get_all_dtypes(
-            no_bool=True, no_none=True, no_complex=True, no_unsigned=True
-        ),
-    )
+    @pytest.mark.parametrize("dt", get_integer_float_dtypes(no_unsigned=True))
     def test_discont(self, dt):
         a = numpy.array([0, 8, 20, 25, 35, 50], dtype=dt)
         ia = dpnp.array(a)

--- a/dpnp/tests/test_mathematical.py
+++ b/dpnp/tests/test_mathematical.py
@@ -29,6 +29,7 @@ from .helper import (
     get_float_complex_dtypes,
     get_float_dtypes,
     get_integer_dtypes,
+    get_integer_float_dtypes,
     has_support_aspect16,
     has_support_aspect64,
     numpy_version,
@@ -50,9 +51,7 @@ class TestAngle:
         # determined by Type Promotion Rules.
         assert_dtype_allclose(result, expected, check_only_type_kind=True)
 
-    @pytest.mark.parametrize(
-        "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
-    )
+    @pytest.mark.parametrize("dtype", get_integer_float_dtypes())
     def test_angle(self, dtype, deg):
         ia = dpnp.arange(10, dtype=dtype)
         a = ia.asnumpy()
@@ -134,9 +133,7 @@ class TestConvolve:
 
 
 class TestClip:
-    @pytest.mark.parametrize(
-        "dtype", get_all_dtypes(no_bool=True, no_none=True, no_complex=True)
-    )
+    @pytest.mark.parametrize("dtype", get_integer_float_dtypes())
     @pytest.mark.parametrize("order", ["C", "F", "A", "K", None])
     def test_clip(self, dtype, order):
         ia = dpnp.asarray([[1, 2, 8], [1, 6, 4], [9, 5, 1]], dtype=dtype)
@@ -148,9 +145,7 @@ class TestClip:
         assert expected.flags.c_contiguous == result.flags.c_contiguous
         assert expected.flags.f_contiguous == result.flags.f_contiguous
 
-    @pytest.mark.parametrize(
-        "dtype", get_all_dtypes(no_bool=True, no_none=True, no_complex=True)
-    )
+    @pytest.mark.parametrize("dtype", get_integer_float_dtypes())
     def test_clip_arrays(self, dtype):
         ia = dpnp.asarray([1, 2, 8, 1, 6, 4, 1], dtype=dtype)
         a = dpnp.asnumpy(ia)
@@ -162,9 +157,7 @@ class TestClip:
         expected = numpy.clip(a, min_v.asnumpy(), max_v.asnumpy())
         assert_allclose(result, expected)
 
-    @pytest.mark.parametrize(
-        "dtype", get_all_dtypes(no_bool=True, no_none=True, no_complex=True)
-    )
+    @pytest.mark.parametrize("dtype", get_integer_float_dtypes())
     @pytest.mark.parametrize("in_dp", [dpnp, dpt])
     @pytest.mark.parametrize("out_dp", [dpnp, dpt])
     def test_clip_out(self, dtype, in_dp, out_dp):
@@ -302,9 +295,7 @@ class TestCumLogSumExp:
         a = dpnp.ones((3, 4))
         assert_raises(TypeError, dpnp.cumlogsumexp, a, axis=(0, 1))
 
-    @pytest.mark.parametrize(
-        "in_dt", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
-    )
+    @pytest.mark.parametrize("in_dt", get_integer_float_dtypes())
     @pytest.mark.parametrize("dt", get_all_dtypes(no_bool=True))
     def test_dtype(self, in_dt, dt):
         a = dpnp.ones(100, dtype=in_dt)
@@ -1119,9 +1110,7 @@ class TestI0:
         na = a.asnumpy()
         assert_dtype_allclose(dpnp.i0(a), numpy.i0(na))
 
-    @pytest.mark.parametrize(
-        "dt", get_all_dtypes(no_bool=True, no_none=True, no_complex=True)
-    )
+    @pytest.mark.parametrize("dt", get_integer_float_dtypes())
     def test_1d(self, dt):
         a = numpy.array(
             [0.49842636, 0.6969809, 0.22011976, 0.0155549, 10.0], dtype=dt
@@ -1225,9 +1214,7 @@ class TestMathematical:
     def test_arctan2(self, dtype, lhs, rhs):
         self._test_mathematical("arctan2", dtype, lhs, rhs)
 
-    @pytest.mark.parametrize(
-        "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
-    )
+    @pytest.mark.parametrize("dtype", get_integer_float_dtypes())
     def test_copysign(self, dtype, lhs, rhs):
         self._test_mathematical("copysign", dtype, lhs, rhs)
 
@@ -1235,20 +1222,16 @@ class TestMathematical:
     def test_divide(self, dtype, lhs, rhs):
         self._test_mathematical("divide", dtype, lhs, rhs)
 
-    @pytest.mark.parametrize(
-        "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
-    )
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     def test_fmax(self, dtype, lhs, rhs):
         self._test_mathematical("fmax", dtype, lhs, rhs, check_type=False)
 
-    @pytest.mark.parametrize(
-        "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
-    )
+    @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     def test_fmin(self, dtype, lhs, rhs):
         self._test_mathematical("fmin", dtype, lhs, rhs, check_type=False)
 
     @pytest.mark.parametrize(
-        "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
+        "dtype", get_all_dtypes(no_none=True, no_complex=True)
     )
     def test_fmod(self, dtype, lhs, rhs):
         if rhs == 0.3 and not has_support_aspect64():
@@ -1276,9 +1259,7 @@ class TestMathematical:
             "floor_divide", dtype, lhs, rhs, check_type=False
         )
 
-    @pytest.mark.parametrize(
-        "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
-    )
+    @pytest.mark.parametrize("dtype", get_integer_float_dtypes())
     def test_hypot(self, dtype, lhs, rhs):
         self._test_mathematical("hypot", dtype, lhs, rhs)
 
@@ -1838,12 +1819,7 @@ class TestUnwrap:
         expected = numpy.unwrap(a)
         assert_dtype_allclose(result, expected)
 
-    @pytest.mark.parametrize(
-        "dt",
-        get_all_dtypes(
-            no_none=True, no_bool=True, no_complex=True, no_unsigned=True
-        ),
-    )
+    @pytest.mark.parametrize("dt", get_integer_float_dtypes(no_unsigned=True))
     def test_period(self, dt):
         a = numpy.array([1, 1 + 108], dtype=dt)
         ia = dpnp.array(a)
@@ -1853,12 +1829,7 @@ class TestUnwrap:
         expected = numpy.unwrap(a, period=107)
         assert_array_equal(result, expected)
 
-    @pytest.mark.parametrize(
-        "dt",
-        get_all_dtypes(
-            no_none=True, no_bool=True, no_complex=True, no_unsigned=True
-        ),
-    )
+    @pytest.mark.parametrize("dt", get_integer_float_dtypes(no_unsigned=True))
     def test_rand_period(self, dt):
         a = generate_random_numpy_array(10, dt, low=-100, high=100)
         ia = dpnp.array(a)
@@ -2309,9 +2280,7 @@ class TestRoundingFuncs:
 
 
 class TestHypot:
-    @pytest.mark.parametrize(
-        "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
-    )
+    @pytest.mark.parametrize("dtype", get_integer_float_dtypes())
     def test_hypot(self, dtype):
         a = generate_random_numpy_array(10, dtype, low=0)
         b = generate_random_numpy_array(10, dtype, low=0)
@@ -2376,9 +2345,7 @@ class TestLogSumExp:
 
         assert_dtype_allclose(res, exp)
 
-    @pytest.mark.parametrize(
-        "in_dt", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
-    )
+    @pytest.mark.parametrize("in_dt", get_integer_float_dtypes())
     @pytest.mark.parametrize("dt", get_all_dtypes(no_bool=True))
     def test_dtype(self, in_dt, dt):
         a = dpnp.ones(100, dtype=in_dt)
@@ -2436,9 +2403,7 @@ class TestReduceHypot:
 
         assert_dtype_allclose(res, exp)
 
-    @pytest.mark.parametrize(
-        "in_dt", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
-    )
+    @pytest.mark.parametrize("in_dtype", get_integer_float_dtypes())
     @pytest.mark.parametrize("dt", get_all_dtypes(no_bool=True))
     def test_dtype(self, in_dt, dt):
         a = dpnp.ones(99, dtype=in_dt)
@@ -2467,9 +2432,7 @@ class TestReduceHypot:
         assert_allclose(result, exp, rtol=1e-06)
 
 
-@pytest.mark.parametrize(
-    "dtype", get_all_dtypes(no_bool=True, no_none=True, no_complex=True)
-)
+@pytest.mark.parametrize("dtype", get_integer_float_dtypes())
 def test_inplace_remainder(dtype):
     size = 21
     a = numpy.arange(size, dtype=dtype)
@@ -2481,9 +2444,7 @@ def test_inplace_remainder(dtype):
     assert_allclose(ia, a)
 
 
-@pytest.mark.parametrize(
-    "dtype", get_all_dtypes(no_bool=True, no_none=True, no_complex=True)
-)
+@pytest.mark.parametrize("dtype", get_integer_float_dtypes())
 def test_inplace_floor_divide(dtype):
     size = 21
     a = numpy.arange(size, dtype=dtype)

--- a/dpnp/tests/test_strides.py
+++ b/dpnp/tests/test_strides.py
@@ -13,6 +13,7 @@ from .helper import (
     get_complex_dtypes,
     get_float_complex_dtypes,
     get_integer_dtypes,
+    get_integer_float_dtypes,
     numpy_version,
 )
 
@@ -90,9 +91,7 @@ def test_1arg_support_complex(func, dtype, stride):
         "unwrap",
     ],
 )
-@pytest.mark.parametrize(
-    "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
-)
+@pytest.mark.parametrize("dtype", get_integer_float_dtypes())
 @pytest.mark.parametrize("stride", [2, -1, -3])
 def test_1arg(func, dtype, stride):
     x = generate_random_numpy_array(10, dtype=dtype)
@@ -112,9 +111,7 @@ def test_1arg(func, dtype, stride):
 
 
 @pytest.mark.usefixtures("suppress_divide_invalid_numpy_warnings")
-@pytest.mark.parametrize(
-    "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
-)
+@pytest.mark.parametrize("dtype", get_integer_float_dtypes())
 @pytest.mark.parametrize("stride", [2, -1, -3])
 def test_rsqrt(dtype, stride):
     x = generate_random_numpy_array(10, dtype=dtype)
@@ -125,9 +122,7 @@ def test_rsqrt(dtype, stride):
     assert_dtype_allclose(result, expected)
 
 
-@pytest.mark.parametrize(
-    "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
-)
+@pytest.mark.parametrize("dtype", get_integer_float_dtypes())
 @pytest.mark.parametrize("stride", [2, -1, -3])
 def test_logsumexp(dtype, stride):
     x = generate_random_numpy_array(10, dtype=dtype)
@@ -141,9 +136,7 @@ def test_logsumexp(dtype, stride):
     assert_dtype_allclose(result, expected, check_only_type_kind=flag)
 
 
-@pytest.mark.parametrize(
-    "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
-)
+@pytest.mark.parametrize("dtype", get_integer_float_dtypes())
 @pytest.mark.parametrize("stride", [2, -1, -3])
 def test_cumlogsumexp(dtype, stride):
     x = generate_random_numpy_array(10, dtype=dtype)
@@ -157,9 +150,7 @@ def test_cumlogsumexp(dtype, stride):
     assert_dtype_allclose(result, expected, check_only_type_kind=flag)
 
 
-@pytest.mark.parametrize(
-    "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
-)
+@pytest.mark.parametrize("dtype", get_integer_float_dtypes())
 @pytest.mark.parametrize("stride", [2, -1, -3])
 def test_reduce_hypot(dtype, stride):
     x = generate_random_numpy_array(10, dtype=dtype)
@@ -175,12 +166,8 @@ def test_reduce_hypot(dtype, stride):
 
 @pytest.mark.parametrize(
     "dtype",
-    get_all_dtypes(
-        no_none=True,
-        no_bool=True,
-        no_complex=True,
-        no_unsigned=True,
-        xfail_dtypes=[dpnp.int8, dpnp.int16],
+    get_integer_float_dtypes(
+        no_unsigned=True, xfail_dtypes=[dpnp.int8, dpnp.int16]
     ),
 )
 def test_erf(dtype):
@@ -235,9 +222,7 @@ def test_angle(dtype, stride):
         "subtract",
     ],
 )
-@pytest.mark.parametrize(
-    "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
-)
+@pytest.mark.parametrize("dtype", get_integer_float_dtypes())
 @pytest.mark.usefixtures("suppress_divide_invalid_numpy_warnings")
 def test_2args(func, dtype):
     # Integers to negative integer powers are not allowed
@@ -269,9 +254,7 @@ def test_bitwise(func, dtype):
     assert_array_equal(result, expected, strict=True)
 
 
-@pytest.mark.parametrize(
-    "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
-)
+@pytest.mark.parametrize("dtype", get_integer_float_dtypes())
 def test_copysign(dtype):
     a = generate_random_numpy_array((3, 3), dtype=dtype)
     ia = dpnp.array(a)
@@ -283,9 +266,7 @@ def test_copysign(dtype):
 
 
 @pytest.mark.parametrize("func", ["fmod", "true_divide", "remainder"])
-@pytest.mark.parametrize(
-    "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
-)
+@pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True, no_complex=True))
 def test_division(func, dtype):
     a = generate_random_numpy_array((3, 3), dtype=dtype)
     ia = dpnp.array(a)
@@ -298,9 +279,7 @@ def test_division(func, dtype):
 
 @pytest.mark.usefixtures("suppress_invalid_numpy_warnings")
 @pytest.mark.parametrize("func", ["add", "multiply", "power", "subtract"])
-@pytest.mark.parametrize(
-    "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
-)
+@pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True, no_bool=True))
 def test_2args_out(func, dtype):
     shape = (5, 3, 2)
     out = numpy.empty(shape, dtype=dtype)[::3]
@@ -319,9 +298,7 @@ def test_2args_out(func, dtype):
 
 @pytest.mark.usefixtures("suppress_invalid_numpy_warnings")
 @pytest.mark.parametrize("func", ["add", "multiply", "power", "subtract"])
-@pytest.mark.parametrize(
-    "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
-)
+@pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True, no_bool=True))
 def test_2args_in_out(func, dtype):
     sh = (3, 4, 2)
     out = numpy.empty(sh, dtype=dtype)[::2]
@@ -341,9 +318,7 @@ def test_2args_in_out(func, dtype):
 
 
 @pytest.mark.parametrize("func", ["add", "multiply", "power", "subtract"])
-@pytest.mark.parametrize(
-    "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
-)
+@pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True, no_bool=True))
 @pytest.mark.skip("dpctl doesn't support type mismatch of out array")
 def test_2args_in_out_diff_out_dtype(func, dtype):
     sh = (3, 3, 2)
@@ -366,9 +341,7 @@ def test_2args_in_out_diff_out_dtype(func, dtype):
 
 @pytest.mark.usefixtures("suppress_invalid_numpy_warnings")
 @pytest.mark.parametrize("func", ["add", "multiply", "power", "subtract"])
-@pytest.mark.parametrize(
-    "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
-)
+@pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True, no_bool=True))
 def test_2args_in_overlap(func, dtype):
     size = 5
     # Integers to negative integer powers are not allowed
@@ -386,9 +359,7 @@ def test_2args_in_overlap(func, dtype):
 
 @pytest.mark.usefixtures("suppress_invalid_numpy_warnings")
 @pytest.mark.parametrize("func", ["add", "multiply", "power", "subtract"])
-@pytest.mark.parametrize(
-    "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
-)
+@pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True, no_bool=True))
 def test_2args_in_out_overlap(func, dtype):
     a = generate_random_numpy_array((4, 3, 2), dtype=dtype)
     b = numpy.full(a[::2].shape, fill_value=0.7, dtype=dtype)

--- a/dpnp/tests/test_sum.py
+++ b/dpnp/tests/test_sum.py
@@ -65,9 +65,7 @@ def test_sum_empty_out(dtype):
     assert_array_equal(out, numpy.array(0, dtype=dtype))
 
 
-@pytest.mark.parametrize(
-    "dtype", get_all_dtypes(no_none=True, no_bool=True, no_complex=True)
-)
+@pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
 @pytest.mark.parametrize("axis", [None, 0, 1, 2, 3])
 def test_sum_empty(dtype, axis):
     a = numpy.empty((1, 2, 0, 4), dtype=dtype)


### PR DESCRIPTION
A new helper function is defined for tests, to get integer and float dtypes.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
