### PR TITLE
Update array API version supported to 2024.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.18.0] - MM/DD/2025
 
+This release achieves 100% compliance with Python Array API specification (revision [2024.12](https://data-apis.org/array-api/2024.12/)).
+
 ### Added
 
 * Added implementation of `dpnp.hamming` [#2341](https://github.com/IntelPython/dpnp/pull/2341), [#2357](https://github.com/IntelPython/dpnp/pull/2357)
@@ -23,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Extended `dpnp.fft.fftfreq` and `dpnp.fft.rfftfreq` functions to support `dtype` keyword per Python Array API spec 2024.12 [#2384](https://github.com/IntelPython/dpnp/pull/2384)
 * Updated `dpnp.fix` to return output with the same data-type of input [#2392](https://github.com/IntelPython/dpnp/pull/2392)
 * Updated `dpnp.einsum` to add support for `order=None` [#2411](https://github.com/IntelPython/dpnp/pull/2411)
+* Updated Python Array API specification version supported to `2024.12`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ This release achieves 100% compliance with Python Array API specification (revis
 * Extended `dpnp.fft.fftfreq` and `dpnp.fft.rfftfreq` functions to support `dtype` keyword per Python Array API spec 2024.12 [#2384](https://github.com/IntelPython/dpnp/pull/2384)
 * Updated `dpnp.fix` to return output with the same data-type of input [#2392](https://github.com/IntelPython/dpnp/pull/2392)
 * Updated `dpnp.einsum` to add support for `order=None` [#2411](https://github.com/IntelPython/dpnp/pull/2411)
-* Updated Python Array API specification version supported to `2024.12`
+* Updated Python Array API specification version supported to `2024.12` [#2416](https://github.com/IntelPython/dpnp/pull/2416)
 
 ### Fixed
 

--- a/doc/reference/array_api.rst
+++ b/doc/reference/array_api.rst
@@ -8,7 +8,7 @@ Array API standard compatibility
 
 DPNP's main namespace as well as the :mod:`dpnp.fft` and :mod:`dpnp.linalg`
 namespaces are compatible with the
-`2023.12 version <https://data-apis.org/array-api/2023.12/index.html>`__
+`2024.12 version <https://data-apis.org/array-api/2024.12/index.html>`__
 of the Python array API standard.
 
 Inspection

--- a/dpnp/tests/test_ndarray.py
+++ b/dpnp/tests/test_ndarray.py
@@ -162,18 +162,20 @@ class TestArrayNamespace:
         xp = a.__array_namespace__()
         assert xp is dpnp
 
-    @pytest.mark.parametrize("api_version", [None, "2023.12"])
+    @pytest.mark.parametrize("api_version", [None, "2024.12"])
     def test_api_version(self, api_version):
         a = dpnp.arange(2)
         xp = a.__array_namespace__(api_version=api_version)
         assert xp is dpnp
 
-    @pytest.mark.parametrize("api_version", ["2021.12", "2022.12", "2024.12"])
+    @pytest.mark.parametrize(
+        "api_version", ["2021.12", "2022.12", "2023.12", "2025.12"]
+    )
     def test_unsupported_api_version(self, api_version):
         a = dpnp.arange(2)
         assert_raises_regex(
             ValueError,
-            "Only 2023.12 is supported",
+            "Only 2024.12 is supported",
             a.__array_namespace__,
             api_version=api_version,
         )


### PR DESCRIPTION
There was `__array_api_version__` set to `2024.12` in [dpctl#2047](https://github.com/IntelPython/dpctl/pull/2047).
This PR updates tests and documentation to state support with the newer spec version.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
