### PR TITLE
Fix fork PR docs workflow

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -13,6 +13,7 @@ env:
   GH_BOT_EMAIL: 'github-actions[bot]@users.noreply.github.com'
   GH_EVENT_PUSH_UPSTREAM: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' &&
                               github.event.ref == 'refs/heads/master' && github.event.repository && !github.event.repository.fork }}
+  GH_EVENT_PR_OPEN: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
   PUBLISH_DIR: doc/_build/html/
 
 defaults:
@@ -202,7 +203,7 @@ jobs:
 
       # Upload artifact for fork PRs
       - name: Upload docs artifact (Fork PRs)
-        if: steps.check_fork.outputs.is_fork == 'true' && github.event.action != 'closed'
+        if: env.GH_EVENT_PR_OPEN == 'true' && steps.check_fork.outputs.is_fork == 'true'
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: pr-${{ github.event.number }}-docs
@@ -224,7 +225,7 @@ jobs:
 
       # The step is only used to build docs while pushing to PR branch
       - name: Publish pull-request docs
-        if: github.event_name == 'pull_request' && github.event.action != 'closed' && steps.check_fork.outputs.is_fork == 'false'
+        if: env.GH_EVENT_PR_OPEN == 'true' && steps.check_fork.outputs.is_fork == 'false'
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -241,7 +242,7 @@ jobs:
       # Note: Fork PRs have read-only GITHUB_TOKEN and cannot post comments
       # See: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflows-in-forked-repositories
       - name: Comment with URL to published pull-request docs
-        if: github.event_name == 'pull_request' && github.event.action != 'closed' && steps.check_fork.outputs.is_fork == 'false'
+        if: env.GH_EVENT_PR_OPEN == 'true' && steps.check_fork.outputs.is_fork == 'false'
         env:
           PR_NUM: ${{ github.event.number }}
         uses: mshick/add-pr-comment@8e4927817251f1ff60c001f04568532b38e0b4a0 # v3.11.0.8.3.11.0

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -191,6 +191,26 @@ jobs:
       - name: Copy backend docs
         run: cp -r dpnp/backend/doc/html ${{ env.PUBLISH_DIR }}/backend_doc
 
+      # Detect if this is a fork PR
+      - name: Check if fork PR
+        id: check_fork
+        run: |
+          IS_FORK="false"
+          if [ "${{ github.event_name }}" == "pull_request" ] && [ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]; then
+            IS_FORK="true"
+          fi
+          echo "is_fork=$IS_FORK" >> "$GITHUB_OUTPUT"
+          echo "Is fork PR: $IS_FORK"
+
+      # Upload artifact for fork PRs
+      - name: Upload docs artifact (Fork PRs)
+        if: steps.check_fork.outputs.is_fork == 'true' && github.event.action != 'closed'
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: pr-${{ github.event.number }}-docs
+          path: ${{ env.PUBLISH_DIR }}
+          retention-days: 30
+
       # The step is only used to build docs while pushing a PR to "master"
       - name: Deploy docs
         if: env.GH_EVENT_PUSH_UPSTREAM == 'true'
@@ -206,7 +226,7 @@ jobs:
 
       # The step is only used to build docs while pushing to PR branch
       - name: Publish pull-request docs
-        if: env.GH_EVENT_OPEN_PR_UPSTREAM == 'true'
+        if: env.GH_EVENT_OPEN_PR_UPSTREAM == 'true' && steps.check_fork.outputs.is_fork == 'false'
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -11,8 +11,6 @@ permissions: read-all
 env:
   GH_BOT_NAME: 'github-actions[bot]'
   GH_BOT_EMAIL: 'github-actions[bot]@users.noreply.github.com'
-  GH_EVENT_OPEN_PR_UPSTREAM: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' &&
-                                 github.event.pull_request.head.repo && !github.event.pull_request.head.repo.fork }}
   GH_EVENT_PUSH_UPSTREAM: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' &&
                               github.event.ref == 'refs/heads/master' && github.event.repository && !github.event.repository.fork }}
   PUBLISH_DIR: doc/_build/html/
@@ -226,7 +224,7 @@ jobs:
 
       # The step is only used to build docs while pushing to PR branch
       - name: Publish pull-request docs
-        if: env.GH_EVENT_OPEN_PR_UPSTREAM == 'true' && steps.check_fork.outputs.is_fork == 'false'
+        if: github.event_name == 'pull_request' && github.event.action != 'closed' && steps.check_fork.outputs.is_fork == 'false'
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -237,57 +237,18 @@ jobs:
           user_name: ${{ env.GH_BOT_NAME }}
           user_email: ${{ env.GH_BOT_EMAIL }}
 
-      # Prepare documentation preview comment based on PR type
-      - name: Prepare docs preview comment
-        if: github.event_name == 'pull_request' && github.event.action != 'closed'
-        id: docs_comment
+      # The step is only used to build docs while pushing to PR branch
+      # Note: Fork PRs have read-only GITHUB_TOKEN and cannot post comments
+      # See: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflows-in-forked-repositories
+      - name: Comment with URL to published pull-request docs
+        if: github.event_name == 'pull_request' && github.event.action != 'closed' && steps.check_fork.outputs.is_fork == 'false'
         env:
           PR_NUM: ${{ github.event.number }}
-          IS_FORK: ${{ steps.check_fork.outputs.is_fork }}
-        run: |
-          if [ "$IS_FORK" == "true" ]; then
-            # Fork PR - provide artifact download instructions
-            cat << 'EOF' >> "$GITHUB_OUTPUT"
-          message<<COMMENT_EOF
-          📚 **Documentation Preview (Fork PR)**
-
-          Your docs have been built successfully! For security reasons, fork PRs cannot automatically publish to GitHub Pages.
-
-          **To view your docs:**
-          ```bash
-          gh run download ${{ github.run_id }} -R ${{ github.repository }} -n pr-${{ env.PR_NUM }}-docs
-          cd pr-${{ env.PR_NUM }}-docs
-          python -m http.server 8000
-          # Open http://localhost:8000 in your browser
-          ```
-
-          **Alternative: Manual download**
-          1. Download artifact `pr-${{ env.PR_NUM }}-docs` from [this workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) (scroll to "Artifacts" section)
-          2. Extract the ZIP file and open `index.html` in your browser
-
-          <details>
-          <summary>Why can't fork PRs publish automatically?</summary>
-
-          Fork PRs run with restricted permissions to prevent malicious code from modifying the repository or accessing secrets. This is a GitHub security feature to protect open source projects.
-          </details>
-          COMMENT_EOF
-          EOF
-          else
-            # Upstream PR - provide direct URL
-            cat << 'EOF' >> "$GITHUB_OUTPUT"
-          message<<COMMENT_EOF
-          View rendered docs @ https://intelpython.github.io/dpnp/pull/${{ env.PR_NUM }}/index.html
-          COMMENT_EOF
-          EOF
-          fi
-
-      # Comment on PR with docs preview
-      - name: Comment with docs preview
-        if: github.event_name == 'pull_request' && github.event.action != 'closed'
         uses: mshick/add-pr-comment@8e4927817251f1ff60c001f04568532b38e0b4a0 # v3.11.0.8.3.11.0
         with:
-          message-id: docs_preview
-          message: ${{ steps.docs_comment.outputs.message }}
+          message-id: url_to_docs
+          message: |
+            View rendered docs @ https://intelpython.github.io/dpnp/pull/${{ env.PR_NUM }}/index.html
           allow-repeats: false
 
   # The job is only used to build docs when PR is closed (action from PR branch)

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -12,7 +12,7 @@ env:
   GH_BOT_NAME: 'github-actions[bot]'
   GH_BOT_EMAIL: 'github-actions[bot]@users.noreply.github.com'
   GH_EVENT_OPEN_PR_UPSTREAM: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' &&
-                                 github.event.pull_request && !github.event.pull_request.base.repo.fork }}
+                                 github.event.pull_request.head.repo && !github.event.pull_request.head.repo.fork }}
   GH_EVENT_PUSH_UPSTREAM: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' &&
                               github.event.ref == 'refs/heads/master' && github.event.repository && !github.event.repository.fork }}
   PUBLISH_DIR: doc/_build/html/
@@ -235,7 +235,7 @@ jobs:
   clean:
     if: |
       github.event_name == 'pull_request' && github.event.action == 'closed' &&
-      github.event.pull_request && !github.event.pull_request.base.repo.fork
+      github.event.pull_request.head.repo && !github.event.pull_request.head.repo.fork
 
     needs: build-and-deploy
 

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -239,16 +239,57 @@ jobs:
           user_name: ${{ env.GH_BOT_NAME }}
           user_email: ${{ env.GH_BOT_EMAIL }}
 
-      # The step is only used to build docs while pushing to PR branch
-      - name: Comment with URL to published pull-request docs
-        if: env.GH_EVENT_OPEN_PR_UPSTREAM == 'true'
+      # Prepare documentation preview comment based on PR type
+      - name: Prepare docs preview comment
+        if: github.event_name == 'pull_request' && github.event.action != 'closed'
+        id: docs_comment
         env:
           PR_NUM: ${{ github.event.number }}
+          IS_FORK: ${{ steps.check_fork.outputs.is_fork }}
+        run: |
+          if [ "$IS_FORK" == "true" ]; then
+            # Fork PR - provide artifact download instructions
+            cat << 'EOF' >> "$GITHUB_OUTPUT"
+          message<<COMMENT_EOF
+          📚 **Documentation Preview (Fork PR)**
+
+          Your docs have been built successfully! For security reasons, fork PRs cannot automatically publish to GitHub Pages.
+
+          **To view your docs:**
+          ```bash
+          gh run download ${{ github.run_id }} -R ${{ github.repository }} -n pr-${{ env.PR_NUM }}-docs
+          cd pr-${{ env.PR_NUM }}-docs
+          python -m http.server 8000
+          # Open http://localhost:8000 in your browser
+          ```
+
+          **Alternative: Manual download**
+          1. Download artifact `pr-${{ env.PR_NUM }}-docs` from [this workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) (scroll to "Artifacts" section)
+          2. Extract the ZIP file and open `index.html` in your browser
+
+          <details>
+          <summary>Why can't fork PRs publish automatically?</summary>
+
+          Fork PRs run with restricted permissions to prevent malicious code from modifying the repository or accessing secrets. This is a GitHub security feature to protect open source projects.
+          </details>
+          COMMENT_EOF
+          EOF
+          else
+            # Upstream PR - provide direct URL
+            cat << 'EOF' >> "$GITHUB_OUTPUT"
+          message<<COMMENT_EOF
+          View rendered docs @ https://intelpython.github.io/dpnp/pull/${{ env.PR_NUM }}/index.html
+          COMMENT_EOF
+          EOF
+          fi
+
+      # Comment on PR with docs preview
+      - name: Comment with docs preview
+        if: github.event_name == 'pull_request' && github.event.action != 'closed'
         uses: mshick/add-pr-comment@8e4927817251f1ff60c001f04568532b38e0b4a0 # v3.11.0.8.3.11.0
         with:
-          message-id: url_to_docs
-          message: |
-            View rendered docs @ https://intelpython.github.io/dpnp/pull/${{ env.PR_NUM }}/index.html
+          message-id: docs_preview
+          message: ${{ steps.docs_comment.outputs.message }}
           allow-repeats: false
 
   # The job is only used to build docs when PR is closed (action from PR branch)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fixed incorrect in-place advanced indexing for 4D arrays when using `range` or `list` as index keys [#2872](https://github.com/IntelPython/dpnp/pull/2872)
 * Fixed `conda build` command syntax in GitHub workflows and documentation to use `conda-build` [#2888](https://github.com/IntelPython/dpnp/pull/2888)
+* Fixed fork PR documentation workflow failures by implementing conditional publishing strategy: upstream PRs publish to GitHub Pages with comment, fork PRs upload artifacts [#2910](https://github.com/IntelPython/dpnp/pull/2910)
 
 ### Security
 


### PR DESCRIPTION
## Problem
Fork PRs to this repository fail the `Build Sphinx` workflow with a 403 permission error:
```
remote: Permission to IntelPython/dpnp.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/IntelPython/dpnp.git/': The requested URL returned error: 403
Error: Action failed with "The process '/usr/bin/git' failed with exit code 128"
```

## GitHub Security Context

Fork PRs run with read-only `GITHUB_TOKEN` and cannot:
- ❌ Push to branches (including `gh-pages`)
- ❌ Post PR comments
- ❌ Access repository secrets

**Reference:** [GitHub Actions documentation on fork PR security](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflows-in-forked-repositories)

> "The `GITHUB_TOKEN` has read-only permissions in pull requests from forked repositories."

This is a security feature that cannot be overridden by workflow permissions.

## Solution

This PR implements a **conditional publishing strategy** that respects GitHub's fork PR security model:

### For Upstream PRs (same-repo branches):
✅ Builds documentation  
✅ Publishes to GitHub Pages (`gh-pages` branch)  
✅ Comments with direct URL: https://intelpython.github.io/dpnp/pull/{number}/index.html  
✅ Workflow passes

### For Fork PRs:
✅ Builds documentation  
✅ Uploads as workflow artifact (30-day retention)  
✅ Workflow passes (no 403 error)  
ℹ️ No comment (cannot post due to read-only token)  
ℹ️ Artifact visible in workflow run's "Artifacts" section
