### PR TITLE
Add installation of missing packages for python 3.13 in `cron-run-tests.yaml`

### DIFF
--- a/.github/workflows/cron-run-tests.yaml
+++ b/.github/workflows/cron-run-tests.yaml
@@ -49,6 +49,8 @@ jobs:
             test-packages: "pytest scipy"
           - python: 3.12
             test-packages: "pytest scipy"
+          - python: 3.13
+            test-packages: "pytest scipy"
 
     steps:
       - name: Cancel Previous Runs


### PR DESCRIPTION
The PR installs missing pytest and scipy packages in the test environment of GitHub action `cron-run-tests.yaml`.
It resolves the issue introduced in #2583.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
