### PR TITLE
Use python 3.14 environment in GitHub workflows

### DIFF
--- a/.github/workflows/check-onemath.yaml
+++ b/.github/workflows/check-onemath.yaml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.13'] # no dpctl package on PyPI with enabled python 3.14 support
+        python: ['3.14']
         os: [ubuntu-latest] # windows-2022 - no DFT support for Windows in oneMKL
 
     runs-on: ${{ matrix.os }}
@@ -187,7 +187,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.13'] # no dpctl package on PyPI with enabled python 3.14 support
+        python: ['3.14']
         os: [ubuntu-latest] # windows-2022 - no DFT support for Windows in oneMKL
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/check-onemath.yaml
+++ b/.github/workflows/check-onemath.yaml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.13'] # no dpctl package on PyPI with enabled python 3.14 support
+        python: ['3.14']
         os: [ubuntu-22.04] # windows-2022 - no DFT support for Windows in oneMKL
 
     runs-on: ${{ matrix.os }}
@@ -187,7 +187,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.13'] # no dpctl package on PyPI with enabled python 3.14 support
+        python: ['3.14']
         os: [ubuntu-22.04] # windows-2022 - no DFT support for Windows in oneMKL
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -659,7 +659,7 @@ jobs:
       dpnp-repo-path: '${{ github.workspace }}/source/'
       array-api-skips-file: '${{ github.workspace }}/source/.github/workflows/array-api-skips.txt'
       create-conda-channel-env: 'source/environments/create_conda_channel.yml'
-      python-ver: '3.13' # it has to be aligned with python in create_conda_channel.yml
+      python-ver: '3.14'
       conda-env-name: 'array-api-conformity'
       channel-path: '${{ github.workspace }}/channel/'
       pkg-path-in-channel: '${{ github.workspace }}/channel/linux-64/'

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -556,7 +556,7 @@ jobs:
       dpnp-repo-path: '${{ github.workspace }}/source/'
       array-api-skips-file: '${{ github.workspace }}/source/.github/workflows/array-api-skips.txt'
       create-conda-channel-env: 'source/environments/create_conda_channel.yml'
-      python-ver: '3.13' # it has to be aligned with python in create_conda_channel.yml
+      python-ver: '3.14'
       conda-env-name: 'array-api-conformity'
       channel-path: '${{ github.workspace }}/channel/'
       pkg-path-in-channel: '${{ github.workspace }}/channel/linux-64/'

--- a/dpnp/tensor/_slicing.pyx
+++ b/dpnp/tensor/_slicing.pyx
@@ -28,6 +28,7 @@
 
 # distutils: language = c++
 # cython: language_level=3
+# cython: linetrace=True
 
 from operator import index
 from cpython.buffer cimport PyObject_CheckBuffer

--- a/dpnp/tensor/_stride_utils.pyx
+++ b/dpnp/tensor/_stride_utils.pyx
@@ -28,6 +28,7 @@
 
 # distutils: language = c++
 # cython: language_level=3
+# cython: linetrace=True
 
 from cpython.mem cimport PyMem_Free, PyMem_Malloc
 from cpython.ref cimport Py_INCREF

--- a/dpnp/tensor/_types.pyx
+++ b/dpnp/tensor/_types.pyx
@@ -28,6 +28,7 @@
 
 # distutils: language = c++
 # cython: language_level=3
+# cython: linetrace=True
 
 import numpy as np
 

--- a/environments/building_docs.yml
+++ b/environments/building_docs.yml
@@ -2,7 +2,7 @@ name: Building docs specific packages
 channels:
   - conda-forge
 dependencies:
-  - python=3.13 # no dpctl package on PyPI with enabled python 3.14 support
+  - python=3.14
   - cupy
   - sphinx
   - sphinx_rtd_theme

--- a/environments/building_docs.yml
+++ b/environments/building_docs.yml
@@ -2,7 +2,7 @@ name: Building docs specific packages
 channels:
   - conda-forge
 dependencies:
-  - python=3.13 # no dpctl package on PyPI with enabled python 3.14 support
+  - python=3.14
   - cupy
   - sphinx
   - furo

--- a/environments/coverage.txt
+++ b/environments/coverage.txt
@@ -1,1 +1,1 @@
-coveralls==4.0.1
+coveralls==4.1.0

--- a/environments/coverage.yml
+++ b/environments/coverage.yml
@@ -2,7 +2,7 @@ name: Coverage specific packages
 channels:
   - conda-forge
 dependencies:
-  - python=3.12 # no python 3.13 support by coveralls
+  - python=3.14
   - coverage[toml]
   - llvm
   - pytest-cov

--- a/environments/upload_cleanup_conda_pkg.yml
+++ b/environments/upload_cleanup_conda_pkg.yml
@@ -2,5 +2,5 @@ name: Upload or clean up a conda package
 channels:
   - conda-forge
 dependencies:
-  - python=3.13
+  - python=3.14
   - anaconda-client=1.14.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,11 @@ omit = [
 
 [tool.coverage.run]
 branch = true
+# Pin the C trace core. On Python 3.14+ coverage.py defaults to the sys.monitoring
+# ("sysmon") core, which (1) does not support plugins such as Cython.Coverage below,
+# and (2) corrupts the exception state when a C/Cython function raises, turning
+# expected exceptions into SystemError (e.g. usm_ndarray.__dlpack__ in test_dlpack.py).
+core = "ctrace"
 omit = [
   "dpnp/tests/*",
   "dpnp/_version.py"


### PR DESCRIPTION
This PR updates the remaining GitHub workflows and conda environments to run under python 3.14, and bumps coveralls to 4.1.0 (which supports 3.14).

### Version bumps (3.13/3.12 → 3.14)
- `check-onemath.yaml` — oneMath interface tests
- `conda-package.yml` — array API conformance tests (`python-ver`)
- `environments/building_docs.yml` — docs build
- `environments/upload_cleanup_conda_pkg.yml` — conda package upload/cleanup
- `environments/coverage.yml` — coverage job (was pinned to `3.12`)

### Coverage job fixes for python 3.14

Bumping the coverage environment from 3.12 to 3.14 surfaced two failures unrelated to dpnp's runtime code — both stem from how coverage instrumentation interacts with 3.14's `sys.monitoring`:

**1. Build failure — `undeclared identifier '__Pyx_MonitoringEventTypes_CyGen_count'`**

Coverage builds compile every extension with `CYTHON_TRACE=1` (`DPNP_GENERATE_COVERAGE=ON`), but Cython line tracing also needs the matching `# cython: linetrace=True` directive at cythonize time. Three `.pyx` files were missing it (`_slicing.pyx`, `_stride_utils.pyx`, `_types.pyx`): without the directive, Cython references `__Pyx_MonitoringEventTypes_CyGen_count` (from the shared generator/coroutine struct) but never defines it. On python ≤3.12 the guarding `CYTHON_USE_SYS_MONITORING` macro is `0`, so the code was unreachable — which is why the previous `3.12` pin hid this; on 3.13+ it becomes reachable and fails to compile. Added the directive to the three files. As a side effect, these files were previously producing no line-coverage data and are now measured.

**2. Test failures — `test_dlpack.py::TestDLPack::test_invaid_stream[scalar|dictionary|device]`**

coverage.py 7.9+ makes the `sys.monitoring` core (`sysmon`) the default on python 3.14. That core (a) does not support plugins such as the `Cython.Coverage` plugin used here, and (b) corrupts the pending exception when a C/Cython function raises — turning dpctl's correct `TypeError` from `usm_ndarray.__dlpack__` into a `SystemError`, so `assert_raises(TypeError, ...)` fails. Pinned the measurement core back to `ctrace` via `core = "ctrace"` in `[tool.coverage.run]` (`pyproject.toml`). `ctrace` supports both the Cython plugin and branch coverage, so no coverage data is lost.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
