### PR TITLE
Bump conda-build to `25.9.0` version

### DIFF
--- a/environments/build_conda_pkg.yml
+++ b/environments/build_conda_pkg.yml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - python=3.13
-  - conda-build=25.7.0
+  - conda-build=25.9.0


### PR DESCRIPTION
The PR updates `conda-build` version from `25.7.0` to `25.9.0`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
