### PR TITLE
set a default value for axis parameter in `dpnp.take_along_axis`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This release achieves 100% compliance with Python Array API specification (revis
 * Updated Python Array API specification version supported to `2024.12` [#2416](https://github.com/IntelPython/dpnp/pull/2416)
 * Removed `einsum_call` keyword from `dpnp.einsum_path` signature [#2421](https://github.com/IntelPython/dpnp/pull/2421)
 * Changed `"max dimensions"` to `None` in array API capabilities [#2432](https://github.com/IntelPython/dpnp/pull/2432)
+* The parameter `axis` in `dpnp.take_along_axis` function has now a default value of `-1` []()
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ This release achieves 100% compliance with Python Array API specification (revis
 * Updated Python Array API specification version supported to `2024.12` [#2416](https://github.com/IntelPython/dpnp/pull/2416)
 * Removed `einsum_call` keyword from `dpnp.einsum_path` signature [#2421](https://github.com/IntelPython/dpnp/pull/2421)
 * Changed `"max dimensions"` to `None` in array API capabilities [#2432](https://github.com/IntelPython/dpnp/pull/2432)
-* The parameter `axis` in `dpnp.take_along_axis` function has now a default value of `-1` []()
+* The parameter `axis` in `dpnp.take_along_axis` function has now a default value of `-1` [#2442](https://github.com/IntelPython/dpnp/pull/2442)
 
 ### Fixed
 

--- a/dpnp/dpnp_iface_indexing.py
+++ b/dpnp/dpnp_iface_indexing.py
@@ -2205,7 +2205,7 @@ def take(a, indices, /, *, axis=None, out=None, mode="wrap"):
     return dpnp.get_result_array(usm_res, out=out)
 
 
-def take_along_axis(a, indices, axis, mode="wrap"):
+def take_along_axis(a, indices, axis=-1, mode="wrap"):
     """
     Take values from the input array by matching 1d index and data slices.
 
@@ -2230,6 +2230,8 @@ def take_along_axis(a, indices, axis, mode="wrap"):
         The axis to take 1d slices along. If axis is ``None``, the input
         array is treated as if it had first been flattened to 1d,
         for consistency with :obj:`dpnp.sort` and :obj:`dpnp.argsort`.
+
+        Default: ``-1``.
     mode : {"wrap", "clip"}, optional
         Specifies how out-of-bounds indices will be handled. Possible values
         are:
@@ -2274,8 +2276,8 @@ def take_along_axis(a, indices, axis, mode="wrap"):
     array([[10, 20, 30],
            [40, 50, 60]])
 
-    The same works for max and min, if you maintain the trivial dimension
-    with ``keepdims``:
+    The same works for :obj:`dpnp.max` and :obj:`dpnp.min`, if you maintain
+    the trivial dimension with ``keepdims``:
 
     >>> np.max(a, axis=1, keepdims=True)
     array([[30],

--- a/dpnp/dpnp_iface_indexing.py
+++ b/dpnp/dpnp_iface_indexing.py
@@ -2227,9 +2227,10 @@ def take_along_axis(a, indices, axis=-1, mode="wrap"):
         dimension of the input array, but dimensions ``Ni`` and ``Nj``
         only need to broadcast against `a`.
     axis : {None, int}
-        The axis to take 1d slices along. If axis is ``None``, the input
-        array is treated as if it had first been flattened to 1d,
-        for consistency with :obj:`dpnp.sort` and :obj:`dpnp.argsort`.
+        The axis to take 1d slices along. If axis is ``None``, the input array
+        is treated as if it had first been flattened to 1d. The default is
+        ``-1``, which takes 1d slices along the last axis. These behaviors are
+        consistent with :obj:`dpnp.sort` and :obj:`dpnp.argsort`.
 
         Default: ``-1``.
     mode : {"wrap", "clip"}, optional

--- a/dpnp/tests/test_indexing.py
+++ b/dpnp/tests/test_indexing.py
@@ -804,7 +804,7 @@ class TestTakeAlongAxis:
         # a = dpnp.random.random(size=(3, 4, 5))
         a = dpnp.asarray(numpy.random.random(size=(3, 4, 5)))
 
-        for axis in list(range(a.ndim)) + [None]:
+        for axis in list(range(a.ndim)) + [None, -1]:
             a_func = func(a, axis=axis, **kwargs)
             ai_func = argfunc(a, axis=axis, **kwargs)
             assert_array_equal(


### PR DESCRIPTION
set a default value of `-1` for axis parameter in `dpnp.take_along_axis`

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
