### PR TITLE
Bump oneMath version to v0.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,7 +215,7 @@ if(_use_onemath)
             onemath_library
             GIT_REPOSITORY https://github.com/uxlfoundation/oneMath.git
             GIT_TAG
-                6ff3a43e555dbb20357017d48f0f6c6263259895  # v0.9
+                6ff3a43e555dbb20357017d48f0f6c6263259895 # v0.9
         )
     endif()
 


### PR DESCRIPTION
The PR bumps `oneMath` version to `v0.9`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
