### PR TITLE
Fix PytestRemovedIn10Warning with new pytest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This release is compatible with NumPy 2.4.5.
 * Fixed a bug in `astype` where casting floating point types to unsigned integral types could cause an intermediate signed integral type to overflow, leading to incorrect results [#2930](https://github.com/IntelPython/dpnp/pull/2930)
 * Fixed incorrect `dpnp.tensor.expm1` result for `complex(±0, 0)` special case on CPU to match the Python Array API specification [#2926](https://github.com/IntelPython/dpnp/pull/2926)
 * Fixed tests which expected lists from `dpctl` functions which now return tuples (i.e., `dpctl.SyclDevice.create_sub_devices`) [#2945](https://github.com/IntelPython/dpnp/pull/2945)
+* Fixed `PytestRemovedIn10Warning` raised by `pytest` 9.1.0 by converting class-scoped fixtures to class methods [#2952](https://github.com/IntelPython/dpnp/pull/2952)
 
 ### Security
 

--- a/dpnp/tests/third_party/cupy/core_tests/test_gufuncs.py
+++ b/dpnp/tests/third_party/cupy/core_tests/test_gufuncs.py
@@ -255,7 +255,7 @@ class TestGUFuncSignatures:
             else:
                 assert dtypes_access[dtype] == default
 
-    @pytest.mark.parametrize("sig,", ["ii->i", "i", ("i", "i", "i")])
+    @pytest.mark.parametrize("sig", ["ii->i", "i", ("i", "i", "i")])
     def test_signature_lookup(self, sig):
         called = False
 
@@ -283,7 +283,7 @@ class TestGUFuncSignatures:
         assert z.dtype == numpy.int32
         assert called
 
-    @pytest.mark.parametrize("sigs,", [("i",), ("",), ("iii->i",), ("ii->",)])
+    @pytest.mark.parametrize("sigs", [("i",), ("",), ("iii->i",), ("ii->",)])
     def test_invalid_signatures(self, sigs):
 
         def default(x, y):
@@ -292,7 +292,7 @@ class TestGUFuncSignatures:
         with pytest.raises(ValueError):
             _GUFunc(default, "(i),(i)->(i)", signatures=sigs)
 
-    @pytest.mark.parametrize("sig,", ["i->i", "id->i", ""])
+    @pytest.mark.parametrize("sig", ["i->i", "id->i", ""])
     def test_invalid_lookup(self, sig):
 
         def default(x, y):

--- a/dpnp/tests/third_party/cupy/core_tests/test_ndarray_reduction.py
+++ b/dpnp/tests/third_party/cupy/core_tests/test_ndarray_reduction.py
@@ -17,7 +17,8 @@ from dpnp.tests.third_party.cupy import testing
 class TestArrayReduction:
 
     @pytest.fixture(scope="class")
-    def exclude_cutensor(self):
+    @classmethod
+    def exclude_cutensor(cls):
         # cuTENSOR seems to have issues in handling inf/nan in reduction-based
         # routines, so we use this fixture to skip testing it
         # self.old_routine_accelerators = _acc.get_routine_accelerators()


### PR DESCRIPTION
This PR backports the fix for PytestRemovedIn10Warning raised with `pytest==9.1` from third party tests.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
