### PR TITLE
Clarify `dpnp.linalg.cond()` behavior with singular matrices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This release achieves 100% compliance with Python Array API specification (revis
 * Updates the list of required python versions documented in `Quick Start Guide` [#2449](https://github.com/IntelPython/dpnp/pull/2449)
 * Updated FFT module to ensure an input array is Hermitian before calling complex-to-real FFT [#2444](https://github.com/IntelPython/dpnp/pull/2444)
 * Aligned `black` configuration with the list of supported python versions [#2457](https://github.com/IntelPython/dpnp/pull/2457)
+* Added a clarification to `dpnp.linalg.cond` docstring about its behavior with singular matrices [#2500] (https://github.com/IntelPython/dpnp/pull/2500)
 
 ### Fixed
 

--- a/dpnp/linalg/dpnp_iface_linalg.py
+++ b/dpnp/linalg/dpnp_iface_linalg.py
@@ -186,6 +186,14 @@ def cond(x, p=None):
 
         Default: ``None``.
 
+    Notes
+    -----
+    This function raises :class:`dpnp.linalg.LinAlgError` for singular input
+    matrices when using norm orders:
+    ``1``, ``-1``, ``inf``, ``-inf``, or ``'fro'``.
+    In contrast, :obj:`numpy.linalg.cond` returns ``inf``for each singular
+    matrix in the input regardless of the norm order.
+
     Returns
     -------
     out : dpnp.ndarray


### PR DESCRIPTION
This PR suggests clarifying the behavior and updating `dpnp.linalg.cond()` tests for singular matrices.
It adds `Notes` section to the docs explaining the difference with NumPy when handling singular input and updates tests to reflect behavior specific to `CUDA backend` and different versions of `OneMKL`


- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
