### PR TITLE
Validate `HIP_TARGETS` format and allow negative values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Adjusted the `pre-commit` configuration to run autoupdate weekly [#2479](https://github.com/IntelPython/dpnp/pull/2479)
+* Improved `--target-hip` handling to accept only gfx-prefixed values and allow disabling HIP build [#2479](https://github.com/IntelPython/dpnp/pull/2479)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Adjusted the `pre-commit` configuration to run autoupdate weekly [#2479](https://github.com/IntelPython/dpnp/pull/2479)
-* Improved `--target-hip` handling to accept only gfx-prefixed values and allow disabling HIP build [#2479](https://github.com/IntelPython/dpnp/pull/2479)
+* Improved validation of `--target-hip` build option to only accept a gfx-prefixed value [#2481](https://github.com/IntelPython/dpnp/pull/2481)
 
 ### Fixed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ if ("x${DPNP_SYCL_TARGETS}" STREQUAL "x")
         else()
             message(FATAL_ERROR
                 "Invalid value for HIP_TARGETS: \"${HIP_TARGETS}\". "
-                "Expected an architecture name starting with 'gfx', such as 'gfx90a' or 'gfx1030'."
+                "Expected an architecture name starting with 'gfx', e.g. 'gfx1030'."
             )
         endif()
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,13 +106,19 @@ if ("x${DPNP_SYCL_TARGETS}" STREQUAL "x")
         set(_use_onemkl_interfaces_cuda ON)
     endif()
 
-    if (NOT "x${HIP_TARGETS}" STREQUAL "x")
-        set(_use_onemkl_interfaces_hip ON)
-
-        if ("x${_dpnp_sycl_targets}" STREQUAL "x")
-            set(_dpnp_sycl_targets "amd_gpu_${HIP_TARGETS},spir64-unknown-unknown")
+    if (HIP_TARGETS)
+        if (HIP_TARGETS MATCHES "^gfx")
+            if ("x${_dpnp_sycl_targets}" STREQUAL "x")
+                set(_dpnp_sycl_targets "amd_gpu_${HIP_TARGETS},spir64-unknown-unknown")
+            else()
+                set(_dpnp_sycl_targets "amd_gpu_${HIP_TARGETS},${_dpnp_sycl_targets}")
+            endif()
+            set(_use_onemkl_interfaces_hip ON)
         else()
-            set(_dpnp_sycl_targets "amd_gpu_${HIP_TARGETS},${_dpnp_sycl_targets}")
+            message(FATAL_ERROR
+                "Invalid value for HIP_TARGETS: \"${HIP_TARGETS}\". "
+                "Expected an architecture name starting with 'gfx', such as 'gfx90a' or 'gfx1030'."
+            )
         endif()
     endif()
 else()


### PR DESCRIPTION
This PR suggests validating the format of `HIP_TARGETS` (set via `--target-hip`) to ensure it starts with `gfx` (e.g., `gfx1030`).
It also allows users to explicitly indicate that no AMD target should be used by passing values like `--target-hip=OFF` or `--target-hip=FALSE` matching the default behavior

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
