### PR TITLE
Temporary mute tests failing with numpy 2.4

### DIFF
--- a/dpnp/tests/test_ndarray.py
+++ b/dpnp/tests/test_ndarray.py
@@ -532,6 +532,7 @@ def test_print_dpnp_zero_shape():
 
 # Numpy will raise an error when converting a.ndim > 0 to a scalar
 # TODO: Discuss dpnp behavior according to these future changes
+@pytest.mark.skip("until dpctl-2223")
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.mark.parametrize("func", [bool, float, int, complex])
 @pytest.mark.parametrize("shape", [tuple(), (1,), (1, 1), (1, 1, 1)])
@@ -547,6 +548,7 @@ def test_scalar_type_casting(func, shape, dtype):
 # Numpy will raise an error when converting a.ndim > 0 to a scalar
 # TODO: Discuss dpnp behavior according to these future changes
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.skip("until dpctl-2223")
 @pytest.mark.parametrize(
     "method", ["__bool__", "__float__", "__int__", "__complex__"]
 )


### PR DESCRIPTION
This PR is aimed to unblock the CI and to temporary mute tests failing with numpy 2.4.
The changes needs to be reverted once [dpctl-2223](https://github.com/IntelPython/dpctl/pull/2223) is merged and dpnp tests will be updated appropriately.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
