### PR TITLE
Adjust Windows-only logic in `__init__.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Replaced `ci` section in `.pre-commit-config.yaml` with a new GitHub workflow with scheduled run to autoupdate the `pre-commit` configuration [#2542](https://github.com/IntelPython/dpnp/pull/2542)
 * FFT module is updated to perform in-place FFT in intermediate steps of ND FFT [#2543](https://github.com/IntelPython/dpnp/pull/2543)
 * Reused dpctl tensor include to enable experimental SYCL namespace for complex types [#2546](https://github.com/IntelPython/dpnp/pull/2546)
+* Changed Windows-specific logic in dpnp initialization [#2553](https://github.com/IntelPython/dpnp/pull/2553)
 
 ### Deprecated
 

--- a/dpnp/__init__.py
+++ b/dpnp/__init__.py
@@ -40,17 +40,13 @@ dpctlpath = os.path.dirname(dpctl.__file__)
 # where to search for DLLs towards both DPNP backend and DPCTL Sycl interface,
 # otherwise DPNP import will be failing. This is because the libraries
 # are not installed under any of default paths where Python is searching.
-from platform import system
 
-if system() == "Windows":  # pragma: no cover
-    if hasattr(os, "add_dll_directory"):
-        os.add_dll_directory(mypath)
-        os.add_dll_directory(dpctlpath)
-
+if sys.platform == "win32":  # pragma: no cover
+    os.add_dll_directory(mypath)
+    os.add_dll_directory(dpctlpath)
     os.environ["PATH"] = os.pathsep.join(
         [os.getenv("PATH", ""), mypath, dpctlpath]
     )
-
     # For virtual environments on Windows, add folder with DPC++ libraries
     # to the DLL search path
     if sys.base_exec_prefix != sys.exec_prefix and os.path.isfile(


### PR DESCRIPTION
This PR suggests small changes to Windows-specific logic in `__init__.py`

`hasattr(os, "add_dll_directory")` is unnecessary after platform check and is removed, and `sys.platform == "win32"` is used which is more commonly seen in the ecosystem and avoids importing `platform` module

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
