### PR TITLE
Correct a path to `cl.cfg` file

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -376,7 +376,7 @@ jobs:
             Write-Warning "File $script_path was NOT found!"
           }
           # Check the variable assisting OpenCL CPU driver to find TBB DLLs which are not located where it expects them by default
-          $cl_cfg="$env:CONDA_PREFIX\Library\lib\cl.cfg"
+          $cl_cfg="$env:CONDA_PREFIX\Library\bin\cl.cfg"
           Get-Content -Tail 5 -Path $cl_cfg
 
       - name: Smoke test

--- a/.github/workflows/cron-run-tests.yaml
+++ b/.github/workflows/cron-run-tests.yaml
@@ -108,7 +108,7 @@ jobs:
             Write-Warning "File $script_path was NOT found!"
           }
           # Check the variable assisting OpenCL CPU driver to find TBB DLLs which are not located where it expects them by default
-          $cl_cfg="$env:CONDA_PREFIX\Library\lib\cl.cfg"
+          $cl_cfg="$env:CONDA_PREFIX\Library\bin\cl.cfg"
           Get-Content -Tail 5 -Path $cl_cfg
 
       - name: Smoke test


### PR DESCRIPTION
The location of `cl.cfg` file created by installing `intel-opencl-rt` conda package was changed few releases back from `%CONDA_PREFIX%\Library\lib\cl.cfg` to `%CONDA_PREFIX%\Library\bin\cl.cfg`.
The file was still created at `Library\lib\cl.cfg` by `intel-opencl-rt-post-link.bat` script but with empty content.

The PR updates public CI to rely on correct path to `cl.cfg` configuration file.
The issue with `intel-opencl-rt-post-link.bat` script has to be updated by separate change in the compiler repo.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
