### PR TITLE
Exclude testing with scipy in the env with python 3.9

### DIFF
--- a/.github/workflows/cron-run-tests.yaml
+++ b/.github/workflows/cron-run-tests.yaml
@@ -39,6 +39,16 @@ jobs:
       matrix:
         python: ['3.9', '3.10', '3.11', '3.12', '3.13']
         runner: [ubuntu-22.04, ubuntu-24.04, windows-2022]
+        include:
+          - python: 3.9
+            # do not install scipy due to import issue
+            test-packages: "pytest"
+          - python: 3.10
+            test-packages: "pytest scipy"
+          - python: 3.11
+            test-packages: "pytest scipy"
+          - python: 3.12
+            test-packages: "pytest scipy"
 
     steps:
       - name: Cancel Previous Runs
@@ -84,12 +94,12 @@ jobs:
         id: install_dpnp
         continue-on-error: true
         run: |
-          mamba install ${{ env.package-name }}=${{ steps.find_latest_tag.outputs.tag }} pytest scipy ${{ env.channels-list }}
+          mamba install ${{ env.package-name }}=${{ steps.find_latest_tag.outputs.tag }} ${{ matrix.test-packages }} ${{ env.channels-list }}
 
       - name: ReInstall dpnp
         if: steps.install_dpnp.outcome == 'failure'
         run: |
-          mamba install ${{ env.package-name }}=${{ steps.find_latest_tag.outputs.tag }} pytest scipy ${{ env.channels-list }}
+          mamba install ${{ env.package-name }}=${{ steps.find_latest_tag.outputs.tag }} ${{ matrix.test-packages }} ${{ env.channels-list }}
 
       - name: List installed packages
         run: mamba list

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -63,7 +63,7 @@ test:
     requires:
       - pytest
       - setuptools
-      - scipy
+      - scipy # [py>39]
 
 about:
     home: https://github.com/IntelPython/dpnp


### PR DESCRIPTION
The PR excludes running scipy relating tests from the scope, because there is the scipy import issue:
```bash
  File "/home/runner/miniconda3/envs/test/lib/python3.9/site-packages/dpctl/__init__.py", line 51, in <module>
    from ._sycl_queue import (
  File "dpctl/_sycl_queue.pyx", line 1, in init dpctl._sycl_queue
  File "/home/runner/miniconda3/envs/test/lib/python3.9/site-packages/dpctl/memory/__init__.py", line 31, in <module>
    from ._memory import (
  File "dpctl/memory/_memory.pyx", line 69, in init dpctl.memory._memory
  File "/home/runner/miniconda3/envs/test/lib/python3.9/site-packages/numpy/__init__.py", line 155, in <module>
    from . import fft
  File "/home/runner/miniconda3/envs/test/lib/python3.9/site-packages/numpy/fft/__init__.py", line 215, in <module>
    import mkl_fft.interfaces.numpy_fft as _nfft
  File "/home/runner/miniconda3/envs/test/lib/python3.9/site-packages/mkl_fft/__init__.py", line 45, in <module>
    import mkl_fft.interfaces  # isort: skip
  File "/home/runner/miniconda3/envs/test/lib/python3.9/site-packages/mkl_fft/interfaces/__init__.py", line 29, in <module>
    import scipy.fft
  File "/home/runner/miniconda3/envs/test/lib/python3.9/site-packages/scipy/__init__.py", line 110, in <module>
    __all__.remove('linalg')
ValueError: list.remove(x): x not in list
```
when installing the packages from `https://software.repos.intel.com/python/conda/` channel.

The support of python 3.9 for scipy was stopped to upload there for a long time ago and the latest available is scipy 1.8.1 which is too old and has the import issue.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
