### PR TITLE
Add job explicit, conservative job timeouts

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -26,6 +26,7 @@ jobs:
     name: Build and Deploy Docs
 
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
 
     permissions:
       # Needed to cancel any previous runs that are not completed for a given workflow
@@ -244,6 +245,7 @@ jobs:
       pull-requests: write
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/check-onemath.yaml
+++ b/.github/workflows/check-onemath.yaml
@@ -29,6 +29,7 @@ jobs:
       actions: write
 
     runs-on: 'ubuntu-latest'
+    timeout-minutes: 5
 
     steps:
       - name: Cancel Previous Runs
@@ -69,6 +70,7 @@ jobs:
         os: [ubuntu-22.04] # windows-2022 - no DFT support for Windows in oneMKL
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
 
     defaults:
       run:
@@ -157,6 +159,7 @@ jobs:
         os: [ubuntu-22.04] # windows-2022 - no DFT support for Windows in oneMKL
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
 
     defaults:
       run:

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -37,6 +37,7 @@ jobs:
       actions: write
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
 
     defaults:
       run:
@@ -118,6 +119,7 @@ jobs:
     needs: build
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
 
     defaults:
       run:
@@ -245,6 +247,7 @@ jobs:
     needs: build
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
 
     defaults:
       run:
@@ -406,6 +409,7 @@ jobs:
         os: [ubuntu-22.04, windows-2022]
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
 
     defaults:
       run:
@@ -487,6 +491,7 @@ jobs:
         os: [ubuntu-22.04]
 
     runs-on:  ${{ matrix.os }}
+    timeout-minutes: 15
 
     defaults:
       run:
@@ -649,6 +654,7 @@ jobs:
     needs: [upload]
 
     runs-on: 'ubuntu-latest'
+    timeout-minutes: 10
 
     defaults:
       run:

--- a/.github/workflows/cron-run-tests.yaml
+++ b/.github/workflows/cron-run-tests.yaml
@@ -26,6 +26,7 @@ jobs:
     if: github.event.repository.fork == false
 
     runs-on:  ${{ matrix.runner }}
+    timeout-minutes: 60
 
     defaults:
       run:

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -9,7 +9,9 @@ permissions: read-all
 jobs:
   generate-coverage:
     name: Generate coverage and push to Coveralls.io
+
     runs-on: ubuntu-latest
+    timeout-minutes: 120
 
     permissions:
       # Needed to cancel any previous runs that are not completed for a given workflow
@@ -154,6 +156,7 @@ jobs:
     needs: generate-coverage
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     container: python:3-slim
 

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -22,6 +22,7 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,4 @@
-name: pre-commit
+name: Run pre-commit
 
 on:
   pull_request:
@@ -9,7 +9,11 @@ permissions: read-all
 
 jobs:
   pre-commit:
+    name: Check
+
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
+
     steps:
       - name: Set up clang-format
         run: |


### PR DESCRIPTION
The PR adds [timeout-minutes](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes) property.
This ensures that run-away jobs would not take extraordinarily long to fail.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
