### PR TITLE
Pin to the lates dpctl release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.19.0] - 2025-MM-DD
+## [0.19.0] - 2025-10-06
 
 This release introduces a set of new `dpnp.ndarray` methods and SciPy-compatible functions to improve CuPy compatibility.
 It also enhances the performance of existing functions and improves documentation completeness.

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,5 +1,5 @@
 numpy:
-    - '1.25'
+    - '1.26'
 c_compiler:                   # [linux]
     - gcc                     # [linux]
 cxx_compiler:                 # [linux]

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set max_compiler_and_mkl_version = environ.get("MAX_BUILD_CMPL_MKL_VERSION", "2026.0a0") %}
 {% set required_compiler_and_mkl_version = "2025.0" %}
-{% set required_dpctl_version = "0.21.0*" %}
+{% set required_dpctl_version = "0.21.0" %}
 
 {% set pyproject = load_file_data('pyproject.toml') %}
 {% set py_build_deps = pyproject.get('build-system', {}).get('requires', []) %}

--- a/dpnp/tests/test_arraycreation.py
+++ b/dpnp/tests/test_arraycreation.py
@@ -938,12 +938,9 @@ def test_logspace(dtype, num, endpoint):
     assert_allclose(dpnp_res, np_res, rtol=1e-06)
 
 
+@testing.with_requires("numpy>=1.25.0")
 @pytest.mark.parametrize("axis", [0, 1])
 def test_logspace_axis(axis):
-    if numpy.lib.NumpyVersion(numpy.__version__) < "1.25.0":
-        pytest.skip(
-            "numpy.logspace supports a non-scalar base argument since 1.25.0"
-        )
     func = lambda xp: xp.logspace(
         [2, 3], [20, 15], num=2, base=[[1, 3], [5, 7]], axis=axis
     )

--- a/environments/dpctl_pkg.txt
+++ b/environments/dpctl_pkg.txt
@@ -1,2 +1,2 @@
 --index-url https://pypi.anaconda.org/dppy/label/dev/simple
-dpctl>=0.21.0dev0
+dpctl>=0.21.0

--- a/environments/dpctl_pkg.yml
+++ b/environments/dpctl_pkg.yml
@@ -2,4 +2,4 @@ name: Install dpctl package
 channels:
   - dppy/label/dev
 dependencies:
-  - dpctl>=0.21.0dev0
+  - dpctl>=0.21.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
   "dpctl>=0.21.0",
   "ninja>=1.11.1; platform_system!='Windows'",
   # NOTE: no DPNP restriction on NumPy version, so follow NumPy's drop schedule
-  "numpy>=1.25.0",
+  "numpy>=1.26.0",
   "scikit-build>=0.18.1",
   "setuptools>=79.0.1",
   "wheel>=0.45.1",
@@ -50,7 +50,7 @@ dependencies = [
   # "intel-cmplr-lib-rt>=0.59.0"
   # WARNING: use the latest dpctl dev version, otherwise stable w/f will fail
   "dpctl>=0.21.0",
-  "numpy>=1.25.0"
+  "numpy>=1.26.0"
 ]
 description = "Data Parallel Extension for NumPy"
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,7 @@ requires = [
   "build>=1.2.2",
   "cmake>=3.31.6",
   "cython>=3.0.12",
-  # WARNING: use only dpctl version available on PyPi
-  "dpctl>=0.19.0",
+  "dpctl>=0.21.0",
   "ninja>=1.11.1; platform_system!='Windows'",
   # NOTE: no DPNP restriction on NumPy version, so follow NumPy's drop schedule
   "numpy>=1.25.0",
@@ -50,7 +49,7 @@ dependencies = [
   # "dpcpp-cpp-rt>=0.59.0",
   # "intel-cmplr-lib-rt>=0.59.0"
   # WARNING: use the latest dpctl dev version, otherwise stable w/f will fail
-  "dpctl>=0.21.0dev0",
+  "dpctl>=0.21.0",
   "numpy>=1.25.0"
 ]
 description = "Data Parallel Extension for NumPy"


### PR DESCRIPTION
The PR pins to the lates dpctl release version `0.20.0`.
Also it sets the release to today and bumps minimum supported NumPy version to 1.26 base on [NEP-0029](https://numpy.org/neps/nep-0029-deprecation_policy.html).

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
