### PR TITLE
Fix `dpnp.tensor.acosh` handling of complex(+-0, NaN)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fixed incorrect in-place advanced indexing for 4D arrays when using `range` or `list` as index keys [#2872](https://github.com/IntelPython/dpnp/pull/2872)
 * Fixed `conda build` command syntax in GitHub workflows and documentation to use `conda-build` [#2888](https://github.com/IntelPython/dpnp/pull/2888)
+* Fixed incorrect `dpnp.tensor.acosh` result for `complex(±0, NaN)` special case to match the Array API specification and NumPy [#2914](https://github.com/IntelPython/dpnp/pull/2914)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fixed incorrect in-place advanced indexing for 4D arrays when using `range` or `list` as index keys [#2872](https://github.com/IntelPython/dpnp/pull/2872)
 * Fixed `conda build` command syntax in GitHub workflows and documentation to use `conda-build` [#2888](https://github.com/IntelPython/dpnp/pull/2888)
-* Fixed incorrect `dpnp.tensor.acosh` result for `complex(±0, NaN)` special case to match the Array API specification and NumPy [#2914](https://github.com/IntelPython/dpnp/pull/2914)
+* Fixed incorrect `dpnp.tensor.acosh` result for `complex(±0, NaN)` special case to match the Python Array API specification [#2914](https://github.com/IntelPython/dpnp/pull/2914)
 
 ### Security
 

--- a/dpnp/tensor/libtensor/include/kernels/elementwise_functions/acosh.hpp
+++ b/dpnp/tensor/libtensor/include/kernels/elementwise_functions/acosh.hpp
@@ -150,10 +150,6 @@ struct AcoshFunctor
             if (std::isnan(rx)) {
                 return resT{sycl::fabs(ry), rx};
             }
-            /* acosh(0 + I*NaN) = NaN + I*NaN */
-            if (std::isnan(ry)) {
-                return resT{ry, ry};
-            }
             /* ordinary cases */
             const realT res_im = sycl::copysign(rx, std::imag(in));
             return resT{sycl::fabs(ry), res_im};

--- a/dpnp/tests/tensor/elementwise/test_hyperbolic.py
+++ b/dpnp/tests/tensor/elementwise/test_hyperbolic.py
@@ -38,7 +38,9 @@ from ..helper import (
 )
 from .utils import (
     _all_dtypes,
+    _complex_fp_dtypes,
     _map_to_device_dtype,
+    _real_fp_dtypes,
 )
 
 _hyper_funcs = [(np.sinh, dpt.sinh), (np.cosh, dpt.cosh), (np.tanh, dpt.tanh)]
@@ -65,7 +67,7 @@ def test_hyper_out_type(np_call, dpt_call, dtype):
 
 
 @pytest.mark.parametrize("np_call, dpt_call", _all_funcs)
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8"])
+@pytest.mark.parametrize("dtype", _real_fp_dtypes)
 def test_hyper_real_contig(np_call, dpt_call, dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
@@ -96,7 +98,7 @@ def test_hyper_real_contig(np_call, dpt_call, dtype):
 
 
 @pytest.mark.parametrize("np_call, dpt_call", _all_funcs)
-@pytest.mark.parametrize("dtype", ["c8", "c16"])
+@pytest.mark.parametrize("dtype", _complex_fp_dtypes)
 def test_hyper_complex_contig(np_call, dpt_call, dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
@@ -123,7 +125,7 @@ def test_hyper_complex_contig(np_call, dpt_call, dtype):
 
 
 @pytest.mark.parametrize("np_call, dpt_call", _all_funcs)
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8"])
+@pytest.mark.parametrize("dtype", _real_fp_dtypes)
 def test_hyper_real_strided(np_call, dpt_call, dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
@@ -157,7 +159,7 @@ def test_hyper_real_strided(np_call, dpt_call, dtype):
 
 
 @pytest.mark.parametrize("np_call, dpt_call", _all_funcs)
-@pytest.mark.parametrize("dtype", ["c8", "c16"])
+@pytest.mark.parametrize("dtype", _complex_fp_dtypes)
 def test_hyper_complex_strided(np_call, dpt_call, dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
@@ -185,7 +187,7 @@ def test_hyper_complex_strided(np_call, dpt_call, dtype):
 
 
 @pytest.mark.parametrize("np_call, dpt_call", _all_funcs)
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8"])
+@pytest.mark.parametrize("dtype", _real_fp_dtypes)
 def test_hyper_real_special_cases(np_call, dpt_call, dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
@@ -202,9 +204,9 @@ def test_hyper_real_special_cases(np_call, dpt_call, dtype):
     assert_allclose(dpt.asnumpy(dpt_call(yf)), Y_np, atol=tol, rtol=tol)
 
 
-@pytest.mark.parametrize("dtype", ["c8", "c16"])
+@pytest.mark.parametrize("dtype", _complex_fp_dtypes)
 def test_acosh_zero_nan(dtype):
-    # check acosh(0 + NaN j) = NaN ± πj/2
+    # check acosh(±0 + NaN j) = NaN ± π/2 j (Array API spec)
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
 
@@ -213,11 +215,8 @@ def test_acosh_zero_nan(dtype):
     xf = np.array(x, dtype=dtype)
     yf = dpt.asarray(xf, dtype=dtype, sycl_queue=q)
 
-    with np.errstate(all="ignore"):
-        Y_np = np.arccosh(xf)
-
     Y_dpt = dpt.asnumpy(dpt.acosh(yf))
 
-    for i in range(len(x)):
-        assert np.isnan(Y_np[i].real) == np.isnan(Y_dpt[i].real)
-        assert_allclose(abs(Y_dpt[i].imag), abs(Y_np[i].imag), atol=1e-6)
+    pi_half = np.full(len(x), np.pi / 2, dtype=xf.real.dtype)
+    assert np.all(np.isnan(Y_dpt.real))
+    assert_allclose(abs(Y_dpt.imag), pi_half, atol=1e-6)

--- a/dpnp/tests/tensor/elementwise/test_hyperbolic.py
+++ b/dpnp/tests/tensor/elementwise/test_hyperbolic.py
@@ -200,3 +200,24 @@ def test_hyper_real_special_cases(np_call, dpt_call, dtype):
 
     tol = 8 * dpt.finfo(dtype).resolution
     assert_allclose(dpt.asnumpy(dpt_call(yf)), Y_np, atol=tol, rtol=tol)
+
+
+@pytest.mark.parametrize("dtype", ["c8", "c16"])
+def test_acosh_zero_nan(dtype):
+    # check acosh(0 + NaN j) = NaN ± πj/2
+    q = get_queue_or_skip()
+    skip_if_dtype_not_supported(dtype, q)
+
+    x = [complex(+0.0, np.nan), complex(-0.0, np.nan)]
+
+    xf = np.array(x, dtype=dtype)
+    yf = dpt.asarray(xf, dtype=dtype, sycl_queue=q)
+
+    with np.errstate(all="ignore"):
+        Y_np = np.arccosh(xf)
+
+    Y_dpt = dpt.asnumpy(dpt.acosh(yf))
+
+    for i in range(len(x)):
+        assert np.isnan(Y_np[i].real) == np.isnan(Y_dpt[i].real)
+        assert_allclose(abs(Y_dpt[i].imag), abs(Y_np[i].imag), atol=1e-6)

--- a/dpnp/tests/tensor/elementwise/test_hyperbolic.py
+++ b/dpnp/tests/tensor/elementwise/test_hyperbolic.py
@@ -217,6 +217,5 @@ def test_acosh_zero_nan(dtype):
 
     Y_dpt = dpt.asnumpy(dpt.acosh(yf))
 
-    pi_half = np.full(len(x), np.pi / 2, dtype=xf.real.dtype)
-    assert np.all(np.isnan(Y_dpt.real))
-    assert_allclose(abs(Y_dpt.imag), pi_half, atol=1e-6)
+    assert np.isnan(Y_dpt.real).all()
+    assert_allclose(np.abs(Y_dpt.imag), np.pi / 2, atol=1e-6, strict=False)


### PR DESCRIPTION
This PR proposes to fix issue #2880  where `dpnp.tensor.acosh(complex(0, NaN))` returned `NaN + NaN j` instead of `NaN ± π/2 j` as required by the Array API specification

The issue was caused by an incorrect early-return branch in acosh.hpp:
```
if (std::isnan(ry)) {
    return resT{ry, ry};
}
```
This special case bypassed the general logic which already produces the correct result.

The fix removes this unnecessary branch making the behavior consistent with both the Array API specification and NumPy
```
In [1]: import dpnp.tensor as dpt

In [2]: import numpy as np

In [3]: a = dpt.asarray([complex(+0, np.nan)])

In [4]: dpt.acosh(a)
Out[4]: usm_ndarray([nan+1.57079633j])

In [5]: a = np.asarray([complex(+0, np.nan)])

In [6]: np.acosh(a)
Out[6]: array([nan+1.57079633j])
```

Also adds a new `test_acosh_zero_nan` test to cover this case


- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [X] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [X] Have you added your changes to the changelog?
