### PR TITLE
Return Python array API compatible device objects from inspection namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ This release is compatible with NumPy 2.5.
 * Fixed `dpnp.linalg.svd(..., hermitian=True)` returning a non-unitary `vh` for singular input arrays due to a zero sign appearing [#2954](https://github.com/IntelPython/dpnp/pull/2954)
 * Fixed scalar conversion of size-one `dpnp.tensor.usm_ndarray` (e.g. `int()`, `float()`, indexing) which failed with NumPy 2.5 after the in-place `ndarray.shape` assignment was deprecated [#2958](https://github.com/IntelPython/dpnp/pull/2958)
 * Fixed `dpnp.mgrid` and `dpnp.ogrid` to return consistent results between single-slice and tuple-of-slices syntax when the step is a complex number with a non-integer magnitude (e.g. `2.5j`) [#2971](https://github.com/IntelPython/dpnp/pull/2971)
-* Fixed `__array_namespace_info__().devices()` to return a tuple of Python array API compatible device objects [#2979](https://github.com/IntelPython/dpnp/pull/2979)
+* Fixed `__array_namespace_info__().devices()` and `.default_device()` to return Python array API compatible device objects [#2979](https://github.com/IntelPython/dpnp/pull/2979)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ This release is compatible with NumPy 2.5.
 * Fixed `dpnp.linalg.svd(..., hermitian=True)` returning a non-unitary `vh` for singular input arrays due to a zero sign appearing [#2954](https://github.com/IntelPython/dpnp/pull/2954)
 * Fixed scalar conversion of size-one `dpnp.tensor.usm_ndarray` (e.g. `int()`, `float()`, indexing) which failed with NumPy 2.5 after the in-place `ndarray.shape` assignment was deprecated [#2958](https://github.com/IntelPython/dpnp/pull/2958)
 * Fixed `dpnp.mgrid` and `dpnp.ogrid` to return consistent results between single-slice and tuple-of-slices syntax when the step is a complex number with a non-integer magnitude (e.g. `2.5j`) [#2971](https://github.com/IntelPython/dpnp/pull/2971)
+* Fixed `__array_namespace_info__().devices()` to return a tuple of Python array API compatible device objects [#2979](https://github.com/IntelPython/dpnp/pull/2979)
 
 ### Security
 

--- a/dpnp/tensor/_array_api.py
+++ b/dpnp/tensor/_array_api.py
@@ -239,9 +239,9 @@ class Info:
         """
         devices()
 
-        Returns a list of supported devices.
+        Returns a tuple of supported devices.
         """
-        return dpctl.get_devices()
+        return tuple(dpt.Device.create_device(d) for d in dpctl.get_devices())
 
 
 def __array_namespace_info__():

--- a/dpnp/tensor/_array_api.py
+++ b/dpnp/tensor/_array_api.py
@@ -132,9 +132,9 @@ class Info:
         """
         default_device()
 
-        Returns the default SYCL device.
+        Returns the default device.
         """
-        return dpctl.select_default_device()
+        return dpt.Device.create_device(dpctl.select_default_device())
 
     def default_dtypes(self, *, device=None):
         """

--- a/dpnp/tests/tensor/test_tensor_array_api_inspection.py
+++ b/dpnp/tests/tensor/test_tensor_array_api_inspection.py
@@ -69,7 +69,7 @@ def test_array_api_inspection_default_device():
         dev = dpctl.select_default_device()
     except dpctl.SyclDeviceCreationError:
         pytest.skip("No default device available")
-    assert dpt.__array_namespace_info__().default_device() == dev
+    assert dpt.__array_namespace_info__().default_device().sycl_device == dev
 
 
 def test_array_api_inspection_devices():
@@ -142,7 +142,7 @@ def test_array_api_inspection_device_dtypes():
     except dpctl.SyclDeviceCreationError:
         pytest.skip("No default device available")
     dtypes = _dtypes_no_fp16_fp64.copy()
-    if dev.has_aspect_fp64:
+    if dev.sycl_device.has_aspect_fp64:
         dtypes["float64"] = dpt.float64
         dtypes["complex128"] = dpt.complex128
 
@@ -210,7 +210,7 @@ def test_array_api_inspection_dtype_kind_errors():
 def test_array_api_inspection_device_types():
     info = dpt.__array_namespace_info__()
     try:
-        dev = info.default_device()
+        dev = info.default_device().sycl_device
     except dpctl.SyclDeviceCreationError:
         pytest.skip("No default device available")
 

--- a/dpnp/tests/tensor/test_tensor_array_api_inspection.py
+++ b/dpnp/tests/tensor/test_tensor_array_api_inspection.py
@@ -79,7 +79,7 @@ def test_array_api_inspection_devices():
         pytest.skip("No default device available")
     devices1 = dpt.__array_namespace_info__().devices()
     assert len(devices1) == len(devices2)
-    assert devices1 == devices2
+    assert tuple(dev.sycl_device for dev in devices1) == devices2
 
 
 def test_array_api_inspection_capabilities():

--- a/dpnp/tests/test_array_api_info.py
+++ b/dpnp/tests/test_array_api_info.py
@@ -130,4 +130,6 @@ def test_dtypes_invalid_device():
 
 
 def test_devices():
-    assert info.devices() == get_devices()
+    devices = info.devices()
+    assert isinstance(devices, tuple)
+    assert tuple(dev.sycl_device for dev in devices) == get_devices()

--- a/dpnp/tests/test_array_api_info.py
+++ b/dpnp/tests/test_array_api_info.py
@@ -22,7 +22,7 @@ def test_capabilities():
 
 
 def test_default_device():
-    assert info.default_device() == default_device
+    assert info.default_device().sycl_device == default_device
 
 
 def test_default_dtypes():


### PR DESCRIPTION
The array API inspection namespace (`__array_namespace_info__()`) returned raw `dpctl.SyclDevice` objects from `devices()` and `default_device()`, while an array's `.device` attribute is a `dpnp.tensor.Device` wrapper.

Because `Device.__eq__` does not consider a bare `SyclDevice` equal, the objects returned by the inspection API did **not** compare equal to `x.device`, which the Python array API standard requires:
```python
import dpnp as np

devices = np.__array_namespace_info__().devices()
devices
# Out:
# (<dpctl.SyclDevice [backend_type.level_zero, device_type.gpu,  Intel(R) Graphics [0x7d41]] at 0x74bb28198030>,
#  <dpctl.SyclDevice [backend_type.opencl, device_type.cpu,  Intel(R) Core(TM) Ultra 7 265U] at 0x74bb28198d30>,
#  <dpctl.SyclDevice [backend_type.opencl, device_type.gpu,  Intel(R) Graphics [0x7d41]] at 0x74bb2a117870>)

x = np.ones(10)
y = np.from_dlpack(x, device=devices[1])
y.device == devices[1]
# Out: False

y.device.sycl_device == devices[1]
# Out: True
```

## Changes

This PR updates `Info.devices()` to return a **tuple** of `dpnp.tensor.Device` wrappers (built via `Device.create_device`), instead of a list of raw `dpctl.SyclDevice` objects. The wrappers carry the default cached queues for each root device, which is sufficient for the common cases.

Additionally `Info.default_device()` likewise now returns a `Device` wrapper for consistency, so `x.device`, `default_device()`, and the elements of `devices()` all compare equal for the default device.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [x] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
