### PR TITLE
Use `ubuntu-latest` runner where possible

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -71,13 +71,6 @@ jobs:
           echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
           sudo apt update
 
-      - name: Update libstdc++-dev
-        run: |
-          sudo apt remove -y gcc-7 g++-7 gcc-8 g++-8 gcc-10 g++-10
-          sudo apt remove -y libstdc++-10-dev
-          sudo apt autoremove
-          sudo apt install --reinstall -y gcc-9 g++-9 libstdc++-9-dev
-
       - name: Install Intel OneAPI
         if: env.oneapi-pkgs-env == ''
         run: |

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -25,7 +25,7 @@ jobs:
   build-and-deploy:
     name: Build and Deploy Docs
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 90
 
     permissions:

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:graphics-drivers/ppa
           sudo apt-get update
-          sudo apt-get install -y libnvidia-gl-450
+          sudo apt-get install -y libnvidia-gl-550
           sudo apt-get install -y nvidia-cuda-toolkit clinfo
 
       - name: Checkout repo

--- a/.github/workflows/check-onemath.yaml
+++ b/.github/workflows/check-onemath.yaml
@@ -71,7 +71,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ['3.13'] # no dpctl package on PyPI with enabled python 3.14 support
-        os: [ubuntu-22.04] # windows-2022 - no DFT support for Windows in oneMKL
+        os: [ubuntu-latest] # windows-2022 - no DFT support for Windows in oneMKL
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
@@ -188,7 +188,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ['3.13'] # no dpctl package on PyPI with enabled python 3.14 support
-        os: [ubuntu-22.04] # windows-2022 - no DFT support for Windows in oneMKL
+        os: [ubuntu-latest] # windows-2022 - no DFT support for Windows in oneMKL
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -457,7 +457,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ['3.10', '3.11', '3.12', '3.13', '3.14']
-        os: [ubuntu-22.04, windows-2022]
+        os: [ubuntu-latest, windows-2022]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
@@ -537,11 +537,7 @@ jobs:
       # Needed to add a comment to a pull request's issue
       pull-requests: write
 
-    strategy:
-      matrix:
-        os: [ubuntu-22.04]
-
-    runs-on:  ${{ matrix.os }}
+    runs-on:  ubuntu-latest
     timeout-minutes: 15
 
     defaults:
@@ -707,7 +703,7 @@ jobs:
 
     needs: [upload]
 
-    runs-on: 'ubuntu-latest'
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     defaults:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,7 +11,7 @@ jobs:
   pre-commit:
     name: Check
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
This PR updates existing GitHub workflows to switch to use `ubuntu-latest` runner instead of `ubuntu-22.04` one where it's possible.

Note, `cron-run-tests.yaml` still assumes to run tests on both `ubuntu-22.04` and `ubuntu-24.04` to validate both deployment paths.
And `conda-package.yml` still builds on `ubuntu-22.04` to support running tests on any Ubuntu since 22.04.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
