### PR TITLE
Temporary disable failing tests for NaN input passed to `dpnp.linalg.cond`

### DIFF
--- a/dpnp/backend/extensions/lapack/getrf_batch.cpp
+++ b/dpnp/backend/extensions/lapack/getrf_batch.cpp
@@ -116,7 +116,7 @@ static sycl::event getrf_batch_impl(sycl::queue &exec_q,
         auto error_matrices_ids_size = error_matrices_ids.size();
         auto dev_info_size = static_cast<std::size_t>(py::len(dev_info));
         if (error_matrices_ids_size != dev_info_size) {
-            throw py::value_error("The size of `dev_info` must be equal to" +
+            throw py::value_error("The size of `dev_info` must be equal to " +
                                   std::to_string(error_matrices_ids_size) +
                                   ", but currently it is " +
                                   std::to_string(dev_info_size) + ".");

--- a/dpnp/backend/extensions/lapack/getri_batch.cpp
+++ b/dpnp/backend/extensions/lapack/getri_batch.cpp
@@ -114,7 +114,7 @@ static sycl::event getri_batch_impl(sycl::queue &exec_q,
         auto error_matrices_ids_size = error_matrices_ids.size();
         auto dev_info_size = static_cast<std::size_t>(py::len(dev_info));
         if (error_matrices_ids_size != dev_info_size) {
-            throw py::value_error("The size of `dev_info` must be equal to" +
+            throw py::value_error("The size of `dev_info` must be equal to " +
                                   std::to_string(error_matrices_ids_size) +
                                   ", but currently it is " +
                                   std::to_string(dev_info_size) + ".");

--- a/dpnp/tests/test_linalg.py
+++ b/dpnp/tests/test_linalg.py
@@ -6,7 +6,6 @@ from dpctl.tensor._numpy_helper import AxisError
 from dpctl.utils import ExecutionPlacementError
 from numpy.testing import (
     assert_allclose,
-    assert_almost_equal,
     assert_array_equal,
     assert_equal,
     assert_raises,
@@ -20,12 +19,13 @@ from .helper import (
     assert_dtype_allclose,
     generate_random_numpy_array,
     get_all_dtypes,
-    get_complex_dtypes,
     get_float_complex_dtypes,
     get_integer_float_dtypes,
     has_support_aspect64,
     is_cpu_device,
     is_cuda_device,
+    is_gpu_device,
+    is_win_platform,
     numpy_version,
 )
 from .third_party.cupy import testing
@@ -334,6 +334,12 @@ class TestCond:
         # while OneMKL returns nans
         if is_cuda_device() and p in [-dpnp.inf, -1, 1, dpnp.inf, "fro"]:
             pytest.skip("Different behavior on CUDA")
+        elif (
+            is_gpu_device()
+            and is_win_platform()
+            and p in [-dpnp.inf, -1, 1, dpnp.inf, "fro"]
+        ):
+            pytest.skip("SAT-7966")
         a = generate_random_numpy_array((2, 2, 2, 2))
         a[0, 0] = 0
         a[1, 1] = 0


### PR DESCRIPTION
The PR mutes the `tests/test_linalg.py::TestCond::test_nan` tests temporary on Windows to unblock the internal CI.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
