### PR TITLE
Increase swap size up to 8GB in GitHub runners

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -139,6 +139,11 @@ jobs:
       ver-json-path: '${{ github.workspace }}/version.json'
 
     steps:
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@49819abfb41bd9b44fb781159c033dba90353a7c # v1.0
+        with:
+          swap-size-gb: 8
+
       - name: Checkout DPNP repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:


### PR DESCRIPTION
There are out-of-memory issues observing when running dpnp tests in parallel with `pytest-xdist` and `-n auto`.
The default swap size was set to 4 GB for Linux runners and it seems not enough to have the parallel tests run, which caused:
> node down: Not properly terminated

The PR proposes to increase the swap size for Linux runners up to 8 GB. That makes the tests run more stable.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
