### PR TITLE
Update math tests to specify a proper tolerance

### DIFF
--- a/dpnp/tests/third_party/cupy/math_tests/test_hyperbolic.py
+++ b/dpnp/tests/third_party/cupy/math_tests/test_hyperbolic.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy
+
 from dpnp.tests.helper import has_support_aspect64
 from dpnp.tests.third_party.cupy import testing
 
@@ -7,13 +9,16 @@ from dpnp.tests.third_party.cupy import testing
 class TestHyperbolic(unittest.TestCase):
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(atol=1e-5, type_check=has_support_aspect64())
+    @testing.numpy_cupy_allclose(
+        atol={numpy.float16: 1e-3, "default": 1e-5},
+        type_check=has_support_aspect64(),
+    )
     def check_unary(self, name, xp, dtype):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return getattr(xp, name)(a)
 
     @testing.for_dtypes(["e", "f", "d"])
-    @testing.numpy_cupy_allclose(atol=1e-5)
+    @testing.numpy_cupy_allclose(atol={numpy.float16: 1e-3, "default": 1e-5})
     def check_unary_unit(self, name, xp, dtype):
         a = xp.array([0.2, 0.4, 0.6, 0.8], dtype=dtype)
         return getattr(xp, name)(a)
@@ -31,7 +36,7 @@ class TestHyperbolic(unittest.TestCase):
         self.check_unary("arcsinh")
 
     @testing.for_dtypes(["e", "f", "d"])
-    @testing.numpy_cupy_allclose(atol=1e-5)
+    @testing.numpy_cupy_allclose(atol={numpy.float16: 1e-3, "default": 1e-5})
     def test_arccosh(self, xp, dtype):
         a = xp.array([1, 2, 3], dtype=dtype)
         return xp.arccosh(a)

--- a/dpnp/tests/third_party/cupy/math_tests/test_trigonometric.py
+++ b/dpnp/tests/third_party/cupy/math_tests/test_trigonometric.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy
 import pytest
 
 from dpnp.tests.helper import has_support_aspect64
@@ -24,7 +25,7 @@ class TestTrigonometric(unittest.TestCase):
         return getattr(xp, name)(a, b)
 
     @testing.for_dtypes(["e", "f", "d"])
-    @testing.numpy_cupy_allclose(atol=1e-5)
+    @testing.numpy_cupy_allclose(atol={numpy.float16: 1e-3, "default": 1e-5})
     def check_unary_unit(self, name, xp, dtype):
         a = xp.array([0.2, 0.4, 0.6, 0.8], dtype=dtype)
         return getattr(xp, name)(a)


### PR DESCRIPTION
The PR updates third party tests for hyperbolic and trigonometric elementwise functions to specify correct tolerance for float16 data type (to set `atol=1e-3`) and to keep `atol=1e-5` for other dtypes.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
