### PR TITLE
Resolve tests failures in rounding functions with numpy 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed `dpnp.linalg.cond` to always return a real dtype [#2547](https://github.com/IntelPython/dpnp/pull/2547)
 * Resolved the issue in `dpnp.random` functions to allow any value of `size` where each element is castable to `Py_ssize_t` type [#2578](https://github.com/IntelPython/dpnp/pull/2578)
 * Resolved `conda build --test` issue in python 3.9 environment [#2583](https://github.com/IntelPython/dpnp/pull/2583)
+* Fixed tests for the rounding functions to depend on minimum required numpy version [#2589](https://github.com/IntelPython/dpnp/pull/2589)
 
 ### Security
 

--- a/dpnp/tests/test_mathematical.py
+++ b/dpnp/tests/test_mathematical.py
@@ -2302,6 +2302,7 @@ class TestProjection:
 
 @pytest.mark.parametrize("func", ["ceil", "floor", "trunc", "fix"])
 class TestRoundingFuncs:
+    @testing.with_requires("numpy>=2.1.0")
     @pytest.mark.parametrize(
         "dt", get_all_dtypes(no_none=True, no_complex=True)
     )


### PR DESCRIPTION
There is data type mismatch in result returned for the rounding functions, because numpy.ceil, numpy.floor, numpy.trunc, and numpy.fix always returns floating dtype for "numpy < 2.1.0".

The dpnp behavior is aligned with "numpy >= 2.1.0", so this PR adds a missing fixture to run the test depending on minimum required numpy version.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
