### PR TITLE
Bump Python array API version to 2025.12

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -769,7 +769,7 @@ jobs:
           python -m pytest --json-report --json-report-file=${{ env.json-report-file }} --disable-deadline --skips-file ${{ env.array-api-skips-file }} array_api_tests || true
         env:
           ARRAY_API_TESTS_MODULE: 'dpnp'
-          ARRAY_API_TESTS_VERSION: '2024.12'
+          ARRAY_API_TESTS_VERSION: '2025.12'
           SYCL_CACHE_PERSISTENT: 1
         working-directory: ${{ env.array-api-tests-path }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This release is compatible with NumPy 2.5.
 * Clarified the summary in `dpnp.reshape` and `dpnp.ndarray.reshape` docstrings [#2964](https://github.com/IntelPython/dpnp/pull/2964)
 * Changed `dpnp.atleast_1d`, `dpnp.atleast_2d`, `dpnp.atleast_3d`, and `dpnp.ogrid` to return a tuple of arrays instead of a list [#2965](https://github.com/IntelPython/dpnp/pull/2965)
 * Improved performance of `dpnp.fft` functions for complex strided input by avoiding oversized allocations and extra copies [#2939](https://github.com/IntelPython/dpnp/pull/2939)
+* Updated Python Array API specification version supported to `2025.12` [#2899](https://github.com/IntelPython/dpnp/pull/2899)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.21.0] - 2026-MM-DD
 
+This release achieves 100% compliance with Python Array API specification (revision [2025.12](https://data-apis.org/array-api/2025.12/)).
 This release is compatible with NumPy 2.5.
 
 ### Added

--- a/doc/reference/array_api.rst
+++ b/doc/reference/array_api.rst
@@ -10,7 +10,7 @@ Array API standard compatibility
 
 DPNP's main namespace as well as the :mod:`dpnp.fft` and :mod:`dpnp.linalg`
 namespaces are compatible with the
-`2024.12 version <https://data-apis.org/array-api/2024.12/index.html>`__
+`2025.12 version <https://data-apis.org/array-api/2025.12/index.html>`__
 of the Python array API standard.
 
 Inspection

--- a/dpnp/tensor/_array_api.py
+++ b/dpnp/tensor/_array_api.py
@@ -77,7 +77,7 @@ def _get_device_impl(d):
             raise TypeError(f"Unsupported type for device argument: {type(d)}")
 
 
-__array_api_version__ = "2024.12"
+__array_api_version__ = "2025.12"
 
 
 class Info:

--- a/dpnp/tests/test_ndarray.py
+++ b/dpnp/tests/test_ndarray.py
@@ -403,20 +403,20 @@ class TestArrayNamespace:
         xp = a.__array_namespace__()
         assert xp is dpnp
 
-    @pytest.mark.parametrize("api_version", [None, "2024.12"])
+    @pytest.mark.parametrize("api_version", [None, "2025.12"])
     def test_api_version(self, api_version):
         a = dpnp.arange(2)
         xp = a.__array_namespace__(api_version=api_version)
         assert xp is dpnp
 
     @pytest.mark.parametrize(
-        "api_version", ["2021.12", "2022.12", "2023.12", "2025.12"]
+        "api_version", ["2021.12", "2022.12", "2023.12", "2024.12", "2026.12"]
     )
     def test_unsupported_api_version(self, api_version):
         a = dpnp.arange(2)
         assert_raises_regex(
             ValueError,
-            "Only 2024.12 is supported",
+            "Only 2025.12 is supported",
             a.__array_namespace__,
             api_version=api_version,
         )


### PR DESCRIPTION
This PR declares `dpnp` support for the **2025.12** version of the Python array API standard, bumping from `2024.12`.

The functional work required by the new revision (e.g. `meshgrid` returning a tuple, `searchsorted` alignment) has already landed in prior PRs; this change flips the declared version, points the conformance suite at the new spec, and updates the docs and tests accordingly.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [x] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
