### PR TITLE
Use a requirement file to install dpctl wheel package

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -42,6 +42,7 @@ jobs:
       oneapi-pkgs-env: ''
       # Enable env when it's required to use only conda packages without OneAPI installation
       # oneapi-pkgs-env: '${{ github.workspace }}/environments/oneapi_pkgs.yml'
+      dpctl-pkg-txt: 'environments/dpctl_pkg.txt'
 
     steps:
       - name: Cancel Previous Runs
@@ -149,7 +150,7 @@ jobs:
       - name: Install dpctl
         if: env.oneapi-pkgs-env == ''
         run: |
-          pip install -i https://pypi.anaconda.org/dppy/label/dev/simple dpctl==0.20.0dev0
+          pip install -r ${{ env.dpctl-pkg-txt }}
 
       - name: Conda info
         run: |

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -26,6 +26,7 @@ jobs:
       oneapi-pkgs-env: ''
       # Enable env when it's required to use only conda packages without OneAPI installation
       # oneapi-pkgs-env: '${{ github.workspace }}/environments/oneapi_pkgs.yml'
+      dpctl-pkg-txt: 'environments/dpctl_pkg.txt'
 
     steps:
       - name: Cancel Previous Runs
@@ -108,7 +109,7 @@ jobs:
       - name: Install dpctl
         if: env.oneapi-pkgs-env == ''
         run: |
-          pip install -i https://pypi.anaconda.org/dppy/label/dev/simple dpctl==0.20.0dev0
+          pip install -r ${{ env.dpctl-pkg-txt }}
 
       - name: Conda info
         run: |

--- a/environments/dpctl_pkg.txt
+++ b/environments/dpctl_pkg.txt
@@ -1,0 +1,2 @@
+--index-url https://pypi.anaconda.org/dppy/label/dev/simple
+dpctl>=0.20.0dev0


### PR DESCRIPTION
The PR proposes to use a requirement file while installing dpctl wheel package through GitHub actions in `Build docs` and `Coverage` workflows.
This will allow to specified the required dpctl version in one requirement file.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
