### PR TITLE
fix failed test in `test_ndarray.py`

### DIFF
--- a/dpnp/tests/test_ndarray.py
+++ b/dpnp/tests/test_ndarray.py
@@ -333,7 +333,7 @@ def test_print_dpnp_special_character(character):
 def test_print_dpnp_1d():
     dtype = dpnp.default_float_type()
     result = repr(dpnp.arange(10000, dtype=dtype))
-    expected = "array([0.000e+00, 1.000e+00, 2.000e+00, ..., 9.997e+03, 9.998e+03,\n       9.999e+03])"
+    expected = "array([0.000e+00, 1.000e+00, 2.000e+00, ..., 9.997e+03, 9.998e+03,\n       9.999e+03], shape=(10000,))"
     if not has_support_aspect64():
         expected = expected[:-1] + ", dtype=float32)"
     assert result == expected
@@ -361,9 +361,9 @@ def test_print_dpnp_2d():
 def test_print_dpnp_zero_shape():
     result = repr(dpnp.empty(shape=(0, 0)))
     if has_support_aspect64():
-        expected = "array([])"
+        expected = "array([], shape=(0, 0), dtype=float64)"
     else:
-        expected = "array([], dtype=float32)"
+        expected = "array([], shape=(0, 0), dtype=float32)"
     assert result == expected
 
     result = str(dpnp.empty(shape=(0, 0)))


### PR DESCRIPTION
The behavior of `repr` was modified in https://github.com/IntelPython/dpctl/pull/2067.

Tests in `dpnp` should be modified to align with this new behavior.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
