### PR TITLE
Update docstring of `xp` keyword in `dpnp.interp`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Improved validation of `--target-hip` build option to only accept a gfx-prefixed value [#2481](https://github.com/IntelPython/dpnp/pull/2481)
 * Simplifies backend implementation of `dpnp.kaiser` by getting rid of unnecessary template [#2472](https://github.com/IntelPython/dpnp/pull/2472)
 * `--onemkl-interfaces` and `--onemkl-interfaces-dir` options for building script are deprecated, instead `--onemath` and `--onemath-dir` are introduced to be aligned with [oneMath specification](https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onemath/source/) [#2487](https://github.com/IntelPython/dpnp/pull/2487)
+* Clarified description of `xp` keyword in docstring of `dpnp.interp` [#2506](https://github.com/IntelPython/dpnp/pull/2506)
 
 ### Deprecated
 

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -2784,7 +2784,7 @@ imag = DPNPImag(
 
 
 def interp(x, xp, fp, left=None, right=None, period=None):
-    """
+    r"""
     One-dimensional linear interpolation.
 
     Returns the one-dimensional piecewise linear interpolant to a function
@@ -2804,7 +2804,7 @@ def interp(x, xp, fp, left=None, right=None, period=None):
         type. The x-coordinates of the data points, must be strictly increasing
         if argument `period` is not specified. Otherwise, `xp` is internally
         sorted after normalizing the periodic boundaries with
-        :math:`xp = xp % period`.
+        :math:`xp = xp \% period`.
 
     fp : {dpnp.ndarray, usm_ndarray}
         Input 1-D array. The y-coordinates of the data points,

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -2800,11 +2800,11 @@ def interp(x, xp, fp, left=None, right=None, period=None):
         to evaluate the interpolated values.
 
     xp : {dpnp.ndarray, usm_ndarray}
-        Input 1-D array, expected to have a real-valued
-        floating-point data type. The x-coordinates of the data points,
-        must be increasing if argument `period` is not specified.
-        Otherwise, `xp` is internally sorted after normalizing
-        the periodic boundaries with ``xp = xp % period``.
+        Input 1-D array, expected to have a real-valued floating-point data
+        type. The x-coordinates of the data points, must be strictly increasing
+        if argument `period` is not specified. Otherwise, `xp` is internally
+        sorted after normalizing the periodic boundaries with
+        :math:`xp = xp % period`.
 
     fp : {dpnp.ndarray, usm_ndarray}
         Input 1-D array. The y-coordinates of the data points,


### PR DESCRIPTION
The PR adds `strict` word in the docstring of `xp` keyword in `dpnp.interp` following similar change implemented in NumPy.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
