### PR TITLE
Add boolean mask validation when slicing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ This release is compatible with NumPy 2.4.5.
 * Fixed incorrect `dpnp.tensor.acosh` result for `complex(±0, NaN)` special case to match the Python Array API specification [#2914](https://github.com/IntelPython/dpnp/pull/2914)
 * Fixed fork PR documentation workflow failures by implementing conditional publishing strategy: upstream PRs publish to GitHub Pages with comment, fork PRs upload artifacts [#2910](https://github.com/IntelPython/dpnp/pull/2910)
 * Fixed missing `libtensor` headers in the installed `dpnp` package [#2915](https://github.com/IntelPython/dpnp/pull/2915)
-* Fixed some edge cases when indexing `dpnp.tensor.usm_ndarray`s and `dpnp.dpnp_array`s with boolean masks where the corresponding axis of the mask is incompatible with the axis of the indexed array [#2929](https://github.com/IntelPython/dpnp/pull/2929)
+* Fixed boolean mask indexing to raise `IndexError` when mask dimensions don't match the indexed array dimensions, aligning with NumPy behavior. Previously, incompatible boolean masks silently returned incorrect results instead of raising an error [#2929](https://github.com/IntelPython/dpnp/pull/2929)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This release is compatible with NumPy 2.4.5.
 * Fixed incorrect `dpnp.tensor.acosh` result for `complex(±0, NaN)` special case to match the Python Array API specification [#2914](https://github.com/IntelPython/dpnp/pull/2914)
 * Fixed fork PR documentation workflow failures by implementing conditional publishing strategy: upstream PRs publish to GitHub Pages with comment, fork PRs upload artifacts [#2910](https://github.com/IntelPython/dpnp/pull/2910)
 * Fixed missing `libtensor` headers in the installed `dpnp` package [#2915](https://github.com/IntelPython/dpnp/pull/2915)
+* Fixed some edge cases when indexing `dpnp.tensor.usm_ndarray`s and `dpnp.dpnp_array`s with boolean masks where the corresponding axis of the mask is incompatible with the axis of the indexed array [#2929](https://github.com/IntelPython/dpnp/pull/2929)
 
 ### Security
 

--- a/dpnp/tensor/_slicing.pxi
+++ b/dpnp/tensor/_slicing.pxi
@@ -107,6 +107,18 @@ cdef bint _is_boolean(object x) except *:
     return False
 
 
+cdef _check_mask_shape(sh : tuple, ma_sh : tuple, Py_ssize_t axis):
+    cdef Py_ssize_t i, sh_i, m_sh
+    for i, ma_i in enumerate(ma_sh):
+        sh_i = sh[axis + i]
+        if ma_i not in (0, sh_i):
+            raise IndexError(
+                "boolean index did not match indexed array along dimension "
+                f"{axis + i}; dimension is {sh_i} but corresponding boolean "
+                f"dimension is {ma_i}"
+            )
+
+
 def _basic_slice_meta(ind, shape : tuple, strides : tuple, offset : int):
     """
     Give basic slicing index `ind` and array layout information produce
@@ -353,6 +365,7 @@ def _basic_slice_meta(ind, shape : tuple, strides : tuple, offset : int):
                 new_advanced_ind.append(ind_i)
                 dt_k = ind_i.dtype.kind
                 if dt_k == "b":
+                    _check_mask_shape(shape, ind_i.shape, k)
                     k_new = k + ind_i.ndim
                 else:
                     k_new = k + 1

--- a/dpnp/tensor/_slicing.pxi
+++ b/dpnp/tensor/_slicing.pxi
@@ -108,7 +108,7 @@ cdef bint _is_boolean(object x) except *:
 
 
 cdef _check_mask_shape(sh : tuple, ma_sh : tuple, Py_ssize_t axis):
-    cdef Py_ssize_t i, sh_i, m_sh
+    cdef Py_ssize_t i, sh_i, ma_i
     for i, ma_i in enumerate(ma_sh):
         sh_i = sh[axis + i]
         if ma_i not in (0, sh_i):

--- a/dpnp/tests/tensor/test_usm_ndarray_indexing.py
+++ b/dpnp/tests/tensor/test_usm_ndarray_indexing.py
@@ -2052,3 +2052,13 @@ def test_getitem_impl_fn_invalid_inp():
     no_array_inds = (2, 3)
     with pytest.raises(TypeError):
         _take_multi_index(x, no_array_inds, 0, 0)
+
+
+def test_boolean_mask_validation():
+    x = dpt.reshape(dpt.arange(3**5, dtype="i4"), (3,) * 5)
+    ii = dpt.asarray(1)
+    i0 = dpt.asarray(0, dtype="?")
+    i1 = dpt.asarray(0, dtype="?")
+
+    with pytest.raises(IndexError):
+        x[ii, i0[dpt.newaxis], ii, i1[dpt.newaxis], :]


### PR DESCRIPTION
This PR proposes the addition of validation for the shape of masks when slicing `tensor.usm_ndarray`s and `dpnp_array`s.

This aligns with NumPy for specific edge cases, such as:
```
import dpnp.tensor as dpt

x = dpt.reshape(dpt.arange(3**5, dtype="i4"), (3,) * 5)
ii = dpt.asarray(1)
i0 = dpt.asarray(0, dtype='?')
i1 = dpt.asarray(0, dtype='?')

x[ii, i0[dpt.newaxis], ii, i1[dpt.newaxis], :]
```

which previously would give `usm_ndarray([], dtype=int32)`, but now raises an error, which aligns with NumPy.

- [X] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [X] Have you checked performance impact of proposed changes?
- [X] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
