### PR TITLE
Suppress DPC++/SYCL header deprecation warnings when building `dpnp.tensor` on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ This release is compatible with NumPy 2.5.
 * Fixed `dpnp.linalg.svd(..., hermitian=True)` returning a non-unitary `vh` for singular input arrays due to a zero sign appearing [#2954](https://github.com/IntelPython/dpnp/pull/2954)
 * Fixed scalar conversion of size-one `dpnp.tensor.usm_ndarray` (e.g. `int()`, `float()`, indexing) which failed with NumPy 2.5 after the in-place `ndarray.shape` assignment was deprecated [#2958](https://github.com/IntelPython/dpnp/pull/2958)
 * Fixed `dpnp.mgrid` and `dpnp.ogrid` to return consistent results between single-slice and tuple-of-slices syntax when the step is a complex number with a non-integer magnitude (e.g. `2.5j`) [#2971](https://github.com/IntelPython/dpnp/pull/2971)
+* Fixed a flood of deprecation warnings from the DPC++/SYCL headers when building `dpnp.tensor` on Windows [#2984](https://github.com/IntelPython/dpnp/pull/2984)
 
 ### Security
 

--- a/dpnp/tensor/CMakeLists.txt
+++ b/dpnp/tensor/CMakeLists.txt
@@ -356,9 +356,16 @@ foreach(python_module_name ${_py_trgts})
         ${python_module_name}
         PRIVATE
             ${CMAKE_SOURCE_DIR}/dpnp/include
-            ${Dpctl_INCLUDE_DIR}
             ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/include
             ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/source/
+    )
+
+    target_include_directories(
+        ${python_module_name}
+        SYSTEM
+        PRIVATE
+            ${SYCL_INCLUDE_DIR}
+            ${Dpctl_INCLUDE_DIR}
             ${CMAKE_BINARY_DIR} # For generated Cython headers
     )
     target_link_options(${python_module_name} PRIVATE ${_linker_options})


### PR DESCRIPTION
This PR is a follow-up to #2856 and #2770. The `dpnp.tensor` target never got the same `SYSTEM` treatment, so it was the one target still leaking these warnings.

The Windows conda build produced a flood of `-Wdeprecated-declarations` warnings (hundreds of thousands of lines in the CI log). All of them originate inside the DPC++/SYCL headers themselves (`.../Library/include/sycl/...`) — none come from dpnp's own sources — so they are out of dpnp's control and are pure noise. They came exclusively from the `dpnp.tensor` `_tensor_*_impl` pybind11 modules built in `dpnp/tensor/CMakeLists.txt`.

In the `dpnp/tensor` target loop, split the include directories so dpnp's own headers stay `PRIVATE`, and the third-party headers (`SYCL_INCLUDE_DIR`, `Dpctl_INCLUDE_DIR`, generated Cython headers) are added as `SYSTEM PRIVATE`, mirroring the pattern established in #2770 for the `backend/extensions/*` targets.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
