### PR TITLE
Define token permissions in "Autoupdate pre-commit" workflow

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -8,12 +8,19 @@ on:
   schedule:
     - cron: '28 2 * * 6' # Saturday at 02:28 UTC
 
+permissions: read-all
+
 jobs:
   autoupdate:
     name: Autoupdate
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
+
+    permissions:
+      # Needed to create a PR with autoupdate changes
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout DPNP repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Resolved the issue in `dpnp.random` functions to allow any value of `size` where each element is castable to `Py_ssize_t` type [#2578](https://github.com/IntelPython/dpnp/pull/2578)
 * Resolved `conda build --test` issue in python 3.9 environment [#2583](https://github.com/IntelPython/dpnp/pull/2583)
 * Fixed tests for the rounding functions to depend on minimum required numpy version [#2589](https://github.com/IntelPython/dpnp/pull/2589)
+* Added missing permission definition in `Autoupdate pre-commit` GitHub workflow [#2591](https://github.com/IntelPython/dpnp/pull/2591)
 
 ### Security
 


### PR DESCRIPTION
The PR adds missing permission definition for "Autoupdate pre-commit" workflow which impacts OpenSSF scope.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
