### PR TITLE
using `syrk` for performing special cases of matrix multiplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added `--target-cuda[=ARCH]` option to replace the deprecated `--target=cuda`, allowing users to build for CUDA devices with optional architecture selection using [CodePlay oneAPI plug-in](https://developer.codeplay.com/products/oneapi/nvidia/home/) [#2478](https://github.com/IntelPython/dpnp/pull/2478)
 * Added several new `pre-commit` rules, including protection against direct commits to master/maintenance branches [#2500](https://github.com/IntelPython/dpnp/pull/2500)
+* Added a new backend routine `syrk` from oneMKL to perform symmetric rank-k update which is used for a specialized matrix multiplication where the result is a symmetric matrix [2509](https://github.com/IntelPython/dpnp/pull/2509)
 
 ### Changed
 

--- a/dpnp/backend/extensions/blas/CMakeLists.txt
+++ b/dpnp/backend/extensions/blas/CMakeLists.txt
@@ -30,6 +30,7 @@ set(_module_src
     ${CMAKE_CURRENT_SOURCE_DIR}/gemm.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gemm_batch.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gemv.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/syrk.cpp
 )
 
 pybind11_add_module(${python_module_name} MODULE ${_module_src})

--- a/dpnp/backend/extensions/blas/CMakeLists.txt
+++ b/dpnp/backend/extensions/blas/CMakeLists.txt
@@ -62,6 +62,7 @@ set_target_properties(${python_module_name} PROPERTIES CMAKE_POSITION_INDEPENDEN
 
 target_include_directories(${python_module_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
 target_include_directories(${python_module_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
+target_include_directories(${python_module_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../common)
 
 target_include_directories(${python_module_name} PUBLIC ${Dpctl_INCLUDE_DIRS})
 target_include_directories(${python_module_name} PUBLIC ${Dpctl_TENSOR_INCLUDE_DIR})

--- a/dpnp/backend/extensions/blas/blas_py.cpp
+++ b/dpnp/backend/extensions/blas/blas_py.cpp
@@ -36,6 +36,7 @@
 #include "dotu.hpp"
 #include "gemm.hpp"
 #include "gemv.hpp"
+#include "syrk.hpp"
 
 namespace blas_ns = dpnp::extensions::blas;
 namespace py = pybind11;
@@ -48,6 +49,7 @@ void init_dispatch_vectors_tables(void)
     blas_ns::init_gemm_batch_dispatch_table();
     blas_ns::init_gemm_dispatch_table();
     blas_ns::init_gemv_dispatch_vector();
+    blas_ns::init_syrk_dispatch_vector();
 }
 
 static dot_impl_fn_ptr_t dot_dispatch_vector[dpctl_td_ns::num_types];
@@ -73,7 +75,7 @@ PYBIND11_MODULE(_blas_impl, m)
         };
 
         m.def("_dot", dot_pyapi,
-              "Call `dot` from OneMKL BLAS library to compute "
+              "Call `dot` from oneMKL BLAS library to compute "
               "the dot product of two real-valued vectors.",
               py::arg("sycl_queue"), py::arg("vectorA"), py::arg("vectorB"),
               py::arg("result"), py::arg("depends") = py::list());
@@ -91,7 +93,7 @@ PYBIND11_MODULE(_blas_impl, m)
         };
 
         m.def("_dotc", dotc_pyapi,
-              "Call `dotc` from OneMKL BLAS library to compute "
+              "Call `dotc` from oneMKL BLAS library to compute "
               "the dot product of two complex vectors, "
               "conjugating the first vector.",
               py::arg("sycl_queue"), py::arg("vectorA"), py::arg("vectorB"),
@@ -110,7 +112,7 @@ PYBIND11_MODULE(_blas_impl, m)
         };
 
         m.def("_dotu", dotu_pyapi,
-              "Call `dotu` from OneMKL BLAS library to compute "
+              "Call `dotu` from oneMKL BLAS library to compute "
               "the dot product of two complex vectors.",
               py::arg("sycl_queue"), py::arg("vectorA"), py::arg("vectorB"),
               py::arg("result"), py::arg("depends") = py::list());
@@ -118,7 +120,7 @@ PYBIND11_MODULE(_blas_impl, m)
 
     {
         m.def("_gemm", &blas_ns::gemm,
-              "Call `gemm` from OneMKL BLAS library to compute "
+              "Call `gemm` from oneMKL BLAS library to compute "
               "the matrix-matrix product with 2-D matrices.",
               py::arg("sycl_queue"), py::arg("matrixA"), py::arg("matrixB"),
               py::arg("resultC"), py::arg("depends") = py::list());
@@ -126,7 +128,7 @@ PYBIND11_MODULE(_blas_impl, m)
 
     {
         m.def("_gemm_batch", &blas_ns::gemm_batch,
-              "Call `gemm_batch` from OneMKL BLAS library to compute "
+              "Call `gemm_batch` from oneMKL BLAS library to compute "
               "the matrix-matrix product for a batch of 2-D matrices.",
               py::arg("sycl_queue"), py::arg("matrixA"), py::arg("matrixB"),
               py::arg("resultC"), py::arg("depends") = py::list());
@@ -134,10 +136,18 @@ PYBIND11_MODULE(_blas_impl, m)
 
     {
         m.def("_gemv", &blas_ns::gemv,
-              "Call `gemv` from OneMKL BLAS library to compute "
+              "Call `gemv` from oneMKL BLAS library to compute "
               "the matrix-vector product with a general matrix.",
               py::arg("sycl_queue"), py::arg("matrixA"), py::arg("vectorX"),
               py::arg("vectorY"), py::arg("transpose"),
+              py::arg("depends") = py::list());
+    }
+
+    {
+        m.def("_syrk", &blas_ns::syrk,
+              "Call `syrk` from oneMKL BLAS library to compute "
+              "the matrix-vector product with a general matrix.",
+              py::arg("sycl_queue"), py::arg("matrixA"), py::arg("resultC"),
               py::arg("depends") = py::list());
     }
 

--- a/dpnp/backend/extensions/blas/dot_common.hpp
+++ b/dpnp/backend/extensions/blas/dot_common.hpp
@@ -128,7 +128,8 @@ std::pair<sycl::event, sycl::event>
     dot_impl_fn_ptr_t dot_fn = dot_dispatch_vector[type_id];
     if (dot_fn == nullptr) {
         throw py::value_error(
-            "Types of input vectors and result array are mismatched.");
+            "No dot implementation is available for the specified data type "
+            "of the input and output arrays.");
     }
 
     char *x_typeless_ptr = vectorX.get_data();

--- a/dpnp/backend/extensions/blas/gemm.cpp
+++ b/dpnp/backend/extensions/blas/gemm.cpp
@@ -129,8 +129,7 @@ static sycl::event gemm_impl(sycl::queue &exec_q,
             Tab(1), // Scaling factor for the product of matrices A and B.
             a,      // Pointer to matrix A.
             lda,    // Leading dimension of matrix A, which is the
-                    // stride between successive rows (for row major
-                    // layout).
+                    // stride between successive rows (for row major layout).
             b,      // Pointer to matrix B.
             ldb,    // Leading dimension of matrix B, similar to lda.
             Tab(0), // Scaling factor for matrix C.
@@ -168,7 +167,8 @@ std::tuple<sycl::event, sycl::event, bool>
     const int resultC_nd = resultC.get_ndim();
 
     if ((matrixA_nd != 2) || (matrixB_nd != 2) || (resultC_nd != 2)) {
-        throw py::value_error("Input matrices must be two-dimensional.");
+        throw py::value_error(
+            "Input and output matrices must be two-dimensional.");
     }
 
     auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
@@ -286,6 +286,8 @@ std::tuple<sycl::event, sycl::event, bool>
         }
     }
     else {
+        // both A and B are f_contig so using column-major gemm and
+        // no transpose is needed
         transA = oneapi::mkl::transpose::N;
         transB = oneapi::mkl::transpose::N;
         lda = m;

--- a/dpnp/backend/extensions/blas/gemm.cpp
+++ b/dpnp/backend/extensions/blas/gemm.cpp
@@ -315,7 +315,8 @@ std::tuple<sycl::event, sycl::event, bool>
         gemm_dispatch_table[matrixAB_type_id][resultC_type_id];
     if (gemm_fn == nullptr) {
         throw py::value_error(
-            "Types of input matrices and result matrix are mismatched.");
+            "No gemm implementation is available for the specified data type "
+            "of the input and output arrays.");
     }
 
     const char *a_typeless_ptr = matrixA.get_data();

--- a/dpnp/backend/extensions/blas/gemm_batch.cpp
+++ b/dpnp/backend/extensions/blas/gemm_batch.cpp
@@ -389,7 +389,8 @@ std::tuple<sycl::event, sycl::event, bool>
         gemm_batch_dispatch_table[matrixAB_type_id][resultC_type_id];
     if (gemm_batch_fn == nullptr) {
         throw py::value_error(
-            "Types of input matrices and result matrix are mismatched.");
+            "No gemm_batch implementation is available for the specified data "
+            "type of the input and output arrays.");
     }
 
     const char *a_typeless_ptr = matrixA.get_data();

--- a/dpnp/backend/extensions/blas/gemv.cpp
+++ b/dpnp/backend/extensions/blas/gemv.cpp
@@ -282,7 +282,8 @@ std::pair<sycl::event, sycl::event>
     gemv_impl_fn_ptr_t gemv_fn = gemv_dispatch_vector[type_id];
     if (gemv_fn == nullptr) {
         throw py::value_error(
-            "Types of input arrays and result array are mismatched.");
+            "No gemv implementation is available for the specified data type "
+            "of the input and output arrays.");
     }
 
     const char *a_typeless_ptr = matrixA.get_data();

--- a/dpnp/backend/extensions/blas/syrk.cpp
+++ b/dpnp/backend/extensions/blas/syrk.cpp
@@ -44,7 +44,7 @@ namespace py = pybind11;
 namespace type_utils = dpctl::tensor::type_utils;
 
 typedef sycl::event (*syrk_impl_fn_ptr_t)(sycl::queue &,
-                                          oneapi::mkl::transpose,
+                                          const oneapi::mkl::transpose,
                                           const std::int64_t,
                                           const std::int64_t,
                                           const char *,
@@ -60,7 +60,7 @@ static syrk_impl_fn_ptr_t syrk_dispatch_vector[dpctl_td_ns::num_types];
 
 template <typename T>
 static sycl::event syrk_impl(sycl::queue &exec_q,
-                             oneapi::mkl::transpose transA,
+                             const oneapi::mkl::transpose transA,
                              const std::int64_t n,
                              const std::int64_t k,
                              const char *matrixA,
@@ -107,7 +107,7 @@ static sycl::event syrk_impl(sycl::queue &exec_q,
         };
 
         // we pass beta = 0, so passing upper or lower does not matter
-        oneapi::mkl::uplo uplo = oneapi::mkl::uplo::upper;
+        static constexpr auto uplo = oneapi::mkl::uplo::upper;
         syrk_event = syrk_func(
             exec_q,
             uplo,   // Specifies whether C’s data is stored in its upper
@@ -198,7 +198,7 @@ std::pair<sycl::event, sycl::event>
 
     const bool is_matrixA_f_contig = matrixA.is_f_contiguous();
     const bool is_matrixA_c_contig = matrixA.is_c_contiguous();
-    if (!is_matrixA_f_contig and !is_matrixA_c_contig) {
+    if (!is_matrixA_f_contig && !is_matrixA_c_contig) {
         throw py::value_error(
             "Input matrix is not c-contiguous nor f-contiguous.");
     }

--- a/dpnp/backend/extensions/blas/syrk.cpp
+++ b/dpnp/backend/extensions/blas/syrk.cpp
@@ -1,0 +1,297 @@
+//*****************************************************************************
+// Copyright (c) 2025, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//*****************************************************************************
+
+#include <stdexcept>
+
+#include <pybind11/pybind11.h>
+
+// dpctl tensor headers
+#include "utils/memory_overlap.hpp"
+#include "utils/output_validation.hpp"
+#include "utils/type_utils.hpp"
+
+#include "syrk.hpp"
+#include "types_matrix.hpp"
+
+#include "dpnp_utils.hpp"
+
+namespace dpnp::extensions::blas
+{
+namespace mkl_blas = oneapi::mkl::blas;
+namespace py = pybind11;
+namespace type_utils = dpctl::tensor::type_utils;
+
+typedef sycl::event (*syrk_impl_fn_ptr_t)(sycl::queue &,
+                                          oneapi::mkl::transpose,
+                                          const std::int64_t,
+                                          const std::int64_t,
+                                          const char *,
+                                          const std::int64_t,
+                                          char *,
+                                          const std::int64_t,
+#if !defined(USE_ONEMATH_CUBLAS)
+                                          const bool,
+#endif // !USE_ONEMATH_CUBLAS
+                                          const std::vector<sycl::event> &);
+
+static syrk_impl_fn_ptr_t syrk_dispatch_vector[dpctl_td_ns::num_types];
+
+template <typename T>
+static sycl::event syrk_impl(sycl::queue &exec_q,
+                             oneapi::mkl::transpose transA,
+                             const std::int64_t n,
+                             const std::int64_t k,
+                             const char *matrixA,
+                             const std::int64_t lda,
+                             char *resultC,
+                             const std::int64_t ldc,
+#if !defined(USE_ONEMATH_CUBLAS)
+                             const bool is_row_major,
+#endif // !USE_ONEMATH_CUBLAS
+                             const std::vector<sycl::event> &depends)
+{
+    type_utils::validate_type_for_device<T>(exec_q);
+
+    const T *a = reinterpret_cast<const T *>(matrixA);
+    T *res = reinterpret_cast<T *>(resultC);
+
+    std::stringstream error_msg;
+    bool is_exception_caught = false;
+
+    sycl::event syrk_event;
+    try {
+        auto syrk_func =
+            [&](sycl::queue &q, oneapi::mkl::uplo upper_lower,
+                oneapi::mkl::transpose transA, const std::int64_t n,
+                const std::int64_t k, T alpha, const T *a,
+                const std::int64_t lda, T beta, T *c, const std::int64_t ldc,
+                const std::vector<sycl::event> &deps) -> sycl::event {
+#if defined(USE_ONEMATH_CUBLAS)
+            return mkl_blas::column_major::syrk(q, upper_lower, transA, n, k,
+                                                alpha, a, lda, beta, c, ldc,
+                                                deps);
+#else
+            if (is_row_major) {
+                return mkl_blas::row_major::syrk(q, upper_lower, transA, n, k,
+                                                 alpha, a, lda, beta, c, ldc,
+                                                 deps);
+            }
+            else {
+                return mkl_blas::column_major::syrk(q, upper_lower, transA, n,
+                                                    k, alpha, a, lda, beta, c,
+                                                    ldc, deps);
+            }
+#endif // USE_ONEMATH_CUBLAS
+        };
+
+        // we pass beta = 0, so passing upper or lower does not matter
+        oneapi::mkl::uplo uplo = oneapi::mkl::uplo::upper;
+        syrk_event = syrk_func(
+            exec_q,
+            uplo,   // Specifies whether C’s data is stored in its upper
+                    // or lower triangle
+            transA, // Defines the transpose operation for matrix A:
+                    // 'N' indicates no transpose, 'T' for transpose,
+                    // or 'C' for a conjugate transpose.
+            n,      // Number of rows in op(A).
+                    // Number of rows and columns in C.
+            k,      // Number of columns in op(A).
+            T(1),   // Scaling factor for the rank-k update.
+            a,      // Pointer to the input matrix A.
+            lda,    // Leading dimension of matrix A, which is the
+                    // stride between successive rows (for row major layout).
+            T(0),   // Scaling factor for matrix C.
+            res,    // Pointer to output matrix c, where the result is stored.
+            ldc,    // Leading dimension of matrix C.
+            depends);
+    } catch (oneapi::mkl::exception const &e) {
+        error_msg
+            << "Unexpected MKL exception caught during syrk() call:\nreason: "
+            << e.what();
+        is_exception_caught = true;
+    } catch (sycl::exception const &e) {
+        error_msg << "Unexpected SYCL exception caught during syrk() call:\n"
+                  << e.what();
+        is_exception_caught = true;
+    }
+
+    if (is_exception_caught) // an unexpected error occurs
+    {
+        throw std::runtime_error(error_msg.str());
+    }
+
+    // kernel to copy upper triangle to lower triangle
+    sycl::event copy_event = exec_q.submit([&](sycl::handler &h) {
+        h.depends_on(syrk_event);
+
+        h.parallel_for(
+            sycl::range<2>{static_cast<size_t>(n), static_cast<size_t>(n)},
+            [=](sycl::id<2> idx) {
+                std::int64_t i = idx[0];
+                std::int64_t j = idx[1];
+                if (j > i) {
+                    res[j * ldc + i] = res[i * ldc + j];
+                }
+            });
+    });
+
+    return copy_event;
+}
+
+std::pair<sycl::event, sycl::event>
+    syrk(sycl::queue &exec_q,
+         const dpctl::tensor::usm_ndarray &matrixA,
+         const dpctl::tensor::usm_ndarray &resultC,
+         const std::vector<sycl::event> &depends)
+{
+    const int matrixA_nd = matrixA.get_ndim();
+    const int resultC_nd = resultC.get_ndim();
+
+    if ((matrixA_nd != 2) || (resultC_nd != 2)) {
+        throw py::value_error("The given arrays have incorrect dimensions.");
+    }
+
+    auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
+    if (overlap(matrixA, resultC)) {
+        throw py::value_error("Input and output matrices are overlapping "
+                              "segments of memory");
+    }
+
+    if (!dpctl::utils::queues_are_compatible(
+            exec_q, {matrixA.get_queue(), resultC.get_queue()}))
+    {
+        throw py::value_error(
+            "USM allocations are not compatible with the execution queue.");
+    }
+
+    const py::ssize_t *a_shape = matrixA.get_shape_raw();
+    const py::ssize_t *c_shape = resultC.get_shape_raw();
+    if (c_shape[0] != c_shape[1]) {
+        throw py::value_error("The output matrix should be square.");
+    }
+    if (a_shape[0] != c_shape[0]) {
+        throw py::value_error("The number of rows in A must be equal to "
+                              "the number of rows in result array.");
+    }
+
+    const bool is_matrixA_f_contig = matrixA.is_f_contiguous();
+    const bool is_matrixA_c_contig = matrixA.is_c_contiguous();
+    if (!is_matrixA_f_contig and !is_matrixA_c_contig) {
+        throw py::value_error(
+            "Input matrix is not c-contiguous nor f-contiguous.");
+    }
+
+    oneapi::mkl::transpose transA;
+    std::size_t src_nelems;
+
+// cuBLAS supports only column-major storage
+#if defined(USE_ONEMATH_CUBLAS)
+    const bool is_row_major = false;
+    std::int64_t n;
+    std::int64_t k;
+
+    if (is_matrixA_f_contig) {
+        transA = oneapi::mkl::transpose::N;
+        n = a_shape[0];
+        k = a_shape[1];
+        src_nelems = n * n;
+    }
+    else {
+        transA = oneapi::mkl::transpose::T;
+        k = a_shape[0];
+        n = a_shape[1];
+        src_nelems = k * k;
+    }
+#else
+    bool is_row_major = true;
+    if (is_matrixA_f_contig) {
+        is_row_major = false;
+    }
+
+    transA = oneapi::mkl::transpose::N;
+    const std::int64_t n = a_shape[0];
+    const std::int64_t k = a_shape[1];
+    src_nelems = n * n;
+#endif // USE_ONEMATH_CUBLAS
+
+    const std::int64_t lda = is_row_major ? k : n;
+    const std::int64_t ldc = n;
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(resultC);
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(resultC,
+                                                               src_nelems);
+
+    const int matrixA_typenum = matrixA.get_typenum();
+    const int resultC_typenum = resultC.get_typenum();
+    if (matrixA_typenum != resultC_typenum) {
+        throw py::value_error("Given arrays must be of the same type.");
+    }
+
+    auto array_types = dpctl_td_ns::usm_ndarray_types();
+    const int type_id = array_types.typenum_to_lookup_id(matrixA_typenum);
+    syrk_impl_fn_ptr_t syrk_fn = syrk_dispatch_vector[type_id];
+    if (syrk_fn == nullptr) {
+        throw py::value_error(
+            "Types of input arrays and result array are mismatched.");
+    }
+
+    const char *a_typeless_ptr = matrixA.get_data();
+    char *r_typeless_ptr = resultC.get_data();
+
+#if defined(USE_ONEMATH_CUBLAS)
+    sycl::event syrk_ev = syrk_fn(exec_q, transA, n, k, a_typeless_ptr, lda,
+                                  r_typeless_ptr, ldc, depends);
+#else
+    sycl::event syrk_ev = syrk_fn(exec_q, transA, n, k, a_typeless_ptr, lda,
+                                  r_typeless_ptr, ldc, is_row_major, depends);
+#endif // USE_ONEMATH_CUBLAS
+
+    sycl::event args_ev =
+        dpctl::utils::keep_args_alive(exec_q, {matrixA, resultC}, {syrk_ev});
+
+    return std::make_pair(args_ev, syrk_ev);
+}
+
+template <typename fnT, typename varT>
+struct SyrkContigFactory
+{
+    fnT get()
+    {
+        if constexpr (types::SyrkTypePairSupportFactory<varT>::is_defined) {
+            return syrk_impl<varT>;
+        }
+        else {
+            return nullptr;
+        }
+    }
+};
+
+void init_syrk_dispatch_vector(void)
+{
+    dpctl_td_ns::DispatchVectorBuilder<syrk_impl_fn_ptr_t, SyrkContigFactory,
+                                       dpctl_td_ns::num_types>
+        contig;
+    contig.populate_dispatch_vector(syrk_dispatch_vector);
+}
+} // namespace dpnp::extensions::blas

--- a/dpnp/backend/extensions/blas/syrk.cpp
+++ b/dpnp/backend/extensions/blas/syrk.cpp
@@ -27,6 +27,8 @@
 
 #include <pybind11/pybind11.h>
 
+#include "ext/common.hpp"
+
 // dpctl tensor headers
 #include "utils/memory_overlap.hpp"
 #include "utils/output_validation.hpp"
@@ -36,6 +38,8 @@
 #include "types_matrix.hpp"
 
 #include "dpnp_utils.hpp"
+
+using ext::common::Align;
 
 namespace dpnp::extensions::blas
 {
@@ -59,6 +63,114 @@ typedef sycl::event (*syrk_impl_fn_ptr_t)(sycl::queue &,
 static syrk_impl_fn_ptr_t syrk_dispatch_vector[dpctl_td_ns::num_types];
 
 template <typename T>
+sycl::event launch_CPU_kernel(sycl::queue &exec_q,
+                              T *res,
+                              const std::int64_t ldc,
+                              const std::int64_t n,
+#if !defined(USE_ONEMATH_CUBLAS)
+                              const bool is_row_major,
+#endif // !USE_ONEMATH_CUBLAS
+                              sycl::event depends)
+{
+    static constexpr std::size_t tile_sz = 8;
+    sycl::range<2> global_range(Align(n, tile_sz), Align(n, tile_sz));
+    sycl::range<2> local_range(tile_sz, tile_sz);
+
+    return exec_q.submit([&](sycl::handler &h) {
+        h.depends_on(depends);
+
+        h.parallel_for(sycl::nd_range<2>(global_range, local_range),
+                       [=](sycl::nd_item<2> item) {
+                           int i = item.get_global_id(0);
+                           int j = item.get_global_id(1);
+
+                           if (i < n && j < n && i > j) {
+#if defined(USE_ONEMATH_CUBLAS)
+                               res[j * ldc + i] = res[i * ldc + j];
+#else
+                    if (is_row_major) {
+                        res[i * ldc + j] = res[j * ldc + i];
+                    } else {
+                        res[j * ldc + i] = res[i * ldc + j];
+                    }
+#endif
+                           }
+                       });
+    });
+}
+
+template <typename T>
+sycl::event launch_GPU_kernel(sycl::queue &exec_q,
+                              T *res,
+                              const std::int64_t ldc,
+                              const std::int64_t n,
+#if !defined(USE_ONEMATH_CUBLAS)
+                              const bool is_row_major,
+#endif // !USE_ONEMATH_CUBLAS
+                              sycl::event depends)
+{
+    return exec_q.submit([&](sycl::handler &h) {
+        h.depends_on(depends);
+
+        h.parallel_for(
+            sycl::range<2>{static_cast<size_t>(n), static_cast<size_t>(n)},
+            [=](sycl::id<2> idx) {
+                int i = idx[0];
+                int j = idx[1];
+
+                if (j > i) {
+#if defined(USE_ONEMATH_CUBLAS)
+                    res[i * ldc + j] = res[j * ldc + i];
+#else
+                    // result form row_major::syrk is row major and result form
+                    // column_major::syrk is column major, so copying upper
+                    // triangle to lower triangle is different for each case
+                    if (is_row_major) {
+                        // row-major: res[i][j] = res[i * ldc + j]
+                        res[j * ldc + i] = res[i * ldc + j];
+                    }
+                    else {
+                        // column-major: res[i][j] = res[i + j * ldc]
+                        res[i * ldc + j] = res[j * ldc + i];
+                    }
+                }
+#endif // !USE_ONEMATH_CUBLAS
+                });
+            });
+}
+
+// kernel to copy upper triangle to lower triangle
+template <typename T>
+sycl::event run_copy(sycl::queue &exec_q,
+                     T *res,
+                     const std::int64_t ldc,
+                     const std::int64_t n,
+#if !defined(USE_ONEMATH_CUBLAS)
+                     const bool is_row_major,
+#endif // !USE_ONEMATH_CUBLAS
+                     sycl::event depends)
+{
+        auto dev_type =
+            exec_q.get_device().get_info<sycl::info::device::device_type>();
+
+        // two separate kernels are used to have better performance compared
+        // to gemm on both CPU and GPU
+        sycl::event copy_event;
+        if (dev_type == sycl::info::device_type::gpu) {
+            copy_event =
+                launch_GPU_kernel(exec_q, res, ldc, n, is_row_major, depends);
+        }
+        else if (dev_type == sycl::info::device_type::cpu) {
+            copy_event =
+                launch_CPU_kernel(exec_q, res, ldc, n, is_row_major, depends);
+        }
+        else {
+            assert(false && "Unsupported device type (not CPU or GPU)");
+        }
+        return copy_event;
+}
+
+template <typename T>
 static sycl::event syrk_impl(sycl::queue &exec_q,
                              const oneapi::mkl::transpose transA,
                              const std::int64_t n,
@@ -72,26 +184,27 @@ static sycl::event syrk_impl(sycl::queue &exec_q,
 #endif // !USE_ONEMATH_CUBLAS
                              const std::vector<sycl::event> &depends)
 {
-    type_utils::validate_type_for_device<T>(exec_q);
+        type_utils::validate_type_for_device<T>(exec_q);
 
-    const T *a = reinterpret_cast<const T *>(matrixA);
-    T *res = reinterpret_cast<T *>(resultC);
+        const T *a = reinterpret_cast<const T *>(matrixA);
+        T *res = reinterpret_cast<T *>(resultC);
 
-    std::stringstream error_msg;
-    bool is_exception_caught = false;
+        std::stringstream error_msg;
+        bool is_exception_caught = false;
 
-    sycl::event syrk_event;
-    try {
-        auto syrk_func =
-            [&](sycl::queue &q, oneapi::mkl::uplo upper_lower,
-                oneapi::mkl::transpose transA, const std::int64_t n,
-                const std::int64_t k, T alpha, const T *a,
-                const std::int64_t lda, T beta, T *c, const std::int64_t ldc,
-                const std::vector<sycl::event> &deps) -> sycl::event {
+        sycl::event syrk_event;
+        try {
+            auto syrk_func =
+                [&](sycl::queue &q, oneapi::mkl::uplo upper_lower,
+                    oneapi::mkl::transpose transA, const std::int64_t n,
+                    const std::int64_t k, T alpha, const T *a,
+                    const std::int64_t lda, T beta, T *c,
+                    const std::int64_t ldc,
+                    const std::vector<sycl::event> &deps) -> sycl::event {
 #if defined(USE_ONEMATH_CUBLAS)
-            return mkl_blas::column_major::syrk(q, upper_lower, transA, n, k,
-                                                alpha, a, lda, beta, c, ldc,
-                                                deps);
+                return mkl_blas::column_major::syrk(q, upper_lower, transA, n,
+                                                    k, alpha, a, lda, beta, c,
+                                                    ldc, deps);
 #else
             if (is_row_major) {
                 return mkl_blas::row_major::syrk(q, upper_lower, transA, n, k,
@@ -104,69 +217,46 @@ static sycl::event syrk_impl(sycl::queue &exec_q,
                                                     ldc, deps);
             }
 #endif // USE_ONEMATH_CUBLAS
-        };
+            };
 
-        // we pass beta = 0, so passing upper or lower does not matter
-        static constexpr auto uplo = oneapi::mkl::uplo::upper;
-        syrk_event = syrk_func(
-            exec_q,
-            uplo,   // Specifies whether C’s data is stored in its upper
-                    // or lower triangle
-            transA, // Defines the transpose operation for matrix A:
-                    // 'N' indicates no transpose, 'T' for transpose,
-                    // or 'C' for a conjugate transpose.
-            n,      // Number of rows in op(A).
-                    // Number of rows and columns in C.
-            k,      // Number of columns in op(A).
-            T(1),   // Scaling factor for the rank-k update.
-            a,      // Pointer to the input matrix A.
-            lda,    // Leading dimension of matrix A, which is the
-                    // stride between successive rows (for row major layout).
-            T(0),   // Scaling factor for matrix C.
-            res,    // Pointer to output matrix c, where the result is stored.
-            ldc,    // Leading dimension of matrix C.
-            depends);
-    } catch (oneapi::mkl::exception const &e) {
-        error_msg
-            << "Unexpected MKL exception caught during syrk() call:\nreason: "
-            << e.what();
-        is_exception_caught = true;
-    } catch (sycl::exception const &e) {
-        error_msg << "Unexpected SYCL exception caught during syrk() call:\n"
-                  << e.what();
-        is_exception_caught = true;
-    }
+            // we pass beta = 0, so passing upper or lower does not matter
+            static constexpr auto uplo = oneapi::mkl::uplo::upper;
+            syrk_event = syrk_func(
+                exec_q,
+                uplo,   // Specifies whether C’s data is stored in its upper
+                        // or lower triangle
+                transA, // Defines the transpose operation for matrix A:
+                        // 'N' indicates no transpose, 'T' for transpose,
+                        // or 'C' for a conjugate transpose.
+                n,      // Number of rows in op(A).
+                        // Number of rows and columns in C.
+                k,      // Number of columns in op(A).
+                T(1),   // Scaling factor for the rank-k update.
+                a,      // Pointer to the input matrix A.
+                lda,    // Leading dimension of matrix A, which is the
+                     // stride between successive rows (for row major layout).
+                T(0), // Scaling factor for matrix C.
+                res,  // Pointer to output matrix c, where the result is stored.
+                ldc,  // Leading dimension of matrix C.
+                depends);
+        } catch (oneapi::mkl::exception const &e) {
+            error_msg << "Unexpected MKL exception caught during syrk() "
+                         "call:\nreason: "
+                      << e.what();
+            is_exception_caught = true;
+        } catch (sycl::exception const &e) {
+            error_msg
+                << "Unexpected SYCL exception caught during syrk() call:\n"
+                << e.what();
+            is_exception_caught = true;
+        }
 
-    if (is_exception_caught) // an unexpected error occurs
-    {
-        throw std::runtime_error(error_msg.str());
-    }
+        if (is_exception_caught) // an unexpected error occurs
+        {
+            throw std::runtime_error(error_msg.str());
+        }
 
-    // kernel to copy upper triangle to lower triangle
-    sycl::event copy_event = exec_q.submit([&](sycl::handler &h) {
-        h.depends_on(syrk_event);
-
-        h.parallel_for(
-            sycl::range<2>{static_cast<size_t>(n), static_cast<size_t>(n)},
-            [=](sycl::id<2> idx) {
-                std::int64_t i = idx[0];
-                std::int64_t j = idx[1];
-                if (j > i) {
-                    // result form row_major::syrk is row major and result form
-                    // column_major::syrk is column major, so copying upper
-                    // triangle to lower triangle is different for each case
-                    if (is_row_major) {
-                        // row-major: res[i][j] = res[i * ldc + j]
-                        res[j * ldc + i] = res[i * ldc + j];
-                    }
-                    else {
-                        // column-major: res[i][j] = res[i + j * ldc]
-                        res[i * ldc + j] = res[j * ldc + i];
-                    }
-                }
-            });
-    });
-    return copy_event;
+        return run_copy(exec_q, res, ldc, n, is_row_major, syrk_event);
 }
 
 std::pair<sycl::event, sycl::event>
@@ -175,64 +265,65 @@ std::pair<sycl::event, sycl::event>
          const dpctl::tensor::usm_ndarray &resultC,
          const std::vector<sycl::event> &depends)
 {
-    const int matrixA_nd = matrixA.get_ndim();
-    const int resultC_nd = resultC.get_ndim();
+        const int matrixA_nd = matrixA.get_ndim();
+        const int resultC_nd = resultC.get_ndim();
 
-    if ((matrixA_nd != 2) || (resultC_nd != 2)) {
-        throw py::value_error("The given arrays have incorrect dimensions.");
-    }
+        if ((matrixA_nd != 2) || (resultC_nd != 2)) {
+            throw py::value_error(
+                "The given arrays have incorrect dimensions.");
+        }
 
-    auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
-    if (overlap(matrixA, resultC)) {
-        throw py::value_error("Input and output matrices are overlapping "
-                              "segments of memory");
-    }
+        auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
+        if (overlap(matrixA, resultC)) {
+            throw py::value_error("Input and output matrices are overlapping "
+                                  "segments of memory");
+        }
 
-    if (!dpctl::utils::queues_are_compatible(
-            exec_q, {matrixA.get_queue(), resultC.get_queue()}))
-    {
-        throw py::value_error(
-            "USM allocations are not compatible with the execution queue.");
-    }
+        if (!dpctl::utils::queues_are_compatible(
+                exec_q, {matrixA.get_queue(), resultC.get_queue()}))
+        {
+            throw py::value_error(
+                "USM allocations are not compatible with the execution queue.");
+        }
 
-    const py::ssize_t *a_shape = matrixA.get_shape_raw();
-    const py::ssize_t *c_shape = resultC.get_shape_raw();
-    if (c_shape[0] != c_shape[1]) {
-        throw py::value_error("The output matrix should be square.");
-    }
-    if (a_shape[0] != c_shape[0]) {
-        throw py::value_error("The number of rows in A must be equal to "
-                              "the number of rows in result array.");
-    }
+        const py::ssize_t *a_shape = matrixA.get_shape_raw();
+        const py::ssize_t *c_shape = resultC.get_shape_raw();
+        if (c_shape[0] != c_shape[1]) {
+            throw py::value_error("The output matrix should be square.");
+        }
+        if (a_shape[0] != c_shape[0]) {
+            throw py::value_error("The number of rows in A must be equal to "
+                                  "the number of rows in result array.");
+        }
 
-    const bool is_matrixA_f_contig = matrixA.is_f_contiguous();
-    const bool is_matrixA_c_contig = matrixA.is_c_contiguous();
-    if (!is_matrixA_f_contig && !is_matrixA_c_contig) {
-        throw py::value_error(
-            "Input matrix is not c-contiguous nor f-contiguous.");
-    }
+        const bool is_matrixA_f_contig = matrixA.is_f_contiguous();
+        const bool is_matrixA_c_contig = matrixA.is_c_contiguous();
+        if (!is_matrixA_f_contig && !is_matrixA_c_contig) {
+            throw py::value_error(
+                "Input matrix is not c-contiguous nor f-contiguous.");
+        }
 
-    oneapi::mkl::transpose transA;
-    std::size_t src_nelems;
+        oneapi::mkl::transpose transA;
+        std::size_t src_nelems;
 
 // cuBLAS supports only column-major storage
 #if defined(USE_ONEMATH_CUBLAS)
-    const bool is_row_major = false;
-    std::int64_t n;
-    std::int64_t k;
+        const bool is_row_major = false;
+        std::int64_t n;
+        std::int64_t k;
 
-    if (is_matrixA_f_contig) {
-        transA = oneapi::mkl::transpose::N;
-        n = a_shape[0];
-        k = a_shape[1];
-        src_nelems = n * n;
-    }
-    else {
-        transA = oneapi::mkl::transpose::T;
-        k = a_shape[0];
-        n = a_shape[1];
-        src_nelems = k * k;
-    }
+        if (is_matrixA_f_contig) {
+            transA = oneapi::mkl::transpose::N;
+            n = a_shape[0];
+            k = a_shape[1];
+            src_nelems = n * n;
+        }
+        else {
+            transA = oneapi::mkl::transpose::T;
+            k = a_shape[0];
+            n = a_shape[1];
+            src_nelems = k * k;
+        }
 #else
     bool is_row_major = true;
     if (is_matrixA_f_contig) {
@@ -245,42 +336,43 @@ std::pair<sycl::event, sycl::event>
     src_nelems = n * n;
 #endif // USE_ONEMATH_CUBLAS
 
-    const std::int64_t lda = is_row_major ? k : n;
-    const std::int64_t ldc = n;
-    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(resultC);
-    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(resultC,
-                                                               src_nelems);
+        const std::int64_t lda = is_row_major ? k : n;
+        const std::int64_t ldc = n;
+        dpctl::tensor::validation::CheckWritable::throw_if_not_writable(
+            resultC);
+        dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(resultC,
+                                                                   src_nelems);
 
-    const int matrixA_typenum = matrixA.get_typenum();
-    const int resultC_typenum = resultC.get_typenum();
-    if (matrixA_typenum != resultC_typenum) {
-        throw py::value_error("Given arrays must be of the same type.");
-    }
+        const int matrixA_typenum = matrixA.get_typenum();
+        const int resultC_typenum = resultC.get_typenum();
+        if (matrixA_typenum != resultC_typenum) {
+            throw py::value_error("Given arrays must be of the same type.");
+        }
 
-    auto array_types = dpctl_td_ns::usm_ndarray_types();
-    const int type_id = array_types.typenum_to_lookup_id(matrixA_typenum);
-    syrk_impl_fn_ptr_t syrk_fn = syrk_dispatch_vector[type_id];
-    if (syrk_fn == nullptr) {
-        throw py::value_error(
-            "No syrk implementation is available for the specified data type "
-            "of the input and output arrays.");
-    }
+        auto array_types = dpctl_td_ns::usm_ndarray_types();
+        const int type_id = array_types.typenum_to_lookup_id(matrixA_typenum);
+        syrk_impl_fn_ptr_t syrk_fn = syrk_dispatch_vector[type_id];
+        if (syrk_fn == nullptr) {
+            throw py::value_error("No syrk implementation is available for the "
+                                  "specified data type "
+                                  "of the input and output arrays.");
+        }
 
-    const char *a_typeless_ptr = matrixA.get_data();
-    char *r_typeless_ptr = resultC.get_data();
+        const char *a_typeless_ptr = matrixA.get_data();
+        char *r_typeless_ptr = resultC.get_data();
 
 #if defined(USE_ONEMATH_CUBLAS)
-    sycl::event syrk_ev = syrk_fn(exec_q, transA, n, k, a_typeless_ptr, lda,
-                                  r_typeless_ptr, ldc, depends);
+        sycl::event syrk_ev = syrk_fn(exec_q, transA, n, k, a_typeless_ptr, lda,
+                                      r_typeless_ptr, ldc, depends);
 #else
     sycl::event syrk_ev = syrk_fn(exec_q, transA, n, k, a_typeless_ptr, lda,
                                   r_typeless_ptr, ldc, is_row_major, depends);
 #endif // USE_ONEMATH_CUBLAS
 
-    sycl::event args_ev =
-        dpctl::utils::keep_args_alive(exec_q, {matrixA, resultC}, {syrk_ev});
+        sycl::event args_ev = dpctl::utils::keep_args_alive(
+            exec_q, {matrixA, resultC}, {syrk_ev});
 
-    return std::make_pair(args_ev, syrk_ev);
+        return std::make_pair(args_ev, syrk_ev);
 }
 
 template <typename fnT, typename varT>
@@ -290,12 +382,13 @@ struct SyrkContigFactory
     {
         if constexpr (types::SyrkTypePairSupportFactory<varT>::is_defined) {
             return syrk_impl<varT>;
-        }
-        else {
-            return nullptr;
-        }
-    }
-};
+}
+else {
+    return nullptr;
+}
+} // namespace dpnp::extensions::blas
+}
+;
 
 void init_syrk_dispatch_vector(void)
 {

--- a/dpnp/backend/extensions/blas/syrk.cpp
+++ b/dpnp/backend/extensions/blas/syrk.cpp
@@ -262,7 +262,8 @@ std::pair<sycl::event, sycl::event>
     syrk_impl_fn_ptr_t syrk_fn = syrk_dispatch_vector[type_id];
     if (syrk_fn == nullptr) {
         throw py::value_error(
-            "Types of input arrays and result array are mismatched.");
+            "No syrk implementation is available for the specified data type "
+            "of the input and output arrays.");
     }
 
     const char *a_typeless_ptr = matrixA.get_data();

--- a/dpnp/backend/extensions/blas/syrk.cpp
+++ b/dpnp/backend/extensions/blas/syrk.cpp
@@ -23,6 +23,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //*****************************************************************************
 
+#include <cassert>
 #include <stdexcept>
 
 #include <pybind11/pybind11.h>
@@ -55,88 +56,67 @@ typedef sycl::event (*syrk_impl_fn_ptr_t)(sycl::queue &,
                                           const std::int64_t,
                                           char *,
                                           const std::int64_t,
-#if !defined(USE_ONEMATH_CUBLAS)
                                           const bool,
-#endif // !USE_ONEMATH_CUBLAS
                                           const std::vector<sycl::event> &);
 
 static syrk_impl_fn_ptr_t syrk_dispatch_vector[dpctl_td_ns::num_types];
 
 template <typename T>
-sycl::event launch_CPU_kernel(sycl::queue &exec_q,
-                              T *res,
-                              const std::int64_t ldc,
-                              const std::int64_t n,
-#if !defined(USE_ONEMATH_CUBLAS)
-                              const bool is_row_major,
-#endif // !USE_ONEMATH_CUBLAS
-                              sycl::event depends)
+constexpr void copy_to_lower_triangle(T *res,
+                                      const std::size_t i,
+                                      const std::size_t j,
+                                      const std::int64_t ldc,
+                                      const std::size_t n,
+                                      const bool is_row_major)
 {
-    static constexpr std::size_t tile_sz = 8;
-    sycl::range<2> global_range(Align(n, tile_sz), Align(n, tile_sz));
-    sycl::range<2> local_range(tile_sz, tile_sz);
-
-    return exec_q.submit([&](sycl::handler &h) {
-        h.depends_on(depends);
-
-        h.parallel_for(sycl::nd_range<2>(global_range, local_range),
-                       [=](sycl::nd_item<2> item) {
-                           int i = item.get_global_id(0);
-                           int j = item.get_global_id(1);
-
-                           if (i < n && j < n && i > j) {
-#if defined(USE_ONEMATH_CUBLAS)
-                               res[j * ldc + i] = res[i * ldc + j];
-#else
-                    if (is_row_major) {
-                        res[i * ldc + j] = res[j * ldc + i];
-                    } else {
-                        res[j * ldc + i] = res[i * ldc + j];
-                    }
-#endif
-                           }
-                       });
-    });
+    if (i < n && j < n && i > j) {
+        // result form row_major::syrk is row major and result form
+        // column_major::syrk is column major, so copying upper
+        // triangle to lower triangle is different for each case
+        if (is_row_major) {
+            res[i * ldc + j] = res[j * ldc + i];
+        }
+        else {
+            res[j * ldc + i] = res[i * ldc + j];
+        }
+    }
 }
 
-template <typename T>
-sycl::event launch_GPU_kernel(sycl::queue &exec_q,
-                              T *res,
-                              const std::int64_t ldc,
-                              const std::int64_t n,
-#if !defined(USE_ONEMATH_CUBLAS)
-                              const bool is_row_major,
-#endif // !USE_ONEMATH_CUBLAS
-                              sycl::event depends)
+template <typename T, bool use_wg>
+class copy_kernel;
+
+template <typename T, bool use_wg = false>
+void submit_copy_kernel(T *res,
+                        const std::int64_t ldc,
+                        const std::size_t n,
+                        const bool is_row_major,
+                        sycl::handler &cgh)
 {
-    return exec_q.submit([&](sycl::handler &h) {
-        h.depends_on(depends);
+    using KernelName = copy_kernel<T, use_wg>;
 
-        h.parallel_for(
-            sycl::range<2>{static_cast<size_t>(n), static_cast<size_t>(n)},
-            [=](sycl::id<2> idx) {
-                int i = idx[0];
-                int j = idx[1];
+    if constexpr (use_wg) {
+        static constexpr std::size_t tile_sz = 8;
+        sycl::range<2> global_range(Align(n, tile_sz), Align(n, tile_sz));
+        sycl::range<2> local_range(tile_sz, tile_sz);
 
-                if (j > i) {
-#if defined(USE_ONEMATH_CUBLAS)
-                    res[i * ldc + j] = res[j * ldc + i];
-#else
-                    // result form row_major::syrk is row major and result form
-                    // column_major::syrk is column major, so copying upper
-                    // triangle to lower triangle is different for each case
-                    if (is_row_major) {
-                        // row-major: res[i][j] = res[i * ldc + j]
-                        res[j * ldc + i] = res[i * ldc + j];
-                    }
-                    else {
-                        // column-major: res[i][j] = res[i + j * ldc]
-                        res[i * ldc + j] = res[j * ldc + i];
-                    }
-                }
-#endif // !USE_ONEMATH_CUBLAS
-                });
+        cgh.parallel_for<KernelName>(
+            sycl::nd_range<2>(global_range, local_range),
+            [=](sycl::nd_item<2> item) {
+                std::size_t i = item.get_global_id(0);
+                std::size_t j = item.get_global_id(1);
+
+                copy_to_lower_triangle(res, i, j, n, ldc, is_row_major);
             });
+    }
+    else {
+        cgh.parallel_for<KernelName>(
+            sycl::range<2>{n, n}, [=](sycl::id<2> idx) {
+                std::size_t i = idx[0];
+                std::size_t j = idx[1];
+
+                copy_to_lower_triangle(res, i, j, n, ldc, is_row_major);
+            });
+    }
 }
 
 // kernel to copy upper triangle to lower triangle
@@ -145,29 +125,24 @@ sycl::event run_copy(sycl::queue &exec_q,
                      T *res,
                      const std::int64_t ldc,
                      const std::int64_t n,
-#if !defined(USE_ONEMATH_CUBLAS)
                      const bool is_row_major,
-#endif // !USE_ONEMATH_CUBLAS
-                     sycl::event depends)
+                     sycl::event &depends)
 {
-        auto dev_type =
-            exec_q.get_device().get_info<sycl::info::device::device_type>();
+    const sycl::device &dev = exec_q.get_device();
+
+    return exec_q.submit([&](sycl::handler &cgh) {
+        cgh.depends_on(depends);
 
         // two separate kernels are used to have better performance compared
         // to gemm on both CPU and GPU
-        sycl::event copy_event;
-        if (dev_type == sycl::info::device_type::gpu) {
-            copy_event =
-                launch_GPU_kernel(exec_q, res, ldc, n, is_row_major, depends);
-        }
-        else if (dev_type == sycl::info::device_type::cpu) {
-            copy_event =
-                launch_CPU_kernel(exec_q, res, ldc, n, is_row_major, depends);
+        if (dev.is_gpu()) {
+            submit_copy_kernel<T, false>(res, ldc, n, is_row_major, cgh);
         }
         else {
-            assert(false && "Unsupported device type (not CPU or GPU)");
+            assert(dev.is_cpu());
+            submit_copy_kernel<T, true>(res, ldc, n, is_row_major, cgh);
         }
-        return copy_event;
+    });
 }
 
 template <typename T>
@@ -179,33 +154,25 @@ static sycl::event syrk_impl(sycl::queue &exec_q,
                              const std::int64_t lda,
                              char *resultC,
                              const std::int64_t ldc,
-#if !defined(USE_ONEMATH_CUBLAS)
                              const bool is_row_major,
-#endif // !USE_ONEMATH_CUBLAS
                              const std::vector<sycl::event> &depends)
 {
-        type_utils::validate_type_for_device<T>(exec_q);
+    type_utils::validate_type_for_device<T>(exec_q);
 
-        const T *a = reinterpret_cast<const T *>(matrixA);
-        T *res = reinterpret_cast<T *>(resultC);
+    const T *a = reinterpret_cast<const T *>(matrixA);
+    T *res = reinterpret_cast<T *>(resultC);
 
-        std::stringstream error_msg;
-        bool is_exception_caught = false;
+    std::stringstream error_msg;
+    bool is_exception_caught = false;
 
-        sycl::event syrk_event;
-        try {
-            auto syrk_func =
-                [&](sycl::queue &q, oneapi::mkl::uplo upper_lower,
-                    oneapi::mkl::transpose transA, const std::int64_t n,
-                    const std::int64_t k, T alpha, const T *a,
-                    const std::int64_t lda, T beta, T *c,
-                    const std::int64_t ldc,
-                    const std::vector<sycl::event> &deps) -> sycl::event {
-#if defined(USE_ONEMATH_CUBLAS)
-                return mkl_blas::column_major::syrk(q, upper_lower, transA, n,
-                                                    k, alpha, a, lda, beta, c,
-                                                    ldc, deps);
-#else
+    sycl::event syrk_event;
+    try {
+        auto syrk_func =
+            [&](sycl::queue &q, oneapi::mkl::uplo upper_lower,
+                oneapi::mkl::transpose transA, const std::int64_t n,
+                const std::int64_t k, T alpha, const T *a,
+                const std::int64_t lda, T beta, T *c, const std::int64_t ldc,
+                const std::vector<sycl::event> &deps) -> sycl::event {
             if (is_row_major) {
                 return mkl_blas::row_major::syrk(q, upper_lower, transA, n, k,
                                                  alpha, a, lda, beta, c, ldc,
@@ -216,47 +183,45 @@ static sycl::event syrk_impl(sycl::queue &exec_q,
                                                     k, alpha, a, lda, beta, c,
                                                     ldc, deps);
             }
-#endif // USE_ONEMATH_CUBLAS
-            };
+        };
 
-            // we pass beta = 0, so passing upper or lower does not matter
-            static constexpr auto uplo = oneapi::mkl::uplo::upper;
-            syrk_event = syrk_func(
-                exec_q,
-                uplo,   // Specifies whether C’s data is stored in its upper
-                        // or lower triangle
-                transA, // Defines the transpose operation for matrix A:
-                        // 'N' indicates no transpose, 'T' for transpose,
-                        // or 'C' for a conjugate transpose.
-                n,      // Number of rows in op(A).
-                        // Number of rows and columns in C.
-                k,      // Number of columns in op(A).
-                T(1),   // Scaling factor for the rank-k update.
-                a,      // Pointer to the input matrix A.
-                lda,    // Leading dimension of matrix A, which is the
-                     // stride between successive rows (for row major layout).
-                T(0), // Scaling factor for matrix C.
-                res,  // Pointer to output matrix c, where the result is stored.
-                ldc,  // Leading dimension of matrix C.
-                depends);
-        } catch (oneapi::mkl::exception const &e) {
-            error_msg << "Unexpected MKL exception caught during syrk() "
-                         "call:\nreason: "
-                      << e.what();
-            is_exception_caught = true;
-        } catch (sycl::exception const &e) {
-            error_msg
-                << "Unexpected SYCL exception caught during syrk() call:\n"
-                << e.what();
-            is_exception_caught = true;
-        }
+        // we pass beta = 0, so passing upper or lower does not matter
+        static constexpr auto uplo = oneapi::mkl::uplo::upper;
+        syrk_event = syrk_func(
+            exec_q,
+            uplo,   // Specifies whether C’s data is stored in its upper
+                    // or lower triangle
+            transA, // Defines the transpose operation for matrix A:
+                    // 'N' indicates no transpose, 'T' for transpose,
+                    // or 'C' for a conjugate transpose.
+            n,      // Number of rows in op(A).
+                    // Number of rows and columns in C.
+            k,      // Number of columns in op(A).
+            T(1),   // Scaling factor for the rank-k update.
+            a,      // Pointer to the input matrix A.
+            lda,    // Leading dimension of matrix A, which is the
+                    // stride between successive rows (for row major layout).
+            T(0),   // Scaling factor for matrix C.
+            res,    // Pointer to output matrix c, where the result is stored.
+            ldc,    // Leading dimension of matrix C.
+            depends);
+    } catch (oneapi::mkl::exception const &e) {
+        error_msg << "Unexpected MKL exception caught during syrk() "
+                     "call:\nreason: "
+                  << e.what();
+        is_exception_caught = true;
+    } catch (sycl::exception const &e) {
+        error_msg << "Unexpected SYCL exception caught during syrk() call:\n"
+                  << e.what();
+        is_exception_caught = true;
+    }
 
-        if (is_exception_caught) // an unexpected error occurs
-        {
-            throw std::runtime_error(error_msg.str());
-        }
+    if (is_exception_caught) // an unexpected error occurs
+    {
+        throw std::runtime_error(error_msg.str());
+    }
 
-        return run_copy(exec_q, res, ldc, n, is_row_major, syrk_event);
+    return run_copy(exec_q, res, ldc, n, is_row_major, syrk_event);
 }
 
 std::pair<sycl::event, sycl::event>
@@ -265,65 +230,64 @@ std::pair<sycl::event, sycl::event>
          const dpctl::tensor::usm_ndarray &resultC,
          const std::vector<sycl::event> &depends)
 {
-        const int matrixA_nd = matrixA.get_ndim();
-        const int resultC_nd = resultC.get_ndim();
+    const int matrixA_nd = matrixA.get_ndim();
+    const int resultC_nd = resultC.get_ndim();
 
-        if ((matrixA_nd != 2) || (resultC_nd != 2)) {
-            throw py::value_error(
-                "The given arrays have incorrect dimensions.");
-        }
+    if ((matrixA_nd != 2) || (resultC_nd != 2)) {
+        throw py::value_error("The given arrays have incorrect dimensions.");
+    }
 
-        auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
-        if (overlap(matrixA, resultC)) {
-            throw py::value_error("Input and output matrices are overlapping "
-                                  "segments of memory");
-        }
+    auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
+    if (overlap(matrixA, resultC)) {
+        throw py::value_error("Input and output matrices are overlapping "
+                              "segments of memory");
+    }
 
-        if (!dpctl::utils::queues_are_compatible(
-                exec_q, {matrixA.get_queue(), resultC.get_queue()}))
-        {
-            throw py::value_error(
-                "USM allocations are not compatible with the execution queue.");
-        }
+    if (!dpctl::utils::queues_are_compatible(
+            exec_q, {matrixA.get_queue(), resultC.get_queue()}))
+    {
+        throw py::value_error(
+            "USM allocations are not compatible with the execution queue.");
+    }
 
-        const py::ssize_t *a_shape = matrixA.get_shape_raw();
-        const py::ssize_t *c_shape = resultC.get_shape_raw();
-        if (c_shape[0] != c_shape[1]) {
-            throw py::value_error("The output matrix should be square.");
-        }
-        if (a_shape[0] != c_shape[0]) {
-            throw py::value_error("The number of rows in A must be equal to "
-                                  "the number of rows in result array.");
-        }
+    const py::ssize_t *a_shape = matrixA.get_shape_raw();
+    const py::ssize_t *c_shape = resultC.get_shape_raw();
+    if (c_shape[0] != c_shape[1]) {
+        throw py::value_error("The output matrix should be square.");
+    }
+    if (a_shape[0] != c_shape[0]) {
+        throw py::value_error("The number of rows in A must be equal to "
+                              "the number of rows in result array.");
+    }
 
-        const bool is_matrixA_f_contig = matrixA.is_f_contiguous();
-        const bool is_matrixA_c_contig = matrixA.is_c_contiguous();
-        if (!is_matrixA_f_contig && !is_matrixA_c_contig) {
-            throw py::value_error(
-                "Input matrix is not c-contiguous nor f-contiguous.");
-        }
+    const bool is_matrixA_f_contig = matrixA.is_f_contiguous();
+    const bool is_matrixA_c_contig = matrixA.is_c_contiguous();
+    if (!is_matrixA_f_contig && !is_matrixA_c_contig) {
+        throw py::value_error(
+            "Input matrix is not c-contiguous nor f-contiguous.");
+    }
 
-        oneapi::mkl::transpose transA;
-        std::size_t src_nelems;
+    oneapi::mkl::transpose transA;
+    std::size_t src_nelems;
 
 // cuBLAS supports only column-major storage
 #if defined(USE_ONEMATH_CUBLAS)
-        const bool is_row_major = false;
-        std::int64_t n;
-        std::int64_t k;
+    const bool is_row_major = false;
+    std::int64_t n;
+    std::int64_t k;
 
-        if (is_matrixA_f_contig) {
-            transA = oneapi::mkl::transpose::N;
-            n = a_shape[0];
-            k = a_shape[1];
-            src_nelems = n * n;
-        }
-        else {
-            transA = oneapi::mkl::transpose::T;
-            k = a_shape[0];
-            n = a_shape[1];
-            src_nelems = k * k;
-        }
+    if (is_matrixA_f_contig) {
+        transA = oneapi::mkl::transpose::N;
+        n = a_shape[0];
+        k = a_shape[1];
+        src_nelems = n * n;
+    }
+    else {
+        transA = oneapi::mkl::transpose::T;
+        k = a_shape[0];
+        n = a_shape[1];
+        src_nelems = k * k;
+    }
 #else
     bool is_row_major = true;
     if (is_matrixA_f_contig) {
@@ -336,43 +300,37 @@ std::pair<sycl::event, sycl::event>
     src_nelems = n * n;
 #endif // USE_ONEMATH_CUBLAS
 
-        const std::int64_t lda = is_row_major ? k : n;
-        const std::int64_t ldc = n;
-        dpctl::tensor::validation::CheckWritable::throw_if_not_writable(
-            resultC);
-        dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(resultC,
-                                                                   src_nelems);
+    const std::int64_t lda = is_row_major ? k : n;
+    const std::int64_t ldc = n;
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(resultC);
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(resultC,
+                                                               src_nelems);
 
-        const int matrixA_typenum = matrixA.get_typenum();
-        const int resultC_typenum = resultC.get_typenum();
-        if (matrixA_typenum != resultC_typenum) {
-            throw py::value_error("Given arrays must be of the same type.");
-        }
+    const int matrixA_typenum = matrixA.get_typenum();
+    const int resultC_typenum = resultC.get_typenum();
+    if (matrixA_typenum != resultC_typenum) {
+        throw py::value_error("Given arrays must be of the same type.");
+    }
 
-        auto array_types = dpctl_td_ns::usm_ndarray_types();
-        const int type_id = array_types.typenum_to_lookup_id(matrixA_typenum);
-        syrk_impl_fn_ptr_t syrk_fn = syrk_dispatch_vector[type_id];
-        if (syrk_fn == nullptr) {
-            throw py::value_error("No syrk implementation is available for the "
-                                  "specified data type "
-                                  "of the input and output arrays.");
-        }
+    auto array_types = dpctl_td_ns::usm_ndarray_types();
+    const int type_id = array_types.typenum_to_lookup_id(matrixA_typenum);
+    syrk_impl_fn_ptr_t syrk_fn = syrk_dispatch_vector[type_id];
+    if (syrk_fn == nullptr) {
+        throw py::value_error("No syrk implementation is available for the "
+                              "specified data type "
+                              "of the input and output arrays.");
+    }
 
-        const char *a_typeless_ptr = matrixA.get_data();
-        char *r_typeless_ptr = resultC.get_data();
+    const char *a_typeless_ptr = matrixA.get_data();
+    char *r_typeless_ptr = resultC.get_data();
 
-#if defined(USE_ONEMATH_CUBLAS)
-        sycl::event syrk_ev = syrk_fn(exec_q, transA, n, k, a_typeless_ptr, lda,
-                                      r_typeless_ptr, ldc, depends);
-#else
     sycl::event syrk_ev = syrk_fn(exec_q, transA, n, k, a_typeless_ptr, lda,
                                   r_typeless_ptr, ldc, is_row_major, depends);
-#endif // USE_ONEMATH_CUBLAS
 
-        sycl::event args_ev = dpctl::utils::keep_args_alive(
-            exec_q, {matrixA, resultC}, {syrk_ev});
+    sycl::event args_ev =
+        dpctl::utils::keep_args_alive(exec_q, {matrixA, resultC}, {syrk_ev});
 
-        return std::make_pair(args_ev, syrk_ev);
+    return std::make_pair(args_ev, syrk_ev);
 }
 
 template <typename fnT, typename varT>
@@ -382,13 +340,12 @@ struct SyrkContigFactory
     {
         if constexpr (types::SyrkTypePairSupportFactory<varT>::is_defined) {
             return syrk_impl<varT>;
-}
-else {
-    return nullptr;
-}
-} // namespace dpnp::extensions::blas
-}
-;
+        }
+        else {
+            return nullptr;
+        }
+    } // namespace dpnp::extensions::blas
+};
 
 void init_syrk_dispatch_vector(void)
 {

--- a/dpnp/backend/extensions/blas/syrk.cpp
+++ b/dpnp/backend/extensions/blas/syrk.cpp
@@ -272,7 +272,7 @@ std::pair<sycl::event, sycl::event>
 
 // cuBLAS supports only column-major storage
 #if defined(USE_ONEMATH_CUBLAS)
-    const bool is_row_major = false;
+    constexpr bool is_row_major = false;
     std::int64_t n;
     std::int64_t k;
 

--- a/dpnp/backend/extensions/blas/syrk.hpp
+++ b/dpnp/backend/extensions/blas/syrk.hpp
@@ -1,5 +1,5 @@
 //*****************************************************************************
-// Copyright (c) 2024-2025, Intel Corporation
+// Copyright (c) 2025, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -33,12 +33,10 @@
 namespace dpnp::extensions::blas
 {
 extern std::pair<sycl::event, sycl::event>
-    gemv(sycl::queue &exec_q,
+    syrk(sycl::queue &exec_q,
          const dpctl::tensor::usm_ndarray &matrixA,
-         const dpctl::tensor::usm_ndarray &vectorX,
-         const dpctl::tensor::usm_ndarray &vectorY,
-         const bool transpose,
+         const dpctl::tensor::usm_ndarray &resultC,
          const std::vector<sycl::event> &depends);
 
-extern void init_gemv_dispatch_vector(void);
+extern void init_syrk_dispatch_vector(void);
 } // namespace dpnp::extensions::blas

--- a/dpnp/backend/extensions/blas/types_matrix.hpp
+++ b/dpnp/backend/extensions/blas/types_matrix.hpp
@@ -186,4 +186,29 @@ struct GemvTypePairSupportFactory
         // fall-through
         dpctl_td_ns::NotDefinedEntry>::is_defined;
 };
+
+/**
+ * @brief A factory to define pairs of supported types for which
+ * MKL BLAS library provides support in oneapi::mkl::blas::syrk<T>
+ * function.
+ *
+ * @tparam T Type of input and output arrays.
+ */
+template <typename T>
+struct SyrkTypePairSupportFactory
+{
+    static constexpr bool is_defined = std::disjunction<
+        dpctl_td_ns::TypePairDefinedEntry<T, float, T, float>,
+        dpctl_td_ns::TypePairDefinedEntry<T, double, T, double>,
+        dpctl_td_ns::TypePairDefinedEntry<T,
+                                          std::complex<float>,
+                                          T,
+                                          std::complex<float>>,
+        dpctl_td_ns::TypePairDefinedEntry<T,
+                                          std::complex<double>,
+                                          T,
+                                          std::complex<double>>,
+        // fall-through
+        dpctl_td_ns::NotDefinedEntry>::is_defined;
+};
 } // namespace dpnp::extensions::blas::types

--- a/dpnp/backend/extensions/lapack/evd_batch_common.hpp
+++ b/dpnp/backend/extensions/lapack/evd_batch_common.hpp
@@ -97,7 +97,8 @@ std::pair<sycl::event, sycl::event>
         evd_batch_dispatch_table[eig_vecs_type_id][eig_vals_type_id];
     if (evd_batch_fn == nullptr) {
         throw py::value_error(
-            "Types of input vectors and result array are mismatched.");
+            "No evd_batch implementation is available for the specified data "
+            "type of the input and output arrays.");
     }
 
     char *eig_vecs_data = eig_vecs.get_data();

--- a/dpnp/backend/extensions/lapack/evd_common.hpp
+++ b/dpnp/backend/extensions/lapack/evd_common.hpp
@@ -91,7 +91,8 @@ std::pair<sycl::event, sycl::event>
         evd_dispatch_table[eig_vecs_type_id][eig_vals_type_id];
     if (evd_fn == nullptr) {
         throw py::value_error(
-            "Types of input vectors and result array are mismatched.");
+            "No evd implementation is available for the specified data type "
+            "of the input and output arrays.");
     }
 
     char *eig_vecs_data = eig_vecs.get_data();

--- a/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
+++ b/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
@@ -947,8 +947,6 @@ def dpnp_multiplication(
     x1_is_2D, x1_is_1D, x1_base_is_1D = _define_dim_flags(x1, axis=-1)
     x2_is_2D, x2_is_1D, x2_base_is_1D = _define_dim_flags(x2, axis=-2)
 
-    # TODO: investigate usage of syrk function from BLAS in
-    # case of a.T @ a and a @ a.T to gain performance.
     if numpy.prod(result_shape) == 0:
         res_shape = result_shape
     elif x1_shape[-1] == 1:

--- a/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
+++ b/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
@@ -1068,12 +1068,13 @@ def dpnp_multiplication(
                     dtype=res_dtype,
                     order=res_order,
                 )
-                x2 = _copy_array(
-                    x2,
-                    copy_flag=not x2_contig_flag,
-                    dtype=res_dtype,
-                    order=res_order,
-                )
+                if call_flag != "syrk":
+                    x2 = _copy_array(
+                        x2,
+                        copy_flag=not x2_contig_flag,
+                        dtype=res_dtype,
+                        order=res_order,
+                    )
 
                 if call_flag == "gemv":
                     if transpose:

--- a/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
+++ b/dpnp/dpnp_utils/dpnp_utils_linearalgebra.py
@@ -986,7 +986,10 @@ def dpnp_multiplication(
         if _is_syrk_compatible(x1, x2):
             call_flag = "syrk"
             res_dtype_orig = res_dtype
-            if dpnp.issubdtype(res_dtype, dpnp.integer):
+            # for exact dtypes, use syrk implementation unlike general approach
+            # where dpctl implementation is used for exact dtypes for better
+            # performance
+            if not dpnp.issubdtype(res_dtype, dpnp.inexact):
                 res_dtype = dpnp.default_float_type(x1.device)
     elif x1_base_is_1D:
         # TODO: implement gemv_batch to use it here with transpose

--- a/dpnp/tests/test_product.py
+++ b/dpnp/tests/test_product.py
@@ -22,9 +22,6 @@ _selected_dtypes = [numpy.int64, numpy.float32]
 
 
 class TestCross:
-    def setup_method(self):
-        numpy.random.seed(42)
-
     @pytest.mark.parametrize("axis", [None, 0])
     @pytest.mark.parametrize("axisc", [-1, 0])
     @pytest.mark.parametrize("axisb", [-1, 0])
@@ -179,9 +176,6 @@ class TestCross:
 
 
 class TestDot:
-    def setup_method(self):
-        numpy.random.seed(42)
-
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     def test_ones(self, dtype):
         n = 10**5
@@ -430,9 +424,6 @@ class TestDot:
 
 
 class TestInner:
-    def setup_method(self):
-        numpy.random.seed(42)
-
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     def test_scalar(self, dtype):
         a = 2
@@ -596,9 +587,6 @@ class TestKron:
 
 
 class TestMatmul:
-    def setup_method(self):
-        numpy.random.seed(42)
-
     @pytest.mark.parametrize("dtype", _selected_dtypes)
     @pytest.mark.parametrize(
         "order1, order2", [("C", "C"), ("C", "F"), ("F", "C"), ("F", "F")]
@@ -1185,7 +1173,7 @@ class TestMatmul:
 
     @pytest.mark.parametrize("dt", get_all_dtypes())
     def test_syrk(self, dt):
-        a = generate_random_numpy_array((6, 9), dtype=dt)
+        a = generate_random_numpy_array((6, 9), dtype=dt, low=-5, high=5)
         ia = dpnp.array(a)
 
         result = dpnp.matmul(ia, ia.mT)
@@ -1507,9 +1495,6 @@ class TestMatmulInvalidCases:
 
 @testing.with_requires("numpy>=2.2")
 class TestMatvec:
-    def setup_method(self):
-        numpy.random.seed(42)
-
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize(
         "shape1, shape2",
@@ -1569,9 +1554,6 @@ class TestMatvec:
 
 
 class TestMultiDot:
-    def setup_method(self):
-        numpy.random.seed(70)
-
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize(
         "shapes",
@@ -1726,9 +1708,6 @@ class TestMultiDot:
 
 
 class TestTensordot:
-    def setup_method(self):
-        numpy.random.seed(87)
-
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     def test_scalar(self, dtype):
         a = 2
@@ -1860,9 +1839,6 @@ class TestTensordot:
 
 
 class TestVdot:
-    def setup_method(self):
-        numpy.random.seed(42)
-
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     def test_scalar(self, dtype):
         a = numpy.array([3.5], dtype=dtype)
@@ -1953,9 +1929,6 @@ class TestVdot:
 
 @testing.with_requires("numpy>=2.0")
 class TestVecdot:
-    def setup_method(self):
-        numpy.random.seed(42)
-
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize(
         "shape1, shape2",
@@ -2233,9 +2206,6 @@ class TestVecdot:
 
 @testing.with_requires("numpy>=2.2")
 class TestVecmat:
-    def setup_method(self):
-        numpy.random.seed(42)
-
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize(
         "shape1, shape2",

--- a/dpnp/tests/test_product.py
+++ b/dpnp/tests/test_product.py
@@ -1198,12 +1198,15 @@ class TestMatmul:
         assert result is iout
         assert_dtype_allclose(result, expected)
 
+        result = ia.mT @ ia
+        expected = a.T @ a
+        assert_dtype_allclose(result, expected)
+
     @pytest.mark.parametrize(
         "order, out_order",
         [("C", "C"), ("C", "F"), ("F", "C"), ("F", "F")],
     )
     def test_syrk_out_order(self, order, out_order):
-        # test syrk with out keyword
         a = generate_random_numpy_array((5, 4), order=order, low=-5, high=5)
         out = numpy.empty((5, 5), dtype=a.dtype, order=out_order)
         ia, iout = dpnp.array(a), dpnp.array(out)
@@ -1213,6 +1216,14 @@ class TestMatmul:
         assert result is iout
         assert result.flags.c_contiguous == expected.flags.c_contiguous
         assert result.flags.f_contiguous == expected.flags.f_contiguous
+        assert_dtype_allclose(result, expected)
+
+    @pytest.mark.parametrize("order", ["F", "C"])
+    def test_syrk_order(self, order):
+        a = generate_random_numpy_array((4, 6), order=order, low=-5, high=5)
+        ia = dpnp.array(a)
+        expected = numpy.matmul(a, a.T)
+        result = dpnp.matmul(ia, ia.mT)
         assert_dtype_allclose(result, expected)
 
     def test_bool(self):

--- a/dpnp/tests/test_product.py
+++ b/dpnp/tests/test_product.py
@@ -1195,6 +1195,7 @@ class TestMatmul:
 
         iout = dpnp.empty(result.shape, dtype=dt)
         result = dpnp.matmul(ia, ia.mT, out=iout)
+        assert result is iout
         assert_dtype_allclose(result, expected)
 
     @pytest.mark.parametrize(

--- a/dpnp/tests/test_product.py
+++ b/dpnp/tests/test_product.py
@@ -1246,7 +1246,7 @@ class TestMatmul:
         ia = dpnp.array(a)
 
         # Result must be square
-        b = a.mT[:, ::2]
+        b = a.T[:, ::2]
         ib = ia.mT[:, ::2]
         expected = numpy.matmul(a, b)
         result = dpnp.matmul(ia, ib)

--- a/dpnp/tests/test_product.py
+++ b/dpnp/tests/test_product.py
@@ -1171,7 +1171,7 @@ class TestMatmul:
         result = dpnp.matmul(ia, ib, out=iout)
         assert_dtype_allclose(result, expected)
 
-    @pytest.mark.parametrize("dt", get_all_dtypes())
+    @pytest.mark.parametrize("dt", get_all_dtypes(no_none=True))
     def test_syrk(self, dt):
         a = generate_random_numpy_array((6, 9), dtype=dt, low=-5, high=5)
         ia = dpnp.array(a)

--- a/dpnp/tests/test_sycl_queue.py
+++ b/dpnp/tests/test_sycl_queue.py
@@ -629,50 +629,50 @@ def test_bitwise_op_2in(op, device):
     assert_sycl_queue_equal(zy.sycl_queue, y.sycl_queue)
 
 
-@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
-@pytest.mark.parametrize("dtype", [dpnp.int32, dpnp.float32])
-@pytest.mark.parametrize(
-    "shape1, shape2",
-    [
-        ((2, 4), (4,)),
-        ((4,), (4, 3)),
-        ((2, 4), (4, 3)),
-        ((2, 0), (0, 3)),
-        ((2, 4), (4, 0)),
-        ((4, 2, 3), (4, 3, 5)),
-        ((4, 2, 3), (4, 3, 1)),
-        ((4, 1, 3), (4, 3, 5)),
-        ((6, 7, 4, 3), (6, 7, 3, 5)),
-    ],
-    ids=[
-        "((2, 4), (4,))",
-        "((4,), (4, 3))",
-        "((2, 4), (4, 3))",
-        "((2, 0), (0, 3))",
-        "((2, 4), (4, 0))",
-        "((4, 2, 3), (4, 3, 5))",
-        "((4, 2, 3), (4, 3, 1))",
-        "((4, 1, 3), (4, 3, 5))",
-        "((6, 7, 4, 3), (6, 7, 3, 5))",
-    ],
-)
-def test_matmul(device, dtype, shape1, shape2):
-    # int32 checks dpctl implementation and float32 checks oneMKL
-    a = dpnp.arange(numpy.prod(shape1), dtype=dtype, device=device)
-    b = dpnp.arange(numpy.prod(shape2), dtype=dtype, device=device)
-    a, b = a.reshape(shape1), b.reshape(shape2)
-    result = dpnp.matmul(a, b)
+class TestMatmul:
+    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
+    @pytest.mark.parametrize("dtype", [dpnp.int32, dpnp.float32])
+    @pytest.mark.parametrize(
+        "shape1, shape2",
+        [
+            ((2, 4), (4,)),
+            ((4,), (4, 3)),
+            ((2, 4), (4, 3)),
+            ((2, 0), (0, 3)),
+            ((2, 4), (4, 0)),
+            ((4, 2, 3), (4, 3, 5)),
+            ((4, 2, 3), (4, 3, 1)),
+            ((4, 1, 3), (4, 3, 5)),
+            ((6, 7, 4, 3), (6, 7, 3, 5)),
+        ],
+        ids=[
+            "((2, 4), (4,))",
+            "((4,), (4, 3))",
+            "((2, 4), (4, 3))",
+            "((2, 0), (0, 3))",
+            "((2, 4), (4, 0))",
+            "((4, 2, 3), (4, 3, 5))",
+            "((4, 2, 3), (4, 3, 1))",
+            "((4, 1, 3), (4, 3, 5))",
+            "((6, 7, 4, 3), (6, 7, 3, 5))",
+        ],
+    )
+    def test_matmul(self, device, dtype, shape1, shape2):
+        # int32 checks dpctl implementation and float32 checks oneMKL
+        a = dpnp.arange(numpy.prod(shape1), dtype=dtype, device=device)
+        b = dpnp.arange(numpy.prod(shape2), dtype=dtype, device=device)
+        a, b = a.reshape(shape1), b.reshape(shape2)
+        result = dpnp.matmul(a, b)
 
-    result_queue = result.sycl_queue
-    assert_sycl_queue_equal(result_queue, a.sycl_queue)
-    assert_sycl_queue_equal(result_queue, b.sycl_queue)
+        result_queue = result.sycl_queue
+        assert_sycl_queue_equal(result_queue, a.sycl_queue)
+        assert_sycl_queue_equal(result_queue, b.sycl_queue)
 
-
-@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
-def test_matmul_syrk(device):
-    a = dpnp.arange(20, dtype=dpnp.float32, device=device).reshape(4, 5)
-    result = dpnp.matmul(a, a.mT)
-    assert_sycl_queue_equal(result.sycl_queue, a.sycl_queue)
+    @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
+    def test_matmul_syrk(self, device):
+        a = dpnp.arange(20, dtype=dpnp.float32, device=device).reshape(4, 5)
+        result = dpnp.matmul(a, a.mT)
+        assert_sycl_queue_equal(result.sycl_queue, a.sycl_queue)
 
 
 @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)

--- a/dpnp/tests/test_usm_type.py
+++ b/dpnp/tests/test_usm_type.py
@@ -403,52 +403,52 @@ def test_bitwise_op_2in(op, usm_type_x, usm_type_y):
     assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
 
 
-@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
-@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
-@pytest.mark.parametrize("dtype", [dpnp.int32, dpnp.float32])
-@pytest.mark.parametrize(
-    "shape1, shape2",
-    [
-        ((2, 4), (4,)),
-        ((4,), (4, 3)),
-        ((2, 4), (4, 3)),
-        ((2, 0), (0, 3)),
-        ((2, 4), (4, 0)),
-        ((4, 2, 3), (4, 3, 5)),
-        ((4, 2, 3), (4, 3, 1)),
-        ((4, 1, 3), (4, 3, 5)),
-        ((6, 7, 4, 3), (6, 7, 3, 5)),
-    ],
-    ids=[
-        "((2, 4), (4,))",
-        "((4,), (4, 3))",
-        "((2, 4), (4, 3))",
-        "((2, 0), (0, 3))",
-        "((2, 4), (4, 0))",
-        "((4, 2, 3), (4, 3, 5))",
-        "((4, 2, 3), (4, 3, 1))",
-        "((4, 1, 3), (4, 3, 5))",
-        "((6, 7, 4, 3), (6, 7, 3, 5))",
-    ],
-)
-def test_matmul(usm_type_x, usm_type_y, dtype, shape1, shape2):
-    # int32 checks dpctl implementation and float32 checks oneMKL
-    x = dpnp.arange(numpy.prod(shape1), dtype=dtype, usm_type=usm_type_x)
-    y = dpnp.arange(numpy.prod(shape2), dtype=dtype, usm_type=usm_type_y)
-    x, y = x.reshape(shape1), y.reshape(shape2)
-    z = dpnp.matmul(x, y)
+class TestMatmul:
+    @pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+    @pytest.mark.parametrize("usm_type_y", list_of_usm_types)
+    @pytest.mark.parametrize("dtype", [dpnp.int32, dpnp.float32])
+    @pytest.mark.parametrize(
+        "shape1, shape2",
+        [
+            ((2, 4), (4,)),
+            ((4,), (4, 3)),
+            ((2, 4), (4, 3)),
+            ((2, 0), (0, 3)),
+            ((2, 4), (4, 0)),
+            ((4, 2, 3), (4, 3, 5)),
+            ((4, 2, 3), (4, 3, 1)),
+            ((4, 1, 3), (4, 3, 5)),
+            ((6, 7, 4, 3), (6, 7, 3, 5)),
+        ],
+        ids=[
+            "((2, 4), (4,))",
+            "((4,), (4, 3))",
+            "((2, 4), (4, 3))",
+            "((2, 0), (0, 3))",
+            "((2, 4), (4, 0))",
+            "((4, 2, 3), (4, 3, 5))",
+            "((4, 2, 3), (4, 3, 1))",
+            "((4, 1, 3), (4, 3, 5))",
+            "((6, 7, 4, 3), (6, 7, 3, 5))",
+        ],
+    )
+    def test_basic(self, usm_type_x, usm_type_y, dtype, shape1, shape2):
+        # int32 checks dpctl implementation and float32 checks oneMKL
+        x = dpnp.arange(numpy.prod(shape1), dtype=dtype, usm_type=usm_type_x)
+        y = dpnp.arange(numpy.prod(shape2), dtype=dtype, usm_type=usm_type_y)
+        x, y = x.reshape(shape1), y.reshape(shape2)
+        z = dpnp.matmul(x, y)
 
-    assert x.usm_type == usm_type_x
-    assert y.usm_type == usm_type_y
-    assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
+        assert x.usm_type == usm_type_x
+        assert y.usm_type == usm_type_y
+        assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
 
+    @pytest.mark.parametrize("usm_type", list_of_usm_types)
+    def test_syrk(self, usm_type):
+        x = dpnp.arange(20, dtype=dpnp.float32, usm_type=usm_type).reshape(4, 5)
+        y = dpnp.matmul(x, x.mT)
 
-@pytest.mark.parametrize("usm_type", list_of_usm_types)
-def test_matmul_syrk(usm_type):
-    x = dpnp.arange(20, dtype=dpnp.float32, usm_type=usm_type).reshape(4, 5)
-    y = dpnp.matmul(x, x.mT)
-
-    assert y.usm_type == usm_type
+        assert y.usm_type == usm_type
 
 
 @pytest.mark.parametrize("usm_type_x", list_of_usm_types)

--- a/dpnp/tests/test_usm_type.py
+++ b/dpnp/tests/test_usm_type.py
@@ -405,6 +405,7 @@ def test_bitwise_op_2in(op, usm_type_x, usm_type_y):
 
 @pytest.mark.parametrize("usm_type_x", list_of_usm_types)
 @pytest.mark.parametrize("usm_type_y", list_of_usm_types)
+@pytest.mark.parametrize("dtype", [dpnp.int32, dpnp.float32])
 @pytest.mark.parametrize(
     "shape1, shape2",
     [
@@ -430,14 +431,24 @@ def test_bitwise_op_2in(op, usm_type_x, usm_type_y):
         "((6, 7, 4, 3), (6, 7, 3, 5))",
     ],
 )
-def test_matmul(usm_type_x, usm_type_y, shape1, shape2):
-    x = dpnp.arange(numpy.prod(shape1), usm_type=usm_type_x).reshape(shape1)
-    y = dpnp.arange(numpy.prod(shape2), usm_type=usm_type_y).reshape(shape2)
+def test_matmul(usm_type_x, usm_type_y, dtype, shape1, shape2):
+    # int32 checks dpctl implementation and float32 checks oneMKL
+    x = dpnp.arange(numpy.prod(shape1), dtype=dtype, usm_type=usm_type_x)
+    y = dpnp.arange(numpy.prod(shape2), dtype=dtype, usm_type=usm_type_y)
+    x, y = x.reshape(shape1), y.reshape(shape2)
     z = dpnp.matmul(x, y)
 
     assert x.usm_type == usm_type_x
     assert y.usm_type == usm_type_y
     assert z.usm_type == du.get_coerced_usm_type([usm_type_x, usm_type_y])
+
+
+@pytest.mark.parametrize("usm_type", list_of_usm_types)
+def test_matmul_syrk(usm_type):
+    x = dpnp.arange(20, dtype=dpnp.float32, usm_type=usm_type).reshape(4, 5)
+    y = dpnp.matmul(x, x.mT)
+
+    assert y.usm_type == usm_type
 
 
 @pytest.mark.parametrize("usm_type_x", list_of_usm_types)


### PR DESCRIPTION
In this PR, the `syrk` routines from oneMKL is used to perform a rank-k update which is used for a specialized matrix multiplication where the result is a symmetric matrix. 

```bash
$ sycl-ls
[level_zero:gpu][level_zero:0] Intel(R) oneAPI Unified Runtime over Level-Zero, Intel(R) Data Center GPU Max 1100 12.60.7 [1.6.31294+9]
[opencl:cpu][opencl:0] Intel(R) OpenCL, Intel(R) Xeon(R) Platinum 8480+ OpenCL 3.0 (Build 0) [2025.19.1.0.16_160000]
[opencl:gpu][opencl:1] Intel(R) OpenCL Graphics, Intel(R) Data Center GPU Max 1100 OpenCL 3.0 NEO  [24.39.31294]
```
| size | syrk-GPU           | gemm-GPU           | syrk-CPU            | gemm-CPU           |
|------|--------------------|--------------------|---------------------|--------------------|
| 2048 | 1.37 ms ± 2.81 μs  | 2.02 ms ± 3.69 μs  | 17.5 ms ± 1.21 ms   | 12 ms ± 365 μs     |
| 4096 | 7.94 ms ± 16.6 μs  | 14.2 ms ± 55.9 μs  | 73.2 ms ± 4.94 ms   | 68.2 ms ± 5.93 ms  |
| 8192 | 59 ms ± 144 μs     | 107 ms ± 126 μs    | 481 ms ± 37.1 ms    | 674 ms ± 56.5 ms   |

Time measurement using:
```python
import dpnp
size = 4096
ia = dpnp.ones((size, 2*size), device="cpu")
%timeit r = dpnp.matmul(ia, ia.mT); r.sycl_queue.wait()
```

Also see timing measured [here](https://github.com/IntelPython/dpnp/pull/2509#discussion_r2195447435).

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
