### PR TITLE
Explicitly set python version in GitHub workflow for testing with `oneMath`

### DIFF
--- a/.github/workflows/check-onemath.yaml
+++ b/.github/workflows/check-onemath.yaml
@@ -100,6 +100,7 @@ jobs:
           miniforge-version: latest
           use-mamba: 'true'
           conda-remove-defaults: 'true'
+          python-version: ${{ matrix.python }}
           environment-file: ${{ env.environment-file }}
           activate-environment: ${{ env.test-env-name }}
 
@@ -110,6 +111,7 @@ jobs:
           miniforge-version: latest
           use-mamba: 'true'
           conda-remove-defaults: 'true'
+          python-version: ${{ matrix.python }}
           environment-file: ${{ env.environment-file }}
           activate-environment: ${{ env.test-env-name }}
 
@@ -204,6 +206,7 @@ jobs:
           miniforge-version: latest
           use-mamba: 'true'
           conda-remove-defaults: 'true'
+          python-version: ${{ matrix.python }}
           environment-file: ${{ env.environment-file }}
           activate-environment: ${{ env.test-env-name }}
 
@@ -214,6 +217,7 @@ jobs:
           miniforge-version: latest
           use-mamba: 'true'
           conda-remove-defaults: 'true'
+          python-version: ${{ matrix.python }}
           environment-file: ${{ env.environment-file }}
           activate-environment: ${{ env.test-env-name }}
 


### PR DESCRIPTION
The PR updates `conda-incubator/setup-miniconda` step in the GH workflow for testing with `oneMath` to explicitly set python version the same as defined in testing matrix, otherwise the latest available python will be taken.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
