### PR TITLE
Remove cython pinning to `< 3.1`

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -13,7 +13,7 @@ requirements:
       - python
       - setuptools
       - numpy >=1.23
-      - cython <3.1
+      - cython
       - cmake >=3.21
       - ninja
       - git

--- a/dpnp/dpnp_algo/dpnp_arraycreation.py
+++ b/dpnp/dpnp_algo/dpnp_arraycreation.py
@@ -32,8 +32,8 @@ import dpctl.utils as dpu
 import numpy
 
 import dpnp
-import dpnp.dpnp_utils as utils
 from dpnp.dpnp_array import dpnp_array
+from dpnp.dpnp_utils import get_usm_allocations, map_dtype_to_device
 
 __all__ = [
     "dpnp_geomspace",
@@ -60,7 +60,7 @@ def dpnp_geomspace(
     endpoint=True,
     axis=0,
 ):
-    usm_type_alloc, sycl_queue_alloc = utils.get_usm_allocations([start, stop])
+    usm_type_alloc, sycl_queue_alloc = get_usm_allocations([start, stop])
 
     if sycl_queue is None and device is None:
         sycl_queue = sycl_queue_alloc
@@ -77,7 +77,7 @@ def dpnp_geomspace(
     stop = _as_usm_ndarray(stop, _usm_type, sycl_queue_normalized)
 
     dt = numpy.result_type(start, stop, float(num))
-    dt = utils.map_dtype_to_device(dt, sycl_queue_normalized.sycl_device)
+    dt = map_dtype_to_device(dt, sycl_queue_normalized.sycl_device)
     if dtype is None:
         dtype = dt
 
@@ -144,7 +144,7 @@ def dpnp_linspace(
     retstep=False,
     axis=0,
 ):
-    usm_type_alloc, sycl_queue_alloc = utils.get_usm_allocations([start, stop])
+    usm_type_alloc, sycl_queue_alloc = get_usm_allocations([start, stop])
 
     if sycl_queue is None and device is None:
         sycl_queue = sycl_queue_alloc
@@ -164,7 +164,7 @@ def dpnp_linspace(
         stop = _as_usm_ndarray(stop, _usm_type, sycl_queue_normalized)
 
     dt = numpy.result_type(start, stop, float(num))
-    dt = utils.map_dtype_to_device(dt, sycl_queue_normalized.sycl_device)
+    dt = map_dtype_to_device(dt, sycl_queue_normalized.sycl_device)
     if dtype is None:
         dtype = dt
 
@@ -251,7 +251,7 @@ def dpnp_logspace(
     axis=0,
 ):
     if not dpnp.isscalar(base):
-        usm_type_alloc, sycl_queue_alloc = utils.get_usm_allocations(
+        usm_type_alloc, sycl_queue_alloc = get_usm_allocations(
             [start, stop, base]
         )
 

--- a/dpnp/dpnp_utils/dpnp_algo_utils.pyx
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pyx
@@ -1,5 +1,5 @@
 # cython: language_level=3
-# cython: linetrace=True
+# cython: linetrace=False
 # -*- coding: utf-8 -*-
 # *****************************************************************************
 # Copyright (c) 2016-2025, Intel Corporation

--- a/dpnp/dpnp_utils/dpnp_algo_utils.pyx
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pyx
@@ -1,5 +1,5 @@
 # cython: language_level=3
-# cython: linetrace=False
+# cython: linetrace=True
 # -*- coding: utf-8 -*-
 # *****************************************************************************
 # Copyright (c) 2016-2025, Intel Corporation
@@ -449,6 +449,7 @@ cdef tuple get_common_usm_allocation(dpnp_descriptor x1, dpnp_descriptor x2):
     return (common_sycl_queue.sycl_device, common_usm_type, common_sycl_queue)
 
 
+@cython.linetrace(False)
 cdef (DPNPFuncType, void *) get_ret_type_and_func(DPNPFuncData kernel_data,
                                                   cpp_bool has_aspect_fp64):
     """

--- a/environments/build_with_oneapi.yml
+++ b/environments/build_with_oneapi.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - cmake
-  - cython <3.1
+  - cython
   - ninja
   - numpy
   - pytest


### PR DESCRIPTION
This PR reverts cython pinning added in #2441 which was added to unblock CI due to compilation error:
```bash
$SRC_DIR/_skbuild/linux-x86_64-3.9/cmake-build/dpnp/dpnp_utils/dpnp_algo_utils.cxx:28898:36: error: use of undeclared identifier '__pyx_convert__to_py___pyx_ctuple_4f2d56__4dpnp_9dpnp_algo_9dpnp_algo_enum__space_DPNPFu__etc'; did you mean '__pyx_ctuple_4f2d56__4dpnp_9dpnp_algo_9dpnp_algo_enum__space_DPNPFu__etc'?
 28898 |   __Pyx_TraceReturnCValue(__pyx_r, __pyx_convert__to_py___pyx_ctuple_4f2d56__4dpnp_9dpnp_algo_9dpnp_algo_enum__space_DPNPFu__etc, 21, 0, __PYX_ERR(0, 466, __pyx_L1_error));
       |                                    ^
$SRC_DIR/_skbuild/linux-x86_64-3.9/cmake-build/dpnp/dpnp_utils/dpnp_algo_utils.cxx:2104:89: note: '__pyx_ctuple_4f2d56__4dpnp_9dpnp_algo_9dpnp_algo_enum__space_DPNPFu__etc' declared here
 2104 | typedef struct __pyx_ctuple_4f2d56__4dpnp_9dpnp_algo_9dpnp_algo_enum__space_DPNPFu__etc __pyx_ctuple_4f2d56__4dpnp_9dpnp_algo_9dpnp_algo_enum__space_DPNPFu__etc;
      |                                                                                         ^
$SRC_DIR/_skbuild/linux-x86_64-3.9/cmake-build/dpnp/dpnp_utils/dpnp_algo_utils.cxx:28898:36: error: use of undeclared identifier '__pyx_convert__to_py___pyx_ctuple_4f2d56__4dpnp_9dpnp_algo_9dpnp_algo_enum__space_DPNPFu__etc'; did you mean '__pyx_ctuple_4f2d56__4dpnp_9dpnp_algo_9dpnp_algo_enum__space_DPNPFu__etc'?
 28898 |   __Pyx_TraceReturnCValue(__pyx_r, __pyx_convert__to_py___pyx_ctuple_4f2d56__4dpnp_9dpnp_algo_9dpnp_algo_enum__space_DPNPFu__etc, 21, 0, __PYX_ERR(0, 466, __pyx_L1_error));
       |                                    ^
$SRC_DIR/_skbuild/linux-x86_64-3.9/cmake-build/dpnp/dpnp_utils/dpnp_algo_utils.cxx:2104:89: note: '__pyx_ctuple_4f2d56__4dpnp_9dpnp_algo_9dpnp_algo_enum__space_DPNPFu__etc' declared here
 2104 | typedef struct __pyx_ctuple_4f2d56__4dpnp_9dpnp_algo_9dpnp_algo_enum__space_DPNPFu__etc __pyx_ctuple_4f2d56__4dpnp_9dpnp_algo_9dpnp_algo_enum__space_DPNPFu__etc;
      |                                                                                         ^
2 errors generated.
```

The error is caused by cython issue when line tracing is enabled and if there is ctuple returned.
It is proposed to disable line tracing per affected function to mitigate the compilation error.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
