### PR TITLE
reverse the order of individual FFTs in rfftn

### DIFF
--- a/dpnp/tests/test_fft.py
+++ b/dpnp/tests/test_fft.py
@@ -401,13 +401,13 @@ class TestFftn:
         result = dpnp.fft.fftn(ia, axes=axes)
         # Intel NumPy ignores repeated axes (mkl_fft-gh-104), handle it one by one
         expected = a
-        for ii in axes:
+        for ii in axes[::-1]:
             expected = numpy.fft.fft(expected, axis=ii)
         assert_dtype_allclose(result, expected)
 
         # inverse FFT
         result = dpnp.fft.ifftn(result, axes=axes)
-        for ii in axes:
+        for ii in axes[::-1]:
             expected = numpy.fft.ifft(expected, axis=ii)
         assert_dtype_allclose(result, expected)
 
@@ -905,7 +905,7 @@ class TestRfftn:
 
         # inverse FFT
         result = dpnp.fft.irfftn(result, axes=axes)
-        for ii in axes[-2::-1]:
+        for ii in axes[:-1]:
             expected = numpy.fft.ifft(expected, axis=ii)
         expected = numpy.fft.irfft(expected, axis=axes[-1])
         assert_dtype_allclose(result, expected)
@@ -924,7 +924,7 @@ class TestRfftn:
         assert_dtype_allclose(result, expected)
 
         result = dpnp.fft.irfftn(result, s=s, axes=axes)
-        for jj, ii in zip(s[-2::-1], axes[-2::-1]):
+        for jj, ii in zip(s[:-1], axes[:-1]):
             expected = numpy.fft.ifft(expected, n=jj, axis=ii)
         expected = numpy.fft.irfft(expected, n=s[-1], axis=axes[-1])
         assert_dtype_allclose(result, expected)
@@ -946,7 +946,7 @@ class TestRfftn:
         assert_dtype_allclose(result, expected)
 
         # inverse FFT
-        for jj, ii in zip(s[-2::-1], axes[-2::-1]):
+        for jj, ii in zip(s[:-1], axes[:-1]):
             expected = numpy.fft.ifft(expected, n=jj, axis=ii)
         expected = numpy.fft.irfft(expected, n=s[-1], axis=axes[-1])
         out = dpnp.empty(expected.shape, dtype=numpy.float32)


### PR DESCRIPTION
For `numpy.fft.fftn` and `numpy.fft.ifftn`, individual FFTs over `axes` are performed in [reverse order](https://github.com/numpy/numpy/blob/v2.2.0/numpy/fft/_pocketfft.py#L739).

Similarly, for `numpy.fft.rfftn`, individual FFTs are performed in [reverse order](https://github.com/numpy/numpy/blob/v2.2.0/numpy/fft/_pocketfft.py#L1382).

However, for `numpy.fft.irfftn` individual FFTs are performed in [forward order](https://github.com/numpy/numpy/blob/v2.2.0/numpy/fft/_pocketfft.py#L1600). 

`dpnp.fft.irfftn` is updated to behave similar to `numpy.fft.irfftn`. 
Note that the order is only important when there is repeated indices in `axes` and `s` is not `None`.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
