### PR TITLE
Suppress `RuntimeWarning` in tests

### DIFF
--- a/dpnp/tests/test_strides.py
+++ b/dpnp/tests/test_strides.py
@@ -182,6 +182,7 @@ def test_erf(dtype):
     assert_dtype_allclose(result, expected)
 
 
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
 @pytest.mark.parametrize("stride", [2, -1, -3])
 def test_reciprocal(dtype, stride):

--- a/dpnp/tests/test_umath.py
+++ b/dpnp/tests/test_umath.py
@@ -445,7 +445,7 @@ class TestRadians:
 
 
 class TestReciprocal:
-    @pytest.mark.usefixtures("suppress_divide_numpy_warnings")
+    @pytest.mark.filterwarnings("ignore::RuntimeWarning")
     @pytest.mark.parametrize("dtype", get_float_complex_dtypes())
     def test_reciprocal(self, dtype):
         a = generate_random_numpy_array(10, dtype)

--- a/dpnp/tests/third_party/cupy/math_tests/test_arithmetic.py
+++ b/dpnp/tests/third_party/cupy/math_tests/test_arithmetic.py
@@ -134,6 +134,7 @@ class TestArithmeticRaisesWithNumpyInput:
 )
 class TestArithmeticUnary:
 
+    @pytest.mark.filterwarnings("ignore::RuntimeWarning")
     @testing.numpy_cupy_allclose(atol=1e-5, type_check=has_support_aspect64())
     def test_unary(self, xp):
         arg1 = self.arg1

--- a/dpnp/tests/third_party/cupy/math_tests/test_misc.py
+++ b/dpnp/tests/third_party/cupy/math_tests/test_misc.py
@@ -250,6 +250,7 @@ class TestMisc:
     def test_nan_to_num_negative_for_old_numpy(self):
         self.check_unary_negative("nan_to_num", no_bool=True)
 
+    @pytest.mark.filterwarnings("ignore::RuntimeWarning")
     def test_nan_to_num_inf(self):
         self.check_unary_inf("nan_to_num")
 
@@ -260,6 +261,7 @@ class TestMisc:
     def test_nan_to_num_scalar_nan(self, xp):
         return xp.nan_to_num(xp.array(xp.nan))
 
+    @pytest.mark.filterwarnings("ignore::RuntimeWarning")
     def test_nan_to_num_inf_nan(self):
         self.check_unary_inf_nan("nan_to_num")
 


### PR DESCRIPTION
The PR suppresses new `RuntimeWarning` numpy raises in the tests.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
