### PR TITLE
Pin cython to unblock public CI

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -13,7 +13,7 @@ requirements:
       - python
       - setuptools
       - numpy >=1.23
-      - cython <3.1 # [linux]
+      - cython <3.1
       - cmake >=3.21
       - ninja
       - git

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -13,7 +13,7 @@ requirements:
       - python
       - setuptools
       - numpy >=1.23
-      - cython
+      - cython <3.1 # [linux]
       - cmake >=3.21
       - ninja
       - git

--- a/environments/build_with_oneapi.yml
+++ b/environments/build_with_oneapi.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - cmake
-  - cython
+  - cython <3.1
   - ninja
   - numpy
   - pytest


### PR DESCRIPTION
This PR pins `cython <3.1` to w/a build failure observing with `3.1.0` in public CI.
The latest stable Cython version was `3.0.12`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
