### PR TITLE
Fix RNG crash on Windows 

### DIFF
--- a/dpnp/backend/src/queue_sycl.hpp
+++ b/dpnp/backend/src/queue_sycl.hpp
@@ -67,7 +67,7 @@ public:
 
     static backend_sycl &get()
     {
-#ifdef _WIN32
+#if defined(_WIN32) && INTEL_MKL_VERSION == 20260000
         // TODO: remove once MKLD-19835 is resolved
         // mt19937 (oneMKL 2026.0) destructor crashes during DLL_PROCESS_DETACH
         // on Windows (Battlemage/Level Zero). Use a heap-allocated

--- a/dpnp/backend/src/queue_sycl.hpp
+++ b/dpnp/backend/src/queue_sycl.hpp
@@ -67,8 +67,17 @@ public:
 
     static backend_sycl &get()
     {
+#ifdef _WIN32
+        // TODO: remove once MKLD-19835 is resolved
+        // mt19937 (oneMKL 2026.0) destructor crashes during DLL_PROCESS_DETACH
+        // on Windows (Battlemage/Level Zero). Use a heap-allocated
+        // process-lifetime singleton to skip destructor; OS reclaims memory.
+        static backend_sycl *backend = new backend_sycl{};
+        return *backend;
+#else
         static backend_sycl backend{};
         return backend;
+#endif
     }
 
     static sycl::queue &get_queue()


### PR DESCRIPTION
This PR adds a Windows workaround for a crash on Battlemage during test runs.

In oneMKL 2026.0 `mkl_rng::mt19937` destructor may crash with `STATUS_STACK_BUFFER_OVERRUN` during `DLL_PROCESS_DETACH` when using the Level Zero backend and static storage inside a DLL.

The workaround heap-allocates `backend_sycl` singleton on Windows to avoid running its destructor at shutdown. Although `~backend_sycl()` is empty, it triggers destruction of its members (including `mkl_rng::mt19937`) which causes the crash. 
Since `backend_sycl` is a process-lifetime singleton, skipping its destruction is safe because OS reclaims all
resources at process exit.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [X] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
