### PR TITLE
Avoid generating singular matrices in TestLuFactor/TestLuFactorBatched

### DIFF
--- a/dpnp/tests/test_linalg.py
+++ b/dpnp/tests/test_linalg.py
@@ -2144,7 +2144,7 @@ class TestLuFactorBatched:
         a_np = self._make_nonsingular_nd_np(
             (5, 3, 3), dpnp.default_float_type(), "F"
         )
-        a_dp = dpnp.array(a_np, order=order)
+        a_dp = dpnp.array(a_np, order="F")
         a_stride = a_dp[::2]
         lu, piv = dpnp.linalg.lu_factor(a_stride, check_finite=False)
         for i in range(a_stride.shape[0]):

--- a/dpnp/tests/test_linalg.py
+++ b/dpnp/tests/test_linalg.py
@@ -2054,9 +2054,8 @@ class TestLuFactorBatched:
                 B[i, i] = A.dtype.type(off + 1.0)
 
         A = A3.reshape(shape)
-        # A3.reshape returns an array in C order by default
-        if order != "C":
-            A = numpy.array(A, order=order)
+        # Ensure reshapes did not break memory order
+        A = numpy.array(A, order=order)
         return A
 
     @staticmethod


### PR DESCRIPTION
This PR suggests adding `_make_nonsingular_np` and ``_make_nonsingular_nd_np functions to `TestLuFactor` and `TestLuFactorBatched` to ensure the generation of non-singular matrices and avoid warnings in test log 


- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
