### PR TITLE
Remove w/a with pinning `libxml2` version

### DIFF
--- a/environments/build_conda_pkg.yml
+++ b/environments/build_conda_pkg.yml
@@ -3,5 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - python=3.12 # conda-build does not support python 3.13
-  - conda-build=25.3.2
-  - libxml2=2.13.7 # libs dependency issue in 2.14.0
+  - conda-build=25.3.1

--- a/environments/build_conda_pkg.yml
+++ b/environments/build_conda_pkg.yml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - python=3.12 # conda-build does not support python 3.13
-  - conda-build=25.3.1
+  - conda-build=25.3.2


### PR DESCRIPTION
This PR removes explicit pinning on libxml2 version `2.13.7` added in scope of #2409.
The issue has been the new build published on conda-forge.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
