### PR TITLE
remove `einsum_call` kwargs from `dpnp.einsum_path` signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ This release achieves 100% compliance with Python Array API specification (revis
 * Updated `dpnp.fix` to return output with the same data-type of input [#2392](https://github.com/IntelPython/dpnp/pull/2392)
 * Updated `dpnp.einsum` to add support for `order=None` [#2411](https://github.com/IntelPython/dpnp/pull/2411)
 * Updated Python Array API specification version supported to `2024.12` [#2416](https://github.com/IntelPython/dpnp/pull/2416)
-* Removed `einsum_call` kwarg from `dpnp.einsum_path` signature [#2421](https://github.com/IntelPython/dpnp/pull/2421)
+* Removed `einsum_call` keyword from `dpnp.einsum_path` signature [#2421](https://github.com/IntelPython/dpnp/pull/2421)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This release achieves 100% compliance with Python Array API specification (revis
 * Updated `dpnp.fix` to return output with the same data-type of input [#2392](https://github.com/IntelPython/dpnp/pull/2392)
 * Updated `dpnp.einsum` to add support for `order=None` [#2411](https://github.com/IntelPython/dpnp/pull/2411)
 * Updated Python Array API specification version supported to `2024.12` [#2416](https://github.com/IntelPython/dpnp/pull/2416)
+* Removed `einsum_call` kwarg from `dpnp.einsum_path` signature [#2421](https://github.com/IntelPython/dpnp/pull/2421)
 
 ### Fixed
 

--- a/dpnp/dpnp_iface_linearalgebra.py
+++ b/dpnp/dpnp_iface_linearalgebra.py
@@ -457,7 +457,7 @@ def einsum(
     )
 
 
-def einsum_path(*operands, optimize="greedy", einsum_call=False):
+def einsum_path(*operands, optimize="greedy"):
     """
     einsum_path(subscripts, *operands, optimize="greedy")
 
@@ -483,7 +483,7 @@ def einsum_path(*operands, optimize="greedy", einsum_call=False):
         * if a list is given that starts with ``einsum_path``, uses this as the
           contraction path
         * if ``False`` or ``None`` no optimization is taken
-        * if ``True`` defaults to the "greedy" algorithm
+        * if ``True`` defaults to the ``"greedy"`` algorithm
         * ``"optimal"`` is an algorithm that combinatorially explores all
           possible ways of contracting the listed tensors and chooses the
           least costly path. Scales exponentially with the number of terms
@@ -586,7 +586,7 @@ def einsum_path(*operands, optimize="greedy", einsum_call=False):
     return numpy.einsum_path(
         *operands,
         optimize=optimize,
-        einsum_call=einsum_call,
+        einsum_call=False,
     )
 
 


### PR DESCRIPTION
`einsum_call` is a [hidden kwarg](https://github.com/numpy/numpy/blob/main/numpy/_core/einsumfunc.pyi#L174). In NumPy, it has been used internally inside `einsum` but it is not needed in dpnp so removing it from the signature.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
