### PR TITLE
Strip GCC-only `-fno-merge-constants` from flags in conda build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ This release is compatible with NumPy 2.5.
 * Fixed `dpnp.linalg.svd(..., hermitian=True)` returning a non-unitary `vh` for singular input arrays due to a zero sign appearing [#2954](https://github.com/IntelPython/dpnp/pull/2954)
 * Fixed scalar conversion of size-one `dpnp.tensor.usm_ndarray` (e.g. `int()`, `float()`, indexing) which failed with NumPy 2.5 after the in-place `ndarray.shape` assignment was deprecated [#2958](https://github.com/IntelPython/dpnp/pull/2958)
 * Fixed `dpnp.mgrid` and `dpnp.ogrid` to return consistent results between single-slice and tuple-of-slices syntax when the step is a complex number with a non-integer magnitude (e.g. `2.5j`) [#2971](https://github.com/IntelPython/dpnp/pull/2971)
+* Fixed `icx`/`icpx` warning during `conda build` by stripping the GCC-only `-fno-merge-constants` flag injected by conda-forge into `CFLAGS`/`CXXFLAGS` [#2978](https://github.com/IntelPython/dpnp/pull/2978)
 
 ### Security
 

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -22,6 +22,15 @@ fi
 export CC=icx
 export CXX=icpx
 
+# conda-forge's gcc/g++ activation injects -fno-merge-constants into CFLAGS/CXXFLAGS
+# when CONDA_BUILD==1. icx/icpx don't implement this GCC flag and emit warning #10430
+# (they have -fmerge-all-constants instead). Drop it to keep the build log clean; it
+# is a no-op for the Intel compiler. See CMPLRLLVM-19167 / CMPLRLLVM-28729 and the
+# conda-forge change that added the flag (later scoped to CONDA_BUILD only in #194):
+# https://github.com/conda-forge/ctng-compiler-activation-feedstock/pull/193
+export CFLAGS="${CFLAGS//-fno-merge-constants/}"
+export CXXFLAGS="${CXXFLAGS//-fno-merge-constants/}"
+
 export CMAKE_GENERATOR=Ninja
 # Make CMake verbose
 export VERBOSE=1

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -23,10 +23,8 @@ export CC=icx
 export CXX=icpx
 
 # conda-forge's gcc/g++ activation injects -fno-merge-constants into CFLAGS/CXXFLAGS
-# when CONDA_BUILD==1. icx/icpx don't implement this GCC flag and emit warning #10430
-# (they have -fmerge-all-constants instead). Drop it to keep the build log clean; it
-# is a no-op for the Intel compiler. See CMPLRLLVM-19167 / CMPLRLLVM-28729 and the
-# conda-forge change that added the flag (later scoped to CONDA_BUILD only in #194):
+# when CONDA_BUILD==1, while icx/icpx doesn't support it and emit the warning.
+# See CMPLRLLVM-19167 / CMPLRLLVM-28729 for more context and PR which added the flag:
 # https://github.com/conda-forge/ctng-compiler-activation-feedstock/pull/193
 export CFLAGS="${CFLAGS//-fno-merge-constants/}"
 export CXXFLAGS="${CXXFLAGS//-fno-merge-constants/}"


### PR DESCRIPTION
conda-forge's `gcc`/`g++` compiler activation injects `-fno-merge-constants` into `CFLAGS`/`CXXFLAGS` when `CONDA_BUILD==1`. 

The dpnp conda recipe builds with the Intel oneAPI compilers (`icx`/`icpx`), which do not implement this GCC flag and emit a warning on every compile unit:
```
icpx: command line warning #10430: Unsupported command line options encountered
These options as listed are not supported.
For more information, use '-qnextgen-diag'.
option list:
-fno-merge-constants
```

This PR removes `-fno-merge-constants` from `CFLAGS`/`CXXFLAGS` in `conda-recipe/build.sh`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
