### PR TITLE
Fix tests for `dpctl` change to return tuples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This release is compatible with NumPy 2.4.5.
 * Replaced `.pxi` includes in `dpnp.tensor` with modular `.pxd`/`.pyx` Cython imports [#2913](https://github.com/IntelPython/dpnp/pull/2913)
 * Reimplemented `dpnp.eye` and `dpnp.tensor.eye` with a branchless kernel [gh-2937](https://github.com/IntelPython/dpnp/pull/2937)
 * Cleaned up Python bindings for indexing functions, renaming `usm_ndarray_take` and `usm_ndarray_put` to `py_take` and `py_put` and refactoring validation [gh-2935](https://github.com/IntelPython/dpnp/pull/2935)
+* Fixed some tests which expected lists from `dpctl` functions which now return tuples (i.e., `dpctl.SyclDevice.create_sub_devices`) [gh-2945](https://github.com/IntelPython/dpnp/pull/2945)
 
 ### Deprecated
 

--- a/dpnp/tests/tensor/test_usm_ndarray_dlpack.py
+++ b/dpnp/tests/tensor/test_usm_ndarray_dlpack.py
@@ -252,7 +252,7 @@ def test_dlpack_from_subdevice():
             sdevs = dev.create_sub_devices(partition=[1, 1])
     except dpctl.SyclSubDeviceCreationError:
         pytest.skip("Default device can not be partitioned")
-    assert isinstance(sdevs, list) and len(sdevs) > 0
+    assert isinstance(sdevs, tuple) and len(sdevs) > 0
     try:
         ctx = sdevs[0].sycl_platform.default_context
     except dpctl.SyclContextCreationError:
@@ -603,7 +603,7 @@ def test_dlpack_from_subdevice_to_kdlcpu():
             sdevs = dev.create_sub_devices(partition=[1, 1])
     except dpctl.SyclSubDeviceCreationError:
         pytest.skip("Default device can not be partitioned")
-    assert isinstance(sdevs, list) and len(sdevs) > 0
+    assert isinstance(sdevs, tuple) and len(sdevs) > 0
     try:
         ctx = sdevs[0].sycl_platform.default_context
     except dpctl.SyclContextCreationError:


### PR DESCRIPTION
dpctl returns tuples now rather than lists for devices, subdevices, etc. as these should be immutable to users

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
