### PR TITLE
Enable array API advanced indexing tests

### DIFF
--- a/.github/workflows/array-api-skips.txt
+++ b/.github/workflows/array-api-skips.txt
@@ -6,9 +6,3 @@ array_api_tests/test_operators_and_elementwise_functions.py::test_clip
 # unexpected result is returned - unmute when dpctl-1986 is resolved
 array_api_tests/test_operators_and_elementwise_functions.py::test_asin
 array_api_tests/test_operators_and_elementwise_functions.py::test_asinh
-
-# advanced indexing relating issues (waiting a fix from dpctl)
-array_api_tests/test_array_object.py::test_getitem_arrays_and_ints_1[1]
-array_api_tests/test_array_object.py::test_getitem_arrays_and_ints_1[None]
-array_api_tests/test_array_object.py::test_getitem_arrays_and_ints_2[1]
-array_api_tests/test_array_object.py::test_getitem_arrays_and_ints_2[None]


### PR DESCRIPTION
`dpctl.tensor` now conforms to array API 2024.12 indexing, so tests can be run

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
