### PR TITLE
Implement `dpnp.linalg.lu_factor` 2D inputs

### DIFF
--- a/dpnp/backend/extensions/lapack/getrf.cpp
+++ b/dpnp/backend/extensions/lapack/getrf.cpp
@@ -71,7 +71,7 @@ static sycl::event getrf_impl(sycl::queue &exec_q,
     T *a = reinterpret_cast<T *>(in_a);
 
     const std::int64_t scratchpad_size =
-        mkl_lapack::getrf_scratchpad_size<T>(exec_q, n, n, lda);
+        mkl_lapack::getrf_scratchpad_size<T>(exec_q, m, n, lda);
     T *scratchpad = nullptr;
 
     std::stringstream error_msg;
@@ -88,9 +88,9 @@ static sycl::event getrf_impl(sycl::queue &exec_q,
                   // It must be a non-negative integer.
             n,    // The number of columns in the input matrix A (0 ≤ n).
                   // It must be a non-negative integer.
-            a,    // Pointer to the input matrix A (n x n).
+            a,    // Pointer to the input matrix A (m x n).
             lda,  // The leading dimension of matrix A.
-                  // It must be at least max(1, n).
+                  // It must be at least max(1, m).
             ipiv, // Pointer to the output array of pivot indices.
             scratchpad, // Pointer to scratchpad memory to be used by MKL
                         // routine for storing intermediate results.

--- a/dpnp/backend/extensions/lapack/getrf.cpp
+++ b/dpnp/backend/extensions/lapack/getrf.cpp
@@ -196,8 +196,7 @@ std::pair<sycl::event, sycl::event>
     bool is_ipiv_array_c_contig = ipiv_array.is_c_contiguous();
     if (!is_a_array_c_contig && !is_a_array_f_contig) {
         throw py::value_error("The input array "
-                              "must be must be either C-contiguous "
-                              "or F-contiguous");
+                              "must be contiguous");
     }
     if (!is_ipiv_array_c_contig) {
         throw py::value_error("The array of pivot indices "

--- a/dpnp/backend/extensions/lapack/getrf.cpp
+++ b/dpnp/backend/extensions/lapack/getrf.cpp
@@ -190,10 +190,12 @@ std::pair<sycl::event, sycl::event>
     }
 
     bool is_a_array_c_contig = a_array.is_c_contiguous();
+    bool is_a_array_f_contig = a_array.is_f_contiguous();
     bool is_ipiv_array_c_contig = ipiv_array.is_c_contiguous();
-    if (!is_a_array_c_contig) {
+    if (!is_a_array_c_contig && !is_a_array_f_contig) {
         throw py::value_error("The input array "
-                              "must be C-contiguous");
+                              "must be must be either C-contiguous "
+                              "or F-contiguous");
     }
     if (!is_ipiv_array_c_contig) {
         throw py::value_error("The array of pivot indices "

--- a/dpnp/backend/extensions/lapack/getrf.cpp
+++ b/dpnp/backend/extensions/lapack/getrf.cpp
@@ -45,6 +45,7 @@ namespace type_utils = dpctl::tensor::type_utils;
 
 typedef sycl::event (*getrf_impl_fn_ptr_t)(sycl::queue &,
                                            const std::int64_t,
+                                           const std::int64_t,
                                            char *,
                                            std::int64_t,
                                            std::int64_t *,
@@ -56,6 +57,7 @@ static getrf_impl_fn_ptr_t getrf_dispatch_vector[dpctl_td_ns::num_types];
 
 template <typename T>
 static sycl::event getrf_impl(sycl::queue &exec_q,
+                              const std::int64_t m,
                               const std::int64_t n,
                               char *in_a,
                               std::int64_t lda,
@@ -82,11 +84,11 @@ static sycl::event getrf_impl(sycl::queue &exec_q,
 
         getrf_event = mkl_lapack::getrf(
             exec_q,
-            n,    // The order of the square matrix A (0 ≤ n).
+            m,    // The number of rows in the input matrix A (0 ≤ m).
                   // It must be a non-negative integer.
-            n,    // The number of columns in the square matrix A (0 ≤ n).
+            n,    // The number of columns in the input matrix A (0 ≤ n).
                   // It must be a non-negative integer.
-            a,    // Pointer to the square matrix A (n x n).
+            a,    // Pointer to the input matrix A (n x n).
             lda,  // The leading dimension of matrix A.
                   // It must be at least max(1, n).
             ipiv, // Pointer to the output array of pivot indices.
@@ -99,7 +101,7 @@ static sycl::event getrf_impl(sycl::queue &exec_q,
 
         if (info < 0) {
             error_msg << "Parameter number " << -info
-                      << " had an illegal value.";
+                      << " had an illegal value";
         }
         else if (info == scratchpad_size && e.detail() != 0) {
             error_msg
@@ -168,13 +170,13 @@ std::pair<sycl::event, sycl::event>
     if (a_array_nd != 2) {
         throw py::value_error(
             "The input array has ndim=" + std::to_string(a_array_nd) +
-            ", but a 2-dimensional array is expected.");
+            ", but a 2-dimensional array is expected");
     }
 
     if (ipiv_array_nd != 1) {
         throw py::value_error("The array of pivot indices has ndim=" +
                               std::to_string(ipiv_array_nd) +
-                              ", but a 1-dimensional array is expected.");
+                              ", but a 1-dimensional array is expected");
     }
 
     // check compatibility of execution queue and allocation queue
@@ -210,7 +212,7 @@ std::pair<sycl::event, sycl::event>
     if (getrf_fn == nullptr) {
         throw py::value_error(
             "No getrf implementation defined for the provided type "
-            "of the input matrix.");
+            "of the input matrix");
     }
 
     auto ipiv_types = dpctl_td_ns::usm_ndarray_types();
@@ -218,19 +220,25 @@ std::pair<sycl::event, sycl::event>
         ipiv_types.typenum_to_lookup_id(ipiv_array.get_typenum());
 
     if (ipiv_array_type_id != static_cast<int>(dpctl_td_ns::typenum_t::INT64)) {
-        throw py::value_error("The type of 'ipiv_array' must be int64.");
+        throw py::value_error("The type of 'ipiv_array' must be int64");
     }
 
-    const std::int64_t n = a_array.get_shape_raw()[0];
+    const py::ssize_t *a_array_shape = a_array.get_shape_raw();
+    const std::int64_t m = a_array_shape[0];
+    const std::int64_t n = a_array_shape[1];
+    const std::int64_t lda = std::max<size_t>(1UL, m);
+
+    if (ipiv_array.get_size() != std::min(m, n)) {
+        throw py::value_error("The size of 'ipiv_array' must be min(m, n)");
+    }
 
     char *a_array_data = a_array.get_data();
-    const std::int64_t lda = std::max<size_t>(1UL, n);
 
     char *ipiv_array_data = ipiv_array.get_data();
     std::int64_t *d_ipiv = reinterpret_cast<std::int64_t *>(ipiv_array_data);
 
     std::vector<sycl::event> host_task_events;
-    sycl::event getrf_ev = getrf_fn(exec_q, n, a_array_data, lda, d_ipiv,
+    sycl::event getrf_ev = getrf_fn(exec_q, m, n, a_array_data, lda, d_ipiv,
                                     dev_info, host_task_events, depends);
 
     sycl::event args_ev = dpctl::utils::keep_args_alive(

--- a/dpnp/backend/extensions/lapack/getrf_batch.cpp
+++ b/dpnp/backend/extensions/lapack/getrf_batch.cpp
@@ -221,10 +221,12 @@ std::pair<sycl::event, sycl::event>
     }
 
     bool is_a_array_c_contig = a_array.is_c_contiguous();
+    bool is_a_array_f_contig = a_array.is_f_contiguous();
     bool is_ipiv_array_c_contig = ipiv_array.is_c_contiguous();
-    if (!is_a_array_c_contig) {
+    if (!is_a_array_c_contig && !is_a_array_f_contig) {
         throw py::value_error("The input array "
-                              "must be C-contiguous");
+                              "must be must be either C-contiguous "
+                              "or F-contiguous");
     }
     if (!is_ipiv_array_c_contig) {
         throw py::value_error("The array of pivot indices "

--- a/dpnp/backend/extensions/lapack/getrf_batch.cpp
+++ b/dpnp/backend/extensions/lapack/getrf_batch.cpp
@@ -225,8 +225,7 @@ std::pair<sycl::event, sycl::event>
     bool is_ipiv_array_c_contig = ipiv_array.is_c_contiguous();
     if (!is_a_array_c_contig && !is_a_array_f_contig) {
         throw py::value_error("The input array "
-                              "must be must be either C-contiguous "
-                              "or F-contiguous");
+                              "must be must contiguous");
     }
     if (!is_ipiv_array_c_contig) {
         throw py::value_error("The array of pivot indices "

--- a/dpnp/backend/extensions/lapack/lapack_py.cpp
+++ b/dpnp/backend/extensions/lapack/lapack_py.cpp
@@ -135,7 +135,7 @@ PYBIND11_MODULE(_lapack_impl, m)
 
     m.def("_getrf", &lapack_ext::getrf,
           "Call `getrf` from OneMKL LAPACK library to return "
-          "the LU factorization of a general n x n matrix",
+          "the LU factorization of a general m x n matrix",
           py::arg("sycl_queue"), py::arg("a_array"), py::arg("ipiv_array"),
           py::arg("dev_info"), py::arg("depends") = py::list());
 

--- a/dpnp/linalg/dpnp_iface_linalg.py
+++ b/dpnp/linalg/dpnp_iface_linalg.py
@@ -56,6 +56,7 @@ from .dpnp_utils_linalg import (
     dpnp_eigh,
     dpnp_inv,
     dpnp_lstsq,
+    dpnp_lu_factor,
     dpnp_matrix_power,
     dpnp_matrix_rank,
     dpnp_multi_dot,
@@ -79,6 +80,7 @@ __all__ = [
     "eigvalsh",
     "inv",
     "lstsq",
+    "lu_factor",
     "matmul",
     "matrix_norm",
     "matrix_power",
@@ -899,6 +901,68 @@ def lstsq(a, b, rcond=None):
         raise TypeError("rcond must be integer, floating type, or None")
 
     return dpnp_lstsq(a, b, rcond=rcond)
+
+
+def lu_factor(a, overwrite_a=False, check_finite=True):
+    """
+    Compute the pivoted LU decomposition of a matrix.
+
+    The decomposition is::
+
+        A = P @ L @ U
+
+    where `P` is a permutation matrix, `L` is lower triangular with unit
+    diagonal elements, and `U` is upper triangular.
+
+    Parameters
+    ----------
+    a : (M, N) {dpnp.ndarray, usm_ndarray}
+        Input array to decompose.
+    overwrite_a : {None, bool}, optional
+        Whether to overwrite data in `a` (may increase performance)
+        Default: ``False``.
+    check_finite : {None, bool}, optional
+        Whether to check that the input matrix contains only finite numbers.
+        Disabling may give a performance gain, but may result in problems
+        (crashes, non-termination) if the inputs do contain infinities or NaNs.
+
+    Returns
+    -------
+    lu :(M, N) dpnp.ndarray
+        Matrix containing U in its upper triangle, and L in its lower triangle.
+        The unit diagonal elements of L are not stored.
+    piv (K, ): dpnp.ndarray
+        Pivot indices representing the permutation matrix P:
+        row i of matrix was interchanged with row piv[i].
+        ``K = min(M, N)``.
+
+    Warning
+    -------
+    This function synchronizes in order to validate array elements
+    when ``check_finite=True``.
+
+    Limitations
+    -----------
+    Only two-dimensional input matrices are supported.
+    Otherwise, the function raises ``NotImplementedError`` exception.
+
+    Examples
+    --------
+    >>> import dpnp as np
+    >>> a = np.array([[4., 3.], [6., 3.]])
+    >>> lu, piv = np.linalg.lu_factor(a)
+    >>> lu
+    array([[6.        , 3.        ],
+           [0.66666667, 1.        ]])
+    >>> piv
+    array([1, 1])
+
+    """
+
+    dpnp.check_supported_arrays_type(a)
+    assert_stacked_2d(a)
+
+    return dpnp_lu_factor(a, overwrite_a=overwrite_a, check_finite=check_finite)
 
 
 def matmul(x1, x2, /):

--- a/dpnp/linalg/dpnp_utils_linalg.py
+++ b/dpnp/linalg/dpnp_utils_linalg.py
@@ -2307,7 +2307,7 @@ def dpnp_lu_factor(a, overwrite_a=False, check_finite=True):
     # accommodate empty arrays
     if a.size == 0:
         lu = dpnp.empty_like(a)
-        piv = dpnp.arange(0, dtype=dpnp.int32)
+        piv = dpnp.arange(0, dtype=dpnp.int64)
         return lu, piv
 
     if check_finite:

--- a/dpnp/linalg/dpnp_utils_linalg.py
+++ b/dpnp/linalg/dpnp_utils_linalg.py
@@ -1009,7 +1009,7 @@ def _is_empty_2d(arr):
     return arr.size == 0 and numpy.prod(arr.shape[-2:]) == 0
 
 
-def _lu_factor(a, res_type, scipy=False, overwrite_a=False):
+def _lu_factor(a, res_type):
     """
     Compute pivoted LU decomposition.
 
@@ -1050,41 +1050,18 @@ def _lu_factor(a, res_type, scipy=False, overwrite_a=False):
 
     a_usm_arr = dpnp.get_usm_ndarray(a)
 
-    if not scipy:
-        # Internal use case (e.g., det(), slogdet()). Always copy.
-        # `a` must be copied because getrf destroys the input matrix
-        a_h = dpnp.empty_like(a, order="C", dtype=res_type)
+    # `a` must be copied because getrf destroys the input matrix
+    a_h = dpnp.empty_like(a, order="C", dtype=res_type)
 
-        # use DPCTL tensor function to fill the сopy of the input array
-        # from the input array
-        ht_ev, copy_ev = ti._copy_usm_ndarray_into_usm_ndarray(
-            src=a_usm_arr,
-            dst=a_h.get_array(),
-            sycl_queue=a_sycl_queue,
-            depends=_manager.submitted_events,
-        )
-        _manager.add_event_pair(ht_ev, copy_ev)
-
-    else:
-        # SciPy-compatible behavior
-        # Copy is required if:
-        # - overwrite_a is False (always copy),
-        # - dtype mismatch,
-        # - not F-contiguous,
-        # - not writeable
-        if not overwrite_a or _is_copy_required(a, res_type):
-            a_h = dpnp.empty_like(a, order="F", dtype=res_type)
-            ht_ev, copy_ev = ti._copy_usm_ndarray_into_usm_ndarray(
-                src=a_usm_arr,
-                dst=a_h.get_array(),
-                sycl_queue=a_sycl_queue,
-                depends=_manager.submitted_events,
-            )
-            _manager.add_event_pair(ht_ev, copy_ev)
-        else:
-            # input is suitable for in-place modification
-            a_h = a
-            copy_ev = None
+    # use DPCTL tensor function to fill the сopy of the input array
+    # from the input array
+    ht_ev, copy_ev = ti._copy_usm_ndarray_into_usm_ndarray(
+        src=a_usm_arr,
+        dst=a_h.get_array(),
+        sycl_queue=a_sycl_queue,
+        depends=_manager.submitted_events,
+    )
+    _manager.add_event_pair(ht_ev, copy_ev)
 
     ipiv_h = dpnp.empty(
         n,
@@ -1102,53 +1079,18 @@ def _lu_factor(a, res_type, scipy=False, overwrite_a=False):
         a_h.get_array(),
         ipiv_h.get_array(),
         dev_info_h,
-        depends=[copy_ev] if copy_ev is not None else [],
+        depends=[copy_ev],
     )
     _manager.add_event_pair(ht_ev, getrf_ev)
 
-    # Return list if called in SciPy-compatible mode
-    # else dpnp.ndarray
-    if scipy:
-        dev_info_array = dev_info_h
-    else:
-        dev_info_array = dpnp.array(
-            dev_info_h, usm_type=a_usm_type, sycl_queue=a_sycl_queue
-        )
+    dev_info_array = dpnp.array(
+        dev_info_h, usm_type=a_usm_type, sycl_queue=a_sycl_queue
+    )
 
     # Return a tuple containing the factorized matrix 'a_h',
     # pivot indices 'ipiv_h'
     # and the status 'dev_info_h' from the LAPACK getrf call
     return (a_h, ipiv_h, dev_info_array)
-
-
-def dpnp_lu_factor(a, overwrite_a=False, check_finite=True):
-    """Compute pivoted LU decomposition."""
-
-    res_type = _common_type(a)
-
-    # accommodate empty arrays
-    if a.size == 0:
-        lu = dpnp.empty_like(a)
-        piv = dpnp.arange(0, dtype=dpnp.int32)
-        return lu, piv
-
-    if check_finite:
-        if not dpnp.isfinite(a).all():
-            raise ValueError("array must not contain infs or NaNs")
-
-    lu, piv, dev_info = _lu_factor(
-        a, res_type, scipy=True, overwrite_a=overwrite_a
-    )
-
-    if any(dev_info):
-        diag_nums = ", ".join(str(v) for v in dev_info if v > 0)
-        warn(
-            f"Diagonal number {diag_nums} are exactly zero. Singular matrix.",
-            RuntimeWarning,
-            stacklevel=2,
-        )
-
-    return lu, piv
 
 
 def _multi_dot(arrays, order, i, j, out=None):
@@ -2347,6 +2289,96 @@ def dpnp_lstsq(a, b, rcond=None):
         resids = dpnp.atleast_1d(_nrm2_last_axis(e.T))
 
     return x, resids, rank, s
+
+
+def dpnp_lu_factor(a, overwrite_a=False, check_finite=True):
+    """
+    dpnp_lu_factor(a, overwrite_a=False, check_finite=True)
+
+    Compute pivoted LU decomposition (SciPy-compatible behavior).
+
+    This function mimics the behavior of `scipy.linalg.lu_factor` including
+    support for `overwrite_a`, `check_finite` and 0-based pivot indexing.
+
+    """
+
+    res_type = _common_type(a)
+
+    # accommodate empty arrays
+    if a.size == 0:
+        lu = dpnp.empty_like(a)
+        piv = dpnp.arange(0, dtype=dpnp.int32)
+        return lu, piv
+
+    if check_finite:
+        if not dpnp.isfinite(a).all():
+            raise ValueError("array must not contain infs or NaNs")
+
+    # if a.ndim > 2:
+    # return _batched_lu_factor_scipy(a, res_type, overwrite_a=overwrite_a)
+
+    n = a.shape[-2]
+
+    a_sycl_queue = a.sycl_queue
+    a_usm_type = a.usm_type
+    _manager = dpu.SequentialOrderManager[a_sycl_queue]
+
+    a_usm_arr = dpnp.get_usm_ndarray(a)
+
+    # SciPy-compatible behavior
+    # Copy is required if:
+    # - overwrite_a is False (always copy),
+    # - dtype mismatch,
+    # - not F-contiguous,
+    # - not writeable
+    if not overwrite_a or _is_copy_required(a, res_type):
+        a_h = dpnp.empty_like(a, order="F", dtype=res_type)
+        ht_ev, copy_ev = ti._copy_usm_ndarray_into_usm_ndarray(
+            src=a_usm_arr,
+            dst=a_h.get_array(),
+            sycl_queue=a_sycl_queue,
+            depends=_manager.submitted_events,
+        )
+        _manager.add_event_pair(ht_ev, copy_ev)
+    else:
+        # input is suitable for in-place modification
+        a_h = a
+        copy_ev = None
+
+    ipiv_h = dpnp.empty(
+        n,
+        dtype=dpnp.int64,
+        order="C",
+        usm_type=a_usm_type,
+        sycl_queue=a_sycl_queue,
+    )
+    dev_info_h = [0]
+
+    # Call the LAPACK extension function _getrf
+    # to perform LU decomposition on the input matrix
+    ht_ev, getrf_ev = li._getrf(
+        a_sycl_queue,
+        a_h.get_array(),
+        ipiv_h.get_array(),
+        dev_info_h,
+        depends=[copy_ev] if copy_ev is not None else [],
+    )
+    _manager.add_event_pair(ht_ev, getrf_ev)
+
+    if any(dev_info_h):
+        diag_nums = ", ".join(str(v) for v in dev_info_h if v > 0)
+        warn(
+            f"Diagonal number {diag_nums} are exactly zero. Singular matrix.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+    # MKL lapack uses 1-origin while SciPy uses 0-origin
+    ipiv_h -= 1
+
+    # Return a tuple containing the factorized matrix 'a_h',
+    # pivot indices 'ipiv_h'
+    return (a_h, ipiv_h)
 
 
 def dpnp_matrix_power(a, n):

--- a/dpnp/linalg/dpnp_utils_linalg.py
+++ b/dpnp/linalg/dpnp_utils_linalg.py
@@ -2314,10 +2314,10 @@ def dpnp_lu_factor(a, overwrite_a=False, check_finite=True):
         if not dpnp.isfinite(a).all():
             raise ValueError("array must not contain infs or NaNs")
 
-    # if a.ndim > 2:
-    # return _batched_lu_factor_scipy(a, res_type, overwrite_a=overwrite_a)
+    if a.ndim > 2:
+        raise NotImplementedError("Batched matrices are not supported")
 
-    n = a.shape[-2]
+    m, n = a.shape
 
     a_sycl_queue = a.sycl_queue
     a_usm_type = a.usm_type
@@ -2346,7 +2346,7 @@ def dpnp_lu_factor(a, overwrite_a=False, check_finite=True):
         copy_ev = None
 
     ipiv_h = dpnp.empty(
-        n,
+        min(m, n),
         dtype=dpnp.int64,
         order="C",
         usm_type=a_usm_type,

--- a/dpnp/linalg/dpnp_utils_linalg.py
+++ b/dpnp/linalg/dpnp_utils_linalg.py
@@ -39,6 +39,7 @@ available as a pybind11 extension.
 # pylint: disable=useless-import-alias
 
 from typing import NamedTuple
+from warnings import warn
 
 import dpctl.tensor._tensor_impl as ti
 import dpctl.utils as dpu
@@ -986,12 +987,29 @@ def _hermitian_svd(a, compute_uv):
     return dpnp.sort(s)[..., ::-1]
 
 
+def _is_copy_required(a, res_type):
+    """
+    Determine if `a` needs to be copied before LU decomposition.
+    This matches SciPy behavior: copy is needed unless input is suitable
+    for in-place modification.
+    """
+
+    if a.dtype != res_type:
+        return True
+    if not a.flags["F_CONTIGUOUS"]:
+        return True
+    if not a.flags["WRITABLE"]:
+        return True
+
+    return False
+
+
 def _is_empty_2d(arr):
     # check size first for efficiency
     return arr.size == 0 and numpy.prod(arr.shape[-2:]) == 0
 
 
-def _lu_factor(a, res_type):
+def _lu_factor(a, res_type, scipy=False, overwrite_a=False):
     """
     Compute pivoted LU decomposition.
 
@@ -1032,18 +1050,41 @@ def _lu_factor(a, res_type):
 
     a_usm_arr = dpnp.get_usm_ndarray(a)
 
-    # `a` must be copied because getrf destroys the input matrix
-    a_h = dpnp.empty_like(a, order="C", dtype=res_type)
+    if not scipy:
+        # Internal use case (e.g., det(), slogdet()). Always copy.
+        # `a` must be copied because getrf destroys the input matrix
+        a_h = dpnp.empty_like(a, order="C", dtype=res_type)
 
-    # use DPCTL tensor function to fill the сopy of the input array
-    # from the input array
-    ht_ev, copy_ev = ti._copy_usm_ndarray_into_usm_ndarray(
-        src=a_usm_arr,
-        dst=a_h.get_array(),
-        sycl_queue=a_sycl_queue,
-        depends=_manager.submitted_events,
-    )
-    _manager.add_event_pair(ht_ev, copy_ev)
+        # use DPCTL tensor function to fill the сopy of the input array
+        # from the input array
+        ht_ev, copy_ev = ti._copy_usm_ndarray_into_usm_ndarray(
+            src=a_usm_arr,
+            dst=a_h.get_array(),
+            sycl_queue=a_sycl_queue,
+            depends=_manager.submitted_events,
+        )
+        _manager.add_event_pair(ht_ev, copy_ev)
+
+    else:
+        # SciPy-compatible behavior
+        # Copy is required if:
+        # - overwrite_a is False (always copy),
+        # - dtype mismatch,
+        # - not F-contiguous,
+        # - not writeable
+        if not overwrite_a or _is_copy_required(a, res_type):
+            a_h = dpnp.empty_like(a, order="F", dtype=res_type)
+            ht_ev, copy_ev = ti._copy_usm_ndarray_into_usm_ndarray(
+                src=a_usm_arr,
+                dst=a_h.get_array(),
+                sycl_queue=a_sycl_queue,
+                depends=_manager.submitted_events,
+            )
+            _manager.add_event_pair(ht_ev, copy_ev)
+        else:
+            # input is suitable for in-place modification
+            a_h = a
+            copy_ev = None
 
     ipiv_h = dpnp.empty(
         n,
@@ -1061,18 +1102,53 @@ def _lu_factor(a, res_type):
         a_h.get_array(),
         ipiv_h.get_array(),
         dev_info_h,
-        depends=[copy_ev],
+        depends=[copy_ev] if copy_ev is not None else [],
     )
     _manager.add_event_pair(ht_ev, getrf_ev)
 
-    dev_info_array = dpnp.array(
-        dev_info_h, usm_type=a_usm_type, sycl_queue=a_sycl_queue
-    )
+    # Return list if called in SciPy-compatible mode
+    # else dpnp.ndarray
+    if scipy:
+        dev_info_array = dev_info_h
+    else:
+        dev_info_array = dpnp.array(
+            dev_info_h, usm_type=a_usm_type, sycl_queue=a_sycl_queue
+        )
 
     # Return a tuple containing the factorized matrix 'a_h',
     # pivot indices 'ipiv_h'
     # and the status 'dev_info_h' from the LAPACK getrf call
     return (a_h, ipiv_h, dev_info_array)
+
+
+def dpnp_lu_factor(a, overwrite_a=False, check_finite=True):
+    """Compute pivoted LU decomposition."""
+
+    res_type = _common_type(a)
+
+    # accommodate empty arrays
+    if a.size == 0:
+        lu = dpnp.empty_like(a)
+        piv = dpnp.arange(0, dtype=dpnp.int32)
+        return lu, piv
+
+    if check_finite:
+        if not dpnp.isfinite(a).all():
+            raise ValueError("array must not contain infs or NaNs")
+
+    lu, piv, dev_info = _lu_factor(
+        a, res_type, scipy=True, overwrite_a=overwrite_a
+    )
+
+    if any(dev_info):
+        diag_nums = ", ".join(str(v) for v in dev_info if v > 0)
+        warn(
+            f"Diagonal number {diag_nums} are exactly zero. Singular matrix.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+    return lu, piv
 
 
 def _multi_dot(arrays, order, i, j, out=None):

--- a/dpnp/tests/test_linalg.py
+++ b/dpnp/tests/test_linalg.py
@@ -1863,13 +1863,17 @@ class TestLuFactor:
     @staticmethod
     def _apply_pivots_rows(A_dp, piv_dp):
         m = A_dp.shape[0]
-        rows = dpnp.arange(m)
-        for i in range(int(piv_dp.shape[0])):
-            r = int(piv_dp[i].item())
+
+        if m == 0 or piv_dp.size == 0:
+            return A_dp
+
+        rows = list(range(m))
+        piv_np = dpnp.asnumpy(piv_dp)
+        for i, r in enumerate(piv_np):
             if i != r:
-                tmp = rows[i].copy()
-                rows[i] = rows[r]
-                rows[r] = tmp
+                rows[i], rows[r] = rows[r], rows[i]
+
+        rows = dpnp.asarray(rows)
         return A_dp[rows]
 
     @staticmethod

--- a/dpnp/tests/test_linalg.py
+++ b/dpnp/tests/test_linalg.py
@@ -1955,7 +1955,7 @@ class TestLuFactor:
         a2_orig = a2.copy()
         a2.flags["WRITABLE"] = False
 
-        for a_dp, a_orig in zip((a1, a1), (a1_orig, a2_orig)):
+        for a_dp, a_orig in zip((a1, a2), (a1_orig, a2_orig)):
             lu, piv = dpnp.linalg.lu_factor(
                 a_dp, overwrite_a=True, check_finite=False
             )

--- a/dpnp/tests/test_linalg.py
+++ b/dpnp/tests/test_linalg.py
@@ -15,7 +15,6 @@ from numpy.testing import (
 )
 
 import dpnp
-import dpnp.linalg
 
 from .helper import (
     assert_dtype_allclose,
@@ -279,15 +278,12 @@ class TestCholesky:
 
 
 class TestCond:
-    def setup_method(self):
-        numpy.random.seed(70)
+    _norms = [None, -dpnp.inf, -2, -1, 1, 2, dpnp.inf, "fro"]
 
     @pytest.mark.parametrize(
-        "shape", [(0, 4, 4), (4, 0, 3, 3)], ids=["(0, 5, 3)", "(4, 0, 2, 3)"]
+        "shape", [(0, 4, 4), (4, 0, 3, 3)], ids=["(0, 4, 4)", "(4, 0, 3, 3)"]
     )
-    @pytest.mark.parametrize(
-        "p", [None, -dpnp.inf, -2, -1, 1, 2, dpnp.inf, "fro"]
-    )
+    @pytest.mark.parametrize("p", _norms)
     def test_empty(self, shape, p):
         a = numpy.empty(shape)
         ia = dpnp.array(a)
@@ -296,26 +292,27 @@ class TestCond:
         expected = numpy.linalg.cond(a, p=p)
         assert_dtype_allclose(result, expected)
 
+    # TODO: uncomment once numpy 2.3.3 release is published
+    # @testing.with_requires("numpy>=2.3.3")
     @pytest.mark.parametrize(
         "dtype", get_all_dtypes(no_none=True, no_bool=True)
     )
     @pytest.mark.parametrize(
         "shape", [(4, 4), (2, 4, 3, 3)], ids=["(4, 4)", "(2, 4, 3, 3)"]
     )
-    @pytest.mark.parametrize(
-        "p", [None, -dpnp.inf, -2, -1, 1, 2, dpnp.inf, "fro"]
-    )
+    @pytest.mark.parametrize("p", _norms)
     def test_basic(self, dtype, shape, p):
         a = generate_random_numpy_array(shape, dtype)
         ia = dpnp.array(a)
 
         result = dpnp.linalg.cond(ia, p=p)
         expected = numpy.linalg.cond(a, p=p)
+        # TODO: remove when numpy#29333 is released
+        if numpy_version() < "2.3.3":
+            expected = expected.real
         assert_dtype_allclose(result, expected, factor=16)
 
-    @pytest.mark.parametrize(
-        "p", [None, -dpnp.inf, -2, -1, 1, 2, dpnp.inf, "fro"]
-    )
+    @pytest.mark.parametrize("p", _norms)
     def test_bool(self, p):
         a = numpy.array([[True, True], [True, False]])
         ia = dpnp.array(a)
@@ -324,9 +321,7 @@ class TestCond:
         expected = numpy.linalg.cond(a, p=p)
         assert_dtype_allclose(result, expected)
 
-    @pytest.mark.parametrize(
-        "p", [None, -dpnp.inf, -2, -1, 1, 2, dpnp.inf, "fro"]
-    )
+    @pytest.mark.parametrize("p", _norms)
     def test_nan_to_inf(self, p):
         a = numpy.zeros((2, 2))
         ia = dpnp.array(a)
@@ -344,9 +339,7 @@ class TestCond:
         else:
             assert_raises(dpnp.linalg.LinAlgError, dpnp.linalg.cond, ia, p=p)
 
-    @pytest.mark.parametrize(
-        "p", [None, -dpnp.inf, -2, -1, 1, 2, dpnp.inf, "fro"]
-    )
+    @pytest.mark.parametrize("p", _norms)
     @pytest.mark.parametrize(
         "stride",
         [(-2, -3, 2, -2), (-2, 4, -4, -4), (2, 3, 4, 4), (-1, 3, 3, -3)],
@@ -358,21 +351,23 @@ class TestCond:
         ],
     )
     def test_strided(self, p, stride):
-        A = numpy.random.rand(6, 8, 10, 10)
-        B = dpnp.asarray(A)
+        A = generate_random_numpy_array(
+            (6, 8, 10, 10), seed_value=70, low=0, high=1
+        )
+        iA = dpnp.array(A)
         slices = tuple(slice(None, None, stride[i]) for i in range(A.ndim))
-        a = A[slices]
-        b = B[slices]
+        a, ia = A[slices], iA[slices]
 
-        result = dpnp.linalg.cond(b, p=p)
+        result = dpnp.linalg.cond(ia, p=p)
         expected = numpy.linalg.cond(a, p=p)
         assert_dtype_allclose(result, expected, factor=24)
 
-    def test_error(self):
+    @pytest.mark.parametrize("xp", [dpnp, numpy])
+    def test_error(self, xp):
         # cond is not defined on empty arrays
-        ia = dpnp.empty((2, 0))
+        a = xp.empty((2, 0))
         with pytest.raises(ValueError):
-            dpnp.linalg.cond(ia, p=1)
+            xp.linalg.cond(a, p=1)
 
 
 class TestDet:

--- a/dpnp/tests/test_sycl_queue.py
+++ b/dpnp/tests/test_sycl_queue.py
@@ -1570,6 +1570,18 @@ class TestLinAlgebra:
             assert_sycl_queue_equal(param_queue, a.sycl_queue)
             assert_sycl_queue_equal(param_queue, b.sycl_queue)
 
+    @pytest.mark.parametrize(
+        "data",
+        [[[1.0, 2.0], [3.0, 5.0]], [[]]],
+    )
+    def test_lu_factor(self, data, device):
+        a = dpnp.array(data, device=device)
+        result = dpnp.linalg.lu_factor(a)
+
+        for param in result:
+            param_queue = param.sycl_queue
+            assert_sycl_queue_equal(param_queue, a.sycl_queue)
+
     @pytest.mark.parametrize("n", [-1, 0, 1, 2, 3])
     def test_matrix_power(self, n, device):
         x = dpnp.array([[1.0, 2.0], [3.0, 5.0]], device=device)

--- a/dpnp/tests/test_usm_type.py
+++ b/dpnp/tests/test_usm_type.py
@@ -1449,6 +1449,18 @@ class TestLinAlgebra:
                 [usm_type, usm_type_other]
             )
 
+    @pytest.mark.parametrize(
+        "data",
+        [[[1.0, 2.0], [3.0, 5.0]], [[]]],
+    )
+    def test_lu_factor(self, data, usm_type):
+        a = dpnp.array(data, usm_type=usm_type)
+        result = dpnp.linalg.lu_factor(a)
+
+        assert a.usm_type == usm_type
+        for param in result:
+            assert param.usm_type == a.usm_type
+
     @pytest.mark.parametrize("n", [-1, 0, 1, 2, 3])
     def test_matrix_power(self, n, usm_type):
         a = dpnp.array([[1, 2], [3, 5]], usm_type=usm_type)


### PR DESCRIPTION
This PR suggests adding `dpnp.linalg.lu_factor()` for 2D arrays similar to `scipy.linalg.lu_factor` 
Support for ND inputs will be added in the next phase.

In addition, this PR includes:

1. An updated implementation of `getrf` to support non-square matrices.
2. Refactoring of `_lu_factor()` by splitting the logic into separate functions to improve readability and maintainability.



- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
