### PR TITLE
Correct dependency on numpy version in `test_1d_equal_nan_axis0`

### DIFF
--- a/dpnp/tests/test_manipulation.py
+++ b/dpnp/tests/test_manipulation.py
@@ -1850,8 +1850,8 @@ class TestUnique:
         expected = numpy.unique(a, **eq_nan_kwd)
         assert_array_equal(result, expected)
 
-    # TODO: uncomment once numpy 2.3.2 release is published
-    # @testing.with_requires("numpy>=2.3.2")
+    # TODO: uncomment once numpy 2.4.0 release is published
+    # @testing.with_requires("numpy>=2.4.0")
     def test_1d_equal_nan_axis0(self):
         a = numpy.array([numpy.nan, 0, 0, numpy.nan])
         ia = dpnp.array(a)
@@ -1859,7 +1859,7 @@ class TestUnique:
         result = dpnp.unique(ia, axis=0, equal_nan=True)
         expected = numpy.unique(a, axis=0, equal_nan=True)
         # TODO: remove when numpy#29372 is released
-        if numpy_version() < "2.3.2":
+        if numpy_version() < "2.4.0":
             expected = numpy.array([0.0, numpy.nan])
         assert_array_equal(result, expected)
 


### PR DESCRIPTION
The `test_1d_equal_nan_axis0` test depends on a fix for numpy#29372. It was not included as part of numpy 2.3.2 release.
The PR proposes to updated the expected dependency on numpy version with the fix.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
