### PR TITLE
Avoid negating unsigned integers in `dpnp.resize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Updated `pre-commit` GitHub workflow to pass `no-commit-to-branch` check [#2501](https://github.com/IntelPython/dpnp/pull/2501)
 * Updated the math formulas in summary of `dpnp.matvec` and `dpnp.vecmat` to correct a typo [#2503](https://github.com/IntelPython/dpnp/pull/2503)
+* Avoided negating unsigned integers in ceil division used in `dpnp.resize` implementation [#2508](https://github.com/IntelPython/dpnp/pull/2503)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Updated `pre-commit` GitHub workflow to pass `no-commit-to-branch` check [#2501](https://github.com/IntelPython/dpnp/pull/2501)
 * Updated the math formulas in summary of `dpnp.matvec` and `dpnp.vecmat` to correct a typo [#2503](https://github.com/IntelPython/dpnp/pull/2503)
-* Avoided negating unsigned integers in ceil division used in `dpnp.resize` implementation [#2508](https://github.com/IntelPython/dpnp/pull/2503)
+* Avoided negating unsigned integers in ceil division used in `dpnp.resize` implementation [#2508](https://github.com/IntelPython/dpnp/pull/2508)
 
 ### Security
 

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -3129,9 +3129,9 @@ def resize(a, new_shape):
     Returns
     -------
     out : dpnp.ndarray
-        The new array is formed from the data in the old array, repeated
-        if necessary to fill out the required number of elements. The
-        data are repeated iterating over the array in C-order.
+        The new array is formed from the data in the old array, repeated if
+        necessary to fill out the required number of elements. The data are
+        repeated iterating over the array in C-order.
 
     See Also
     --------
@@ -3146,8 +3146,10 @@ def resize(a, new_shape):
     be used. In most other cases either indexing (to reduce the size) or
     padding (to increase the size) may be a more appropriate solution.
 
-    Warning: This functionality does **not** consider axes separately,
-    i.e. it does not apply interpolation/extrapolation.
+    Warning
+    -------
+    This functionality does **not** consider axes separately, i.e. it does not
+    apply interpolation/extrapolation.
     It fills the return array with the required number of elements, iterating
     over `a` in C-order, disregarding axes (and cycling back from the start if
     the new shape is larger). This functionality is therefore not suitable to
@@ -3187,7 +3189,8 @@ def resize(a, new_shape):
         # First case must zero fill. The second would have repeats == 0.
         return dpnp.zeros_like(a, shape=new_shape)
 
-    repeats = -(-new_size // a_size)  # ceil division
+    # ceiling division without negating new_size
+    repeats = (new_size + a_size - 1) // a_size
     a = dpnp.concatenate((dpnp.ravel(a),) * repeats)[:new_size]
 
     return a.reshape(new_shape)

--- a/dpnp/tests/test_manipulation.py
+++ b/dpnp/tests/test_manipulation.py
@@ -1238,6 +1238,16 @@ class TestResize:
         with pytest.raises(ValueError, match=r"negative"):
             xp.resize(a, new_shape=new_shape)
 
+    @testing.with_requires("numpy>=2.3.1")
+    @pytest.mark.parametrize("dt", [dpnp.uint32, dpnp.uint64])
+    def test_unsigned_resize(self, dt):
+        a = numpy.array([[23, 95], [66, 37]])
+        ia = dpnp.array(a)
+
+        result = dpnp.resize(ia, dt(1))
+        expected = numpy.resize(a, dt(1))
+        assert_array_equal(result, expected)
+
 
 class TestRot90:
     @pytest.mark.parametrize("xp", [numpy, dpnp])


### PR DESCRIPTION
This PR resolves an issue when calling `dpnp.resize` with unsigned integer size.

The negation of an unsigned int underflows and creates a large positive repeats, which leads to a runtime error. The PR fixes the used ceil division.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
