### PR TITLE
Avoid overflow in linspace test

### DIFF
--- a/dpnp/tests/third_party/cupy/creation_tests/test_ranges.py
+++ b/dpnp/tests/third_party/cupy/creation_tests/test_ranges.py
@@ -226,10 +226,13 @@ class TestRanges(unittest.TestCase):
         # TODO (ev-br): np 2.0: check if can re-enable float16
         # TODO (ev-br): np 2.0: had to bump the default rtol on Windows
         #               and numpy 1.26+weak promotion from 0 to 5e-6
-        if xp.dtype(dtype_range).kind in "u":
+        if xp.dtype(dtype_range).kind == "u":
             # to avoid overflow, limit `val` to be smaller
             # than xp.iinfo(dtype).max
-            if dtype_range in [xp.uint8, xp.uint16] or dtype_out == xp.uint8:
+            if dtype_range in [xp.uint8, xp.uint16] or dtype_out in [
+                xp.int8,
+                xp.uint8,
+            ]:
                 val = 125
             else:
                 val = 160


### PR DESCRIPTION
The PR resolves overflow issue observing in `test_linspace_mixed_start_stop2` test when running with `DPNP_TEST_ALL_INT_TYPES=1` on ARL-S machine.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
