### PR TITLE
Fix `dpnp.unique` with axis=0 and 1d input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Updated `pre-commit` GitHub workflow to pass `no-commit-to-branch` check [#2501](https://github.com/IntelPython/dpnp/pull/2501)
 * Updated the math formulas in summary of `dpnp.matvec` and `dpnp.vecmat` to correct a typo [#2503](https://github.com/IntelPython/dpnp/pull/2503)
 * Avoided negating unsigned integers in ceil division used in `dpnp.resize` implementation [#2508](https://github.com/IntelPython/dpnp/pull/2508)
+* Fixed `dpnp.unique` with 1d input array and `axis=0`, `equal_nan=True` keywords passed where the produced result doesn't collapse the NaNs [#2530](https://github.com/IntelPython/dpnp/pull/2530)
 
 ### Security
 

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -4245,7 +4245,7 @@ def unique(
 
     """
 
-    if axis is None:
+    if axis is None or (axis == 0 and ar.ndim == 1):
         return _unique_1d(
             ar, return_index, return_inverse, return_counts, equal_nan
         )

--- a/dpnp/tests/helper.py
+++ b/dpnp/tests/helper.py
@@ -343,7 +343,7 @@ def get_integer_dtypes(all_int_types=False, no_unsigned=False):
     if config.all_int_types or all_int_types:
         dtypes += [dpnp.int8, dpnp.int16]
         if not no_unsigned:
-            dtypes += [dpnp.uint8, dpnp.uint16, dpnp.uint32, dpnp.uint64]
+            dtypes += get_unsigned_dtypes()
 
     return dtypes
 
@@ -376,6 +376,14 @@ def get_integer_float_dtypes(
 
     dtypes = [mark_xfail(dtype) for dtype in dtypes if not_excluded(dtype)]
     return dtypes
+
+
+def get_unsigned_dtypes():
+    """
+    Build a list of unsigned integer types supported by DPNP.
+    """
+
+    return [dpnp.uint8, dpnp.uint16, dpnp.uint32, dpnp.uint64]
 
 
 def has_support_aspect16(device=None):

--- a/dpnp/tests/test_manipulation.py
+++ b/dpnp/tests/test_manipulation.py
@@ -21,6 +21,7 @@ from .helper import (
     get_float_dtypes,
     get_integer_dtypes,
     get_integer_float_dtypes,
+    get_unsigned_dtypes,
     has_support_aspect64,
     numpy_version,
 )
@@ -1799,8 +1800,18 @@ class TestUnique:
         expected = numpy.unique(a, axis=0)
         assert_array_equal(result, expected)
 
+    @pytest.mark.parametrize("axis", [None, 0, 1])
+    @pytest.mark.parametrize("dt", get_unsigned_dtypes())
+    def test_2d_axis_unsigned_inetger(self, axis, dt):
+        a = numpy.array([[7, 1, 2, 1], [5, 7, 5, 7]], dtype=dt)
+        ia = dpnp.array(a)
+
+        result = dpnp.unique(ia, axis=axis)
+        expected = numpy.unique(a, axis=axis)
+        assert_array_equal(result, expected)
+
     @pytest.mark.parametrize("axis", [None, 0])
-    @pytest.mark.parametrize("dt", "bBhHiIlLqQ")
+    @pytest.mark.parametrize("dt", get_integer_dtypes(all_int_types=True))
     def test_1d_axis_all_inetger(self, axis, dt):
         a = numpy.array([5, 7, 1, 2, 1, 5, 7], dtype=dt)
         ia = dpnp.array(a)

--- a/dpnp/tests/test_manipulation.py
+++ b/dpnp/tests/test_manipulation.py
@@ -1825,13 +1825,17 @@ class TestUnique:
         expected = numpy.unique(a, **eq_nan_kwd)
         assert_array_equal(result, expected)
 
-    @testing.with_requires("numpy>=2.3.2")
+    # TODO: uncomment once numpy 2.3.2 release is published
+    # @testing.with_requires("numpy>=2.3.2")
     def test_1d_equal_nan_axis0(self):
         a = numpy.array([numpy.nan, 0, 0, numpy.nan])
         ia = dpnp.array(a)
 
         result = dpnp.unique(ia, axis=0, equal_nan=True)
         expected = numpy.unique(a, axis=0, equal_nan=True)
+        # TODO: remove
+        if numpy_version() < "2.3.2":
+            expected = numpy.array([0.0, numpy.nan])
         assert_array_equal(result, expected)
 
     @testing.with_requires("numpy>=2.0.1")

--- a/dpnp/tests/test_manipulation.py
+++ b/dpnp/tests/test_manipulation.py
@@ -1685,6 +1685,7 @@ class TestUnique:
         expected = numpy.unique(a, axis=axis)
         assert_array_equal(result, expected)
 
+    @testing.with_requires("numpy>=2.0.1")
     @pytest.mark.parametrize("dt", get_all_dtypes(no_none=True))
     @pytest.mark.parametrize(
         "axis_kwd",
@@ -1716,17 +1717,6 @@ class TestUnique:
         if len(return_kwds) == 0:
             assert_array_equal(result, expected)
         else:
-            if (
-                len(axis_kwd) == 0
-                and numpy.lib.NumpyVersion(numpy.__version__) < "2.0.1"
-            ):
-                # gh-26961: numpy.unique(..., return_inverse=True, axis=None)
-                # returned flatten unique_inverse till 2.0.1 version
-                expected = (
-                    expected[:2]
-                    + (expected[2].reshape(a.shape),)
-                    + expected[3:]
-                )
             for iv, v in zip(result, expected):
                 assert_array_equal(iv, v)
 
@@ -1756,6 +1746,7 @@ class TestUnique:
         expected = numpy.unique(a, axis=axis)
         assert_array_equal(result, expected)
 
+    @testing.with_requires("numpy>=2.0.1")
     @pytest.mark.parametrize("axis", [None, 0, -1])
     def test_2d_axis_inverse(self, axis):
         a = numpy.array([[4, 4, 3], [2, 2, 1], [2, 2, 1], [4, 4, 3]])
@@ -1763,10 +1754,6 @@ class TestUnique:
 
         result = dpnp.unique(ia, return_inverse=True, axis=axis)
         expected = numpy.unique(a, return_inverse=True, axis=axis)
-        if axis is None and numpy.lib.NumpyVersion(numpy.__version__) < "2.0.1":
-            # gh-26961: numpy.unique(..., return_inverse=True, axis=None)
-            # returned flatten unique_inverse till 2.0.1 version
-            expected = expected[:1] + (expected[1].reshape(a.shape),)
 
         for iv, v in zip(result, expected):
             assert_array_equal(iv, v)
@@ -1847,6 +1834,7 @@ class TestUnique:
         expected = numpy.unique(a, axis=0, equal_nan=True)
         assert_array_equal(result, expected)
 
+    @testing.with_requires("numpy>=2.0.1")
     @pytest.mark.parametrize("dt", get_float_complex_dtypes())
     @pytest.mark.parametrize(
         "axis_kwd",
@@ -1888,14 +1876,6 @@ class TestUnique:
         if len(return_kwds) == 0:
             assert_array_equal(result, expected)
         else:
-            if len(axis_kwd) == 0 and numpy_version() < "2.0.1":
-                # gh-26961: numpy.unique(..., return_inverse=True, axis=None)
-                # returned flatten unique_inverse till 2.0.1 version
-                expected = (
-                    expected[:2]
-                    + (expected[2].reshape(a.shape),)
-                    + expected[3:]
-                )
             for iv, v in zip(result, expected):
                 assert_array_equal(iv, v)
 

--- a/dpnp/tests/test_manipulation.py
+++ b/dpnp/tests/test_manipulation.py
@@ -1838,6 +1838,15 @@ class TestUnique:
         expected = numpy.unique(a, **eq_nan_kwd)
         assert_array_equal(result, expected)
 
+    @testing.with_requires("numpy>=2.3.2")
+    def test_1d_equal_nan_axis0(self):
+        a = numpy.array([numpy.nan, 0, 0, numpy.nan])
+        ia = dpnp.array(a)
+
+        result = dpnp.unique(ia, axis=0, equal_nan=True)
+        expected = numpy.unique(a, axis=0, equal_nan=True)
+        assert_array_equal(result, expected)
+
     @pytest.mark.parametrize("dt", get_float_complex_dtypes())
     @pytest.mark.parametrize(
         "axis_kwd",

--- a/dpnp/tests/test_manipulation.py
+++ b/dpnp/tests/test_manipulation.py
@@ -1833,7 +1833,7 @@ class TestUnique:
 
         result = dpnp.unique(ia, axis=0, equal_nan=True)
         expected = numpy.unique(a, axis=0, equal_nan=True)
-        # TODO: remove
+        # TODO: remove when numpy#29372 is released
         if numpy_version() < "2.3.2":
             expected = numpy.array([0.0, numpy.nan])
         assert_array_equal(result, expected)


### PR DESCRIPTION
The PR fixes `dpnp.unique` with 1d input array and `axis=0`, `equal_nan=True` keywords passed where the produced result is wrong and doesn't collapse the NaNs.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
