### PR TITLE
Use `hasattr` instead of `getattr` in checks for convert_item call

### DIFF
--- a/dpnp/dpnp_utils/dpnp_algo_utils.pyx
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pyx
@@ -76,9 +76,9 @@ cdef ERROR_PREFIX = "DPNP error:"
 
 
 def convert_item(item):
-    if getattr(item, "__sycl_usm_array_interface__", False):
+    if hasattr(item, "__sycl_usm_array_interface__"):
         item_converted = dpnp.asnumpy(item)
-    elif getattr(item, "__array_interface__", False):  # detect if it is a container (TODO any better way?)
+    elif hasattr(item, "__array_interface__"):  # detect if it is a container (TODO any better way?)
         mod_name = getattr(item, "__module__", 'none')
         if (mod_name != 'numpy'):
             item_converted = dpnp.asnumpy(item)


### PR DESCRIPTION
The PR improves tests logic to replace unnecessary `getattr` with `hasattr` call to check an item interface.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
