### PR TITLE
Bump conda versions

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -191,10 +191,6 @@ jobs:
           echo PACKAGE_VERSION=${PACKAGE_VERSION}
           echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
 
-      # conda-index does not support python 3.13, but we need to test DPNP package with python 3.13
-      - name: Remove conda-index
-        run: mamba remove conda-index
-
       - name: Install dpnp
         id: install_dpnp
         continue-on-error: true
@@ -324,10 +320,6 @@ jobs:
           (echo CONDA_LIB_PATH=%CONDA_PREFIX%\Library\lib\) >> %GITHUB_ENV%
           (echo CONDA_LIB_BIN_PATH=%CONDA_PREFIX%\Library\bin\) >> %GITHUB_ENV%
 
-      - name: Install conda-index
-        run: |
-          mamba install conda-index=${{ env.CONDA_INDEX_VERSION }}
-
       - name: Create conda channel
         run: |
           @echo on
@@ -350,10 +342,6 @@ jobs:
           )
           echo PACKAGE_VERSION: %PACKAGE_VERSION%
           (echo PACKAGE_VERSION=%PACKAGE_VERSION%) >> %GITHUB_ENV%
-
-      # conda-index does not support python 3.13, but we need to test DPNP package with python 3.13
-      - name: Remove conda-index
-        run: mamba remove conda-index
 
       - name: Install dpnp
         run: |

--- a/environments/build_conda_pkg.yml
+++ b/environments/build_conda_pkg.yml
@@ -2,5 +2,5 @@ name: Build DPNP conda package
 channels:
   - conda-forge
 dependencies:
-  - python=3.12 # conda-build does not support python 3.13
+  - python=3.13
   - conda-build=25.5.0

--- a/environments/build_conda_pkg.yml
+++ b/environments/build_conda_pkg.yml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - python=3.12 # conda-build does not support python 3.13
-  - conda-build=25.4.2
+  - conda-build=25.5.0

--- a/environments/create_conda_channel.yml
+++ b/environments/create_conda_channel.yml
@@ -2,5 +2,5 @@ name: Create conda channel with DPNP package
 channels:
   - conda-forge
 dependencies:
-  - python=3.12 # conda does not support python 3.13
+  - python=3.12 # DPNP does not support python 3.13
   - conda-index=0.6.1

--- a/environments/create_conda_channel.yml
+++ b/environments/create_conda_channel.yml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - python=3.12 # conda does not support python 3.13
-  - conda-index=0.6.0
+  - conda-index=0.6.1


### PR DESCRIPTION
The PR updates `conda-build` version to `25.0.0` and `conda-index` vrsion to `0.6.1`.
Also the conda packages are now supporting python 3.13, so removing all w/a or limitation due to that in affected GH actions.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
