### PR TITLE
Use dpctl tensor include to use experimental SYCL namespace for complex types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Updated `dpnp.size` to accept tuple of ints for `axes` argument [#2536](https://github.com/IntelPython/dpnp/pull/2536)
 * Replaced `ci` section in `.pre-commit-config.yaml` with a new GitHub workflow with scheduled run to autoupdate the `pre-commit` configuration [#2542](https://github.com/IntelPython/dpnp/pull/2542)
 * FFT module is updated to perform in-place FFT in intermediate steps of ND FFT [#2543](https://github.com/IntelPython/dpnp/pull/2543)
+* Reused dpctl tensor include to enable experimental SYCL namespace for complex types [#2546](https://github.com/IntelPython/dpnp/pull/2546)
 
 ### Deprecated
 

--- a/dpnp/backend/kernels/elementwise_functions/sinc.hpp
+++ b/dpnp/backend/kernels/elementwise_functions/sinc.hpp
@@ -25,16 +25,15 @@
 
 #pragma once
 
-#define SYCL_EXT_ONEAPI_COMPLEX
-#if __has_include(<sycl/ext/oneapi/experimental/sycl_complex.hpp>)
-#include <sycl/ext/oneapi/experimental/sycl_complex.hpp>
-#else
-#include <sycl/ext/oneapi/experimental/complex/complex.hpp>
-#endif
+#include <cmath>
+#include <complex>
+#include <limits>
+#include <type_traits>
 
 #include <sycl/sycl.hpp>
 
 // dpctl tensor headers
+#include "kernels/elementwise_functions/sycl_complex.hpp"
 #include "utils/type_utils.hpp"
 
 namespace dpnp::kernels::sinc
@@ -43,8 +42,6 @@ namespace tu_ns = dpctl::tensor::type_utils;
 
 namespace impl
 {
-namespace exprm_ns = sycl::ext::oneapi::experimental;
-
 template <typename Tp>
 inline Tp sin(const Tp &in)
 {


### PR DESCRIPTION
The PR proposes to reuse dpctl, since it exposes `sycl_complex.hpp` header which enables experimental SYCL namespace for complex types.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
