### PR TITLE
Add test with 0d `out` array for `dpnp.einsum`

### DIFF
--- a/dpnp/tests/test_linalg.py
+++ b/dpnp/tests/test_linalg.py
@@ -601,6 +601,16 @@ class TestEinsum:
         expected = numpy.einsum("ii->i", a.asnumpy())
         assert_dtype_allclose(result, expected)
 
+    def test_out_0d(self):
+        a = numpy.ones(7, dtype=int)
+        out = numpy.array(0, dtype=a.dtype)
+        ia, iout = dpnp.array(a), dpnp.array(out)
+
+        result = dpnp.einsum("i,i->", ia, ia, out=iout, optimize="optimal")
+        expected = numpy.einsum("i,i->", a, a, out=out, optimize="optimal")
+        assert_dtype_allclose(result, expected)
+        assert result is iout
+
     def test_einsum_error1(self):
         a = dpnp.ones((5, 5))
         out = dpnp.empty((5,), sycl_queue=dpctl.SyclQueue())

--- a/dpnp/tests/test_linalg.py
+++ b/dpnp/tests/test_linalg.py
@@ -567,7 +567,7 @@ class TestEigenvalue:
 
 
 class TestEinsum:
-    def test_einsum_trivial_cases(self):
+    def test_trivial_cases(self):
         a = dpnp.arange(25).reshape(5, 5)
         b = dpnp.arange(5)
         a_np = a.asnumpy()
@@ -593,7 +593,7 @@ class TestEinsum:
         expected = numpy.einsum("i,i,i", b_np, b_np, b_np, optimize="greedy")
         assert_dtype_allclose(result, expected)
 
-    def test_einsum_out(self):
+    def test_out(self):
         a = dpnp.ones((5, 5))
         out = dpnp.empty((5,))
         result = dpnp.einsum("ii->i", a, out=out)
@@ -611,7 +611,7 @@ class TestEinsum:
         assert_dtype_allclose(result, expected)
         assert result is iout
 
-    def test_einsum_error1(self):
+    def test_error1(self):
         a = dpnp.ones((5, 5))
         out = dpnp.empty((5,), sycl_queue=dpctl.SyclQueue())
         # inconsistent sycl_queue
@@ -633,7 +633,7 @@ class TestEinsum:
 
     @pytest.mark.parametrize("do_opt", [True, False])
     @pytest.mark.parametrize("xp", [numpy, dpnp])
-    def test_einsum_error2(self, do_opt, xp):
+    def test_error2(self, do_opt, xp):
         a = xp.asarray(0)
         b = xp.asarray([0])
         c = xp.asarray([0, 0])
@@ -692,7 +692,7 @@ class TestEinsum:
 
     @pytest.mark.parametrize("do_opt", [True, False])
     @pytest.mark.parametrize("xp", [numpy, dpnp])
-    def test_einsum_specific_errors(self, do_opt, xp):
+    def test_specific_errors(self, do_opt, xp):
         a = xp.asarray(0)
         # out parameter must be an array
         assert_raises(TypeError, xp.einsum, "", a, out="test", optimize=do_opt)
@@ -1211,35 +1211,35 @@ class TestEinsum:
             numpy.einsum("ij,i->", a, b, optimize=do_opt),
         )
 
-    def test_einsum_sums_int32(self):
+    def test_sums_int32(self):
         self.check_einsum_sums("i4")
         self.check_einsum_sums("i4", True)
 
-    def test_einsum_sums_uint32(self):
+    def test_sums_uint32(self):
         self.check_einsum_sums("u4")
         self.check_einsum_sums("u4", True)
 
-    def test_einsum_sums_int64(self):
+    def test_sums_int64(self):
         self.check_einsum_sums("i8")
 
-    def test_einsum_sums_uint64(self):
+    def test_sums_uint64(self):
         self.check_einsum_sums("u8")
 
-    def test_einsum_sums_float32(self):
+    def test_sums_float32(self):
         self.check_einsum_sums("f4")
 
-    def test_einsum_sums_float64(self):
+    def test_sums_float64(self):
         self.check_einsum_sums("f8")
         self.check_einsum_sums("f8", True)
 
-    def test_einsum_sums_cfloat64(self):
+    def test_sums_cfloat64(self):
         self.check_einsum_sums("c8")
         self.check_einsum_sums("c8", True)
 
-    def test_einsum_sums_cfloat128(self):
+    def test_sums_cfloat128(self):
         self.check_einsum_sums("c16")
 
-    def test_einsum_misc(self):
+    def test_misc(self):
         for opt in [True, False]:
             a = numpy.ones((1, 2))
             b = numpy.ones((2, 2, 1))
@@ -1299,7 +1299,7 @@ class TestEinsum:
         assert_raises(ValueError, dpnp.einsum, a, [0, 52], b, [52, 2], [0, 2])
         assert_raises(ValueError, dpnp.einsum, a, [-1, 5], b, [5, 2], [-1, 2])
 
-    def test_einsum_broadcast(self):
+    def test_broadcast(self):
         a = numpy.arange(2 * 3 * 4).reshape(2, 3, 4)
         b = numpy.arange(3)
         a_dp = dpnp.array(a)
@@ -1377,7 +1377,7 @@ class TestEinsum:
                 expected,
             )
 
-    def test_einsum_stride(self):
+    def test_stride(self):
         a = numpy.arange(2 * 3).reshape(2, 3).astype(numpy.float32)
         b = numpy.arange(2 * 3 * 2731).reshape(2, 3, 2731).astype(numpy.int16)
         a_dp = dpnp.array(a)
@@ -1395,7 +1395,7 @@ class TestEinsum:
         result = dpnp.einsum("cl, cpxy->lpxy", a_dp, b_dp)
         assert_dtype_allclose(result, expected)
 
-    def test_einsum_collapsing(self):
+    def test_collapsing(self):
         x = numpy.random.normal(0, 1, (5, 5, 5, 5))
         y = numpy.zeros((5, 5))
         expected = numpy.einsum("aabb->ab", x, out=y)
@@ -1405,7 +1405,7 @@ class TestEinsum:
         assert result is y_dp
         assert_dtype_allclose(result, expected)
 
-    def test_einsum_tensor(self):
+    def test_tensor(self):
         tensor = numpy.random.random_sample((10, 10, 10, 10))
         tensor_dp = dpnp.array(tensor)
         expected = numpy.einsum("ijij->", tensor)
@@ -1667,7 +1667,7 @@ class TestEinsum:
             tmp = dpnp.einsum("...ft,mf->...mt", d, c, order="a", optimize=opt)
             assert tmp.flags.c_contiguous
 
-    def test_einsum_path(self):
+    def test_path(self):
         # Test einsum path for covergae
         a = numpy.random.rand(1, 2, 3, 4)
         b = numpy.random.rand(4, 3, 2, 1)


### PR DESCRIPTION
The PR extends tests coverage for `dpnp.einsum` and align tests names.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
