### PR TITLE
Enable a workflow with OpenSSF Scorecard report to be triggered manually

### DIFF
--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -7,13 +7,16 @@ on:
   # For Branch-Protection check. Only the default branch is supported. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
   branch_protection_rule:
+  # To be able to be triggered manually
+  workflow_dispatch:
   # To guarantee Maintained check is occasionally updated. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
     - cron: '28 2 * * 1'
     - cron: '28 2 * * 4'
   push:
-    branches: [ "master" ]
+    branches:
+      - master
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
The PR adds `workflow_dispatch` to `openssf-scorecard.yml` workflow.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
