### PR TITLE
Update test to align with dpctl in array API capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This release achieves 100% compliance with Python Array API specification (revis
 * Updated `dpnp.einsum` to add support for `order=None` [#2411](https://github.com/IntelPython/dpnp/pull/2411)
 * Updated Python Array API specification version supported to `2024.12` [#2416](https://github.com/IntelPython/dpnp/pull/2416)
 * Removed `einsum_call` keyword from `dpnp.einsum_path` signature [#2421](https://github.com/IntelPython/dpnp/pull/2421)
+* Changed `"max dimensions"` to `None` in array API capabilities [#2432](https://github.com/IntelPython/dpnp/pull/2432)
 
 ### Fixed
 

--- a/dpnp/tests/test_array_api_info.py
+++ b/dpnp/tests/test_array_api_info.py
@@ -18,7 +18,7 @@ def test_capabilities():
     caps = info.capabilities()
     assert caps["boolean indexing"] is True
     assert caps["data-dependent shapes"] is True
-    assert caps["max dimensions"] == 64
+    assert caps["max dimensions"] == None
 
 
 def test_default_device():


### PR DESCRIPTION
[dpctl-2071](https://github.com/IntelPython/dpctl/pull/2071) is going to change `"max dimensions"` to `None` in array API capabilities.
This PR updates a test to align with that change.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
