### PR TITLE
Disable w/a for dpctl-2030 on CPU device

### DIFF
--- a/dpnp/tests/test_mathematical.py
+++ b/dpnp/tests/test_mathematical.py
@@ -32,6 +32,7 @@ from .helper import (
     get_integer_float_dtypes,
     has_support_aspect16,
     has_support_aspect64,
+    is_gpu_device,
     numpy_version,
 )
 from .third_party.cupy import testing
@@ -2177,7 +2178,12 @@ class TestRoundingFuncs:
         if dt_in != dt_out:
             if numpy.can_cast(dt_in, dt_out, casting="same_kind"):
                 # NumPy allows "same_kind" casting, dpnp does not
-                if func != "fix" and dt_in == dpnp.bool and dt_out == dpnp.int8:
+                if (
+                    func != "fix"
+                    and dt_in == dpnp.bool
+                    and dt_out == dpnp.int8
+                    and is_gpu_device()
+                ):
                     # TODO: get rid of w/a when dpctl#2030 is fixed
                     pass
                 else:
@@ -2186,7 +2192,7 @@ class TestRoundingFuncs:
                 assert_raises(ValueError, getattr(dpnp, func), ia, out=iout)
                 assert_raises(TypeError, getattr(numpy, func), a, out=out)
         else:
-            if func != "fix" and dt_in == dpnp.bool:
+            if func != "fix" and dt_in == dpnp.bool and is_gpu_device():
                 # TODO: get rid of w/a when dpctl#2030 is fixed
                 out = out.astype(numpy.int8)
                 iout = iout.astype(dpnp.int8)
@@ -2216,7 +2222,7 @@ class TestRoundingFuncs:
         out = numpy.empty(a.shape, dtype=dt)
         ia, usm_out = dpnp.array(a), dpt.asarray(out)
 
-        if func != "fix" and dt == dpnp.bool:
+        if func != "fix" and dt == dpnp.bool and is_gpu_device():
             # TODO: get rid of w/a when dpctl#2030 is fixed
             out = out.astype(numpy.int8)
             usm_out = dpt.asarray(usm_out, dtype=dpnp.int8)


### PR DESCRIPTION
The PR proposes to partly merge changes from #2403 to unblock coverage GitHub action.
The workaround for dpctl-2030 was kept only for testing with GPU device (the use case from internal CI, where the changes from dpctl-2030 is not available).

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
