### PR TITLE
Fix `dpnp.mgrid`/`dpnp.ogrid` inconsistency for complex steps with non-integer magnitude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This release is compatible with NumPy 2.5.
 * Fixed `PytestRemovedIn10Warning` raised by `pytest` 9.1.0 by converting class-scoped fixtures to class methods [#2952](https://github.com/IntelPython/dpnp/pull/2952)
 * Fixed `dpnp.linalg.svd(..., hermitian=True)` returning a non-unitary `vh` for singular input arrays due to a zero sign appearing [#2954](https://github.com/IntelPython/dpnp/pull/2954)
 * Fixed scalar conversion of size-one `dpnp.tensor.usm_ndarray` (e.g. `int()`, `float()`, indexing) which failed with NumPy 2.5 after the in-place `ndarray.shape` assignment was deprecated [#2958](https://github.com/IntelPython/dpnp/pull/2958)
+* Fixed `dpnp.mgrid` and `dpnp.ogrid` to return consistent results between single-slice and tuple-of-slices syntax when the step is a complex number with a non-integer magnitude (e.g. `2.5j`) [#2971](https://github.com/IntelPython/dpnp/pull/2971)
 
 ### Security
 

--- a/dpnp/dpnp_algo/dpnp_arraycreation.py
+++ b/dpnp/dpnp_algo/dpnp_arraycreation.py
@@ -354,11 +354,10 @@ class dpnp_nd_grid:
             if start is None:
                 start = 0
             if isinstance(step, complex):
-                step = abs(step)
-                length = int(step)
+                step_float = abs(step)
+                step = length = int(step_float)
                 if step != 1:
                     step = (stop - start) / float(step - 1)
-                stop = stop + step
                 return (
                     dpnp.arange(
                         0,

--- a/dpnp/tests/test_arraycreation.py
+++ b/dpnp/tests/test_arraycreation.py
@@ -1072,6 +1072,7 @@ class TestGrid:
             slice(0, 5, 1j),  # complex step
             slice(0, 5, 5j),  # complex step
             slice(0, 10, 2.5j),  # complex step with non-integer magnitude
+            slice(0, 10, 3.5j),  # non-integer magnitude with interior points
             slice(None, 5, 1),  # no start
             slice(0, 5, None),  # no step
         ],
@@ -1093,7 +1094,7 @@ class TestGrid:
             ),  # float start and complex step
             (
                 slice(0, 10, 2.5j),
-                slice(0, 5, 1.5j),
+                slice(0, 10, 3.5j),
             ),  # complex step with non-integer magnitude
         ],
     )

--- a/dpnp/tests/test_arraycreation.py
+++ b/dpnp/tests/test_arraycreation.py
@@ -1071,6 +1071,7 @@ class TestGrid:
             slice(0, 5, 0.5),  # float step
             slice(0, 5, 1j),  # complex step
             slice(0, 5, 5j),  # complex step
+            slice(0, 10, 2.5j),  # complex step with non-integer magnitude
             slice(None, 5, 1),  # no start
             slice(0, 5, None),  # no step
         ],
@@ -1090,6 +1091,10 @@ class TestGrid:
                 slice(0.0, 5, 1),
                 slice(0, 10, 1j),
             ),  # float start and complex step
+            (
+                slice(0, 10, 2.5j),
+                slice(0, 5, 1.5j),
+            ),  # complex step with non-integer magnitude
         ],
     )
     def test_md_slice(self, grid, slices):


### PR DESCRIPTION
For a complex step, the integer part of its magnitude is the number of points to generate (start and stop inclusive). The single-slice and tuple-of-slices code paths disagreed when the step magnitude was **not** an integer (e.g. `2.5j`):
- the tuple path used `int(abs(step)) - 1` as the divisor (correct), while
- the single-slice path used the float magnitude `abs(step) - 1` as the divisor.

As a result `dpnp.mgrid[0:10:2.5j]` and `dpnp.mgrid[0:10:2.5j,]` produced different arrays, and the single-slice form disagreed with NumPy.

```python
>>> dpnp.mgrid[0:10:2.5j]      # before: [0. , 6.667]   after: [ 0., 10.]
>>> dpnp.mgrid[0:10:2.5j,][0]  # always: [ 0., 10.]     (matches NumPy)
```

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
