### PR TITLE
Re-enable dim=4 in strided matmul test with proper cross-BLAS tolerances

### DIFF
--- a/dpnp/tests/test_product.py
+++ b/dpnp/tests/test_product.py
@@ -887,6 +887,13 @@ class TestMatmul:
         ids=["-2", "2", "(-2, 2)", "(2, -2)"],
     )
     def test_strided1(self, dtype, stride):
+        # dpnp copies the strided input into a c-contiguous array and runs the
+        # batched product through oneMKL gemm_batch, while NumPy uses OpenBLAS.
+        # The two backends accumulate in a different order, so the float32
+        # result deviates at the noise floor (~2e-5 for a length-20 contraction
+        # with dim=4), which exceeds the default tolerance. Integer input is
+        # exact, so the factor only affects the float32 case.
+        factor = 24 if dtype == numpy.float32 else 16
         for dim in [1, 2, 3, 4]:
             shape = tuple(20 for _ in range(dim))
             A = generate_random_numpy_array(shape, dtype)
@@ -898,7 +905,7 @@ class TestMatmul:
             # the 2D base is not c-contiguous nor f-contigous
             result = dpnp.matmul(ia, ia)
             expected = numpy.matmul(a, a)
-            assert_dtype_allclose(result, expected, factor=16)
+            assert_dtype_allclose(result, expected, factor=factor)
 
             OUT = numpy.empty(shape, dtype=result.dtype)
             out = OUT[slices]
@@ -907,7 +914,7 @@ class TestMatmul:
             result = dpnp.matmul(ia, ia, out=iout)
             assert result is iout
             expected = numpy.matmul(a, a, out=out)
-            assert_dtype_allclose(result, expected, factor=16)
+            assert_dtype_allclose(result, expected, factor=factor)
 
     @pytest.mark.parametrize("dtype", _selected_dtypes)
     @pytest.mark.parametrize(

--- a/dpnp/tests/test_product.py
+++ b/dpnp/tests/test_product.py
@@ -887,9 +887,7 @@ class TestMatmul:
         ids=["-2", "2", "(-2, 2)", "(2, -2)"],
     )
     def test_strided1(self, dtype, stride):
-        # TODO: enable back when the root cause is identified
-        # for dim in [1, 2, 3, 4]:
-        for dim in [1, 2, 3]:
+        for dim in [1, 2, 3, 4]:
             shape = tuple(20 for _ in range(dim))
             A = generate_random_numpy_array(shape, dtype)
             iA = dpnp.array(A)
@@ -1544,9 +1542,7 @@ class TestMatvec:
 
         result = dpnp.matvec(ia, ib, axes=axes)
         expected = numpy.matvec(a, b, axes=axes)
-
-        # TODO: check if failing with newer NumPy
-        assert_dtype_allclose(result, expected, factor=40)
+        assert_dtype_allclose(result, expected)
 
     @pytest.mark.parametrize("xp", [numpy, dpnp])
     def test_error(self, xp):

--- a/dpnp/tests/test_product.py
+++ b/dpnp/tests/test_product.py
@@ -878,9 +878,7 @@ class TestMatmul:
         ids=["-2", "2", "(-2, 2)", "(2, -2)"],
     )
     def test_strided1(self, dtype, stride):
-        # TODO: enable back when the root cause is identified
-        # for dim in [1, 2, 3, 4]:
-        for dim in [1, 2, 3]:
+        for dim in [1, 2, 3, 4]:
             shape = tuple(20 for _ in range(dim))
             A = generate_random_numpy_array(shape, dtype)
             iA = dpnp.array(A)
@@ -1535,9 +1533,7 @@ class TestMatvec:
 
         result = dpnp.matvec(ia, ib, axes=axes)
         expected = numpy.matvec(a, b, axes=axes)
-
-        # TODO: check if failing with newer NumPy
-        assert_dtype_allclose(result, expected, factor=40)
+        assert_dtype_allclose(result, expected)
 
     @pytest.mark.parametrize("xp", [numpy, dpnp])
     def test_error(self, xp):

--- a/dpnp/tests/test_product.py
+++ b/dpnp/tests/test_product.py
@@ -1542,7 +1542,11 @@ class TestMatvec:
 
         result = dpnp.matvec(ia, ib, axes=axes)
         expected = numpy.matvec(a, b, axes=axes)
-        assert_dtype_allclose(result, expected)
+
+        # dpnp uses oneMKL gemm_batch while NumPy uses OpenBLAS gemv, so the
+        # summation order differs and the float64 result deviates at the noise
+        # floor (~1e-14), which exceeds the default tolerance
+        assert_dtype_allclose(result, expected, factor=40)
 
     @pytest.mark.parametrize("xp", [numpy, dpnp])
     def test_error(self, xp):


### PR DESCRIPTION
## Summary

gh-2912 introduced two temporary test workarounds after a CI failure on `ubuntu-latest`:
- widened the tolerance on `TestMatvec::test_axes` to `factor=40`;
- disabled the `dim=4` iteration in `TestMatmul::test_strided1`.

Both failures share the same benign root cause, so this PR re-enables the disabled coverage and replaces the ad-hoc mitigations with documented, dtype-aware tolerances:

- **`test_axes`** (matvec, float64) — keeps `factor=40`. dpnp computes `matvec` via oneMKL `gemm_batch` while NumPy uses OpenBLAS `gemv`; the summation order differs and the float64 result deviates at the noise floor (~1.4e-14), which exceeds the default `8e-15` tolerance.
- **`test_strided1`** (matmul) — re-enables `dim=4`. dpnp copies the strided input to c-contiguous and runs it through oneMKL `gemm_batch`, again against NumPy's OpenBLAS. For float32, the length-20 contraction deviates by ~1.87e-5, just above the old `factor=16` bound (~1.81e-5), so the tolerance is bumped to `factor=24` **for float32 only** (pass-bound ~2.27e-5). Integer input is compared exactly and is unaffected.

## Root cause

Neither discrepancy is a dpnp correctness bug. Both are expected floating-point non-associativity between two different BLAS backends (oneMKL vs OpenBLAS), surfaced when the conda-forge NumPy in CI advanced its bundled OpenBLAS. There is nothing to fix upstream, so documented tolerances are the correct handling and let us keep full test coverage (including `dim=4`).

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?