### PR TITLE
Fix typo in DPNPBinaryFunc docstring

### DIFF
--- a/dpnp/dpnp_algo/dpnp_elementwise_common.py
+++ b/dpnp/dpnp_algo/dpnp_elementwise_common.py
@@ -593,7 +593,7 @@ class DPNPBinaryFunc(BinaryElementwiseFunc):
         Function to influence type promotion behavior for Python scalar types
         of this binary function. The function takes 3 arguments:
             o1_dtype - Data type or Python scalar type of the first argument
-            o2_dtype - Data type or Python scalar type of of the second argument
+            o2_dtype - Data type or Python scalar type of the second argument
             sycl_dev - The :class:`dpctl.SyclDevice` where the function
                 evaluation is carried out.
         One of `o1_dtype` and `o2_dtype` must be a ``dtype`` instance.


### PR DESCRIPTION
The PR removes a duplicate word ("of of") in the `DPNPBinaryFunc` class docstring.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [x] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
