### PR TITLE
Makes tests with floor_divide more stable on PVC

### DIFF
--- a/dpnp/tests/test_binary_ufuncs.py
+++ b/dpnp/tests/test_binary_ufuncs.py
@@ -291,7 +291,7 @@ class TestFloorDivideRemainder:
     @pytest.mark.parametrize("dtype", ALL_DTYPES)
     def test_basic(self, func, dtype):
         a = generate_random_numpy_array(10, dtype)
-        b = generate_random_numpy_array(10, dtype)
+        b = generate_random_numpy_array(10, dtype, low=-5, high=5, seed_value=8)
         expected = getattr(numpy, func)(a, b)
 
         ia, ib = dpnp.array(a), dpnp.array(b)


### PR DESCRIPTION
`TestFloorDivideRemainder::test_basic` test generates the same values for both input array.
The PR proposes to change values for divisor input array and to make them different from dividend input array. That should makes test more stable with `float32` data type.
Currently it might fail on PVC with LTS driver for case with `floor_divide` function.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
