### PR TITLE
add support for `order=None` in `dpnp.einsum`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The vector norms `ord={None, 1, 2, inf}` and the matrix norms `ord={None, 1, 2, inf, "fro", "nuc"}` now consistently return zero for empty arrays, which are arrays with at least one axis of size zero. This change affects `dpnp.linalg.norm`, `dpnp.linalg.vector_norm`, and `dpnp.linalg.matrix_norm`. Previously, dpnp would either raise errors or return zero depending on the parameters provided [#2371](https://github.com/IntelPython/dpnp/pull/2371)
 * Extended `dpnp.fft.fftfreq` and `dpnp.fft.rfftfreq` functions to support `dtype` keyword per Python Array API spec 2024.12 [#2384](https://github.com/IntelPython/dpnp/pull/2384)
 * Updated `dpnp.fix` to return output with the same data-type of input [#2392](https://github.com/IntelPython/dpnp/pull/2392)
+* Updated `dpnp.einsum` to add support for `order=None` [#2411](https://github.com/IntelPython/dpnp/pull/2411)
 
 ### Fixed
 

--- a/dpnp/dpnp_iface_linearalgebra.py
+++ b/dpnp/dpnp_iface_linearalgebra.py
@@ -215,12 +215,13 @@ def einsum(
         If provided, forces the calculation to use the data type specified.
 
         Default: ``None``.
-    order : {"C", "F", "A", "K"}, optional
+    order : {None, "C", "F", "A", "K"}, optional
         Controls the memory layout of the output. ``"C"`` means it should be
         C-contiguous. ``"F"`` means it should be F-contiguous, ``"A"`` means
         it should be ``"F"`` if the inputs are all ``"F"``, ``"C"`` otherwise.
         ``"K"`` means it should be as close to the layout as the inputs as
-        is possible, including arbitrarily permuted axes.
+        is possible, including arbitrarily permuted axes. ``order=None`` is
+        equivalent to ``order="K"``.
 
         Default: ``"K"``.
     casting : {"no", "equiv", "safe", "same_kind", "unsafe"}, optional

--- a/dpnp/dpnp_utils/dpnp_utils_einsum.py
+++ b/dpnp/dpnp_utils/dpnp_utils_einsum.py
@@ -1034,7 +1034,7 @@ def dpnp_einsum(
             )
             arrays.append(operands[id])
     result_dtype = dpnp.result_type(*arrays) if dtype is None else dtype
-    if order in "aA":
+    if order is not None and order in "aA":
         order = "F" if all(arr.flags.fnc for arr in arrays) else "C"
 
     input_subscripts = [

--- a/dpnp/tests/test_linalg.py
+++ b/dpnp/tests/test_linalg.py
@@ -1647,6 +1647,10 @@ class TestEinsum:
             assert tmp.flags.c_contiguous is False
             assert tmp.flags.f_contiguous is False
 
+            tmp = dpnp.einsum("...ft,mf->...mt", a, b, order=None, optimize=opt)
+            assert tmp.flags.c_contiguous is False
+            assert tmp.flags.f_contiguous is False
+
             tmp = dpnp.einsum("...ft,mf->...mt", a, b, optimize=opt)
             assert tmp.flags.c_contiguous is False
             assert tmp.flags.f_contiguous is False


### PR DESCRIPTION
Add support for `order=None` for `dpnp.einsum`

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
