### PR TITLE
Change order for step with installing OCL CPU RT

### DIFF
--- a/.github/workflows/cron-run-tests.yaml
+++ b/.github/workflows/cron-run-tests.yaml
@@ -81,6 +81,9 @@ jobs:
           python-version: ${{ matrix.python }}
           activate-environment: ${{ env.test-env-name }}
 
+      - name: Install OCL CPU RT from Intel channel
+        run: mamba install intel-opencl-rt=*=intel_* ${{ env.channels-list }}
+
       - name: Install dpnp
         id: install_dpnp
         continue-on-error: true
@@ -91,9 +94,6 @@ jobs:
         if: steps.install_dpnp.outcome == 'failure'
         run: |
           mamba install ${{ env.package-name }}=${{ steps.find_latest_tag.outputs.tag }} ${{ env.test-packages }} ${{ env.channels-list }}
-
-      - name: Install OCL CPU RT from Intel channel
-        run: mamba install intel-opencl-rt=*=intel_* ${{ env.channels-list }}
 
       - name: List installed packages
         run: mamba list


### PR DESCRIPTION
The PR fixes the issue in GitHub workflow to scheduled run of the tests.

We have to install proper `intel-opencl-rt` package first, since otherwise installing `intel-opencl-rt` next step after installing dpnp might cause reinstall of older dpnp version, since we don't use strict conda channel priority.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
