### PR TITLE
Pin to the lates dpctl release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.18.0] - 06/23/2025
+## [0.18.0] - 06/04/2025
 
 This release achieves 100% compliance with Python Array API specification (revision [2024.12](https://data-apis.org/array-api/2024.12/)).
 The release provides enhanced compatibility with NumPy 2.2.5. Window and mathematical routines are complemented by a set of new functions.

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set max_compiler_and_mkl_version = environ.get("MAX_BUILD_CMPL_MKL_VERSION", "2026.0a0") %}
 {% set required_compiler_and_mkl_version = "2025.0" %}
-{% set required_dpctl_version = "0.20.0*" %}
+{% set required_dpctl_version = "0.20.0" %}
 
 {% set pyproject = load_file_data('pyproject.toml') %}
 {% set py_build_deps = pyproject.get('build-system', {}).get('requires', []) %}

--- a/environments/dpctl_pkg.txt
+++ b/environments/dpctl_pkg.txt
@@ -1,2 +1,2 @@
 --index-url https://pypi.anaconda.org/dppy/label/dev/simple
-dpctl>=0.20.0dev0
+dpctl>=0.20.0

--- a/environments/dpctl_pkg.yml
+++ b/environments/dpctl_pkg.yml
@@ -2,4 +2,4 @@ name: Install dpctl package
 channels:
   - dppy/label/dev
 dependencies:
-  - dpctl>=0.20.0dev0
+  - dpctl>=0.20.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,7 @@ requires = [
   "build>=1.2.2",
   "cmake>=3.31.6",
   "cython>=3.0.12",
-  # WARNING: use only dpctl version available on PyPi
-  "dpctl>=0.19.0",
+  "dpctl>=0.20.0",
   "ninja>=1.11.1; platform_system!='Windows'",
   # NOTE: no DPNP restriction on NumPy version, so follow NumPy's drop schedule
   "numpy>=1.25.0",
@@ -48,8 +47,7 @@ dependencies = [
   # TODO: do we have to set sycl runtime dependencies here
   # "dpcpp-cpp-rt>=0.59.0",
   # "intel-cmplr-lib-rt>=0.59.0"
-  # WARNING: use the latest dpctl dev version, otherwise stable w/f will fail
-  "dpctl>=0.20.0dev0",
+  "dpctl>=0.20.0",
   "numpy>=1.25.0"
 ]
 description = "Data Parallel Extension for NumPy"


### PR DESCRIPTION
The PR pins to the lates dpctl release version `0.20.0`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
