### PR TITLE
Resolve gh-2882

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This release is compatible with NumPy 2.4.5.
 * Fixed incorrect `dpnp.tensor.acosh` result for `complex(±0, NaN)` special case to match the Python Array API specification [#2914](https://github.com/IntelPython/dpnp/pull/2914)
 * Fixed fork PR documentation workflow failures by implementing conditional publishing strategy: upstream PRs publish to GitHub Pages with comment, fork PRs upload artifacts [#2910](https://github.com/IntelPython/dpnp/pull/2910)
 * Fixed missing `libtensor` headers in the installed `dpnp` package [#2915](https://github.com/IntelPython/dpnp/pull/2915)
+* Fixed a bug in `astype` where casting floating point types to unsigned integral types could cause an intermediate signed integral type to overflow, leading to incorrect results [#2930](https://github.com/IntelPython/dpnp/pull/2930)
 
 ### Security
 

--- a/dpnp/tensor/libtensor/include/utils/type_utils.hpp
+++ b/dpnp/tensor/libtensor/include/utils/type_utils.hpp
@@ -99,9 +99,12 @@ dstTy convert_impl(const srcTy &v)
     else if constexpr (!std::is_integral_v<srcTy> &&
                        !std::is_same_v<dstTy, bool> &&
                        std::is_integral_v<dstTy> && std::is_unsigned_v<dstTy>) {
-        // first cast to signed variant, the cast to unsigned one
-        using signedT = typename std::make_signed_t<dstTy>;
-        return static_cast<dstTy>(convert_impl<signedT, srcTy>(v));
+        // cast through sufficiently large signed integer type to preserve
+        // two's complement
+        using intermediateT =
+            std::conditional_t<sizeof(dstTy) <= sizeof(std::int32_t),
+                               std::int32_t, std::int64_t>;
+        return static_cast<dstTy>(static_cast<intermediateT>(v));
     }
     else {
         return static_cast<dstTy>(v);

--- a/dpnp/tensor/libtensor/include/utils/type_utils.hpp
+++ b/dpnp/tensor/libtensor/include/utils/type_utils.hpp
@@ -102,7 +102,7 @@ dstTy convert_impl(const srcTy &v)
         // cast through sufficiently large signed integer type to preserve
         // two's complement
         using intermediateT =
-            std::conditional_t<sizeof(dstTy) <= sizeof(std::int32_t),
+            std::conditional_t<sizeof(dstTy) < sizeof(std::int32_t),
                                std::int32_t, std::int64_t>;
         return static_cast<dstTy>(static_cast<intermediateT>(v));
     }

--- a/dpnp/tensor/libtensor/include/utils/type_utils.hpp
+++ b/dpnp/tensor/libtensor/include/utils/type_utils.hpp
@@ -99,12 +99,14 @@ dstTy convert_impl(const srcTy &v)
     else if constexpr (!std::is_integral_v<srcTy> &&
                        !std::is_same_v<dstTy, bool> &&
                        std::is_integral_v<dstTy> && std::is_unsigned_v<dstTy>) {
-        // cast through sufficiently large signed integer type to preserve
-        // two's complement
+        // for negative values, cast through signed integer to get two's
+        // complement wrapping
         using intermediateT =
-            std::conditional_t<sizeof(dstTy) < sizeof(std::int32_t),
-                               std::int32_t, std::int64_t>;
-        return static_cast<dstTy>(static_cast<intermediateT>(v));
+            std::conditional_t<sizeof(dstTy) < sizeof(std::int32_t), std::int32_t,
+                           std::int64_t>;
+        return (v < srcTy{0})
+                   ? static_cast<dstTy>(static_cast<intermediateT>(v))
+                   : static_cast<dstTy>(v);
     }
     else {
         return static_cast<dstTy>(v);

--- a/dpnp/tensor/libtensor/include/utils/type_utils.hpp
+++ b/dpnp/tensor/libtensor/include/utils/type_utils.hpp
@@ -102,8 +102,8 @@ dstTy convert_impl(const srcTy &v)
         // for negative values, cast through signed integer to get two's
         // complement wrapping
         using intermediateT =
-            std::conditional_t<sizeof(dstTy) < sizeof(std::int32_t), std::int32_t,
-                           std::int64_t>;
+            std::conditional_t<sizeof(dstTy) < sizeof(std::int32_t),
+                               std::int32_t, std::int64_t>;
         return (v < srcTy{0})
                    ? static_cast<dstTy>(static_cast<intermediateT>(v))
                    : static_cast<dstTy>(v);

--- a/dpnp/tests/tensor/test_usm_ndarray_ctor.py
+++ b/dpnp/tests/tensor/test_usm_ndarray_ctor.py
@@ -1100,6 +1100,15 @@ def test_astype_gh_2121():
     assert dpt.all(res == expected)
 
 
+def test_astype_gh_2882():
+    get_queue_or_skip()
+
+    x = dpt.asarray([160., 120.], dtype="f4")
+    r = dpt.astype(x, dpt.uint8)
+    expected = dpt.asarray([160, 120], dtype="u1")
+    assert dpt.all(r == expected)
+
+
 def test_copy():
     try:
         X = dpt.usm_ndarray((5, 5), "i4")[2:4, 1:4]

--- a/dpnp/tests/tensor/test_usm_ndarray_ctor.py
+++ b/dpnp/tests/tensor/test_usm_ndarray_ctor.py
@@ -1103,7 +1103,7 @@ def test_astype_gh_2121():
 def test_astype_gh_2882():
     get_queue_or_skip()
 
-    x = dpt.asarray([160., 120.], dtype="f4")
+    x = dpt.asarray([160.0, 120.0], dtype="f4")
     r = dpt.astype(x, dpt.uint8)
     expected = dpt.asarray([160, 120], dtype="u1")
     assert dpt.all(r == expected)


### PR DESCRIPTION
This PR adds a fix for gh-2882

When floats were previously converted by `convert_impl` to unsigned integral types, they would pass through an equally sized, signed integral type

If the float was in bounds for the unsigned integral type but out of bounds for the signed type, however, undefined behavior could be encountered.

This PR proposes a solution of casting to a sufficiently large intermediate type first, before casting into the unsigned integral type.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
