### PR TITLE
Add a `strict` keyword to testing f/w

### DIFF
--- a/dpnp/tests/third_party/cupy/linalg_tests/test_einsum.py
+++ b/dpnp/tests/third_party/cupy/linalg_tests/test_einsum.py
@@ -373,6 +373,8 @@ class TestEinSumUnaryOperation:
     def test_einsum_unary_dtype(self, xp, dtype_a, dtype_out):
         if not numpy.can_cast(dtype_a, dtype_out):
             pytest.skip()
+        if cupy.issubdtype(dtype_a, cupy.unsignedinteger):
+            pytest.skip("dpctl-2055")
         a = testing.shaped_arange(self.shape_a, xp, dtype_a)
         return xp.einsum(self.subscripts, a, dtype=dtype_out)
 

--- a/dpnp/tests/third_party/cupy/testing/_array.py
+++ b/dpnp/tests/third_party/cupy/testing/_array.py
@@ -1,3 +1,6 @@
+import warnings
+
+import numpy
 import numpy.testing
 
 import dpnp as cupy
@@ -6,7 +9,15 @@ import dpnp as cupy
 
 
 def assert_allclose(
-    actual, desired, rtol=1e-7, atol=0, err_msg="", verbose=True
+    actual,
+    desired,
+    rtol=1e-7,
+    atol=0,
+    equal_nan=True,
+    err_msg="",
+    verbose=True,
+    *,
+    strict=False,
 ):
     """Raises an AssertionError if objects are not equal up to desired tolerance.
 
@@ -22,17 +33,42 @@ def assert_allclose(
     .. seealso:: :func:`numpy.testing.assert_allclose`
 
     """
-    numpy.testing.assert_allclose(
-        cupy.asnumpy(actual),
-        cupy.asnumpy(desired),
-        rtol=rtol,
-        atol=atol,
-        err_msg=err_msg,
-        verbose=verbose,
-    )
+    if numpy.lib.NumpyVersion(numpy.__version__) >= "2.0.0":
+        numpy.testing.assert_allclose(
+            cupy.asnumpy(actual),
+            cupy.asnumpy(desired),
+            rtol=rtol,
+            atol=atol,
+            equal_nan=equal_nan,
+            err_msg=err_msg,
+            verbose=verbose,
+            strict=strict,
+        )
+    else:
+        if strict:
+            warnings.warn(
+                "`dpnp.tests.third_party.cupy.testing.assert_allclose` does not support `strict` "
+                "option with NumPy v1.",
+                RuntimeWarning,
+            )
+        numpy.testing.assert_allclose(
+            cupy.asnumpy(actual),
+            cupy.asnumpy(desired),
+            rtol=rtol,
+            atol=atol,
+            equal_nan=equal_nan,
+            err_msg=err_msg,
+            verbose=verbose,
+        )
 
 
-def assert_array_almost_equal(x, y, decimal=6, err_msg="", verbose=True):
+def assert_array_almost_equal(
+    actual,
+    desired,
+    decimal=6,
+    err_msg="",
+    verbose=True,
+):
     """Raises an AssertionError if objects are not equal up to desired precision.
 
     Args:
@@ -46,8 +82,8 @@ def assert_array_almost_equal(x, y, decimal=6, err_msg="", verbose=True):
     .. seealso:: :func:`numpy.testing.assert_array_almost_equal`
     """
     numpy.testing.assert_array_almost_equal(
-        cupy.asnumpy(x),
-        cupy.asnumpy(y),
+        cupy.asnumpy(actual),
+        cupy.asnumpy(desired),
         decimal=decimal,
         err_msg=err_msg,
         verbose=verbose,
@@ -87,7 +123,13 @@ def assert_array_max_ulp(a, b, maxulp=1, dtype=None):
 
 
 def assert_array_equal(
-    x, y, err_msg="", verbose=True, strides_check=False, **kwargs
+    actual,
+    desired,
+    err_msg="",
+    verbose=True,
+    *,
+    strict=False,
+    strides_check=False,
 ):
     """Raises an AssertionError if two array_like objects are not equal.
 
@@ -105,22 +147,36 @@ def assert_array_equal(
 
     .. seealso:: :func:`numpy.testing.assert_array_equal`
     """
-    numpy.testing.assert_array_equal(
-        cupy.asnumpy(x),
-        cupy.asnumpy(y),
-        err_msg=err_msg,
-        verbose=verbose,
-        **kwargs,
-    )
+    if numpy.lib.NumpyVersion(numpy.__version__) >= "1.24.0":
+        numpy.testing.assert_array_equal(
+            cupy.asnumpy(actual),
+            cupy.asnumpy(desired),
+            err_msg=err_msg,
+            verbose=verbose,
+            strict=strict,
+        )
+    else:
+        if strict:
+            warnings.warn(
+                "`dpnp.tests.third_party.cupy.testing.assert_allclose` does not support `strict` "
+                "option with NumPy v1.",
+                RuntimeWarning,
+            )
+        numpy.testing.assert_array_equal(
+            cupy.asnumpy(actual),
+            cupy.asnumpy(desired),
+            err_msg=err_msg,
+            verbose=verbose,
+        )
 
     if strides_check:
-        if x.strides != y.strides:
+        if actual.strides != desired.strides:
             msg = ["Strides are not equal:"]
             if err_msg:
                 msg = [msg[0] + " " + err_msg]
             if verbose:
-                msg.append(" x: {}".format(x.strides))
-                msg.append(" y: {}".format(y.strides))
+                msg.append(" x: {}".format(actual.strides))
+                msg.append(" y: {}".format(desired.strides))
             raise AssertionError("\n".join(msg))
 
 
@@ -163,7 +219,7 @@ def assert_array_list_equal(xlist, ylist, err_msg="", verbose=True):
         )
 
 
-def assert_array_less(x, y, err_msg="", verbose=True):
+def assert_array_less(x, y, err_msg="", verbose=True, *, strict=False):
     """Raises an AssertionError if array_like objects are not ordered by less than.
 
     Args:
@@ -175,6 +231,24 @@ def assert_array_less(x, y, err_msg="", verbose=True):
 
     .. seealso:: :func:`numpy.testing.assert_array_less`
     """
-    numpy.testing.assert_array_less(
-        cupy.asnumpy(x), cupy.asnumpy(y), err_msg=err_msg, verbose=verbose
-    )
+    if numpy.lib.NumpyVersion(numpy.__version__) >= "2.0.0":
+        numpy.testing.assert_array_less(
+            cupy.asnumpy(x),
+            cupy.asnumpy(y),
+            err_msg=err_msg,
+            verbose=verbose,
+            strict=strict,
+        )
+    else:
+        if strict:
+            warnings.warn(
+                "`dpnp.tests.third_party.cupy.testing.assert_allclose` does not support `strict` "
+                "option with NumPy v1.",
+                RuntimeWarning,
+            )
+        numpy.testing.assert_array_less(
+            cupy.asnumpy(x),
+            cupy.asnumpy(y),
+            err_msg=err_msg,
+            verbose=verbose,
+        )

--- a/dpnp/tests/third_party/cupy/testing/_loops.py
+++ b/dpnp/tests/third_party/cupy/testing/_loops.py
@@ -408,7 +408,9 @@ numpy: {}""".format(
                     if cupy_r.shape == ():
                         skip = (mask == 0).all()
                     else:
-                        cupy_r = cupy_r[mask].asnumpy()
+                        # mask is numpy.ndarray here which is not supported now
+                        # TODO remove asarray() once dpctl-2053 is addressed
+                        cupy_r = cupy_r[cupy.asarray(mask)].asnumpy()
                         numpy_r = numpy_r[mask]
 
                 if not skip:


### PR DESCRIPTION
This PR updates test f/w to align with the recent changes and to add a `strict` keyword to third party testing.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
