### PR TITLE
Start dpnp 0.21 development

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -377,7 +377,7 @@ jobs:
           MAMBA_NO_LOW_SPEED_LIMIT: 1
 
       - name: Install OCL CPU RT from Intel channel
-        run: mamba install intel-opencl-rt=*=intel_* ${{ env.channels-list }}
+        run: mamba install ${{ env.package-name }}=${{ env.PACKAGE_VERSION }} intel-opencl-rt=*=intel_* ${{ env.channels-list }}
 
       - name: List installed packages
         run: mamba list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.20.0] - MM/DD/2026
+## [0.21.0] - MM/DD/2026
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+
+## [0.20.0] - 2026-04-22
 
 This release introduces a major architectural change: the Array API-compliant tensor implementation has been migrated from `dpctl.tensor` into `dpnp.tensor`, simplifying maintenance, reducing cross-project dependencies, and allows the tensor implementation to evolve within `dpnp`.
 This release changes the license from `BSD-2-Clause` to `BSD-3-Clause`.
@@ -28,7 +43,7 @@ Also, that release drops support for Python 3.9, making Python 3.10 the minimum 
 * Added implementation of `dpnp.divmod` [#2674](https://github.com/IntelPython/dpnp/pull/2674)
 * Added implementation of `dpnp.isin` function [#2595](https://github.com/IntelPython/dpnp/pull/2595)
 * Added implementation of `dpnp.scipy.linalg.lu` (SciPy-compatible) [#2787](https://github.com/IntelPython/dpnp/pull/2787)
-* Added support for ndarray subclassing via `dpnp.ndarray.view` method with `type` parameter [#2815](https://github.com/IntelPython/dpnp/issues/2815)
+* Added support for ndarray subclassing via `dpnp.ndarray.view` method with `type` parameter [#2815](https://github.com/IntelPython/dpnp/pull/2815)
 * Migrated tensor implementation from `dpctl.tensor` into `dpnp.tensor`, making `dpnp` the primary owner of the Array API-compliant tensor layer [#2856](https://github.com/IntelPython/dpnp/pull/2856)
 
 ### Changed
@@ -92,8 +107,6 @@ Also, that release drops support for Python 3.9, making Python 3.10 the minimum 
 * Fixed `dpnp.tensor.round` to use device-aware output dtype for boolean input [#2851](https://github.com/IntelPython/dpnp/pull/2851)
 * Resolved a deadlock in `dpnp.linalg.qr` by releasing the GIL before OneMKL `orgqr` call to prevent host tasks contention [#2850](https://github.com/IntelPython/dpnp/pull/2850)
 * Fixed `dpnp.linalg.matrix_rank` to properly handle an empty input array [#2853](https://github.com/IntelPython/dpnp/pull/2853)
-
-### Security
 
 
 ## [0.19.1] - 2025-11-27

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ cmake_minimum_required(VERSION 3.21...3.27 FATAL_ERROR)
 
 project(
     dpnp
-    VERSION 0.20
+    VERSION 0.21
     LANGUAGES CXX
     DESCRIPTION "NumPy-like API accelerated by SYCL."
 )

--- a/dpnp/tests/third_party/cupy/core_tests/test_ndarray_elementwise_op.py
+++ b/dpnp/tests/third_party/cupy/core_tests/test_ndarray_elementwise_op.py
@@ -625,11 +625,9 @@ class TestArrayElementwiseOp:
         b = xp.array([[3, 1, 4], [-1, -5, -9]], numpy.int8).view(bool)
         return op(a, b)
 
-    @testing.with_requires("dpctl>=0.22.0dev0")
     def test_add_array_boolarray(self):
         self.check_array_boolarray_op(operator.add)
 
-    @testing.with_requires("dpctl>=0.22.0dev0")
     def test_iadd_array_boolarray(self):
         self.check_array_boolarray_op(operator.iadd)
 


### PR DESCRIPTION
The PR initiates `0.21` development.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
