### PR TITLE
Bump `conda-build` version

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -94,6 +94,13 @@ jobs:
           environment-file: ${{ env.build-conda-pkg-env }}
           activate-environment: ${{ env.build-env-name }}
 
+      # Workaround for a conda-build crash during overlinking checks on Windows
+      # with py-lief 0.17: "AttributeError: 'Binary' object has no attribute
+      # 'exported_functions'". Pin py-lief back to 0.16 only on Windows.
+      - name: Pin py-lief on Windows
+        if: runner.os == 'Windows'
+        run: mamba install -y "py-lief<0.17"
+
       - name: List installed packages
         run: mamba list
 

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -97,9 +97,9 @@ jobs:
       # Workaround for a conda-build crash during overlinking checks on Windows
       # with py-lief 0.17: "AttributeError: 'Binary' object has no attribute
       # 'exported_functions'". Pin py-lief back to 0.16 only on Windows.
-      - name: Pin py-lief on Windows
-        if: runner.os == 'Windows'
-        run: mamba install -y "py-lief<0.17"
+      # - name: Pin py-lief on Windows
+      #   if: runner.os == 'Windows'
+      #   run: mamba install -y "py-lief<0.17"
 
       - name: List installed packages
         run: mamba list

--- a/environments/build_conda_pkg.yml
+++ b/environments/build_conda_pkg.yml
@@ -2,4 +2,4 @@ name: Build DPNP conda package
 channels:
   - conda-forge
 dependencies:
-  - conda-build=26.3.0
+  - conda-build=26.5.0

--- a/environments/build_conda_pkg.yml
+++ b/environments/build_conda_pkg.yml
@@ -2,4 +2,4 @@ name: Build DPNP conda package
 channels:
   - conda-forge
 dependencies:
-  - conda-build=25.11.1
+  - conda-build=26.1.0

--- a/environments/build_conda_pkg.yml
+++ b/environments/build_conda_pkg.yml
@@ -2,4 +2,4 @@ name: Build DPNP conda package
 channels:
   - conda-forge
 dependencies:
-  - conda-build=26.1.0
+  - conda-build=26.3.0

--- a/environments/build_conda_pkg.yml
+++ b/environments/build_conda_pkg.yml
@@ -2,5 +2,5 @@ name: Build DPNP conda package
 channels:
   - conda-forge
 dependencies:
-  - conda-build=25.11.1
+  - conda-build=26.1.0
   - conda-verify=3.4.2

--- a/environments/build_conda_pkg.yml
+++ b/environments/build_conda_pkg.yml
@@ -2,5 +2,5 @@ name: Build DPNP conda package
 channels:
   - conda-forge
 dependencies:
-  - conda-build=26.7.0
+  - conda-build=26.7.1
   - conda-verify=3.4.2

--- a/environments/build_conda_pkg.yml
+++ b/environments/build_conda_pkg.yml
@@ -2,5 +2,5 @@ name: Build DPNP conda package
 channels:
   - conda-forge
 dependencies:
-  - conda-build=26.3.0
+  - conda-build=26.5.0
   - conda-verify=3.4.2

--- a/environments/build_conda_pkg.yml
+++ b/environments/build_conda_pkg.yml
@@ -2,5 +2,5 @@ name: Build DPNP conda package
 channels:
   - conda-forge
 dependencies:
-  - conda-build=26.5.0
+  - conda-build=26.7.0
   - conda-verify=3.4.2

--- a/environments/build_conda_pkg.yml
+++ b/environments/build_conda_pkg.yml
@@ -2,5 +2,5 @@ name: Build DPNP conda package
 channels:
   - conda-forge
 dependencies:
-  - conda-build=26.1.0
+  - conda-build=26.3.0
   - conda-verify=3.4.2


### PR DESCRIPTION
This PR bumps `conda-build` version from 25.11.1 to 26.5.0.

The upgrade pulls in `py-lief 0.17`, which crashes `conda-build`'s post-build overlinking check on Windows while inspecting the compiled `dpnp` backend DLL:
```bash
File ".../conda_build/os_utils/liefldd.py", line 1092, in get_exports
result = [str(e) for e in binary.exported_functions]
AttributeError: 'Binary' object has no attribute 'exported_functions'
```

The failure occurs during the `Packaging dpnp` phase.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
