### PR TITLE
Update third party tests since support of `shape=None` was dropped in numpy 2.3

### DIFF
--- a/dpnp/tests/third_party/cupy/core_tests/test_internal.py
+++ b/dpnp/tests/third_party/cupy/core_tests/test_internal.py
@@ -38,10 +38,6 @@ class TestProdSequence(unittest.TestCase):
 
 class TestGetSize:
 
-    def test_none(self):
-        with testing.assert_warns(DeprecationWarning):
-            assert internal.get_size(None) == ()
-
     def check_collection(self, a):
         assert internal.get_size(a) == tuple(a)
 

--- a/dpnp/tests/third_party/cupy/core_tests/test_ndarray.py
+++ b/dpnp/tests/third_party/cupy/core_tests/test_ndarray.py
@@ -25,11 +25,10 @@ def wrap_take(array, *args, **kwargs):
 
 
 class TestNdarrayInit(unittest.TestCase):
-    @pytest.mark.skip("passing 'None' into shape arguments is not supported")
+
     def test_shape_none(self):
-        with testing.assert_warns(DeprecationWarning):
-            a = cupy.ndarray(None)
-        assert a.shape == ()
+        with pytest.raises(TypeError):
+            cupy.ndarray(None)
 
     def test_shape_int(self):
         a = cupy.ndarray(3)

--- a/dpnp/tests/third_party/cupy/creation_tests/test_basic.py
+++ b/dpnp/tests/third_party/cupy/creation_tests/test_basic.py
@@ -47,16 +47,13 @@ class TestBasic:
         a.fill(0)
         return a
 
-    @pytest.mark.skip("passing 'None' into shape arguments is not supported")
-    @testing.with_requires("numpy>=1.20")
+    @testing.with_requires("numpy>=2.3")
     @testing.for_CF_orders()
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_equal()
-    def test_empty_scalar_none(self, xp, dtype, order):
-        with testing.assert_warns(DeprecationWarning):
-            a = xp.empty(None, dtype=dtype, order=order)
-        a.fill(0)
-        return a
+    def test_empty_scalar_none(self, dtype, order):
+        for xp in (numpy, cupy):
+            with pytest.raises(TypeError):
+                xp.empty(None, dtype=dtype, order=order)
 
     @testing.for_CF_orders()
     @testing.for_all_dtypes()
@@ -206,14 +203,13 @@ class TestBasic:
     def test_zeros_scalar(self, xp, dtype, order):
         return xp.zeros((), dtype=dtype, order=order)
 
-    @pytest.mark.skip("passing 'None' into shape arguments is not supported")
-    @testing.with_requires("numpy>=1.20")
+    @testing.with_requires("numpy>=2.3")
     @testing.for_CF_orders()
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_equal()
-    def test_zeros_scalar_none(self, xp, dtype, order):
-        with testing.assert_warns(DeprecationWarning):
-            return xp.zeros(None, dtype=dtype, order=order)
+    def test_zeros_scalar_none(self, dtype, order):
+        for xp in (numpy, cupy):
+            with pytest.raises(TypeError):
+                xp.zeros(None, dtype=dtype, order=order)
 
     @testing.for_CF_orders()
     @testing.for_all_dtypes()


### PR DESCRIPTION
The PR updates third party tests, since numpy 2.3 [dropped](https://numpy.org/devdocs/release/2.3.0-notes.html#expired-deprecations) support of passing `shape=None` to functions with a non-optional shape argument errors.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
