### PR TITLE
Add `dpnp.ndarray.__contains__`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added a new backend routine `syrk` from oneMKL to perform symmetric rank-k update which is used for a specialized matrix multiplication where the result is a symmetric matrix [2509](https://github.com/IntelPython/dpnp/pull/2509)
 * Added `timeout-minutes` property to GitHub jobs [#2526](https://github.com/IntelPython/dpnp/pull/2526)
 * Added implementation of `dpnp.ndarray.data` and `dpnp.ndarray.data.ptr` attributes [#2521](https://github.com/IntelPython/dpnp/pull/2521)
+* Added `dpnp.ndarray.__contains__` method [#2534](https://github.com/IntelPython/dpnp/pull/2534)
 
 ### Changed
 

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -242,7 +242,9 @@ class dpnp_array:
     def __complex__(self):
         return self._array_obj.__complex__()
 
-    # '__contains__',
+    def __contains__(self, key, /):
+        """Return :math:`key in self`."""
+        return (self == key).any()
 
     def __copy__(self):
         """

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -242,9 +242,9 @@ class dpnp_array:
     def __complex__(self):
         return self._array_obj.__complex__()
 
-    def __contains__(self, key, /):
-        """Return :math:`key in self`."""
-        return (self == key).any()
+    def __contains__(self, value, /):
+        """Return :math:`value in self`."""
+        return (self == value).any()
 
     def __copy__(self):
         """

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -243,7 +243,7 @@ class dpnp_array:
         return self._array_obj.__complex__()
 
     def __contains__(self, value, /):
-        """Return :math:`value in self`."""
+        r"""Return :math:`\text{value in self}`."""
         return (self == value).any()
 
     def __copy__(self):

--- a/dpnp/tests/test_ndarray.py
+++ b/dpnp/tests/test_ndarray.py
@@ -74,6 +74,39 @@ class TestAttributes:
         assert_equal(self.two.itemsize, self.two.dtype.itemsize)
 
 
+@testing.parameterize(*testing.product({"xp": [dpnp, numpy]}))
+class TestContains:
+    def test_basic(self):
+        a = self.xp.arange(10).reshape((2, 5))
+        assert 4 in a
+        assert 20 not in a
+
+    def test_broadcast(self):
+        xp = self.xp
+        a = xp.arange(6).reshape((2, 3))
+        assert 4 in a
+        assert xp.array([0, 1, 2]) in a
+        assert xp.array([5, 3, 4]) not in a
+
+    def test_broadcast_error(self):
+        a = self.xp.arange(10).reshape((2, 5))
+        with pytest.raises(
+            ValueError,
+            match="operands could not be broadcast together with shapes",
+        ):
+            self.xp.array([1, 2]) in a
+
+    def test_strides(self):
+        xp = self.xp
+        a = xp.arange(10).reshape((2, 5))
+        a = a[:, ::2]
+        assert 4 in a
+        assert 8 not in a
+        assert xp.full(a.shape[-1], fill_value=2) in a
+        assert xp.full_like(a, fill_value=7) in a
+        assert xp.full_like(a, fill_value=6) not in a
+
+
 class TestView:
     def test_none_dtype(self):
         a = numpy.ones((1, 2, 4), dtype=numpy.int32)


### PR DESCRIPTION
The PR implements `__contains__` method which needs to define the `in` operator for a `dpnp.ndarray`.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
