### PR TITLE
Mute tests with `dpnp.cumlogsumexp`

### DIFF
--- a/dpnp/tests/test_mathematical.py
+++ b/dpnp/tests/test_mathematical.py
@@ -34,7 +34,6 @@ from .helper import (
     has_support_aspect64,
     is_intel_numpy,
     is_ptl,
-    is_win_platform,
     numpy_version,
 )
 from .third_party.cupy import testing
@@ -219,7 +218,7 @@ class TestCumLogSumExp:
     @pytest.mark.parametrize("axis", [None, 2, -1])
     @pytest.mark.parametrize("include_initial", [True, False])
     def test_basic(self, dtype, axis, include_initial):
-        if axis is None and is_ptl() and not is_win_platform():
+        if axis is None and is_ptl():
             pytest.skip("due to SAT-8336")
 
         a = dpnp.ones((3, 4, 5, 6, 7), dtype=dtype)
@@ -239,7 +238,7 @@ class TestCumLogSumExp:
     @pytest.mark.parametrize("axis", [None, 2, -1])
     @pytest.mark.parametrize("include_initial", [True, False])
     def test_include_initial(self, dtype, axis, include_initial):
-        if axis is None and is_ptl() and not is_win_platform():
+        if axis is None and is_ptl():
             pytest.skip("due to SAT-8336")
 
         a = dpnp.ones((3, 4, 5, 6, 7), dtype=dtype)


### PR DESCRIPTION
The PR proposes temporary disable tests with `dpnp.cumlogsumexp` when `axis is None` and running on PTL GPU device.
The tests must be enabled back once the issue in internal CI is resolved.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
