### PR TITLE
make array Hermitian before calling complex-to-real FFT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ This release achieves 100% compliance with Python Array API specification (revis
 * Removed `einsum_call` keyword from `dpnp.einsum_path` signature [#2421](https://github.com/IntelPython/dpnp/pull/2421)
 * Changed `"max dimensions"` to `None` in array API capabilities [#2432](https://github.com/IntelPython/dpnp/pull/2432)
 * Updated kernel header `i0.hpp` to expose `cyl_bessel_i0` function depending on build target [#2440](https://github.com/IntelPython/dpnp/pull/2440)
-* Updated FFT module to make input array Hermitian before calling complex-to-real FFT [#2444](https://github.com/IntelPython/dpnp/pull/2444)
+* Updated FFT module to ensure an input array is Hermitian before calling complex-to-real FFT [#2444](https://github.com/IntelPython/dpnp/pull/2444)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This release achieves 100% compliance with Python Array API specification (revis
 * Removed `einsum_call` keyword from `dpnp.einsum_path` signature [#2421](https://github.com/IntelPython/dpnp/pull/2421)
 * Changed `"max dimensions"` to `None` in array API capabilities [#2432](https://github.com/IntelPython/dpnp/pull/2432)
 * Updated kernel header `i0.hpp` to expose `cyl_bessel_i0` function depending on build target [#2440](https://github.com/IntelPython/dpnp/pull/2440)
+* Updated FFT module to make input array Hermitian before calling complex-to-real FFT [#2444](https://github.com/IntelPython/dpnp/pull/2444)
 
 ### Fixed
 

--- a/dpnp/fft/dpnp_iface_fft.py
+++ b/dpnp/fft/dpnp_iface_fft.py
@@ -640,11 +640,11 @@ def ifft(a, n=None, axis=-1, norm=None, out=None):
     :obj:`dpnp.fft.fft`, i.e.,
 
     * ``a[0]`` should contain the zero frequency term,
-    * ``a[1:n//2]`` should contain the positive-frequency terms,
+    * ``a[1:(n+1)//2]`` should contain the positive-frequency terms,
     * ``a[n//2 + 1:]`` should contain the negative-frequency terms, in
       increasing order starting from the most negative frequency.
 
-    For an even number of input points, ``A[n//2]`` represents the sum of
+    For an even number of input points, ``a[n//2]`` represents the sum of
     the values at the positive and negative Nyquist frequencies, as the two
     are aliased together.
 
@@ -1062,7 +1062,7 @@ def irfft(a, n=None, axis=-1, norm=None, out=None):
 
     This function computes the inverse of the one-dimensional *n*-point
     discrete Fourier Transform of real input computed by :obj:`dpnp.fft.rfft`.
-    In other words, ``irfft(rfft(a), len(a)) == a`` to within numerical
+    In other words, ``irfft(rfft(a), n=len(a)) == a`` to within numerical
     accuracy. (See Notes below for why ``len(a)`` is necessary here.)
 
     The input is expected to be in the form returned by :obj:`dpnp.fft.rfft`,
@@ -1265,9 +1265,9 @@ def irfftn(a, s=None, axes=None, norm=None, out=None):
     This function computes the inverse of the *N*-dimensional discrete Fourier
     Transform for real input over any number of axes in an *M*-dimensional
     array by means of the Fast Fourier Transform (FFT). In other words,
-    ``irfftn(rfftn(a), a.shape) == a`` to within numerical accuracy. (The
-    ``a.shape`` is necessary like ``len(a)`` is for :obj:`dpnp.fft.irfft`,
-    and for the same reason.)
+    ``irfftn(rfftn(a), s=a.shape, axes=range(a.ndim)) == a`` to within
+    numerical accuracy. (The ``a.shape`` is necessary like ``len(a)`` is for
+    :obj:`dpnp.fft.irfft`, and for the same reason.)
 
     The input should be ordered in the same way as is returned by
     :obj:`dpnp.fft.rfftn`, i.e. as for :obj:`dpnp.fft.irfft` for the final

--- a/dpnp/tests/third_party/cupy/fft_tests/test_fft.py
+++ b/dpnp/tests/third_party/cupy/fft_tests/test_fft.py
@@ -1047,10 +1047,6 @@ class TestRfft2:
     )
     def test_irfft2(self, xp, dtype, order, enable_nd):
         # assert config.enable_nd_planning == enable_nd
-
-        if self.s is None and self.axes in [None, (-2, -1)]:
-            pytest.skip("Input is not Hermitian Symmetric")
-
         a = testing.shaped_random(self.shape, xp, dtype)
         if order == "F":
             a = xp.asfortranarray(a)
@@ -1137,10 +1133,6 @@ class TestRfftn:
     )
     def test_irfftn(self, xp, dtype, order, enable_nd):
         # assert config.enable_nd_planning == enable_nd
-
-        if self.s is None and self.axes in [None, (-2, -1)]:
-            pytest.skip("Input is not Hermitian Symmetric")
-
         a = testing.shaped_random(self.shape, xp, dtype)
         if order == "F":
             a = xp.asfortranarray(a)

--- a/dpnp/tests/third_party/cupy/fft_tests/test_fft.py
+++ b/dpnp/tests/third_party/cupy/fft_tests/test_fft.py
@@ -912,7 +912,8 @@ class TestRfft:
         atol=2e-6,
         accept_error=ValueError,
         contiguous_check=False,
-        type_check=has_support_aspect64(),
+        # TODO: replace with has_support_aspect64() when mkl_fft-gh-180 is merged
+        type_check=False,
     )
     def test_irfft(self, xp, dtype):
         a = testing.shaped_random(self.shape, xp, dtype)
@@ -1043,7 +1044,8 @@ class TestRfft2:
         atol=1e-7,
         accept_error=ValueError,
         contiguous_check=False,
-        type_check=has_support_aspect64(),
+        # TODO: replace with has_support_aspect64() when mkl_fft-gh-180 is merged
+        type_check=False,
     )
     def test_irfft2(self, xp, dtype, order, enable_nd):
         # assert config.enable_nd_planning == enable_nd
@@ -1129,7 +1131,8 @@ class TestRfftn:
         atol=1e-7,
         accept_error=ValueError,
         contiguous_check=False,
-        type_check=has_support_aspect64(),
+        # TODO: replace with has_support_aspect64() when mkl_fft-gh-180 is merged
+        type_check=False,
     )
     def test_irfftn(self, xp, dtype, order, enable_nd):
         # assert config.enable_nd_planning == enable_nd
@@ -1323,7 +1326,8 @@ class TestHfft:
         atol=2e-6,
         accept_error=ValueError,
         contiguous_check=False,
-        type_check=has_support_aspect64(),
+        # TODO: replace with has_support_aspect64() when mkl_fft-gh-180 is merged
+        type_check=False,
     )
     def test_hfft(self, xp, dtype):
         a = testing.shaped_random(self.shape, xp, dtype)


### PR DESCRIPTION
In this PR, input array is made Hermitian before calling complex-to-real FFT.

Input array should be Hermitian before calling complex-to-real FFT otherwise the behavior is undefined. Although it is user responsibility to validate this feature, [NumPy](https://github.com/numpy/numpy/blob/maintenance/2.2.x/numpy/fft/_pocketfft_umath.cpp#L265) and [CuPy](https://github.com/cupy/cupy/blob/v13.4.1/cupy/fft/_fft.py#L109) internally make the input array Hermitian. So, it is done in dpnp for consistency.


- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
