### PR TITLE
Fix DeprecationWarning in `TestInterp` for unsigned integer dtypes

### DIFF
--- a/dpnp/tests/test_mathematical.py
+++ b/dpnp/tests/test_mathematical.py
@@ -1188,7 +1188,7 @@ class TestInterp:
         "left, right", [[-40, 40], [dpnp.array(-40), dpnp.array(40)]]
     )
     def test_left_right_args(self, dtype, left, right):
-        x = numpy.array([-1, 0, 1, 2, 3, 4, 5, 6], dtype=dtype)
+        x = numpy.array([0, 1, 2, 3, 4, 5, 6], dtype=dtype)
         xp = numpy.array([0, 3, 6], dtype=dtype)
         fp = numpy.array([0, 9, 18], dtype=dtype)
 


### PR DESCRIPTION
This PR suggests update `TestInterp::test_left_right_args` to avoid `DeprecationWarning` that occurs when using negative values with unsigned integer dtypes (when DPNP_TEST_ALL_INT_TYPES=1)

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
