### PR TITLE
Clarify dpnp.reshape docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This release is compatible with NumPy 2.5.
 * Cleaned up Python bindings for indexing functions, renaming `usm_ndarray_take` and `usm_ndarray_put` to `py_take` and `py_put` and refactoring validation [#2935](https://github.com/IntelPython/dpnp/pull/2935)
 * Updated `dpnp.linalg.eig` and `dpnp.linalg.eigvals` documentation to reflect NumPy's always-complex eigenvalue output for general matrices [#2953](https://github.com/IntelPython/dpnp/pull/2953)
 * Clarified support for negative axes in `dpnp.transpose`/`dpnp.permute_dims` documentation [#2940](https://github.com/IntelPython/dpnp/pull/2940)
+* Clarified the summary in `dpnp.reshape` and `dpnp.ndarray.reshape` docstrings [#2964](https://github.com/IntelPython/dpnp/pull/2964)
 
 ### Deprecated
 

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -2399,8 +2399,8 @@ class dpnp_array:
         :obj:`dpnp.transpose` : Equivalent function.
         :obj:`dpnp.ndarray.ndarray.T` : Array property returning the array
             transposed.
-        :obj:`dpnp.ndarray.reshape` : Give a new shape to an array without
-            changing its data.
+        :obj:`dpnp.ndarray.reshape` : Return a reshaped ndarray without
+            changing data.
 
         Examples
         --------

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -1768,7 +1768,7 @@ class dpnp_array:
 
     def reshape(self, /, *shape, order="C", copy=None):
         """
-        Return an array containing the same data with a new shape.
+        Return a reshaped array without changing data.
 
         Refer to :obj:`dpnp.reshape` for full documentation.
 

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -2951,7 +2951,7 @@ def require(a, dtype=None, requirements=None, *, like=None):
 
 def reshape(a, /, shape, order="C", *, copy=None):
     """
-    Gives a new shape to an array without changing its data.
+    Return a reshaped ndarray without changing data.
 
     For full documentation refer to :obj:`numpy.reshape`.
 


### PR DESCRIPTION
Updates the `dpnp.reshape` docstring summary line (and the corresponding "See Also" reference in `dpnp.ndarray`) to clarify that it returns a reshaped array, preventing confusion about whether it modifies the array in-place.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
