### PR TITLE
Bump dpctl dependency up to 0.23.0 dev

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set max_compiler_and_mkl_version = environ.get("MAX_BUILD_CMPL_MKL_VERSION", "2027.0a0") %}
 {% set required_compiler_and_mkl_version = "2026.0" %}
-{% set required_dpctl_version = "0.22.0" %}
+{% set required_dpctl_version = "0.23.0dev0" %}
 
 {% set pyproject = load_file_data('pyproject.toml') %}
 {% set py_build_deps = pyproject.get('build-system', {}).get('requires', []) %}

--- a/environments/dpctl_pkg.txt
+++ b/environments/dpctl_pkg.txt
@@ -1,2 +1,2 @@
 --index-url https://pypi.anaconda.org/dppy/label/dev/simple
-dpctl>=0.22.0dev0
+dpctl>=0.23.0dev0

--- a/environments/dpctl_pkg.yml
+++ b/environments/dpctl_pkg.yml
@@ -2,4 +2,4 @@ name: Install dpctl package
 channels:
   - dppy/label/dev
 dependencies:
-  - dpctl>=0.22.0dev0
+  - dpctl>=0.23.0dev0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
   # "dpcpp-cpp-rt>=0.59.0",
   # "intel-cmplr-lib-rt>=0.59.0"
   # WARNING: use the latest dpctl dev version, otherwise stable w/f will fail
-  "dpctl>=0.22.0dev0",
+  "dpctl>=0.23.0dev0",
   "numpy>=1.26.0"
 ]
 description = "Data Parallel Extension for NumPy"


### PR DESCRIPTION
dpctl returns tuples rather than lists for devices, subdevices, etc. since 0.23.0dev0 version. The tests were updated in #2945.
That PR bumps the dependency on dpctl up to `0.23.0dev0`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
