### PR TITLE
Cast test env variables with dtype scope to boolean value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Resolved an issue with an incorrect result returned due to missing dependency from the strided kernel on a copy event in `dpnp.erf` [#2378](https://github.com/IntelPython/dpnp/pull/2378)
 * Updated `conda create` commands build and install instructions of `Quick start guide` to avoid a compilation error [#2395](https://github.com/IntelPython/dpnp/pull/2395)
+* Added handling of empty string passed to a test env variable defining data type scope as a `False` value [#2415](https://github.com/IntelPython/dpnp/pull/2415)
 
 
 ## [0.17.0] - 02/26/2025

--- a/dpnp/tests/config.py
+++ b/dpnp/tests/config.py
@@ -1,6 +1,6 @@
 import os
 
-all_int_types = int(os.getenv("DPNP_TEST_ALL_INT_TYPES", 0))
-float16_types = int(os.getenv("DPNP_TEST_FLOAT_16", 0))
-complex_types = int(os.getenv("DPNP_TEST_COMPLEX_TYPES", 0))
-bool_types = int(os.getenv("DPNP_TEST_BOOL_TYPES", 0))
+all_int_types = bool(os.getenv("DPNP_TEST_ALL_INT_TYPES", 0))
+float16_types = bool(os.getenv("DPNP_TEST_FLOAT_16", 0))
+complex_types = bool(os.getenv("DPNP_TEST_COMPLEX_TYPES", 0))
+bool_types = bool(os.getenv("DPNP_TEST_BOOL_TYPES", 0))


### PR DESCRIPTION
The PR closes #2324. It is proposes to cast test env variables with dtype scope to boolean value which can handle empty string as a False value.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
