### PR TITLE
Remove references to the unimplemented `dpnp.ndarray.resize` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This release is compatible with NumPy 2.5.
 
 * Removed support for arrays of 2-dimensional vectors in `dpnp.cross`, which now requires (arrays of) 3-dimensional vectors and raises `ValueError` otherwise [#2950](https://github.com/IntelPython/dpnp/pull/2950)
 * Removed `dpnp.row_stack` in favor of `dpnp.vstack` [#2956](https://github.com/IntelPython/dpnp/pull/2956)
+* Removed all references to the unimplemented `dpnp.ndarray.resize` method from the documentation [#2989](https://github.com/IntelPython/dpnp/pull/2989)
 
 ### Fixed
 

--- a/doc/reference/ndarray.rst
+++ b/doc/reference/ndarray.rst
@@ -168,15 +168,14 @@ Array conversion
 Shape manipulation
 ------------------
 
-For reshape, resize, and transpose, the single tuple argument may be
-replaced with ``n`` integers which will be interpreted as an n-tuple.
+For reshape and transpose, the single tuple argument may be replaced with ``n``
+integers which will be interpreted as an n-tuple.
 
 .. autosummary::
    :toctree: generated/
    :nosignatures:
 
    ndarray.reshape
-   ndarray.resize
    ndarray.transpose
    ndarray.swapaxes
    ndarray.flatten

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -1806,8 +1806,6 @@ class dpnp_array:
             shape = shape[0]
         return dpnp.reshape(self, shape, order=order, copy=copy)
 
-    # 'resize',
-
     def round(self, /, decimals=0, *, out=None):
         """
         Return array with each element rounded to the given number of decimals.

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -3070,9 +3070,7 @@ def resize(a, new_shape):
     Return a new array with the specified shape.
 
     If the new array is larger than the original array, then the new array is
-    filled with repeated copies of `a`. Note that this behavior is different
-    from ``a.resize(new_shape)`` which fills with zeros instead of repeated
-    copies of `a`.
+    filled with repeated copies of `a`.
 
     For full documentation refer to :obj:`numpy.resize`.
 
@@ -3092,7 +3090,6 @@ def resize(a, new_shape):
 
     See Also
     --------
-    :obj:`dpnp.ndarray.resize` : Resize an array in-place.
     :obj:`dpnp.reshape` : Reshape an array without changing the total size.
     :obj:`dpnp.pad` : Enlarge and pad an array.
     :obj:`dpnp.repeat` : Repeat elements of an array.


### PR DESCRIPTION
NumPy deprecated the `numpy.ndarray.resize` method in NumPy 2.5.

While `dpnp` has **never implemented** the in-place `dpnp.ndarray.resize` method.
However, several places in the documentation and docstrings still referenced the method as if it existed or was planned, which is misleading to users and would only diverge further from NumPy now that the method is deprecated upstream.

This PR removes all such references.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [x] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
