### PR TITLE
Enable tests for `dpnp.einsum` since `dpctl` issue is resolved

### DIFF
--- a/dpnp/tests/third_party/cupy/linalg_tests/test_einsum.py
+++ b/dpnp/tests/third_party/cupy/linalg_tests/test_einsum.py
@@ -373,8 +373,6 @@ class TestEinSumUnaryOperation:
     def test_einsum_unary_dtype(self, xp, dtype_a, dtype_out):
         if not numpy.can_cast(dtype_a, dtype_out):
             pytest.skip()
-        if cupy.issubdtype(dtype_a, cupy.unsignedinteger):
-            pytest.skip("dpctl-2055")
         a = testing.shaped_arange(self.shape_a, xp, dtype_a)
         return xp.einsum(self.subscripts, a, dtype=dtype_out)
 


### PR DESCRIPTION
[dpctl-2055](https://github.com/IntelPython/dpctl/issues/2055) has  been resolved by [dpctl-2058](https://github.com/IntelPython/dpctl/pull/2058).
This PR enables previously muted tests for `dpnp.einsum` failing due to dpctl issue.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
