### PR TITLE
Fix license deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,8 @@ keywords = [
   "gpu",
   "dpcpp"
 ]
-license = {text = "Apache 2.0"}
+license = "Apache 2.0"
+license-files = ["LICENSE.txt"]
 maintainers = [{name = "Intel Corporation"}]
 name = "dpnp"
 readme = {file = "README.md", content-type = "text/markdown"}


### PR DESCRIPTION
Table-based license keys of the form `license = {text = "<license-string>"}` are deprecated since `setuptools >= 77.0.0` and produces warning:
> SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated

This PR aligns with new format of license expression ([PEP 639](https://peps.python.org/pep-0639/#add-license-expression-field)).

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
