### PR TITLE
Fix typo in docstring of `matvec` and `vecmat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Updated `pre-commit` GitHub workflow to pass `no-commit-to-branch` check [#2501](https://github.com/IntelPython/dpnp/pull/2501)
+* Updated the math formulas in summary of `dpnp.matvec` and `dpnp.vecmat` to correct a typo [#2503](https://github.com/IntelPython/dpnp/pull/2503)
 
 ### Security
 

--- a/dpnp/dpnp_iface_linearalgebra.py
+++ b/dpnp/dpnp_iface_linearalgebra.py
@@ -956,7 +956,7 @@ def matvec(
     matrix-vector product is defined as:
 
     .. math::
-       \mathbf{A} \cdot \mathbf{b} = \sum_{i=0}^{n-1} A_{ij}v_j
+       \mathbf{A} \cdot \mathbf{v} = \sum_{j=0}^{n-1} A_{ij} v_j
 
     where the sum is over the last dimensions in `x1` and `x2` (unless `axes`
     is specified). (For a matrix-vector product with the vector conjugated,
@@ -1457,7 +1457,7 @@ def vecmat(
     is defined as:
 
     .. math::
-       \mathbf{b} \cdot \mathbf{A} = \sum_{i=0}^{n-1} \overline{v_i}A_{ij}
+       \mathbf{v} \cdot \mathbf{A} = \sum_{i=0}^{n-1} \overline{v_i}A_{ij}
 
     where the sum is over the last dimension of `x1` and the one-but-last
     dimensions in `x2` (unless `axes` is specified) and where


### PR DESCRIPTION
The PR updates maths in summary of `dpnp.matvec` and `dpnp.vecmat` to fix the typo.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
