### PR TITLE
Enable muted test since dpctl-2121 is resolved

### DIFF
--- a/dpnp/tests/test_manipulation.py
+++ b/dpnp/tests/test_manipulation.py
@@ -1836,8 +1836,8 @@ class TestUnique:
         expected = numpy.unique(a, **eq_nan_kwd)
         assert_array_equal(result, expected)
 
-    # TODO: uncomment once numpy 2.3.2 release is published
-    # @testing.with_requires("numpy>=2.3.2")
+    # TODO: uncomment once numpy 2.4.0 release is published
+    # @testing.with_requires("numpy>=2.4.0")
     def test_1d_equal_nan_axis0(self):
         a = numpy.array([numpy.nan, 0, 0, numpy.nan])
         ia = dpnp.array(a)
@@ -1845,7 +1845,7 @@ class TestUnique:
         result = dpnp.unique(ia, axis=0, equal_nan=True)
         expected = numpy.unique(a, axis=0, equal_nan=True)
         # TODO: remove when numpy#29372 is released
-        if numpy_version() < "2.3.2":
+        if numpy_version() < "2.4.0":
             expected = numpy.array([0.0, numpy.nan])
         assert_array_equal(result, expected)
 

--- a/dpnp/tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py
+++ b/dpnp/tests/third_party/cupy/core_tests/test_ndarray_copy_and_view.py
@@ -386,7 +386,6 @@ class TestArrayAsType:
         dst = astype_without_warning(src, dst_dtype, order="K")
         return get_strides(xp, dst)
 
-    @pytest.mark.skip("dpctl-2121")
     @testing.numpy_cupy_array_equal()
     def test_astype_boolean_view(self, xp):
         # See #4354


### PR DESCRIPTION
The PR enables previously muted test due to the [issue](https://github.com/IntelPython/dpctl/issues/2121) in dpctl.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
