### PR TITLE
Fix `dpnp.ndarray` constructor call with buffer passed as data property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Updated the math formulas in summary of `dpnp.matvec` and `dpnp.vecmat` to correct a typo [#2503](https://github.com/IntelPython/dpnp/pull/2503)
 * Avoided negating unsigned integers in ceil division used in `dpnp.resize` implementation [#2508](https://github.com/IntelPython/dpnp/pull/2508)
 * Fixed `dpnp.unique` with 1d input array and `axis=0`, `equal_nan=True` keywords passed where the produced result doesn't collapse the NaNs [#2530](https://github.com/IntelPython/dpnp/pull/2530)
+* Resolved issue when `dpnp.ndarray` constructor is called with `dpnp.ndarray.data` as `buffer` keyword [#2533](https://github.com/IntelPython/dpnp/pull/2533)
 
 ### Security
 

--- a/dpnp/memory/_memory.py
+++ b/dpnp/memory/_memory.py
@@ -95,6 +95,9 @@ def create_data(x):
         )
     usm_data = x.usm_data
 
+    if isinstance(usm_data, tuple(dispatch.keys())):
+        return usm_data
+
     cls = dispatch.get(type(usm_data), None)
     if cls:
         data = cls(usm_data)

--- a/dpnp/memory/_memory.py
+++ b/dpnp/memory/_memory.py
@@ -95,7 +95,7 @@ def create_data(x):
         )
     usm_data = x.usm_data
 
-    if isinstance(usm_data, tuple(dispatch.keys())):
+    if isinstance(usm_data, tuple(dispatch.values())):
         return usm_data
 
     cls = dispatch.get(type(usm_data), None)

--- a/dpnp/tests/test_memory.py
+++ b/dpnp/tests/test_memory.py
@@ -30,4 +30,4 @@ class TestCreateData:
     def test_ndarray_from_data(self):
         a = dpnp.empty(5)
         b = dpnp.ndarray(a.shape, buffer=a.data)
-        assert b.data is a.data
+        assert b.data.ptr == a.data.ptr

--- a/dpnp/tests/test_memory.py
+++ b/dpnp/tests/test_memory.py
@@ -26,3 +26,8 @@ class TestCreateData:
 
         with pytest.raises(TypeError):
             dpm.create_data(d)
+
+    def test_ndarray_from_data(self):
+        a = dpnp.empty(5)
+        b = dpnp.ndarray(a.shape, buffer=a.data)
+        assert b.data is a.data


### PR DESCRIPTION
The PR closes gh-2532.

In the faulty example the buffer was passed with `.data` of dpnp.ndarray. In that case there is no need to cast dpctl's `usm_data` to DPNP memory object.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
