### PR TITLE
Align erf-like tests with `scipy>=0.16.0`

### DIFF
--- a/dpnp/tests/test_special.py
+++ b/dpnp/tests/test_special.py
@@ -29,7 +29,7 @@ class TestCommon:
         expected = getattr(scipy.special, func)(a)
 
         # scipy >= 0.16.0 returns float64, but dpnp returns float32
-        to_float32 = dt in (dpnp.bool, dpnp.float16)
+        to_float32 = dpnp.result_type(dt, dpnp.float32) == dpnp.float32
         only_type_kind = installed("scipy>=0.16.0") and to_float32
         assert_dtype_allclose(
             result, expected, check_only_type_kind=only_type_kind


### PR DESCRIPTION
The PR updates a test for erf functions to consider setting `DPNP_TEST_ALL_INT_TYPES=1` during the tests run with the latest SciPy installed in the test env.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
