### PR TITLE
Bump `oneMath` version to `v0.7`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This release achieves 100% compliance with Python Array API specification (revis
 * Changed `"max dimensions"` to `None` in array API capabilities [#2432](https://github.com/IntelPython/dpnp/pull/2432)
 * Updated kernel header `i0.hpp` to expose `cyl_bessel_i0` function depending on build target [#2440](https://github.com/IntelPython/dpnp/pull/2440)
 * Added MKL functions `arg`, `copysign`, `i0`, and `inv` from VM namespace to be used by implementation of the appropriate element-wise functions [#2445](https://github.com/IntelPython/dpnp/pull/2445)
+* Clarified details about conda install instructions in `Quick start quide` and `README` [#2446](https://github.com/IntelPython/dpnp/pull/2446)
 * Bumped oneMKL version up to `0.7` [#2448](https://github.com/IntelPython/dpnp/pull/2448)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This release achieves 100% compliance with Python Array API specification (revis
 * Changed `"max dimensions"` to `None` in array API capabilities [#2432](https://github.com/IntelPython/dpnp/pull/2432)
 * Updated kernel header `i0.hpp` to expose `cyl_bessel_i0` function depending on build target [#2440](https://github.com/IntelPython/dpnp/pull/2440)
 * Added MKL functions `arg`, `copysign`, `i0`, and `inv` from VM namespace to be used by implementation of the appropriate element-wise functions [#2445](https://github.com/IntelPython/dpnp/pull/2445)
+* Bumped oneMKL version up to `0.7` [#2448](https://github.com/IntelPython/dpnp/pull/2448)
 
 ### Fixed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ if(_use_onemkl_interfaces)
         FetchContent_Declare(
                 onemkl_interfaces_library
                 GIT_REPOSITORY https://github.com/uxlfoundation/oneMath.git
-                GIT_TAG 8f4312ef966420b9b8b4b82b9d5c22e2c91a1fe7  # v0.6
+                GIT_TAG 20ba6fd7ae4af6ed693246cfd22c343e6522edbe  # v0.7
         )
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,16 +117,16 @@ if(_use_onemkl_interfaces)
     endif()
 
     if(DPNP_ONEMKL_INTERFACES_DIR)
-        FetchContent_Declare(onemkl_interfaces_library SOURCE_DIR "${DPNP_ONEMKL_INTERFACES_DIR}")
+        FetchContent_Declare(onemath_library SOURCE_DIR "${DPNP_ONEMKL_INTERFACES_DIR}")
     else()
         FetchContent_Declare(
-                onemkl_interfaces_library
+            onemath_library
                 GIT_REPOSITORY https://github.com/uxlfoundation/oneMath.git
                 GIT_TAG 20ba6fd7ae4af6ed693246cfd22c343e6522edbe  # v0.7
         )
     endif()
 
-    FetchContent_MakeAvailable(onemkl_interfaces_library)
+    FetchContent_MakeAvailable(onemath_library)
     if(TARGET onemath)
         set(MKL_INTERFACES_LIB "onemath" CACHE INTERNAL "OneMath lib target")
     elseif(TARGET onemkl)


### PR DESCRIPTION
There was a new `oneMath` release [v0.7](https://github.com/uxlfoundation/oneMath/releases/tag/v0.7) published.
Thus the PR updates `oneMath` version used by default dpnp build with enabled oneMKL interfaces.

Also, the name of fetched oneMath library changed from legacy `onemkl_interfaces_library` to `onemath_library` to reflact the actual library naming.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
