### PR TITLE
Enabled tests previously muted for numpy 2.3

### DIFF
--- a/dpnp/tests/test_product.py
+++ b/dpnp/tests/test_product.py
@@ -843,8 +843,7 @@ class TestMatmul:
             assert_raises(TypeError, dpnp.matmul, ia, ib, out=iout)
             assert_raises(TypeError, numpy.matmul, a, b, out=out)
 
-    # TODO: include numpy-2.3 when numpy-issue-29164 is resolved
-    @testing.with_requires("numpy<2.3")
+    @testing.with_requires("numpy!=2.3.0")
     @pytest.mark.parametrize("dtype", _selected_dtypes)
     @pytest.mark.parametrize("order1", ["C", "F", "A"])
     @pytest.mark.parametrize("order2", ["C", "F", "A"])
@@ -882,8 +881,7 @@ class TestMatmul:
         assert result.flags.f_contiguous == expected.flags.f_contiguous
         assert_dtype_allclose(result, expected)
 
-    # TODO: include numpy-2.3 when numpy-issue-29164 is resolved
-    @testing.with_requires("numpy<2.3")
+    @testing.with_requires("numpy!=2.3.0")
     @pytest.mark.parametrize("dtype", _selected_dtypes)
     @pytest.mark.parametrize(
         "stride",

--- a/dpnp/tests/third_party/cupy/math_tests/test_matmul.py
+++ b/dpnp/tests/third_party/cupy/math_tests/test_matmul.py
@@ -99,8 +99,7 @@ class TestMatmul(unittest.TestCase):
 )
 class TestMatmulOut(unittest.TestCase):
 
-    # TODO: include numpy-2.3 when numpy-issue-29164 is resolved
-    @testing.with_requires("numpy<2.3")
+    @testing.with_requires("numpy!=2.3.0")
     # no_int8=True is added to avoid overflow
     @testing.for_all_dtypes(name="dtype1", no_int8=True)
     @testing.for_all_dtypes(name="dtype2", no_int8=True)


### PR DESCRIPTION
The new numpy release `2.3.1` has been published which includes the fix for numpy#29164.
That PR enables the previously muted tests for numpy 2.3.1 in #2477.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
