### PR TITLE
Avoid using `sycl/ext/intel/math.hpp` on non-Intel devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ This release achieves 100% compliance with Python Array API specification (revis
 * Updated Python Array API specification version supported to `2024.12` [#2416](https://github.com/IntelPython/dpnp/pull/2416)
 * Removed `einsum_call` keyword from `dpnp.einsum_path` signature [#2421](https://github.com/IntelPython/dpnp/pull/2421)
 * Changed `"max dimensions"` to `None` in array API capabilities [#2432](https://github.com/IntelPython/dpnp/pull/2432)
-* Added CUDA compatibility for `dpnp.i0` and `dpnp.kaiser` functions [#2439](https://github.com/IntelPython/dpnp/pull/2439)
+* Added `dpnp.i0` and `dpnp.kaiser` compatibility with non-Intel devices [#2439](https://github.com/IntelPython/dpnp/pull/2439)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,13 +28,13 @@ This release achieves 100% compliance with Python Array API specification (revis
 * Updated Python Array API specification version supported to `2024.12` [#2416](https://github.com/IntelPython/dpnp/pull/2416)
 * Removed `einsum_call` keyword from `dpnp.einsum_path` signature [#2421](https://github.com/IntelPython/dpnp/pull/2421)
 * Changed `"max dimensions"` to `None` in array API capabilities [#2432](https://github.com/IntelPython/dpnp/pull/2432)
-* Added `dpnp.i0` and `dpnp.kaiser` compatibility with non-Intel devices [#2439](https://github.com/IntelPython/dpnp/pull/2439)
 
 ### Fixed
 
 * Resolved an issue with an incorrect result returned due to missing dependency from the strided kernel on a copy event in `dpnp.erf` [#2378](https://github.com/IntelPython/dpnp/pull/2378)
 * Updated `conda create` commands build and install instructions of `Quick start guide` to avoid a compilation error [#2395](https://github.com/IntelPython/dpnp/pull/2395)
 * Added handling of empty string passed to a test env variable defining data type scope as a `False` value [#2415](https://github.com/IntelPython/dpnp/pull/2415)
+* Resolved build issues on non-Intel targets in `dpnp.i0` and `dpnp.kaiser` [#2439](https://github.com/IntelPython/dpnp/pull/2439)
 
 
 ## [0.17.0] - 02/26/2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This release achieves 100% compliance with Python Array API specification (revis
 * Updated Python Array API specification version supported to `2024.12` [#2416](https://github.com/IntelPython/dpnp/pull/2416)
 * Removed `einsum_call` keyword from `dpnp.einsum_path` signature [#2421](https://github.com/IntelPython/dpnp/pull/2421)
 * Changed `"max dimensions"` to `None` in array API capabilities [#2432](https://github.com/IntelPython/dpnp/pull/2432)
+* Added CUDA compatibility for `dpnp.i0` and `dpnp.kaiser` functions [#2439](https://github.com/IntelPython/dpnp/pull/2439)
 
 ### Fixed
 

--- a/dpnp/backend/extensions/window/kaiser.cpp
+++ b/dpnp/backend/extensions/window/kaiser.cpp
@@ -40,10 +40,10 @@
 #define __SYCL_COMPILER_BESSEL_I0_SUPPORT 20241208L
 #endif
 
-// The <sycl/ext/intel/math.hpp> header and related types like
-// _iml_half_internal are not compatible with NVIDIA GPUs and cause compilation
-// errors when building with -fsycl-targets=nvptx64-nvidia-cuda.
-#if !defined(__NVPTX__) &&                                                     \
+// Include <sycl/ext/intel/math.hpp> only when targeting Intel devices.
+// This header relies on intel-specific types like _iml_half_internal,
+// which are not supported on non-intel backends (e.g., CUDA, AMD)
+#if defined(__SPIR__) && defined(__INTEL_LLVM_COMPILER) &&                     \
     (__SYCL_COMPILER_VERSION >= __SYCL_COMPILER_BESSEL_I0_SUPPORT)
 #include <sycl/ext/intel/math.hpp>
 #endif
@@ -78,7 +78,7 @@ public:
 
     void operator()(sycl::id<1> id) const
     {
-#if !defined(__NVPTX__) &&                                                     \
+#if defined(__SPIR__) && defined(__INTEL_LLVM_COMPILER) &&                     \
     (__SYCL_COMPILER_VERSION >= __SYCL_COMPILER_BESSEL_I0_SUPPORT)
         using sycl::ext::intel::math::cyl_bessel_i0;
 #else

--- a/dpnp/backend/extensions/window/kaiser.cpp
+++ b/dpnp/backend/extensions/window/kaiser.cpp
@@ -40,7 +40,11 @@
 #define __SYCL_COMPILER_BESSEL_I0_SUPPORT 20241208L
 #endif
 
-#if __SYCL_COMPILER_VERSION >= __SYCL_COMPILER_BESSEL_I0_SUPPORT
+// The <sycl/ext/intel/math.hpp> header and related types like
+// _iml_half_internal are not compatible with NVIDIA GPUs and cause compilation
+// errors when building with -fsycl-targets=nvptx64-nvidia-cuda.
+#if !defined(__NVPTX__) &&                                                     \
+    (__SYCL_COMPILER_VERSION >= __SYCL_COMPILER_BESSEL_I0_SUPPORT)
 #include <sycl/ext/intel/math.hpp>
 #endif
 
@@ -74,7 +78,8 @@ public:
 
     void operator()(sycl::id<1> id) const
     {
-#if __SYCL_COMPILER_VERSION >= __SYCL_COMPILER_BESSEL_I0_SUPPORT
+#if !defined(__NVPTX__) &&                                                     \
+    (__SYCL_COMPILER_VERSION >= __SYCL_COMPILER_BESSEL_I0_SUPPORT)
         using sycl::ext::intel::math::cyl_bessel_i0;
 #else
         using dpnp::kernels::i0::impl::cyl_bessel_i0;

--- a/dpnp/backend/kernels/elementwise_functions/i0.hpp
+++ b/dpnp/backend/kernels/elementwise_functions/i0.hpp
@@ -35,10 +35,10 @@
 #define __SYCL_COMPILER_BESSEL_I0_SUPPORT 20241208L
 #endif
 
-// The <sycl/ext/intel/math.hpp> header and related types like
-// _iml_half_internal are not compatible with NVIDIA GPUs and cause compilation
-// errors when building with -fsycl-targets=nvptx64-nvidia-cuda.
-#if !defined(__NVPTX__) &&                                                     \
+// Include <sycl/ext/intel/math.hpp> only when targeting Intel devices.
+// This header relies on intel-specific types like _iml_half_internal,
+// which are not supported on non-intel backends (e.g., CUDA, AMD)
+#if defined(__SPIR__) && defined(__INTEL_LLVM_COMPILER) &&                     \
     (__SYCL_COMPILER_VERSION >= __SYCL_COMPILER_BESSEL_I0_SUPPORT)
 #include <sycl/ext/intel/math.hpp>
 #endif
@@ -257,7 +257,7 @@ struct I0Functor
 
     resT operator()(const argT &x) const
     {
-#if !defined(__NVPTX__) &&                                                     \
+#if defined(__SPIR__) && defined(__INTEL_LLVM_COMPILER) &&                     \
     (__SYCL_COMPILER_VERSION >= __SYCL_COMPILER_BESSEL_I0_SUPPORT)
         using sycl::ext::intel::math::cyl_bessel_i0;
 #else

--- a/dpnp/backend/kernels/elementwise_functions/i0.hpp
+++ b/dpnp/backend/kernels/elementwise_functions/i0.hpp
@@ -35,7 +35,11 @@
 #define __SYCL_COMPILER_BESSEL_I0_SUPPORT 20241208L
 #endif
 
-#if __SYCL_COMPILER_VERSION >= __SYCL_COMPILER_BESSEL_I0_SUPPORT
+// The <sycl/ext/intel/math.hpp> header and related types like
+// _iml_half_internal are not compatible with NVIDIA GPUs and cause compilation
+// errors when building with -fsycl-targets=nvptx64-nvidia-cuda.
+#if !defined(__NVPTX__) &&                                                     \
+    (__SYCL_COMPILER_VERSION >= __SYCL_COMPILER_BESSEL_I0_SUPPORT)
 #include <sycl/ext/intel/math.hpp>
 #endif
 
@@ -253,7 +257,8 @@ struct I0Functor
 
     resT operator()(const argT &x) const
     {
-#if __SYCL_COMPILER_VERSION >= __SYCL_COMPILER_BESSEL_I0_SUPPORT
+#if !defined(__NVPTX__) &&                                                     \
+    (__SYCL_COMPILER_VERSION >= __SYCL_COMPILER_BESSEL_I0_SUPPORT)
         using sycl::ext::intel::math::cyl_bessel_i0;
 #else
         using impl::cyl_bessel_i0;


### PR DESCRIPTION
This PR suggests updating `dpnp.i0()` and `dpnp.kaiser()`  to avoid including `<sycl/ext/intel/math.hpp>` due to its incompatibility with non-Intel backend (CUDA, AMD).

Instead of using `sycl::ext::intel::math::cyl_bessel_i0`, `dpnp::kernels::i0::impl::cyl_bessel_i0`  is now used when building on non-Intel targets.

Including `<sycl/ext/intel/math.hpp>` with `-fsycl-targets=nvptx64-nvidia-cuda`  or `-fsycl-targets=amdgcn-amd-amdhsa `causes compilation errors due to type conflicts
```
In file included from dpnp/dpnp/backend/extensions/window/kaiser.cpp:44:
In file included from /opt/intel/oneapi/compiler/2025.1/bin/compiler/../../include/sycl/ext/intel/math.hpp:40:
/opt/intel/oneapi/compiler/2025.1/bin/compiler/../../include/sycl/ext/intel/math/imf_fp_conversions.hpp:108:14: error: conflicting types for '__imf_half2uint_rn'
  108 | unsigned int __imf_half2uint_rn(_iml_half_internal);
      |              ^
/opt/intel/oneapi/compiler/2025.1/bin/compiler/../../include/sycl/builtins.hpp:189:43: note: previous declaration is here
  189 | extern __DPCPP_SYCL_EXTERNAL unsigned int __imf_half2uint_rn(_Float16 x);
      |                                           ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
```

This happens because the header `<sycl/ext/intel/math.hpp>` defines intel-specific types such as `_iml_half_internal` which are incompatible with non-Intel backend and conflict with standard types like `_Float16`

The issue is discussed [here](https://support.codeplay.com/t/use-of-intel-oneapi-sycl-ext-intel-math-hpp-and-fsycl-targets-nvptx64-nvidia-cuda/737) 


- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
