### PR TITLE
 Use `dpctl_capi.h` header in `dpnp4pybind11.hpp`

### DIFF
--- a/dpnp/backend/include/dpnp4pybind11.hpp
+++ b/dpnp/backend/include/dpnp4pybind11.hpp
@@ -28,29 +28,8 @@
 
 #pragma once
 
-// Include dpctl SYCL interface from external dpctl package
-#include "syclinterface/dpctl_sycl_extension_interface.h"
-#include "syclinterface/dpctl_sycl_types.h"
-
-#ifdef __cplusplus
-#define CYTHON_EXTERN_C extern "C"
-#else
-#define CYTHON_EXTERN_C
-#endif
-
-// Include dpctl C-API headers (both declarations and import functions)
-#include "dpctl/_sycl_context.h"
-#include "dpctl/_sycl_context_api.h"
-#include "dpctl/_sycl_device.h"
-#include "dpctl/_sycl_device_api.h"
-#include "dpctl/_sycl_event.h"
-#include "dpctl/_sycl_event_api.h"
-#include "dpctl/_sycl_queue.h"
-#include "dpctl/_sycl_queue_api.h"
-#include "dpctl/memory/_memory.h"
-#include "dpctl/memory/_memory_api.h"
-#include "dpctl/program/_program.h"
-#include "dpctl/program/_program_api.h"
+// Include dpctl C-API headers
+#include "dpctl_capi.h"
 
 // Include generated Cython headers for usm_ndarray
 // (struct definition and constants only)
@@ -253,14 +232,9 @@ private:
           default_usm_memory_{}, default_usm_ndarray_{}, as_usm_memory_{}
 
     {
-        // Import dpctl SYCL interface modules
-        // This imports python modules and initializes pointers to Python types
-        import_dpctl___sycl_device();
-        import_dpctl___sycl_context();
-        import_dpctl___sycl_event();
-        import_dpctl___sycl_queue();
-        import_dpctl__memory___memory();
-        import_dpctl__program___program();
+        // Import dpctl C-API
+        // (device, context, event, queue, memory, program)
+        import_dpctl();
         // Import dpnp tensor module for PyUSMArrayType
         import_dpnp__tensor___usmarray();
 

--- a/dpnp/tests/tensor/elementwise/test_exp.py
+++ b/dpnp/tests/tensor/elementwise/test_exp.py
@@ -78,7 +78,7 @@ def test_exp_real_contig(dtype):
     assert_allclose(dpt.asnumpy(Z), np.repeat(Ynp, n_rep), atol=tol, rtol=tol)
 
 
-@pytest.mark.filterwarnings("ignore:overflow encountered:RuntimeWarning")
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("dtype", ["c8", "c16"])
 def test_exp_complex_contig(dtype):
     q = get_queue_or_skip()


### PR DESCRIPTION
This PR proposes replacing the individual dpctl C-API includes and import calls in `dpnp4pybind11.hpp` with `dpctl_capi.h` header and its `import_dpctl()` function.
Previous changes to the explicit imports were made to avoid conflicting with dpctl which contained a tensor;
now that dpctl no longer contains a tensor, we can use the header directly.

Additionally, fixes `RuntimeWarning` filter in `test_exp_complex_contig` 

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [X] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
