### PR TITLE
Improve handling of large values by inverse hyperbolic and trigonometric functions

### DIFF
--- a/.github/workflows/array-api-skips.txt
+++ b/.github/workflows/array-api-skips.txt
@@ -1,5 +1,1 @@
 # array API tests to be skipped
-
-# unexpected result is returned - unmute when dpctl-1986 is resolved
-array_api_tests/test_operators_and_elementwise_functions.py::test_asin
-array_api_tests/test_operators_and_elementwise_functions.py::test_asinh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ This release is compatible with NumPy 2.5.
 * Fixed `dpnp.linalg.svd(..., hermitian=True)` returning a non-unitary `vh` for singular input arrays due to a zero sign appearing [#2954](https://github.com/IntelPython/dpnp/pull/2954)
 * Fixed scalar conversion of size-one `dpnp.tensor.usm_ndarray` (e.g. `int()`, `float()`, indexing) which failed with NumPy 2.5 after the in-place `ndarray.shape` assignment was deprecated [#2958](https://github.com/IntelPython/dpnp/pull/2958)
 * Fixed `dpnp.mgrid` and `dpnp.ogrid` to return consistent results between single-slice and tuple-of-slices syntax when the step is a complex number with a non-integer magnitude (e.g. `2.5j`) [#2971](https://github.com/IntelPython/dpnp/pull/2971)
+* Fixed `dpnp.tensor.acosh` and `dpnp.tensor.acos` returning infinity for complex numbers with large negative real parts [#2928](https://github.com/IntelPython/dpnp/pull/2928)
 
 ### Security
 

--- a/dpnp/tensor/libtensor/include/kernels/elementwise_functions/acos.hpp
+++ b/dpnp/tensor/libtensor/include/kernels/elementwise_functions/acos.hpp
@@ -39,11 +39,11 @@
 #include <type_traits>
 #include <vector>
 
+#include "common.hpp"
 #include "complex_math.hpp"
 #include "vec_size_util.hpp"
 
 #include "kernels/dpnp_tensor_types.hpp"
-#include "kernels/elementwise_functions/common.hpp"
 
 #include "utils/type_dispatch_building.hpp"
 #include "utils/type_utils.hpp"

--- a/dpnp/tensor/libtensor/include/kernels/elementwise_functions/acos.hpp
+++ b/dpnp/tensor/libtensor/include/kernels/elementwise_functions/acos.hpp
@@ -33,15 +33,13 @@
 //===---------------------------------------------------------------------===//
 
 #pragma once
-#include <cmath>
 #include <complex>
 #include <cstddef>
 #include <cstdint>
-#include <limits>
 #include <type_traits>
 #include <vector>
 
-#include "sycl_complex.hpp"
+#include "complex_math.hpp"
 #include "vec_size_util.hpp"
 
 #include "kernels/dpnp_tensor_types.hpp"
@@ -75,58 +73,7 @@ struct AcosFunctor
     resT operator()(const argT &in) const
     {
         if constexpr (is_complex<argT>::value) {
-            using realT = typename argT::value_type;
-
-            static constexpr realT q_nan =
-                std::numeric_limits<realT>::quiet_NaN();
-
-            const realT x = std::real(in);
-            const realT y = std::imag(in);
-
-            if (std::isnan(x)) {
-                /* acos(NaN + I*+-Inf) = NaN + I*-+Inf */
-                if (std::isinf(y)) {
-                    return resT{q_nan, -y};
-                }
-
-                /* all other cases involving NaN return NaN + I*NaN. */
-                return resT{q_nan, q_nan};
-            }
-            if (std::isnan(y)) {
-                /* acos(+-Inf + I*NaN) = NaN + I*opt(-)Inf */
-                if (std::isinf(x)) {
-                    return resT{q_nan, -std::numeric_limits<realT>::infinity()};
-                }
-                /* acos(0 + I*NaN) = PI/2 + I*NaN with inexact */
-                if (x == realT(0)) {
-                    const realT res_re = sycl::atan(realT(1)) * 2; // PI/2
-                    return resT{res_re, q_nan};
-                }
-
-                /* all other cases involving NaN return NaN + I*NaN. */
-                return resT{q_nan, q_nan};
-            }
-
-            /*
-             * For large x or y including acos(+-Inf + I*+-Inf)
-             */
-            static constexpr realT r_eps =
-                realT(1) / std::numeric_limits<realT>::epsilon();
-            if (sycl::fabs(x) > r_eps || sycl::fabs(y) > r_eps) {
-                using sycl_complexT = exprm_ns::complex<realT>;
-                sycl_complexT log_in =
-                    exprm_ns::log(exprm_ns::complex<realT>(in));
-
-                const realT wx = log_in.real();
-                const realT wy = log_in.imag();
-                const realT rx = sycl::fabs(wy);
-
-                realT ry = wx + sycl::log(realT(2));
-                return resT{rx, (sycl::signbit(y)) ? ry : -ry};
-            }
-
-            /* ordinary cases */
-            return exprm_ns::acos(exprm_ns::complex<realT>(in)); // acos(in);
+            return dpnp::tensor::kernels::complex_math::cacos<argT>(in);
         }
         else {
             static_assert(std::is_floating_point_v<argT> ||

--- a/dpnp/tensor/libtensor/include/kernels/elementwise_functions/acosh.hpp
+++ b/dpnp/tensor/libtensor/include/kernels/elementwise_functions/acosh.hpp
@@ -37,13 +37,12 @@
 #include <complex>
 #include <cstddef>
 #include <cstdint>
-#include <limits>
 #include <type_traits>
 #include <vector>
 
 #include <sycl/sycl.hpp>
 
-#include "sycl_complex.hpp"
+#include "complex_math.hpp"
 #include "vec_size_util.hpp"
 
 #include "kernels/dpnp_tensor_types.hpp"
@@ -79,63 +78,8 @@ struct AcoshFunctor
         if constexpr (is_complex<argT>::value) {
             using realT = typename argT::value_type;
 
-            static constexpr realT q_nan =
-                std::numeric_limits<realT>::quiet_NaN();
-            /*
-             * acosh(in) = I*acos(in) or -I*acos(in)
-             * where the sign is chosen so Re(acosh(in)) >= 0.
-             * So, we first calculate acos(in) and then acosh(in).
-             */
-            const realT x = std::real(in);
-            const realT y = std::imag(in);
-
-            resT acos_in;
-            if (std::isnan(x)) {
-                /* acos(NaN + I*+-Inf) = NaN + I*-+Inf */
-                if (std::isinf(y)) {
-                    acos_in = resT{q_nan, -y};
-                }
-                else {
-                    acos_in = resT{q_nan, q_nan};
-                }
-            }
-            else if (std::isnan(y)) {
-                /* acos(+-Inf + I*NaN) = NaN + I*opt(-)Inf */
-                static constexpr realT inf =
-                    std::numeric_limits<realT>::infinity();
-
-                if (std::isinf(x)) {
-                    acos_in = resT{q_nan, -inf};
-                }
-                /* acos(0 + I*NaN) = Pi/2 + I*NaN with inexact */
-                else if (x == realT(0)) {
-                    const realT pi_half = sycl::atan(realT(1)) * 2;
-                    acos_in = resT{pi_half, q_nan};
-                }
-                else {
-                    acos_in = resT{q_nan, q_nan};
-                }
-            }
-
-            static constexpr realT r_eps =
-                realT(1) / std::numeric_limits<realT>::epsilon();
-            /*
-             * For large x or y including acos(+-Inf + I*+-Inf)
-             */
-            if (sycl::fabs(x) > r_eps || sycl::fabs(y) > r_eps) {
-                using sycl_complexT = typename exprm_ns::complex<realT>;
-                const sycl_complexT log_in = exprm_ns::log(sycl_complexT(in));
-                const realT wx = log_in.real();
-                const realT wy = log_in.imag();
-                const realT rx = sycl::fabs(wy);
-                realT ry = wx + sycl::log(realT(2));
-                acos_in = resT{rx, (sycl::signbit(y)) ? ry : -ry};
-            }
-            else {
-                /* ordinary cases */
-                acos_in =
-                    exprm_ns::acos(exprm_ns::complex<realT>(in)); // acos(in);
-            }
+            /* calculate acos value */
+            resT acos_in = dpnp::tensor::kernels::complex_math::cacos<argT>(in);
 
             /* Now we calculate acosh(z) */
             const realT rx = std::real(acos_in);

--- a/dpnp/tensor/libtensor/include/kernels/elementwise_functions/acosh.hpp
+++ b/dpnp/tensor/libtensor/include/kernels/elementwise_functions/acosh.hpp
@@ -42,11 +42,11 @@
 
 #include <sycl/sycl.hpp>
 
+#include "common.hpp"
 #include "complex_math.hpp"
 #include "vec_size_util.hpp"
 
 #include "kernels/dpnp_tensor_types.hpp"
-#include "kernels/elementwise_functions/common.hpp"
 
 #include "utils/type_dispatch_building.hpp"
 #include "utils/type_utils.hpp"

--- a/dpnp/tensor/libtensor/include/kernels/elementwise_functions/asin.hpp
+++ b/dpnp/tensor/libtensor/include/kernels/elementwise_functions/asin.hpp
@@ -33,21 +33,18 @@
 //===---------------------------------------------------------------------===//
 
 #pragma once
-#include <cmath>
-#include <complex>
 #include <cstddef>
 #include <cstdint>
-#include <limits>
 #include <type_traits>
 #include <vector>
 
 #include <sycl/sycl.hpp>
 
-#include "sycl_complex.hpp"
+#include "common.hpp"
+#include "complex_math.hpp"
 #include "vec_size_util.hpp"
 
 #include "kernels/dpnp_tensor_types.hpp"
-#include "kernels/elementwise_functions/common.hpp"
 
 #include "utils/type_dispatch_building.hpp"
 #include "utils/type_utils.hpp"
@@ -77,78 +74,7 @@ struct AsinFunctor
     resT operator()(const argT &in) const
     {
         if constexpr (is_complex<argT>::value) {
-            using realT = typename argT::value_type;
-
-            static constexpr realT q_nan =
-                std::numeric_limits<realT>::quiet_NaN();
-
-            /*
-             * asin(in) = I * conj( asinh(I * conj(in)) )
-             * so we first calculate w = asinh(I * conj(in)) with
-             * x = real(I * conj(in)) = imag(in)
-             * y = imag(I * conj(in)) = real(in)
-             * and then return {imag(w), real(w)} which is asin(in)
-             */
-            const realT x = std::imag(in);
-            const realT y = std::real(in);
-
-            if (std::isnan(x)) {
-                /* asinh(NaN + I*+-Inf) = opt(+-)Inf + I*NaN */
-                if (std::isinf(y)) {
-                    const realT asinh_re = y;
-                    const realT asinh_im = q_nan;
-                    return resT{asinh_im, asinh_re};
-                }
-                /* asinh(NaN + I*0) = NaN + I*0 */
-                if (y == realT(0)) {
-                    const realT asinh_re = q_nan;
-                    const realT asinh_im = y;
-                    return resT{asinh_im, asinh_re};
-                }
-                /* All other cases involving NaN return NaN + I*NaN. */
-                return resT{q_nan, q_nan};
-            }
-            else if (std::isnan(y)) {
-                /* asinh(+-Inf + I*NaN) = +-Inf + I*NaN */
-                if (std::isinf(x)) {
-                    const realT asinh_re = x;
-                    const realT asinh_im = q_nan;
-                    return resT{asinh_im, asinh_re};
-                }
-                /* All other cases involving NaN return NaN + I*NaN. */
-                return resT{q_nan, q_nan};
-            }
-
-            /*
-             * For large x or y including asinh(+-Inf + I*+-Inf)
-             * asinh(in) = sign(x)*log(sign(x)*in) + O(1/in^2)   as in ->
-             * infinity The above formula works for the imaginary part as well,
-             * because Im(asinh(in)) = sign(x)*atan2(sign(x)*y, fabs(x)) +
-             * O(y/in^3) as in -> infinity, uniformly in y
-             */
-            static constexpr realT r_eps =
-                realT(1) / std::numeric_limits<realT>::epsilon();
-            if (sycl::fabs(x) > r_eps || sycl::fabs(y) > r_eps) {
-                using sycl_complexT = exprm_ns::complex<realT>;
-                const sycl_complexT z{x, y};
-                realT wx, wy;
-                if (!sycl::signbit(x)) {
-                    const auto log_z = exprm_ns::log(z);
-                    wx = log_z.real() + sycl::log(realT(2));
-                    wy = log_z.imag();
-                }
-                else {
-                    const auto log_mz = exprm_ns::log(-z);
-                    wx = log_mz.real() + sycl::log(realT(2));
-                    wy = log_mz.imag();
-                }
-                const realT asinh_re = sycl::copysign(wx, x);
-                const realT asinh_im = sycl::copysign(wy, y);
-                return resT{asinh_im, asinh_re};
-            }
-            /* ordinary cases */
-            return exprm_ns::asin(
-                exprm_ns::complex<realT>(in)); // sycl::asin(in);
+            return complex_math::casin(in);
         }
         else {
             static_assert(std::is_floating_point_v<argT> ||

--- a/dpnp/tensor/libtensor/include/kernels/elementwise_functions/asinh.hpp
+++ b/dpnp/tensor/libtensor/include/kernels/elementwise_functions/asinh.hpp
@@ -33,21 +33,18 @@
 //===---------------------------------------------------------------------===//
 
 #pragma once
-#include <cmath>
-#include <complex>
 #include <cstddef>
 #include <cstdint>
-#include <limits>
 #include <type_traits>
 #include <vector>
 
 #include <sycl/sycl.hpp>
 
-#include "sycl_complex.hpp"
+#include "common.hpp"
+#include "complex_math.hpp"
 #include "vec_size_util.hpp"
 
 #include "kernels/dpnp_tensor_types.hpp"
-#include "kernels/elementwise_functions/common.hpp"
 
 #include "utils/type_dispatch_building.hpp"
 #include "utils/type_utils.hpp"
@@ -77,61 +74,7 @@ struct AsinhFunctor
     resT operator()(const argT &in) const
     {
         if constexpr (is_complex<argT>::value) {
-            using realT = typename argT::value_type;
-
-            static constexpr realT q_nan =
-                std::numeric_limits<realT>::quiet_NaN();
-
-            const realT x = std::real(in);
-            const realT y = std::imag(in);
-
-            if (std::isnan(x)) {
-                /* asinh(NaN + I*+-Inf) = opt(+-)Inf + I*NaN */
-                if (std::isinf(y)) {
-                    return resT{y, q_nan};
-                }
-                /* asinh(NaN + I*0) = NaN + I*0 */
-                if (y == realT(0)) {
-                    return resT{q_nan, y};
-                }
-                /* All other cases involving NaN return NaN + I*NaN. */
-                return resT{q_nan, q_nan};
-            }
-
-            if (std::isnan(y)) {
-                /* asinh(+-Inf + I*NaN) = +-Inf + I*NaN */
-                if (std::isinf(x)) {
-                    return resT{x, q_nan};
-                }
-                /* All other cases involving NaN return NaN + I*NaN. */
-                return resT{q_nan, q_nan};
-            }
-
-            /*
-             * For large x or y including asinh(+-Inf + I*+-Inf)
-             * asinh(in) = sign(x)*log(sign(x)*in) + O(1/in^2)   as in ->
-             * infinity The above formula works for the imaginary part as well,
-             * because Im(asinh(in)) = sign(x)*atan2(sign(x)*y, fabs(x)) +
-             * O(y/in^3) as in -> infinity, uniformly in y
-             */
-            static constexpr realT r_eps =
-                realT(1) / std::numeric_limits<realT>::epsilon();
-
-            if (sycl::fabs(x) > r_eps || sycl::fabs(y) > r_eps) {
-                using sycl_complexT = exprm_ns::complex<realT>;
-                sycl_complexT log_in = (sycl::signbit(x))
-                                           ? exprm_ns::log(sycl_complexT(-in))
-                                           : exprm_ns::log(sycl_complexT(in));
-                realT wx = log_in.real() + sycl::log(realT(2));
-                realT wy = log_in.imag();
-
-                const realT res_re = sycl::copysign(wx, x);
-                const realT res_im = sycl::copysign(wy, y);
-                return resT{res_re, res_im};
-            }
-
-            /* ordinary cases */
-            return exprm_ns::asinh(exprm_ns::complex<realT>(in)); // asinh(in);
+            return complex_math::casinh(in);
         }
         else {
             static_assert(std::is_floating_point_v<argT> ||

--- a/dpnp/tensor/libtensor/include/kernels/elementwise_functions/atan.hpp
+++ b/dpnp/tensor/libtensor/include/kernels/elementwise_functions/atan.hpp
@@ -33,21 +33,18 @@
 //===---------------------------------------------------------------------===//
 
 #pragma once
-#include <cmath>
-#include <complex>
 #include <cstddef>
 #include <cstdint>
-#include <limits>
 #include <type_traits>
 #include <vector>
 
 #include <sycl/sycl.hpp>
 
-#include "sycl_complex.hpp"
+#include "common.hpp"
+#include "complex_math.hpp"
 #include "vec_size_util.hpp"
 
 #include "kernels/dpnp_tensor_types.hpp"
-#include "kernels/elementwise_functions/common.hpp"
 
 #include "utils/type_dispatch_building.hpp"
 #include "utils/type_utils.hpp"
@@ -80,67 +77,7 @@ struct AtanFunctor
     resT operator()(const argT &in) const
     {
         if constexpr (is_complex<argT>::value) {
-            using realT = typename argT::value_type;
-
-            static constexpr realT q_nan =
-                std::numeric_limits<realT>::quiet_NaN();
-            /*
-             * atan(in) = I * conj( atanh(I * conj(in)) )
-             * so we first calculate w = atanh(I * conj(in)) with
-             * x = real(I * conj(in)) = imag(in)
-             * y = imag(I * conj(in)) = real(in)
-             * and then return {imag(w), real(w)} which is atan(in)
-             */
-            const realT x = std::imag(in);
-            const realT y = std::real(in);
-            if (std::isnan(x)) {
-                /* atanh(NaN + I*+-Inf) = sign(NaN)*0 + I*+-Pi/2 */
-                if (std::isinf(y)) {
-                    const realT pi_half = sycl::atan(realT(1)) * 2;
-
-                    const realT atanh_re = sycl::copysign(realT(0), x);
-                    const realT atanh_im = sycl::copysign(pi_half, y);
-                    return resT{atanh_im, atanh_re};
-                }
-                /*
-                 * All other cases involving NaN return NaN + I*NaN.
-                 */
-                return resT{q_nan, q_nan};
-            }
-            else if (std::isnan(y)) {
-                /* atanh(+-Inf + I*NaN) = +-0 + I*NaN */
-                if (std::isinf(x)) {
-                    const realT atanh_re = sycl::copysign(realT(0), x);
-                    const realT atanh_im = q_nan;
-                    return resT{atanh_im, atanh_re};
-                }
-                /* atanh(+-0 + I*NaN) = +-0 + I*NaN */
-                if (x == realT(0)) {
-                    return resT{q_nan, x};
-                }
-                /*
-                 * All other cases involving NaN return NaN + I*NaN.
-                 */
-                return resT{q_nan, q_nan};
-            }
-
-            /*
-             * For large x or y including
-             * atanh(+-Inf + I*+-Inf) = 0 + I*+-PI/2
-             * The sign of pi/2 depends on the sign of imaginary part of the
-             * input.
-             */
-            static constexpr realT r_eps =
-                realT(1) / std::numeric_limits<realT>::epsilon();
-            if (sycl::fabs(x) > r_eps || sycl::fabs(y) > r_eps) {
-                const realT pi_half = sycl::atan(realT(1)) * 2;
-
-                const realT atanh_re = realT(0);
-                const realT atanh_im = sycl::copysign(pi_half, y);
-                return resT{atanh_im, atanh_re};
-            }
-            /* ordinary cases */
-            return exprm_ns::atan(exprm_ns::complex<realT>(in)); // atan(in);
+            return complex_math::catan(in);
         }
         else {
             static_assert(std::is_floating_point_v<argT> ||

--- a/dpnp/tensor/libtensor/include/kernels/elementwise_functions/atanh.hpp
+++ b/dpnp/tensor/libtensor/include/kernels/elementwise_functions/atanh.hpp
@@ -34,21 +34,18 @@
 
 #pragma once
 
-#include <cmath>
-#include <complex>
 #include <cstddef>
 #include <cstdint>
-#include <limits>
 #include <type_traits>
 #include <vector>
 
 #include <sycl/sycl.hpp>
 
-#include "sycl_complex.hpp"
+#include "common.hpp"
+#include "complex_math.hpp"
 #include "vec_size_util.hpp"
 
 #include "kernels/dpnp_tensor_types.hpp"
-#include "kernels/elementwise_functions/common.hpp"
 
 #include "utils/type_dispatch_building.hpp"
 #include "utils/type_utils.hpp"
@@ -78,61 +75,7 @@ struct AtanhFunctor
     resT operator()(const argT &in) const
     {
         if constexpr (is_complex<argT>::value) {
-            using realT = typename argT::value_type;
-            static constexpr realT q_nan =
-                std::numeric_limits<realT>::quiet_NaN();
-
-            const realT x = std::real(in);
-            const realT y = std::imag(in);
-
-            if (std::isnan(x)) {
-                /* atanh(NaN + I*+-Inf) = sign(NaN)0 + I*+-PI/2 */
-                if (std::isinf(y)) {
-                    const realT pi_half = sycl::atan(realT(1)) * 2;
-
-                    const realT res_re = sycl::copysign(realT(0), x);
-                    const realT res_im = sycl::copysign(pi_half, y);
-                    return resT{res_re, res_im};
-                }
-                /*
-                 * All other cases involving NaN return NaN + I*NaN.
-                 */
-                return resT{q_nan, q_nan};
-            }
-            else if (std::isnan(y)) {
-                /* atanh(+-Inf + I*NaN) = +-0 + I*NaN */
-                if (std::isinf(x)) {
-                    const realT res_re = sycl::copysign(realT(0), x);
-                    return resT{res_re, q_nan};
-                }
-                /* atanh(+-0 + I*NaN) = +-0 + I*NaN */
-                if (x == realT(0)) {
-                    return resT{x, q_nan};
-                }
-                /*
-                 * All other cases involving NaN return NaN + I*NaN.
-                 */
-                return resT{q_nan, q_nan};
-            }
-
-            /*
-             * For large x or y including
-             * atanh(+-Inf + I*+-Inf) = 0 + I*+-PI/2
-             * The sign of PI/2 depends on the sign of imaginary part of the
-             * input.
-             */
-            const realT RECIP_EPSILON =
-                realT(1) / std::numeric_limits<realT>::epsilon();
-            if (sycl::fabs(x) > RECIP_EPSILON ||
-                sycl::fabs(y) > RECIP_EPSILON) {
-                const realT pi_half = sycl::atan(realT(1)) * 2;
-
-                const realT res_re = realT(0);
-                const realT res_im = sycl::copysign(pi_half, y);
-                return resT{res_re, res_im};
-            }
-            /* ordinary cases */
-            return exprm_ns::atanh(exprm_ns::complex<realT>(in)); // atanh(in);
+            return complex_math::catanh(in);
         }
         else {
             static_assert(std::is_floating_point_v<argT> ||

--- a/dpnp/tensor/libtensor/include/kernels/elementwise_functions/complex_math.hpp
+++ b/dpnp/tensor/libtensor/include/kernels/elementwise_functions/complex_math.hpp
@@ -181,4 +181,78 @@ T casin(const T &in)
     // reverse result back: swap real and imaginary parts
     return T{std::imag(w), std::real(w)};
 }
+
+template <typename T>
+T catanh(const T &in)
+{
+    using realT = typename T::value_type;
+
+    static constexpr realT pio2 = realT(pi) / realT(2); // PI/2
+
+    const realT x = std::real(in);
+    const realT y = std::imag(in);
+
+    if (std::isnan(x)) {
+        // atanh(NaN + I*+-Inf) = sign(NaN)*0 + I*+-PI/2
+        if (std::isinf(y)) {
+            const realT res_re = sycl::copysign(realT(0), x);
+            const realT res_im = sycl::copysign(pio2, y);
+            return T{res_re, res_im};
+        }
+
+        // all other cases involving NaN return NaN + I*NaN
+        return T{q_nan<realT>, q_nan<realT>};
+    }
+
+    if (std::isnan(y)) {
+        // atanh(+-Inf + I*NaN) = +-0 + I*NaN
+        if (std::isinf(x)) {
+            const realT res_re = sycl::copysign(realT(0), x);
+            return T{res_re, q_nan<realT>};
+        }
+
+        // atanh(+-0 + I*NaN) = +-0 + I*NaN
+        if (x == realT(0)) {
+            return T{x, q_nan<realT>};
+        }
+
+        // all other cases involving NaN return NaN + I*NaN
+        return T{q_nan<realT>, q_nan<realT>};
+    }
+
+    /*
+     * For large x or y including atanh(+-Inf + I*+-Inf) = 0 + I*+-PI/2
+     * The sign of PI/2 depends on the sign of imaginary part of the input.
+     *
+     * exprm_ns::atanh(x) is based on calculating log((1 + x) / (1 - x)) / 2,
+     * so r_eps = 1/eps is appropriate precision loss point.
+     */
+    const realT r_eps = realT(1) / std::numeric_limits<realT>::epsilon();
+    if (sycl::fabs(x) > r_eps || sycl::fabs(y) > r_eps) {
+        const realT res_re = realT(0);
+        const realT res_im = sycl::copysign(pio2, y);
+        return T{res_re, res_im};
+    }
+
+    // ordinary cases
+    return exprm_ns::atanh(exprm_ns::complex<realT>(in));
+}
+
+template <typename T>
+T catan(const T &in)
+{
+    /*
+     * catan(z) = reverse(catanh(reverse(z))),
+     * where reverse(x + I*y) = y + I*x = I*conj(z)
+     */
+
+    // reverse(z): swap real and imaginary parts
+    T reversed{std::imag(in), std::real(in)};
+
+    // compute atanh of reversed input
+    T w = catanh(reversed);
+
+    // reverse result back: swap real and imaginary parts
+    return T{std::imag(w), std::real(w)};
+}
 } // namespace dpnp::tensor::kernels::complex_math

--- a/dpnp/tensor/libtensor/include/kernels/elementwise_functions/complex_math.hpp
+++ b/dpnp/tensor/libtensor/include/kernels/elementwise_functions/complex_math.hpp
@@ -42,8 +42,15 @@
 
 namespace dpnp::tensor::kernels::complex_math
 {
-static constexpr double ln2 = 0.6931471805599453094172321214581765L;
-static constexpr double pi = 3.1415926535897932384626433832795029L;
+template <typename realT>
+static constexpr realT ln2 = 0.6931471805599453094172321214581765L;
+
+template <typename realT>
+static constexpr realT pi = 3.1415926535897932384626433832795029L;
+
+template <typename realT>
+static constexpr realT inv_eps =
+    realT(1) / std::numeric_limits<realT>::epsilon();
 
 template <typename realT>
 static constexpr realT q_nan = std::numeric_limits<realT>::quiet_NaN();
@@ -75,7 +82,7 @@ T cacos(const T &in)
 
         // acos(0 + I*NaN) = PI/2 + I*NaN with inexact
         if (x == realT(0)) {
-            static constexpr realT pio2 = realT(pi) / realT(2); // PI/2
+            static constexpr realT pio2 = pi<realT> / realT(2); // PI/2
             return T{pio2, q_nan<realT>};
         }
 
@@ -88,8 +95,7 @@ T cacos(const T &in)
      * exprm_ns::acos(x) is based on calculating log(x + sqrt(x^2 - 1)),
      * so r_eps = sqrt(1/eps)/2 is appropriate precision loss point.
      */
-    const realT r_eps =
-        sycl::sqrt(realT(1) / std::numeric_limits<realT>::epsilon()) / 2;
+    const realT r_eps = sycl::sqrt(inv_eps<realT>) / 2;
     if (sycl::fabs(x) > r_eps || sycl::fabs(y) > r_eps) {
         sycl_complexT log_in = exprm_ns::log(sycl_complexT(in));
 
@@ -97,7 +103,7 @@ T cacos(const T &in)
         const realT wy = log_in.imag();
         const realT rx = sycl::fabs(wy);
 
-        realT ry = wx + realT(ln2);
+        realT ry = wx + ln2<realT>;
         return T{rx, (sycl::signbit(y)) ? ry : -ry};
     }
 
@@ -146,13 +152,12 @@ T casinh(const T &in)
      * exprm_ns::asinh(x) is based on calculating log(x + sqrt(x^2 + 1)),
      * so r_eps = sqrt(1/eps)/2 is appropriate precision loss point.
      */
-    const realT r_eps =
-        sycl::sqrt(realT(1) / std::numeric_limits<realT>::epsilon()) / 2;
+    const realT r_eps = sycl::sqrt(inv_eps<realT>) / 2;
     if (sycl::fabs(x) > r_eps || sycl::fabs(y) > r_eps) {
         sycl_complexT log_in = (sycl::signbit(x))
                                    ? exprm_ns::log(sycl_complexT(-in))
                                    : exprm_ns::log(sycl_complexT(in));
-        realT wx = log_in.real() + realT(ln2);
+        realT wx = log_in.real() + ln2<realT>;
         realT wy = log_in.imag();
 
         const realT res_re = sycl::copysign(wx, x);
@@ -187,7 +192,7 @@ T catanh(const T &in)
 {
     using realT = typename T::value_type;
 
-    static constexpr realT pio2 = realT(pi) / realT(2); // PI/2
+    static constexpr realT pio2 = pi<realT> / realT(2); // PI/2
 
     const realT x = std::real(in);
     const realT y = std::imag(in);
@@ -227,7 +232,7 @@ T catanh(const T &in)
      * exprm_ns::atanh(x) is based on calculating log((1 + x) / (1 - x)) / 2,
      * so r_eps = 1/eps is appropriate precision loss point.
      */
-    const realT r_eps = realT(1) / std::numeric_limits<realT>::epsilon();
+    static constexpr realT r_eps = inv_eps<realT>;
     if (sycl::fabs(x) > r_eps || sycl::fabs(y) > r_eps) {
         const realT res_re = realT(0);
         const realT res_im = sycl::copysign(pio2, y);

--- a/dpnp/tensor/libtensor/include/kernels/elementwise_functions/complex_math.hpp
+++ b/dpnp/tensor/libtensor/include/kernels/elementwise_functions/complex_math.hpp
@@ -85,10 +85,10 @@ T cacos(const T &in)
     /*
      * For large x or y including acos(+-Inf + I*+-Inf).
      * exprm_ns::acos(x) is based on calculating log(x + sqrt(x^2 - 1)),
-     * so r_eps = sqrt(1/eps) is appropriate precision loss point.
+     * so r_eps = sqrt(1/eps)/2 is appropriate precision loss point.
      */
     const realT r_eps =
-        sycl::sqrt(realT(1) / std::numeric_limits<realT>::epsilon());
+        sycl::sqrt(realT(1) / std::numeric_limits<realT>::epsilon()) / 2;
     if (sycl::fabs(x) > r_eps || sycl::fabs(y) > r_eps) {
         sycl_complexT log_in = exprm_ns::log(sycl_complexT(in));
 

--- a/dpnp/tensor/libtensor/include/kernels/elementwise_functions/complex_math.hpp
+++ b/dpnp/tensor/libtensor/include/kernels/elementwise_functions/complex_math.hpp
@@ -1,0 +1,106 @@
+//*****************************************************************************
+// Copyright (c) 2026, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// - Neither the name of the copyright holder nor the names of its contributors
+//   may be used to endorse or promote products derived from this software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//*****************************************************************************
+///
+/// \file
+/// This file defines complex math functions.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <cmath>
+#include <complex>
+#include <limits>
+
+#include <sycl/sycl.hpp>
+
+#include "sycl_complex.hpp" // for exprm_ns
+
+namespace dpnp::tensor::kernels::complex_math
+{
+static constexpr double ln2 = 0.6931471805599453094172321214581765L;
+static constexpr double pi = 3.1415926535897932384626433832795029L;
+
+template <typename T>
+T cacos(const T &in)
+{
+    using realT = typename T::value_type;
+    using sycl_complexT = exprm_ns::complex<realT>;
+
+    static constexpr realT q_nan = std::numeric_limits<realT>::quiet_NaN();
+
+    const realT x = std::real(in);
+    const realT y = std::imag(in);
+
+    if (std::isnan(x)) {
+        // acos(NaN + I*+-Inf) = NaN + I*-+Inf
+        if (std::isinf(y)) {
+            return T(q_nan, -y);
+        }
+
+        // all other cases involving NaN return NaN + I*NaN
+        return T(q_nan, q_nan);
+    }
+
+    if (std::isnan(y)) {
+        // acos(+-Inf + I*NaN) = NaN + I*opt(-)Inf
+        if (std::isinf(x)) {
+            return T(q_nan, -std::numeric_limits<realT>::infinity());
+        }
+
+        // acos(0 + I*NaN) = PI/2 + I*NaN with inexact
+        if (x == realT(0)) {
+            static constexpr realT pio2 = realT(pi) / realT(2); // PI/2
+            return T(pio2, q_nan);
+        }
+
+        // all other cases involving NaN return NaN + I*NaN
+        return T(q_nan, q_nan);
+    }
+
+    /*
+     * For large x or y including acos(+-Inf + I*+-Inf).
+     * exprm_ns::acos(x) is based on calculating log(x + sqrt(x^2 - 1)),
+     * so r_eps = sqrt(1/eps) is appropriate precision loss point.
+     */
+    const realT r_eps =
+        sycl::sqrt(realT(1) / std::numeric_limits<realT>::epsilon());
+    if (sycl::fabs(x) > r_eps || sycl::fabs(y) > r_eps) {
+        sycl_complexT log_in = exprm_ns::log(sycl_complexT(in));
+
+        const realT wx = log_in.real();
+        const realT wy = log_in.imag();
+        const realT rx = sycl::fabs(wy);
+
+        realT ry = wx + realT(ln2);
+        return T(rx, (sycl::signbit(y)) ? ry : -ry);
+    }
+
+    // ordinary cases
+    return exprm_ns::acos(sycl_complexT(in)); // sycl::acos(in);
+}
+} // namespace dpnp::tensor::kernels::complex_math

--- a/dpnp/tensor/libtensor/include/kernels/elementwise_functions/complex_math.hpp
+++ b/dpnp/tensor/libtensor/include/kernels/elementwise_functions/complex_math.hpp
@@ -45,13 +45,14 @@ namespace dpnp::tensor::kernels::complex_math
 static constexpr double ln2 = 0.6931471805599453094172321214581765L;
 static constexpr double pi = 3.1415926535897932384626433832795029L;
 
+template <typename realT>
+static constexpr realT q_nan = std::numeric_limits<realT>::quiet_NaN();
+
 template <typename T>
 T cacos(const T &in)
 {
     using realT = typename T::value_type;
     using sycl_complexT = exprm_ns::complex<realT>;
-
-    static constexpr realT q_nan = std::numeric_limits<realT>::quiet_NaN();
 
     const realT x = std::real(in);
     const realT y = std::imag(in);
@@ -59,27 +60,27 @@ T cacos(const T &in)
     if (std::isnan(x)) {
         // acos(NaN + I*+-Inf) = NaN + I*-+Inf
         if (std::isinf(y)) {
-            return T(q_nan, -y);
+            return T{q_nan<realT>, -y};
         }
 
         // all other cases involving NaN return NaN + I*NaN
-        return T(q_nan, q_nan);
+        return T{q_nan<realT>, q_nan<realT>};
     }
 
     if (std::isnan(y)) {
         // acos(+-Inf + I*NaN) = NaN + I*opt(-)Inf
         if (std::isinf(x)) {
-            return T(q_nan, -std::numeric_limits<realT>::infinity());
+            return T{q_nan<realT>, -std::numeric_limits<realT>::infinity()};
         }
 
         // acos(0 + I*NaN) = PI/2 + I*NaN with inexact
         if (x == realT(0)) {
             static constexpr realT pio2 = realT(pi) / realT(2); // PI/2
-            return T(pio2, q_nan);
+            return T{pio2, q_nan<realT>};
         }
 
         // all other cases involving NaN return NaN + I*NaN
-        return T(q_nan, q_nan);
+        return T{q_nan<realT>, q_nan<realT>};
     }
 
     /*
@@ -97,10 +98,87 @@ T cacos(const T &in)
         const realT rx = sycl::fabs(wy);
 
         realT ry = wx + realT(ln2);
-        return T(rx, (sycl::signbit(y)) ? ry : -ry);
+        return T{rx, (sycl::signbit(y)) ? ry : -ry};
     }
 
     // ordinary cases
     return exprm_ns::acos(sycl_complexT(in)); // sycl::acos(in);
+}
+
+template <typename T>
+T casinh(const T &in)
+{
+    using realT = typename T::value_type;
+    using sycl_complexT = exprm_ns::complex<realT>;
+
+    const realT x = std::real(in);
+    const realT y = std::imag(in);
+
+    if (std::isnan(x)) {
+        // asinh(NaN + I*+-Inf) = opt(+-)Inf + I*NaN
+        if (std::isinf(y)) {
+            return T{y, q_nan<realT>};
+        }
+        // asinh(NaN + I*0) = NaN + I*0
+        if (y == realT(0)) {
+            return T{q_nan<realT>, y};
+        }
+        // all other cases involving NaN return NaN + I*NaN
+        return T{q_nan<realT>, q_nan<realT>};
+    }
+
+    if (std::isnan(y)) {
+        // asinh(+-Inf + I*NaN) = +-Inf + I*NaN
+        if (std::isinf(x)) {
+            return T{x, q_nan<realT>};
+        }
+        // all other cases involving NaN return NaN + I*NaN
+        return T{q_nan<realT>, q_nan<realT>};
+    }
+
+    /*
+     * For large x or y including asinh(+-Inf + I*+-Inf)
+     * asinh(in) = sign(x)*log(sign(x)*in) + O(1/in^2)   as in -> infinity
+     * The above formula works for the imaginary part as well, because
+     * Im(asinh(in)) = sign(x)*atan2(sign(x)*y, fabs(x)) + O(y/in^3)
+     * as in -> infinity, uniformly in y.
+     *
+     * exprm_ns::asinh(x) is based on calculating log(x + sqrt(x^2 + 1)),
+     * so r_eps = sqrt(1/eps)/2 is appropriate precision loss point.
+     */
+    const realT r_eps =
+        sycl::sqrt(realT(1) / std::numeric_limits<realT>::epsilon()) / 2;
+    if (sycl::fabs(x) > r_eps || sycl::fabs(y) > r_eps) {
+        sycl_complexT log_in = (sycl::signbit(x))
+                                   ? exprm_ns::log(sycl_complexT(-in))
+                                   : exprm_ns::log(sycl_complexT(in));
+        realT wx = log_in.real() + realT(ln2);
+        realT wy = log_in.imag();
+
+        const realT res_re = sycl::copysign(wx, x);
+        const realT res_im = sycl::copysign(wy, y);
+        return T{res_re, res_im};
+    }
+
+    // ordinary cases
+    return exprm_ns::asinh(sycl_complexT(in));
+}
+
+template <typename T>
+T casin(const T &in)
+{
+    /*
+     * casin(z) = reverse(casinh(reverse(z))),
+     * where reverse(x + I*y) = y + I*x = I*conj(z)
+     */
+
+    // reverse(z): swap real and imaginary parts
+    T reversed{std::imag(in), std::real(in)};
+
+    // compute asinh of reversed input
+    T w = casinh(reversed);
+
+    // reverse result back: swap real and imaginary parts
+    return T{std::imag(w), std::real(w)};
 }
 } // namespace dpnp::tensor::kernels::complex_math

--- a/dpnp/tests/tensor/elementwise/test_hyperbolic.py
+++ b/dpnp/tests/tensor/elementwise/test_hyperbolic.py
@@ -221,7 +221,9 @@ def test_acosh_zero_nan(dtype):
     assert_allclose(np.abs(Y_dpt.imag), np.pi / 2, atol=1e-6, strict=False)
 
 
-@pytest.mark.parametrize("np_call, dpt_call", [(np.arccosh, dpt.acosh)])
+@pytest.mark.parametrize(
+    "np_call, dpt_call", [(np.arcsinh, dpt.asinh), (np.arccosh, dpt.acosh)]
+)
 # @pytest.mark.parametrize("np_call, dpt_call", _inv_hyper_funcs)
 @pytest.mark.parametrize("dtype", _complex_fp_dtypes)
 def test_inv_hyper_large_negative_real(np_call, dpt_call, dtype):
@@ -258,7 +260,9 @@ def test_inv_hyper_large_negative_real(np_call, dpt_call, dtype):
     assert_allclose(dpt.asnumpy(result), expected, atol=tol, rtol=tol)
 
 
-@pytest.mark.parametrize("np_call, dpt_call", [(np.arccosh, dpt.acosh)])
+@pytest.mark.parametrize(
+    "np_call, dpt_call", [(np.arcsinh, dpt.asinh), (np.arccosh, dpt.acosh)]
+)
 # @pytest.mark.parametrize("np_call, dpt_call", _inv_hyper_funcs)
 @pytest.mark.parametrize("dtype", _complex_fp_dtypes)
 @pytest.mark.parametrize("magnitude", [4e7, 9e7, 1e8, 4.45e8])

--- a/dpnp/tests/tensor/elementwise/test_hyperbolic.py
+++ b/dpnp/tests/tensor/elementwise/test_hyperbolic.py
@@ -221,10 +221,7 @@ def test_acosh_zero_nan(dtype):
     assert_allclose(np.abs(Y_dpt.imag), np.pi / 2, atol=1e-6, strict=False)
 
 
-@pytest.mark.parametrize(
-    "np_call, dpt_call", [(np.arcsinh, dpt.asinh), (np.arccosh, dpt.acosh)]
-)
-# @pytest.mark.parametrize("np_call, dpt_call", _inv_hyper_funcs)
+@pytest.mark.parametrize("np_call, dpt_call", _inv_hyper_funcs)
 @pytest.mark.parametrize("dtype", _complex_fp_dtypes)
 def test_inv_hyper_large_negative_real(np_call, dpt_call, dtype):
     """
@@ -239,14 +236,19 @@ def test_inv_hyper_large_negative_real(np_call, dpt_call, dtype):
     skip_if_dtype_not_supported(dtype, q)
 
     # input values that previously returned infinity
-    thr = np.sqrt(1 / dpt.finfo(dtype).eps) / 2
+    thr1 = 1 / dpt.finfo(dtype).eps  # acosh, asinh
+    thr2 = np.sqrt(thr1) / 2  # atanh
     x = [
         complex(-4e7, 1.0),  # Boundary of bug zone
         complex(-9e7, 1.0),  # Middle of bug zone
         complex(-1e8, 1.0),  # Upper range
         complex(-4.45712982e8, 1.0),  # Original reported value
-        complex(thr, 1.0),  # Exact threshold value
-        complex(np.nextafter(thr, np.inf), 1.0),  # Next after threshold
+        # Exact threshold values
+        complex(thr1, 1.0),
+        complex(thr2, 1.0),
+        # Next values after threshold
+        complex(np.nextafter(thr1, np.inf), 1.0),
+        complex(np.nextafter(thr2, np.inf), 1.0),
     ]
 
     xf = np.asarray(x, dtype=dtype)
@@ -260,10 +262,7 @@ def test_inv_hyper_large_negative_real(np_call, dpt_call, dtype):
     assert_allclose(dpt.asnumpy(result), expected, atol=tol, rtol=tol)
 
 
-@pytest.mark.parametrize(
-    "np_call, dpt_call", [(np.arcsinh, dpt.asinh), (np.arccosh, dpt.acosh)]
-)
-# @pytest.mark.parametrize("np_call, dpt_call", _inv_hyper_funcs)
+@pytest.mark.parametrize("np_call, dpt_call", _inv_hyper_funcs)
 @pytest.mark.parametrize("dtype", _complex_fp_dtypes)
 @pytest.mark.parametrize("magnitude", [4e7, 9e7, 1e8, 4.45e8])
 def test_inv_hyper_all_quadrants_large(np_call, dpt_call, dtype, magnitude):
@@ -278,11 +277,19 @@ def test_inv_hyper_all_quadrants_large(np_call, dpt_call, dtype, magnitude):
     skip_if_dtype_not_supported(dtype, q)
 
     # input values with four quadrants with large magnitude
+    thr1 = 1 / dpt.finfo(dtype).eps  # acosh, asinh
+    thr2 = np.sqrt(thr1) / 2  # atanh
     x = [
-        complex(magnitude, 1.0),  # +Re, +Im
-        complex(-magnitude, 1.0),  # -Re, +Im (bug zone)
-        complex(magnitude, -1.0),  # +Re, -Im
-        complex(-magnitude, -1.0),  # -Re, -Im (bug zone)
+        complex(-4e7, 1.0),  # Boundary of bug zone
+        complex(-9e7, 1.0),  # Middle of bug zone
+        complex(-1e8, 1.0),  # Upper range
+        complex(-4.45712982e8, 1.0),  # Original reported value
+        # Exact threshold values
+        complex(thr1, 1.0),
+        complex(thr2, 1.0),
+        # Next values after threshold
+        complex(np.nextafter(thr1, np.inf), 1.0),
+        complex(np.nextafter(thr2, np.inf), 1.0),
     ]
 
     xf = np.asarray(x, dtype=dtype)

--- a/dpnp/tests/tensor/elementwise/test_hyperbolic.py
+++ b/dpnp/tests/tensor/elementwise/test_hyperbolic.py
@@ -219,3 +219,74 @@ def test_acosh_zero_nan(dtype):
 
     assert np.isnan(Y_dpt.real).all()
     assert_allclose(np.abs(Y_dpt.imag), np.pi / 2, atol=1e-6, strict=False)
+
+
+@pytest.mark.parametrize("np_call, dpt_call", [(np.arccosh, dpt.acosh)])
+# @pytest.mark.parametrize("np_call, dpt_call", _inv_hyper_funcs)
+@pytest.mark.parametrize("dtype", _complex_fp_dtypes)
+def test_inv_hyper_large_negative_real(np_call, dpt_call, dtype):
+    """
+    Test inverse hyperbolic functions for large negative real parts.
+
+    Regression acosh test for threshold bug where catastrophic cancellation in
+    z + sqrt(z² - 1) caused log(0) = -infinity for |Re(z)| in [4e7, 9e7+]
+    with negative real parts (gh-2924).
+    """
+
+    q = get_queue_or_skip()
+    skip_if_dtype_not_supported(dtype, q)
+
+    # input values that previously returned infinity
+    thr = np.sqrt(1 / dpt.finfo(dtype).eps) / 2
+    x = [
+        complex(-4e7, 1.0),  # Boundary of bug zone
+        complex(-9e7, 1.0),  # Middle of bug zone
+        complex(-1e8, 1.0),  # Upper range
+        complex(-4.45712982e8, 1.0),  # Original reported value
+        complex(thr, 1.0),  # Exact threshold value
+        complex(np.nextafter(thr, np.inf), 1.0),  # Next after threshold
+    ]
+
+    xf = np.asarray(x, dtype=dtype)
+    yf = dpt.asarray(x, dtype=dtype, sycl_queue=q)
+
+    result = dpt_call(yf)
+    expected = np_call(xf)
+
+    tol = 8 * dpt.finfo(dtype).resolution
+    assert not dpt.any(dpt.isinf(result))
+    assert_allclose(dpt.asnumpy(result), expected, atol=tol, rtol=tol)
+
+
+@pytest.mark.parametrize("np_call, dpt_call", [(np.arccosh, dpt.acosh)])
+# @pytest.mark.parametrize("np_call, dpt_call", _inv_hyper_funcs)
+@pytest.mark.parametrize("dtype", _complex_fp_dtypes)
+@pytest.mark.parametrize("magnitude", [4e7, 9e7, 1e8, 4.45e8])
+def test_inv_hyper_all_quadrants_large(np_call, dpt_call, dtype, magnitude):
+    """
+    Test inverse hyperbolic functions for large complex values in all quadrants.
+
+    Ensures the threshold fix works correctly for all sign combinations
+    of real and imaginary parts.
+    """
+
+    q = get_queue_or_skip()
+    skip_if_dtype_not_supported(dtype, q)
+
+    # input values with four quadrants with large magnitude
+    x = [
+        complex(magnitude, 1.0),  # +Re, +Im
+        complex(-magnitude, 1.0),  # -Re, +Im (bug zone)
+        complex(magnitude, -1.0),  # +Re, -Im
+        complex(-magnitude, -1.0),  # -Re, -Im (bug zone)
+    ]
+
+    xf = np.asarray(x, dtype=dtype)
+    yf = dpt.asarray(x, dtype=dtype, sycl_queue=q)
+
+    result = dpt_call(yf)
+    expected = np_call(xf)
+
+    tol = 8 * dpt.finfo(dtype).resolution
+    assert not dpt.any(dpt.isinf(result))
+    assert_allclose(dpt.asnumpy(result), expected, atol=tol, rtol=tol)

--- a/dpnp/tests/tensor/elementwise/test_trigonometric.py
+++ b/dpnp/tests/tensor/elementwise/test_trigonometric.py
@@ -236,10 +236,7 @@ def test_trig_real_special_cases(np_call, dpt_call, dtype):
     assert_allclose(dpt.asnumpy(Y), Y_np, atol=tol, rtol=tol)
 
 
-@pytest.mark.parametrize(
-    "np_call, dpt_call", [(np.arcsin, dpt.asin), (np.arccos, dpt.acos)]
-)
-# @pytest.mark.parametrize("np_call, dpt_call", _inv_trig_funcs)
+@pytest.mark.parametrize("np_call, dpt_call", _inv_trig_funcs)
 @pytest.mark.parametrize("dtype", _complex_fp_dtypes)
 def test_inv_trig_large_negative_real(np_call, dpt_call, dtype):
     """
@@ -254,14 +251,19 @@ def test_inv_trig_large_negative_real(np_call, dpt_call, dtype):
     skip_if_dtype_not_supported(dtype, q)
 
     # input values that previously returned infinity
-    thr = np.sqrt(1 / dpt.finfo(dtype).eps) / 2
+    thr1 = 1 / dpt.finfo(dtype).eps  # acos, asin
+    thr2 = np.sqrt(thr1) / 2  # atan
     x = [
         complex(-4e7, 1.0),  # Boundary of bug zone
         complex(-9e7, 1.0),  # Middle of bug zone
         complex(-1e8, 1.0),  # Upper range
         complex(-4.45712982e8, 1.0),  # Original reported value
-        complex(thr, 1.0),  # Exact threshold value
-        complex(np.nextafter(thr, np.inf), 1.0),  # Next after threshold
+        # Exact threshold values
+        complex(thr1, 1.0),
+        complex(thr2, 1.0),
+        # Next values after threshold
+        complex(np.nextafter(thr1, np.inf), 1.0),
+        complex(np.nextafter(thr2, np.inf), 1.0),
     ]
 
     xf = np.asarray(x, dtype=dtype)

--- a/dpnp/tests/tensor/elementwise/test_trigonometric.py
+++ b/dpnp/tests/tensor/elementwise/test_trigonometric.py
@@ -38,7 +38,9 @@ from ..helper import (
 )
 from .utils import (
     _all_dtypes,
+    _complex_fp_dtypes,
     _map_to_device_dtype,
+    _real_fp_dtypes,
 )
 
 _trig_funcs = [(np.sin, dpt.sin), (np.cos, dpt.cos), (np.tan, dpt.tan)]
@@ -63,7 +65,7 @@ def test_trig_out_type(np_call, dpt_call, dtype):
 
 
 @pytest.mark.parametrize("np_call, dpt_call", _all_funcs)
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8"])
+@pytest.mark.parametrize("dtype", _real_fp_dtypes)
 def test_trig_real_contig(np_call, dpt_call, dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
@@ -96,7 +98,7 @@ def test_trig_real_contig(np_call, dpt_call, dtype):
 
 
 @pytest.mark.parametrize("np_call, dpt_call", _all_funcs)
-@pytest.mark.parametrize("dtype", ["c8", "c16"])
+@pytest.mark.parametrize("dtype", _complex_fp_dtypes)
 def test_trig_complex_contig(np_call, dpt_call, dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
@@ -134,7 +136,7 @@ def test_trig_complex_contig(np_call, dpt_call, dtype):
 
 
 @pytest.mark.parametrize("np_call, dpt_call", _all_funcs)
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8"])
+@pytest.mark.parametrize("dtype", _real_fp_dtypes)
 def test_trig_real_strided(np_call, dpt_call, dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
@@ -168,7 +170,7 @@ def test_trig_real_strided(np_call, dpt_call, dtype):
 
 
 @pytest.mark.parametrize("np_call, dpt_call", _all_funcs)
-@pytest.mark.parametrize("dtype", ["c8", "c16"])
+@pytest.mark.parametrize("dtype", _complex_fp_dtypes)
 def test_trig_complex_strided(np_call, dpt_call, dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
@@ -216,7 +218,7 @@ def test_trig_complex_strided(np_call, dpt_call, dtype):
 
 
 @pytest.mark.parametrize("np_call, dpt_call", _all_funcs)
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8"])
+@pytest.mark.parametrize("dtype", _real_fp_dtypes)
 def test_trig_real_special_cases(np_call, dpt_call, dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
@@ -232,3 +234,40 @@ def test_trig_real_special_cases(np_call, dpt_call, dtype):
     tol = 8 * dpt.finfo(dtype).resolution
     Y = dpt_call(yf)
     assert_allclose(dpt.asnumpy(Y), Y_np, atol=tol, rtol=tol)
+
+
+@pytest.mark.parametrize("np_call, dpt_call", [(np.arccos, dpt.acos)])
+# @pytest.mark.parametrize("np_call, dpt_call", _inv_trig_funcs)
+@pytest.mark.parametrize("dtype", _complex_fp_dtypes)
+def test_inv_trig_large_negative_real(np_call, dpt_call, dtype):
+    """
+    Test inverse trigonometric functions for large negative real parts.
+
+    Regression acos test for threshold bug where catastrophic cancellation in
+    z + sqrt(z² - 1) caused log(0) = -infinity for |Re(z)| in [4e7, 9e7+]
+    with negative real parts.
+    """
+
+    q = get_queue_or_skip()
+    skip_if_dtype_not_supported(dtype, q)
+
+    # input values that previously returned infinity
+    thr = np.sqrt(1 / dpt.finfo(dtype).eps) / 2
+    x = [
+        complex(-4e7, 1.0),  # Boundary of bug zone
+        complex(-9e7, 1.0),  # Middle of bug zone
+        complex(-1e8, 1.0),  # Upper range
+        complex(-4.45712982e8, 1.0),  # Original reported value
+        complex(thr, 1.0),  # Exact threshold value
+        complex(np.nextafter(thr, np.inf), 1.0),  # Next after threshold
+    ]
+
+    xf = np.asarray(x, dtype=dtype)
+    yf = dpt.asarray(x, dtype=dtype, sycl_queue=q)
+
+    result = dpt_call(yf)
+    expected = np_call(xf)
+
+    tol = 8 * dpt.finfo(dtype).resolution
+    assert not dpt.any(dpt.isinf(result))
+    assert_allclose(dpt.asnumpy(result), expected, atol=tol, rtol=tol)

--- a/dpnp/tests/tensor/elementwise/test_trigonometric.py
+++ b/dpnp/tests/tensor/elementwise/test_trigonometric.py
@@ -236,7 +236,9 @@ def test_trig_real_special_cases(np_call, dpt_call, dtype):
     assert_allclose(dpt.asnumpy(Y), Y_np, atol=tol, rtol=tol)
 
 
-@pytest.mark.parametrize("np_call, dpt_call", [(np.arccos, dpt.acos)])
+@pytest.mark.parametrize(
+    "np_call, dpt_call", [(np.arcsin, dpt.asin), (np.arccos, dpt.acos)]
+)
 # @pytest.mark.parametrize("np_call, dpt_call", _inv_trig_funcs)
 @pytest.mark.parametrize("dtype", _complex_fp_dtypes)
 def test_inv_trig_large_negative_real(np_call, dpt_call, dtype):


### PR DESCRIPTION
The `dpnp.tensor.acosh` function was returning incorrect results (infinity) for complex numbers with large negative real parts (see #2924, #2896).

The issue was caused by the threshold used `1/epsilon` to decide when to switch from acos in SYCL's experimental complex extension (`exprm_ns::acos()`) to a log-based formula. 
The SYCL `exprm_ns::acos()` returns incorrect results for large negative real parts, due to used formula `z + sqrt(z² - 1)`, which leads to `log(0) = -infinity`.

The PR proposes to change the threshold from `1/epsilon` to `sqrt(1/epsilon)/2` for all inverse trig/hyperbolic functions. This is the precision loss point where `sqrt(z² ± 1)` calculations become unstable.

Also the PR reduces code duplication by creating shared `casinh()`, `casin()`, `catanh()`, `catan()` functions in new `complex_math.hpp` header.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
