### PR TITLE
Clarify order of indices returned in `dpnp.tril_indices` and `dpnp.triu_indices`

### DIFF
--- a/dpnp/dpnp_iface_indexing.py
+++ b/dpnp/dpnp_iface_indexing.py
@@ -2375,8 +2375,9 @@ def tril_indices(
     Returns
     -------
     inds : tuple of dpnp.ndarray
-        The indices for the triangle. The returned tuple contains two arrays,
-        each with the indices along one dimension of the array.
+        The row and column indices, respectively. The row indices are sorted in
+        non-decreasing order, and the corresponding column indices are strictly
+        increasing for each row.
 
     See Also
     --------
@@ -2394,7 +2395,13 @@ def tril_indices(
 
     >>> import dpnp as np
     >>> il1 = np.tril_indices(4)
-    >>> il2 = np.tril_indices(4, 2)
+    >>> il1
+    (array([0, 1, 1, 2, 2, 2, 3, 3, 3, 3]),
+     array([0, 0, 1, 0, 1, 2, 0, 1, 2, 3]))
+
+    Note that row indices (first array) are non-decreasing, and the
+    corresponding column indices (second array) are strictly increasing for
+    each row.
 
     Here is how they can be used with a sample array:
 
@@ -2421,6 +2428,7 @@ def tril_indices(
 
     These cover almost the whole array (two diagonals right of the main one):
 
+    >>> il2 = np.tril_indices(4, 2)
     >>> a[il2] = -10
     >>> a
     array([[-10, -10, -10,   3],
@@ -2584,9 +2592,9 @@ def triu_indices(
     Returns
     -------
     inds : tuple of dpnp.ndarray
-        The indices for the triangle. The returned tuple contains two arrays,
-        each with the indices along one dimension of the array. Can be used
-        to slice a ndarray of shape(`n`, `n`).
+        The row and column indices, respectively. The row indices are sorted in
+        non-decreasing order, and the corresponding column indices are strictly
+        increasing for each row.
 
     See Also
     --------
@@ -2604,7 +2612,13 @@ def triu_indices(
 
     >>> import dpnp as np
     >>> iu1 = np.triu_indices(4)
-    >>> iu2 = np.triu_indices(4, 2)
+    >>> iu1
+    (array([0, 0, 0, 0, 1, 1, 1, 2, 2, 3]),
+     array([0, 1, 2, 3, 1, 2, 3, 2, 3, 3]))
+
+    Note that row indices (first array) are non-decreasing, and the
+    corresponding column indices (second array) are strictly increasing for
+    each row.
 
     Here is how they can be used with a sample array:
 
@@ -2632,6 +2646,7 @@ def triu_indices(
     These cover only a small part of the whole array (two diagonals right
     of the main one):
 
+    >>> iu2 = np.triu_indices(4, 2)
     >>> a[iu2] = -10
     >>> a
     array([[ -1,  -1, -10, -10],


### PR DESCRIPTION
The PR updates docstrings to clarify the order of indices returned by the functions.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
