### PR TITLE
Apply w/a for expected result in spacing test only on non-Intel NumPy

### DIFF
--- a/dpnp/tests/helper.py
+++ b/dpnp/tests/helper.py
@@ -414,6 +414,22 @@ def is_gpu_device(device=None):
     return dev.has_aspect_gpu
 
 
+def is_intel_numpy():
+    """
+    Return True if Intel NumPy is used during testing.
+
+    The check is based on MKL backend name stored in Build Dependencies, where
+    in case of Intel Numpy there "mkl-dynamic" is expected to be a part of the
+    name for both BLAS and LAPACK (the full name is "mkl-dynamic-ilp64-iomp").
+
+    """
+
+    build_deps = numpy.show_config(mode="dicts")["Build Dependencies"]
+    blas = build_deps["blas"]
+    lapack = build_deps["lapack"]
+    return all("mkl-dynamic" in dep["name"] for dep in [blas, lapack])
+
+
 def is_win_platform():
     """
     Return True if a test is running on Windows OS, False otherwise.

--- a/dpnp/tests/helper.py
+++ b/dpnp/tests/helper.py
@@ -427,6 +427,10 @@ def is_intel_numpy():
     build_deps = numpy.show_config(mode="dicts")["Build Dependencies"]
     blas = build_deps["blas"]
     lapack = build_deps["lapack"]
+
+    if numpy_version() < "2.0.0":
+        # numpy 1.26.4 has LAPACK name equals to 'dep140030038112336'
+        return "mkl-dynamic" in blas["name"]
     return all("mkl-dynamic" in dep["name"] for dep in [blas, lapack])
 
 

--- a/dpnp/tests/helper.py
+++ b/dpnp/tests/helper.py
@@ -419,8 +419,8 @@ def is_intel_numpy():
     Return True if Intel NumPy is used during testing.
 
     The check is based on MKL backend name stored in Build Dependencies, where
-    in case of Intel Numpy there "mkl-dynamic" is expected to be a part of the
-    name for both BLAS and LAPACK (the full name is "mkl-dynamic-ilp64-iomp").
+    in case of Intel Numpy there "mkl" is expected at the beginning of the name
+    for both BLAS and LAPACK (the full name is "mkl-dynamic-ilp64-iomp").
 
     """
 
@@ -430,8 +430,8 @@ def is_intel_numpy():
 
     if numpy_version() < "2.0.0":
         # numpy 1.26.4 has LAPACK name equals to 'dep140030038112336'
-        return "mkl-dynamic" in blas["name"]
-    return all("mkl-dynamic" in dep["name"] for dep in [blas, lapack])
+        return blas["name"].startswith("mkl")
+    return all(dep["name"].startswith("mkl") for dep in [blas, lapack])
 
 
 def is_win_platform():

--- a/dpnp/tests/test_mathematical.py
+++ b/dpnp/tests/test_mathematical.py
@@ -32,6 +32,7 @@ from .helper import (
     get_integer_float_dtypes,
     has_support_aspect16,
     has_support_aspect64,
+    is_intel_numpy,
     numpy_version,
 )
 from .third_party.cupy import testing
@@ -1751,11 +1752,11 @@ class TestSpacing:
 
         result = dpnp.spacing(ia)
         expected = numpy.spacing(a)
-        if numpy_version() < "2.0.0":
+        if is_intel_numpy():
             assert_allclose(result, expected)
         else:
-            # numpy.spacing(-0.0) == numpy.spacing(0.0), i.e. NumPy returns
-            # positive value (looks as a bug in NumPy), because for any other
+            # numpy.spacing(-0.0) == numpy.spacing(0.0), i.e. the stock NumPy
+            # returns positive value (looks as a bug), because for any other
             # negative input the NumPy result will be also a negative value.
             expected[1] *= -1
             assert_allclose(result, expected)


### PR DESCRIPTION
The stock NumPy returns incorrect result for `numpy.spacing(-0.0)`, while Intel NumPy returns the expected one (the same as dpnp also).
It might be the case when dpnp test is running with the stock NumPy. Thus the PR add a conditional check to update expected result in `TestSpacing::test_zeros` in case when non-Intel NumPy is used.

Previously the same logic was based on NumPy version, assuming Intel NumPy has always `version < "2.0.0"`, but it is not the case anymore.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
