### PR TITLE
Pin Intel OneAPI to 2025.3 in CI workflows for coverage

### DIFF
--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -46,16 +46,18 @@ jobs:
           echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
           sudo apt update
 
-      - name: Install latest Intel OneAPI
+      # Pinned to OneAPI 2025.3 to match the version used to build dpctl packages.
+      # TODO: remove pinning once dpctl is built with the latest OneAPI.
+      - name: Install Intel OneAPI 2025.3
         if: env.oneapi-pkgs-env == ''
         run: |
-          sudo apt install hwloc                           \
-                           intel-oneapi-mkl                \
-                           intel-oneapi-umf                \
-                           intel-oneapi-mkl-devel          \
-                           intel-oneapi-tbb-devel          \
-                           intel-oneapi-libdpstd-devel     \
-                           intel-oneapi-compiler-dpcpp-cpp
+          sudo apt install hwloc                                   \
+                           intel-oneapi-mkl-2025.3                 \
+                           intel-oneapi-umf-1.0                    \
+                           intel-oneapi-mkl-devel-2025.3           \
+                           intel-oneapi-tbb-devel-2022.3           \
+                           intel-oneapi-libdpstd-devel-2022.10     \
+                           intel-oneapi-compiler-dpcpp-cpp-2025.3
 
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -46,9 +46,9 @@ jobs:
           echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
           sudo apt update
 
-      # Pinned to OneAPI 2025.3 to match the version used to build dpctl packages.
-      # TODO: remove pinning once dpctl is built with the latest OneAPI.
-      - name: Install Intel OneAPI 2025.3
+      # Pinned to OneAPI 2025.3 due to known 2026.0 DPC++ compiler issue with Segfault during the sycl-post-link
+      # TODO: renmove once CMPLRLLVM-75178 is resolved and released
+      - name: Install Intel OneAPI
         if: env.oneapi-pkgs-env == ''
         run: |
           sudo apt install hwloc                                   \

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -109,10 +109,14 @@ jobs:
       # with a newer version of the DPC++ compiler).
       # Installing dpctl via the pip manager has no such limitation, as the package has no
       # run dependency on the DPC++ RT pip package, so this is why the step is necessary here.
+      # - name: Install dpctl
+      #   if: env.oneapi-pkgs-env == ''
+      #   run: |
+      #     pip install -r ${{ env.dpctl-pkg-txt }}
+      # TODO: renmove pinning once CMPLRLLVM-75178 is resolved and released
       - name: Install dpctl
-        if: env.oneapi-pkgs-env == ''
         run: |
-          pip install -r ${{ env.dpctl-pkg-txt }}
+          pip install dpctl==0.21.1
 
       - name: Conda info
         run: |

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -116,7 +116,7 @@ jobs:
       # TODO: renmove pinning once CMPLRLLVM-75178 is resolved and released
       - name: Install dpctl
         run: |
-          pip install dpctl==0.21.1
+          pip install dpctl>=0.23.0dev0 --index-url https://pypi.anaconda.org/dppy/label/coverage/simple
 
       - name: Conda info
         run: |


### PR DESCRIPTION
This PR proposes using OneAPI 2025.3 for `build-sphinx` and `generate_coverage` workflows to match the compiler version used to build dpctl packages since dpctl is waiting for the latest compiler to become available on conda-forge [dpctl#2300](https://github.com/IntelPython/dpctl/pull/2300/changes#diff-a88e46d7ba5cf89249cb4894a9dbbc93a2f6b8a631a87dc2241c3e8e3acf8eeeL575)

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
