### PR TITLE
Remove workflow trigger on change in branch protection rules

### DIFF
--- a/.github/workflows/cron-run-tests.yaml
+++ b/.github/workflows/cron-run-tests.yaml
@@ -1,13 +1,11 @@
 name: Run tests suite
 on:
-  # For Branch-Protection check. Only the default branch is supported. See
-  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
-  branch_protection_rule:
+  # To be able to be triggered manually
+  workflow_dispatch:
   # To guarantee Maintained check is occasionally updated. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
     - cron: '28 2 * * *'
-  workflow_dispatch:
 
 permissions: read-all
 

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -1,14 +1,12 @@
 name: Autoupdate pre-commit
 
 on:
-  # For Branch-Protection check. Only the default branch is supported. See
-  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
-  branch_protection_rule:
+  # To be able to be triggered manually
+  workflow_dispatch:
   # To guarantee Maintained check is occasionally updated. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
     - cron: '28 2 * * 6' # Saturday at 02:28 UTC
-  workflow_dispatch:
 
 jobs:
   autoupdate:


### PR DESCRIPTION
There is no need to trigger workflows with `Autoupdate pre-commit` and `Run tests suite` on any change in branch protection rules. That trigger was intended only to `Scorecard supply-chain security` workflow.
Thus the PR removes that triggers.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
