### PR TITLE
Follow up the fix implemented in gh-2530 to fix `dpnp.unique` with axis=0 and 1d input

### DIFF
--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -4270,7 +4270,13 @@ def unique(
 
     """
 
-    if axis is None or (axis == 0 and ar.ndim == 1):
+    dpnp.check_supported_arrays_type(ar)
+    nd = ar.ndim
+
+    if axis is None or nd == 1:
+        if axis is not None:
+            normalize_axis_index(axis, nd)
+
         return _unique_1d(
             ar, return_index, return_inverse, return_counts, equal_nan
         )
@@ -4280,7 +4286,7 @@ def unique(
         ar = dpnp.moveaxis(ar, axis, 0)
     except AxisError:
         # this removes the "axis1" or "axis2" prefix from the error message
-        raise AxisError(axis, ar.ndim) from None
+        raise AxisError(axis, nd) from None
 
     # reshape input array into a contiguous 2D array
     orig_sh = ar.shape

--- a/dpnp/tests/test_manipulation.py
+++ b/dpnp/tests/test_manipulation.py
@@ -1852,16 +1852,27 @@ class TestUnique:
 
     # TODO: uncomment once numpy 2.4.0 release is published
     # @testing.with_requires("numpy>=2.4.0")
-    def test_1d_equal_nan_axis0(self):
+    @pytest.mark.parametrize("axis", [0, -1])
+    def test_1d_equal_nan_axis(self, axis):
         a = numpy.array([numpy.nan, 0, 0, numpy.nan])
         ia = dpnp.array(a)
 
-        result = dpnp.unique(ia, axis=0, equal_nan=True)
-        expected = numpy.unique(a, axis=0, equal_nan=True)
+        result = dpnp.unique(ia, axis=axis, equal_nan=True)
+        expected = numpy.unique(a, axis=axis, equal_nan=True)
         # TODO: remove when numpy#29372 is released
         if numpy_version() < "2.4.0":
             expected = numpy.array([0.0, numpy.nan])
         assert_array_equal(result, expected)
+
+    # TODO: uncomment once numpy 2.4.0 release is published
+    # @testing.with_requires("numpy>=2.4.0")
+    @pytest.mark.parametrize("equal_nan", [True, False])
+    # @pytest.mark.parametrize("xp", [numpy, dpnp])
+    @pytest.mark.parametrize("xp", [dpnp])
+    def test_1d_axis_float_raises_typeerror(self, xp, equal_nan):
+        a = xp.array([xp.nan, 0, 0, xp.nan])
+        with pytest.raises(TypeError, match="integer argument expected"):
+            xp.unique(a, axis=0.0, equal_nan=equal_nan)
 
     @testing.with_requires("numpy>=2.0.1")
     @pytest.mark.parametrize("dt", get_float_complex_dtypes())


### PR DESCRIPTION
The PR improves the fix implemented in `dpnp.unique` for axis=0 and 1d input.
Also it adds an explicit validation in case of floating axis passed.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
