### PR TITLE
Fix in-place indexing with range/list for 4D arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed incorrect in-place advanced indexing for 4D arrays when using `range` or `list` as index keys [#2872](https://github.com/IntelPython/dpnp/pull/2872)
+
 ### Security
 
 

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -38,6 +38,8 @@ elements stored in a USM allocation on a SYCL device.
 
 import warnings
 
+import numpy
+
 import dpnp
 import dpnp.tensor as dpt
 import dpnp.tensor._type_utils as dtu
@@ -46,23 +48,39 @@ from . import memory as dpm
 from .exceptions import AxisError
 
 
+def _unwrap_index_element(x):
+    """
+    Unwrap a single index element for the tensor indexing layer.
+
+    Converts dpnp arrays to usm_ndarray and array-like objects (range, list)
+    to numpy arrays with intp dtype for NumPy-compatible advanced indexing.
+
+    """
+
+    if isinstance(x, dpnp_array):
+        return x.get_array()
+    if isinstance(x, (range, list)):
+        return numpy.asarray(x, dtype=numpy.intp)
+    return x
+
+
 def _get_unwrapped_index_key(key):
     """
     Get an unwrapped index key.
 
     Return a key where each nested instance of DPNP array is unwrapped into
-    USM ndarray for further processing in DPCTL advanced indexing functions.
+    USM ndarray, and array-like objects (range, list) are converted to numpy
+    arrays for further processing in advanced indexing functions.
 
     """
 
     if isinstance(key, tuple):
-        if any(isinstance(x, dpnp_array) for x in key):
-            # create a new tuple from the input key with unwrapped DPNP arrays
-            return tuple(
-                x.get_array() if isinstance(x, dpnp_array) else x for x in key
-            )
+        if any(isinstance(x, (dpnp_array, range, list)) for x in key):
+            return tuple(_unwrap_index_element(x) for x in key)
     elif isinstance(key, dpnp_array):
         return key.get_array()
+    elif isinstance(key, (range, list)):
+        return numpy.asarray(key, dtype=numpy.intp)
     return key
 
 

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -57,6 +57,8 @@ def _unwrap_index_element(x):
 
     """
 
+    if isinstance(x, dpt.usm_ndarray):
+        return x
     if isinstance(x, dpnp_array):
         return x.get_array()
     if isinstance(x, range):
@@ -83,11 +85,8 @@ def _get_unwrapped_index_key(key):
     """
 
     if isinstance(key, tuple):
-        if any(isinstance(x, (dpnp_array, range, list)) for x in key):
-            return tuple(_unwrap_index_element(x) for x in key)
-    elif isinstance(key, (dpnp_array, range, list)):
-        return _unwrap_index_element(key)
-    return key
+        return tuple(_unwrap_index_element(x) for x in key)
+    return _unwrap_index_element(key)
 
 
 # pylint: disable=too-many-public-methods

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -59,8 +59,16 @@ def _unwrap_index_element(x):
 
     if isinstance(x, dpnp_array):
         return x.get_array()
-    if isinstance(x, (range, list)):
+    if isinstance(x, range):
         return numpy.asarray(x, dtype=numpy.intp)
+    if isinstance(x, list):
+        # keep boolean lists as boolean
+        arr = numpy.asarray(x)
+        # cast empty lists (float64 in NumPy) to intp
+        # for correct tensor indexing
+        if arr.size == 0:
+            arr = arr.astype(numpy.intp)
+        return arr
     return x
 
 
@@ -77,10 +85,8 @@ def _get_unwrapped_index_key(key):
     if isinstance(key, tuple):
         if any(isinstance(x, (dpnp_array, range, list)) for x in key):
             return tuple(_unwrap_index_element(x) for x in key)
-    elif isinstance(key, dpnp_array):
-        return key.get_array()
-    elif isinstance(key, (range, list)):
-        return numpy.asarray(key, dtype=numpy.intp)
+    elif isinstance(key, (dpnp_array, range, list)):
+        return _unwrap_index_element(key)
     return key
 
 

--- a/dpnp/tensor/_slicing.pxi
+++ b/dpnp/tensor/_slicing.pxi
@@ -104,12 +104,6 @@ cdef bint _is_boolean(object x) except *:
             return f in "?"
         else:
             return False
-    if callable(getattr(x, "__bool__", None)):
-        try:
-            x.__bool__()
-        except (TypeError, ValueError):
-            return False
-        return True
     return False
 
 

--- a/dpnp/tests/test_indexing.py
+++ b/dpnp/tests/test_indexing.py
@@ -353,6 +353,59 @@ class TestIndexing:
         arr[slices] = 10
         assert_equal(arr, 10.0, strict=False)
 
+    @pytest.mark.parametrize(
+        "idx",
+        [
+            (range(2), range(2)),
+            ([0, 1], [0, 1]),
+        ],
+        ids=["range", "list"],
+    )
+    def test_array_like_index_getitem(self, idx):
+        np_a = numpy.arange(36).reshape(2, 2, 3, 3)
+        dp_a = dpnp.arange(36).reshape(2, 2, 3, 3)
+        assert_array_equal(dp_a[idx], np_a[idx])
+
+    @pytest.mark.parametrize(
+        "idx",
+        [
+            (range(2), range(2)),
+            ([0, 1], [0, 1]),
+        ],
+        ids=["range", "list"],
+    )
+    def test_array_like_index_setitem(self, idx):
+        np_a = numpy.arange(36).reshape(2, 2, 3, 3)
+        dp_a = dpnp.arange(36).reshape(2, 2, 3, 3)
+        np_a[idx] = 0
+        dp_a[idx] = 0
+        assert_array_equal(dp_a, np_a)
+
+    def test_array_like_index_inplace_add(self):
+        np_a = numpy.arange(36).reshape(2, 2, 3, 3)
+        dp_a = dpnp.arange(36).reshape(2, 2, 3, 3)
+        np_tmp = -numpy.ones((2, 3, 3), dtype=numpy.intp)
+        dp_tmp = -dpnp.ones((2, 3, 3), dtype=numpy.intp)
+
+        np_a[range(2), range(2)] += 2 * np_tmp
+        dp_a[range(2), range(2)] += 2 * dp_tmp
+        assert_array_equal(dp_a, np_a)
+
+    @pytest.mark.parametrize(
+        "idx",
+        [
+            range(2),
+            [0, 1],
+            range(0),
+            [],
+        ],
+        ids=["range", "list", "empty_range", "empty_list"],
+    )
+    def test_array_like_single_index(self, idx):
+        np_a = numpy.arange(24).reshape(2, 3, 4)
+        dp_a = dpnp.arange(24).reshape(2, 3, 4)
+        assert_array_equal(dp_a[idx], np_a[idx])
+
 
 class TestIx:
     @pytest.mark.parametrize(


### PR DESCRIPTION
This PR proposes to fix #2783 by addressing incorrect in-place updates for 4D arrays.

`_is_boolean()` in `_slicing.pxi` had a `__bool__` fallback that misclassified `range` objects as boolean scalar indices since `range` exposes `__bool__`. This caused them to insert `newaxis(1)` instead of being treated as integer index arrays. 
The fallback was removed because all legitimate boolean types are already caught by earlier checks in the same function.

 `range` and `list` are not part of the Python Array API indexing spec but NumPy accepts them as integer index arrays.
Conversion of these types to numpy arrays is added in `_get_unwrapped_index_key()` in `dpnp_array.py` which is the NumPy compatibility layer but keeping the tensor layer Array API compliant.

Also added tests for `range` and `list` advanced indexing covering to `test_indexing.py`


- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [X] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [X] Have you added your changes to the changelog?
