### PR TITLE
Fix compilation warnings

### DIFF
--- a/dpnp/backend/extensions/statistics/histogram.cpp
+++ b/dpnp/backend/extensions/statistics/histogram.cpp
@@ -139,12 +139,12 @@ struct HistogramF
             auto dispatch_edges = [&](uint32_t local_mem, const auto &weights,
                                       auto &hist) {
                 if (device.is_gpu() && (local_mem >= bins_count + 1)) {
-                    auto edges = CachedEdges(bins_edges, bins_count + 1, cgh);
+                    auto edges = CachedEdges<BinsT>(bins_edges, bins_count + 1, cgh);
                     submit_histogram(in, size, dims, WorkPI, hist, edges,
                                      weights, nd_range, cgh);
                 }
                 else {
-                    auto edges = UncachedEdges(bins_edges, bins_count + 1, cgh);
+                    auto edges = UncachedEdges<BinsT>(bins_edges, bins_count + 1, cgh);
                     submit_histogram(in, size, dims, WorkPI, hist, edges,
                                      weights, nd_range, cgh);
                 }
@@ -165,7 +165,7 @@ struct HistogramF
                 }
                 else {
                     auto hist = HistGlobalMemory<HistType>(out);
-                    auto edges = UncachedEdges(bins_edges, bins_count + 1, cgh);
+                    auto edges = UncachedEdges<BinsT>(bins_edges, bins_count + 1, cgh);
                     submit_histogram(in, size, dims, WorkPI, hist, edges,
                                      weights, nd_range, cgh);
                 }


### PR DESCRIPTION
This PR resolves compilation warnings:
> warning: class template argument deduction for alias templates is a C++20 extension [-Wc++20-extensions]

As for now DPNP is building with C++17 standard, and Class Template Argument Deduction is available where only for a class template, but not for a type alias. What support was added in C++20 standard.

Since there are currently no plans to move to the C++20 standard, the code has been updated to conform to the C++17 standard.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
