### PR TITLE
Work around broken conda 26.5.3 _1 rebuild breaking the conda package CI build

### DIFF
--- a/environments/build_conda_pkg.yml
+++ b/environments/build_conda_pkg.yml
@@ -3,3 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - conda-build=25.11.1
+  - conda=26.5.3=*_0 # conda-forge/conda-feedstock/issues/304


### PR DESCRIPTION
The "Conda package" CI job started failing with:
```
File ".../envs/build/bin/conda", line 12, in <module>
    from conda.cli import main
ModuleNotFoundError: No module named 'conda'
...
BuildScriptException: Command '[..., 'conda_build.sh']' returned non-zero exit status 1.
```

`conda-forge` rebuilt `conda 26.5.3` as build `_1`. The `_1` package ships the `bin/conda` entry point with a `#!/usr/bin/env python` shebang instead of the previous prefix-relocated `#!<env>/bin/python`.

The `conda-recipe/build.sh` calls `conda list '^sysroot_linux-64$'` (to derive the glibc version for the manylinux wheel tag). That runs inside conda-build's host sandbox, where the sandbox's `python` — which does **not** contain the `conda` module — is first on `PATH`. With the old shebang this was fine (conda used its own env's python); with the `_1` shebang it resolves to the sandbox
python and fails with `ModuleNotFoundError: No module named 'conda'`.

Reported upstream:
[conda-forge/conda-feedstock#304](https://github.com/conda-forge/conda-feedstock/issues/304).

This PR pins `conda` to the known-good build `_0` in the build environment spec.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
