### PR TITLE
Resolve conda-build’s dependency analysis warnings

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -63,7 +63,7 @@ build:
     script_env:
       - WHEELS_OUTPUT_FOLDER
       - OVERRIDE_INTEL_IPO  # [win]
-    ignore_run_export:
+    ignore_run_exports:
       - dpctl
 
 test:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -45,6 +45,8 @@ requirements:
       - python-gil     # [py>=314]
       - {{ pin_compatible('dpctl', min_pin='x.x.x', max_pin=None) }}
       - {{ pin_compatible('dpcpp-cpp-rt', min_pin='x.x', max_pin='x') }}
+      - {{ pin_compatible('intel-sycl-rt', min_pin='x.x', max_pin='x') }}
+      - {{ pin_compatible('intel-cmplr-lib-rt', min_pin='x.x', max_pin='x') }}
       - {{ pin_compatible('onemkl-sycl-blas', min_pin='x.x', max_pin='x') }}
       - {{ pin_compatible('onemkl-sycl-dft', min_pin='x.x', max_pin='x') }}
       - {{ pin_compatible('onemkl-sycl-lapack', min_pin='x.x', max_pin='x') }}

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -47,6 +47,7 @@ requirements:
       - {{ pin_compatible('dpcpp-cpp-rt', min_pin='x.x', max_pin='x') }}
       - {{ pin_compatible('intel-sycl-rt', min_pin='x.x', max_pin='x') }}
       - {{ pin_compatible('intel-cmplr-lib-rt', min_pin='x.x', max_pin='x') }}
+      - {{ pin_compatible('mkl', min_pin='x.x', max_pin='x') }}
       - {{ pin_compatible('onemkl-sycl-blas', min_pin='x.x', max_pin='x') }}
       - {{ pin_compatible('onemkl-sycl-dft', min_pin='x.x', max_pin='x') }}
       - {{ pin_compatible('onemkl-sycl-lapack', min_pin='x.x', max_pin='x') }}

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -60,6 +60,8 @@ build:
     script_env:
       - WHEELS_OUTPUT_FOLDER
       - OVERRIDE_INTEL_IPO  # [win]
+    ignore_run_export:
+      - dpctl
 
 test:
     requires:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -64,6 +64,8 @@ build:
       - OVERRIDE_INTEL_IPO  # [win]
     ignore_run_exports:
       - dpctl
+      - numpy
+      - python
 
 test:
     requires:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -66,8 +66,12 @@ build:
       - dpctl
       - numpy
       - python
+      # building with Intel DPC++ and do not import the MSVC runtime DLLs
+      - vc14_runtime  # [win]
+      - ucrt          # [win]
     missing_dso_whitelist:
-      - '*/libDPCTLSyclInterface.so'
+      - '*DPCTLSyclInterface*'
+      - '*/dpnp_backend_c.dll'        # [win]
 
 test:
     requires:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -66,6 +66,8 @@ build:
       - dpctl
       - numpy
       - python
+    missing_dso_whitelist:
+      - '*/libDPCTLSyclInterface.so'
 
 test:
     requires:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -59,6 +59,8 @@ build:
     script_env:
       - WHEELS_OUTPUT_FOLDER
       - OVERRIDE_INTEL_IPO  # [win]
+    ignore_run_export:
+      - dpctl
 
 test:
     requires:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -62,7 +62,7 @@ build:
     script_env:
       - WHEELS_OUTPUT_FOLDER
       - OVERRIDE_INTEL_IPO  # [win]
-    ignore_run_export:
+    ignore_run_exports:
       - dpctl
 
 test:

--- a/environments/build_conda_pkg.yml
+++ b/environments/build_conda_pkg.yml
@@ -4,3 +4,4 @@ channels:
 dependencies:
   - python=3.13 # no python 3.14 support by conda-build
   - conda-build=25.11.1
+  - conda-verify=3.4.2

--- a/environments/build_conda_pkg.yml
+++ b/environments/build_conda_pkg.yml
@@ -3,3 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - conda-build=25.11.1
+  - conda-verify=3.4.2


### PR DESCRIPTION
The conda-build's post-build dependency analysis was emitting a number of warnings on every package build (both Linux and Windows). This PR resolves them — partly by adding genuinely-missing run dependencies, and partly by silencing the
false positives that come from conda-build's static scan being unable to see header-only usage and runtime (RPATH / `add_dll_directory`) library resolution.

No runtime behavior changes; this is a conda recipe / CI hygiene change.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
