### PR TITLE
Pin `libxml2` version to 2.13.7

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -82,6 +82,9 @@ jobs:
           environment-file: ${{ env.build-conda-pkg-env }}
           activate-environment: ${{ env.build-env-name }}
 
+      - name: List installed packages
+        run: mamba list
+
       - name: Store conda paths as envs
         shell: bash -el {0}
         run: |

--- a/environments/build_conda_pkg.yml
+++ b/environments/build_conda_pkg.yml
@@ -4,4 +4,4 @@ channels:
 dependencies:
   - python=3.12 # conda-build does not support python 3.13
   - conda-build=25.3.1
-  - libxml2=2.13.7
+  - libxml2=2.13.7 # libs dependency issue in 2.14.0

--- a/environments/build_conda_pkg.yml
+++ b/environments/build_conda_pkg.yml
@@ -4,3 +4,4 @@ channels:
 dependencies:
   - python=3.12 # conda-build does not support python 3.13
   - conda-build=25.3.1
+  - libxml2=2.13.7


### PR DESCRIPTION
This PR pins `libxml2` version to `2.13.7` due to libs dependency issue with `2.14.0` version as reported on [#146](https://github.com/conda-forge/libxml2-feedstock/issues/146).

Without that change the conda package can not be build through GitHub action, since `conda-build` raises error:
```python
Traceback (most recent call last):
  File "C:\Users\runneradmin\miniconda3\envs\build\Scripts\conda-build-script.py", line 6, in <module>
    from conda_build.cli.main_build import execute
  File "C:\Users\runneradmin\miniconda3\envs\build\Lib\site-packages\conda_build\cli\main_build.py", line 19, in <module>
    from .. import api, build, source, utils
  File "C:\Users\runneradmin\miniconda3\envs\build\Lib\site-packages\conda_build\api.py", line [24](https://github.com/IntelPython/dpnp/actions/runs/14267019048/job/39991206345#step:8:25), in <module>
    from .config import DEFAULT_PREFIX_LENGTH as _prefix_length
  File "C:\Users\runneradmin\miniconda3\envs\build\Lib\site-packages\conda_build\config.py", line 28, in <module>
    from .utils import (
  File "C:\Users\runneradmin\miniconda3\envs\build\Lib\site-packages\conda_build\utils.py", line 51, in <module>
    import libarchive
  File "C:\Users\runneradmin\miniconda3\envs\build\Lib\site-packages\libarchive\__init__.py", line 1, in <module>
    from .entry import ArchiveEntry
  File "C:\Users\runneradmin\miniconda3\envs\build\Lib\site-packages\libarchive\entry.py", line 6, in <module>
    from . import ffi
  File "C:\Users\runneradmin\miniconda3\envs\build\Lib\site-packages\libarchive\ffi.py", line [26](https://github.com/IntelPython/dpnp/actions/runs/14267019048/job/39991206345#step:8:27), in <module>
    libarchive = ctypes.cdll.LoadLibrary(libarchive_path)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\runneradmin\miniconda3\envs\build\Lib\ctypes\__init__.py", line 460, in LoadLibrary
    return self._dlltype(name)
           ^^^^^^^^^^^^^^^^^^^
  File "C:\Users\runneradmin\miniconda3\envs\build\Lib\ctypes\__init__.py", line 379, in __init__
    self._handle = _dlopen(self._name, mode)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: [WinError 1[27](https://github.com/IntelPython/dpnp/actions/runs/14267019048/job/39991206345#step:8:28)] The specified procedure could not be found
```
Here is a [link](https://github.com/IntelPython/dpnp/actions/runs/14267019048/job/39991206345) to the full log with the error.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
