### PR TITLE
Bump required dpctl version

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set max_compiler_and_mkl_version = environ.get("MAX_BUILD_CMPL_MKL_VERSION", "2026.0a0") %}
 {% set required_compiler_and_mkl_version = "2025.0" %}
-{% set required_dpctl_version = "0.19.0*" %}
+{% set required_dpctl_version = "0.20.0*" %}
 
 package:
     name: dpnp

--- a/setup.py
+++ b/setup.py
@@ -84,5 +84,5 @@ setup(
     },
     include_package_data=False,
     python_requires=">=3.9,<3.14",
-    install_requires=["dpctl >= 0.19.0dev0", "numpy"],
+    install_requires=["dpctl >= 0.20.0dev0", "numpy"],
 )


### PR DESCRIPTION
This PR bumps min required dpctl version to `0.20.0dev0`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
