### PR TITLE
Temporary disable `test_minimum_nan` for float16

### DIFF
--- a/dpnp/tests/helper.py
+++ b/dpnp/tests/helper.py
@@ -13,7 +13,6 @@ from . import config
 
 
 class LTS_VERSION(Enum):
-    V1_3 = "1.3"
     V1_6 = "1.6"
 
 
@@ -489,7 +488,7 @@ def is_lnl(device=None):
     return _get_dev_mask(device) == 0x6400
 
 
-def is_lts_driver(version=LTS_VERSION.V1_3, device=None):
+def is_lts_driver(version=LTS_VERSION.V1_6, device=None):
     """
     Return True if a test is running on a GPU device with LTS driver version,
     False otherwise.

--- a/dpnp/tests/third_party/cupy/math_tests/test_misc.py
+++ b/dpnp/tests/third_party/cupy/math_tests/test_misc.py
@@ -4,7 +4,12 @@ import numpy
 import pytest
 
 import dpnp as cupy
-from dpnp.tests.helper import has_support_aspect64, numpy_version
+from dpnp.tests.helper import (
+    has_support_aspect64,
+    is_lts_driver,
+    is_win_platform,
+    numpy_version,
+)
 from dpnp.tests.third_party.cupy import testing
 
 
@@ -113,6 +118,14 @@ class TestMisc:
     @testing.for_dtypes(["e", "f", "d", "F", "D"])
     @testing.numpy_cupy_array_equal()
     def check_binary_nan(self, name, xp, dtype):
+        if (
+            not is_win_platform()
+            and not is_lts_driver()
+            and name == "minimum"
+            and dtype == numpy.float16
+        ):
+            pytest.skip("GSD-12679")
+
         a = xp.array(
             [-3, numpy.nan, -1, numpy.nan, 0, numpy.nan, 2], dtype=dtype
         )


### PR DESCRIPTION
This PR adds skip for known IGC driver issue to unblock the internal CI until the driver releases the fix.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
