### PR TITLE
Temporary skip bached cholesky tests failing on win dg2

### DIFF
--- a/dpnp/tests/helper.py
+++ b/dpnp/tests/helper.py
@@ -464,6 +464,14 @@ def is_lts_driver(device=None):
     return dev.has_aspect_gpu and "1.3" in dev.driver_version
 
 
+def is_dg2(device=None):
+    """
+    Return True if a test is running on DG2 (Intel Arc Alchemist family) GPU device,
+    False otherwise.
+    """
+    return _get_dev_mask(device) in (0x4F00, 0x5600)
+
+
 def is_ptl(device=None):
     """
     Return True if a test is running on Panther Lake with Iris Xe3 GPU device,

--- a/dpnp/tests/test_linalg.py
+++ b/dpnp/tests/test_linalg.py
@@ -23,7 +23,8 @@ from .helper import (
     get_float_complex_dtypes,
     get_integer_float_dtypes,
     has_support_aspect64,
-    is_cpu_device,
+    is_dg2,
+    is_win_platform,
     numpy_version,
 )
 from .third_party.cupy import testing
@@ -158,6 +159,8 @@ class TestCholesky:
     def test_cholesky(self, array, dtype):
         a = numpy.array(array, dtype=dtype)
         ia = dpnp.array(a)
+        if ia.ndim > 2 and is_win_platform() and is_dg2():
+            pytest.skip("SAT-8206")
         result = dpnp.linalg.cholesky(ia)
         expected = numpy.linalg.cholesky(a)
         assert_dtype_allclose(result, expected)
@@ -177,6 +180,8 @@ class TestCholesky:
     @pytest.mark.parametrize("dtype", get_all_dtypes(no_bool=True))
     def test_cholesky_upper(self, array, dtype):
         ia = dpnp.array(array, dtype=dtype)
+        if ia.ndim > 2 and is_win_platform() and is_dg2():
+            pytest.skip("SAT-8206")
         result = dpnp.linalg.cholesky(ia, upper=True)
 
         if ia.ndim > 2:
@@ -219,6 +224,8 @@ class TestCholesky:
     def test_cholesky_upper_numpy(self, array, dtype):
         a = numpy.array(array, dtype=dtype)
         ia = dpnp.array(a)
+        if ia.ndim > 2 and is_win_platform() and is_dg2():
+            pytest.skip("SAT-8206")
         result = dpnp.linalg.cholesky(ia, upper=True)
         expected = numpy.linalg.cholesky(a, upper=True)
         assert_dtype_allclose(result, expected)

--- a/dpnp/tests/test_sycl_queue.py
+++ b/dpnp/tests/test_sycl_queue.py
@@ -12,7 +12,12 @@ import dpnp
 from dpnp.dpnp_array import dpnp_array
 from dpnp.dpnp_utils import get_usm_allocations
 
-from .helper import generate_random_numpy_array, get_all_dtypes, is_win_platform
+from .helper import (
+    generate_random_numpy_array,
+    get_all_dtypes,
+    is_dg2,
+    is_win_platform,
+)
 
 list_of_backend_str = ["cuda", "host", "level_zero", "opencl"]
 
@@ -1488,6 +1493,8 @@ class TestLinAlgebra:
         else:
             dtype = dpnp.default_float_type(device)
             x = dpnp.array(data, dtype=dtype, device=device)
+            if x.ndim > 2 and is_win_platform() and is_dg2():
+                pytest.skip("SAT-8206")
 
         result = dpnp.linalg.cholesky(x)
         assert_sycl_queue_equal(result.sycl_queue, x.sycl_queue)

--- a/dpnp/tests/test_usm_type.py
+++ b/dpnp/tests/test_usm_type.py
@@ -10,7 +10,7 @@ import pytest
 import dpnp
 from dpnp.dpnp_utils import get_usm_allocations
 
-from .helper import generate_random_numpy_array, is_win_platform
+from .helper import generate_random_numpy_array, is_dg2, is_win_platform
 
 list_of_usm_types = ["device", "shared", "host"]
 
@@ -1341,6 +1341,8 @@ class TestLinAlgebra:
             x = dpnp.empty(data, dtype=dtype, usm_type=usm_type)
         else:
             x = dpnp.array(data, dtype=dtype, usm_type=usm_type)
+            if x.ndim > 2 and is_win_platform() and is_dg2():
+                pytest.skip("SAT-8206")
 
         result = dpnp.linalg.cholesky(x)
         assert x.usm_type == result.usm_type

--- a/dpnp/tests/third_party/cupy/linalg_tests/test_decomposition.py
+++ b/dpnp/tests/third_party/cupy/linalg_tests/test_decomposition.py
@@ -7,6 +7,8 @@ import dpnp as cupy
 from dpnp.tests.helper import (
     has_support_aspect64,
     is_cpu_device,
+    is_dg2,
+    is_win_platform,
 )
 from dpnp.tests.third_party.cupy import testing
 from dpnp.tests.third_party.cupy.testing import _condition
@@ -82,6 +84,7 @@ class TestCholeskyDecomposition:
         # np.linalg.cholesky only uses a lower triangle of an array
         self.check_L(numpy.array([[1, 2], [1, 9]], dtype))
 
+    @pytest.mark.skipif(is_win_platform() and is_dg2(), reason="SAT-8206")
     @testing.for_dtypes(
         [
             numpy.int32,


### PR DESCRIPTION
The PR proposes to skip tests (**dpnp.linalg.cholesky() batch**) which are failing in internal CI due to known issue on Intel Arc Alchemist family GPU windows 

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
