### PR TITLE
Skip tensor tests by default in conda recipe to avoid OOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Also, that release drops support for Python 3.9, making Python 3.10 the minimum 
 * Updated QR tests to avoid element-wise comparisons for `raw` and `r` modes [#2785](https://github.com/IntelPython/dpnp/pull/2785)
 * Moved all SYCL kernel functors from `backend/extensions/` to a unified `backend/kernels/` directory hierarchy [#2816](https://github.com/IntelPython/dpnp/pull/2816)
 * `dpnp` uses pybind11 3.0.3 [#2834](https://github.com/IntelPython/dpnp/pull/2834)
+* Disabled `dpnp.tensor` tests by default in conda recipe to prevent OOM failures during package testing [#2859](https://github.com/IntelPython/dpnp/pull/2859)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ Also, that release drops support for Python 3.9, making Python 3.10 the minimum 
 * Updated QR tests to avoid element-wise comparisons for `raw` and `r` modes [#2785](https://github.com/IntelPython/dpnp/pull/2785)
 * Moved all SYCL kernel functors from `backend/extensions/` to a unified `backend/kernels/` directory hierarchy [#2816](https://github.com/IntelPython/dpnp/pull/2816)
 * `dpnp` uses pybind11 3.0.3 [#2834](https://github.com/IntelPython/dpnp/pull/2834)
-* Disabled `dpnp.tensor` tests by default in conda recipe to prevent OOM failures during package testing [#2859](https://github.com/IntelPython/dpnp/pull/2859)
+* Disabled `dpnp.tensor` tests by default in `conda build --test` to prevent OOM failures during package testing. Set `SKIP_TENSOR_TESTS=0` to re-enable them on systems with enough memory [#2860](https://github.com/IntelPython/dpnp/pull/2860)
 
 ### Deprecated
 

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -31,6 +31,12 @@ if not defined PYTHON (
 )
 
 
+REM Skip tensor tests by default to avoid OOM in conda builds.
+REM Set SKIP_TENSOR_TESTS=0 to run them on machines with enough memory.
+if not defined SKIP_TENSOR_TESTS (
+    set "SKIP_TENSOR_TESTS=1"
+)
+
 "%PYTHON%" -c "import dpnp; print(dpnp.__version__)"
 if %errorlevel% neq 0 exit 1
 

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -33,6 +33,12 @@ if [ -z "${PYTHON}" ]; then
     PYTHON=$PREFIX/bin/python
 fi
 
+# Skip tensor tests by default to avoid OOM in conda builds.
+# Set SKIP_TENSOR_TESTS=0 to run them on machines with enough memory.
+if [ -z "${SKIP_TENSOR_TESTS}" ]; then
+    export SKIP_TENSOR_TESTS=1
+fi
+
 set -e
 
 $PYTHON -c "import dpnp; print(dpnp.__version__)"


### PR DESCRIPTION
Tensor tests require significant device memory and frequently cause OOM crashes on internal CI machines during conda package testing (mostly on Linux) often manifesting as Python abort signals instead of regular failures.

This PR sets `SKIP_TENSOR_TESTS=1` by default in `conda recipe` test scripts to avoid such crashes.

Users or CI environments can opt in by setting `SKIP_TENSOR_TESTS=0` on systems with sufficient memory.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
