### PR TITLE
Remove temporary workaround in tests where "in_order" SYCL queue was used

### DIFF
--- a/dpnp/tests/test_sycl_queue.py
+++ b/dpnp/tests/test_sycl_queue.py
@@ -772,10 +772,7 @@ def test_random(func, args, kwargs, device, usm_type):
     assert device == res_array.sycl_device
     assert usm_type == res_array.usm_type
 
-    # SAT-7414: w/a to avoid crash on Windows (observing on LNL and ARL)
-    # sycl_queue = dpctl.SyclQueue(device, property="in_order")
-    # TODO: remove the w/a once resolved
-    sycl_queue = dpctl.SyclQueue(device, property="enable_profiling")
+    sycl_queue = dpctl.SyclQueue(device, property="in_order")
     kwargs["device"] = None
     kwargs["sycl_queue"] = sycl_queue
 
@@ -814,10 +811,7 @@ def test_random_state(func, args, kwargs, device, usm_type):
     assert device == res_array.sycl_device
     assert usm_type == res_array.usm_type
 
-    # SAT-7414: w/a to avoid crash on Windows (observing on LNL and ARL)
-    # sycl_queue = dpctl.SyclQueue(device, property="in_order")
-    # TODO: remove the w/a once resolved
-    sycl_queue = dpctl.SyclQueue(device, property="enable_profiling")
+    sycl_queue = dpctl.SyclQueue(device, property="in_order")
 
     # test with in-order SYCL queue per a device and passed as argument
     seed = (147, 56, 896) if device.is_cpu else 987654


### PR DESCRIPTION
The PR removes temporary w/a implemented due to crash on Windows in `test_random` and `test_random_state`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
