### PR TITLE
Add w/a to missing script in `intel-opencl-rt` package from conda-forge

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -355,7 +355,7 @@ jobs:
           MAMBA_NO_LOW_SPEED_LIMIT: 1
 
       - name: Install OCL CPU RT from Intel channel
-        run: mamba install intel-opencl-rt=*=intel_* -c ${{ env.channels-list }}
+        run: mamba install intel-opencl-rt=*=intel_* ${{ env.channels-list }}
 
       - name: List installed packages
         run: mamba list

--- a/.github/workflows/cron-run-tests.yaml
+++ b/.github/workflows/cron-run-tests.yaml
@@ -93,7 +93,7 @@ jobs:
           mamba install ${{ env.package-name }}=${{ steps.find_latest_tag.outputs.tag }} ${{ env.test-packages }} ${{ env.channels-list }}
 
       - name: Install OCL CPU RT from Intel channel
-        run: mamba install intel-opencl-rt=*=intel_* -c ${{ env.channels-list }}
+        run: mamba install intel-opencl-rt=*=intel_* ${{ env.channels-list }}
 
       - name: List installed packages
         run: mamba list


### PR DESCRIPTION
There are missing `set-intel-ocl-icd-registry.ps1` and `unset-intel-ocl-icd-registry.ps1` scripts when installing `intel-opencl-rt` package from the conda-forge ([intel-compiler-repack-feedstock/#72](https://github.com/conda-forge/intel-compiler-repack-feedstock/issues/72)).

This PR implements a temporary w/a until the issue is resolved. The w/a assumes to force `intel-opencl-rt` installation from Intel channel.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
