### PR TITLE
Use canonical `dpnp.max`/`dpnp.min` instead of `amax`/`amin` aliases in docstrings and internal code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This release is compatible with NumPy 2.5.
 * Improved performance of `dpnp.fft` functions for complex strided input by avoiding oversized allocations and extra copies [#2939](https://github.com/IntelPython/dpnp/pull/2939)
 * Refreshed `dpnp` documentation styling with the Furo theme [#2934](https://github.com/IntelPython/dpnp/pull/2934)
 * Updated Python Array API specification version supported to `2025.12` [#2899](https://github.com/IntelPython/dpnp/pull/2899)
+* Replaced references to the `dpnp.amax`/`dpnp.amin` aliases with the canonical `dpnp.max`/`dpnp.min` in docstrings and code internally [#2990](https://github.com/IntelPython/dpnp/pull/2990)
 
 ### Deprecated
 

--- a/dpnp/dpnp_iface_histograms.py
+++ b/dpnp/dpnp_iface_histograms.py
@@ -346,7 +346,7 @@ def bincount(x, weights=None, minlength=0):
     array([1, 3, 1, 1, 0, 0, 0, 1])
 
     >>> x = np.array([0, 1, 1, 3, 2, 1, 7, 23])
-    >>> np.bincount(x).size == np.amax(x) + 1
+    >>> np.bincount(x).size == np.max(x) + 1
     array(True)
 
     The input array needs to be of integer dtype, otherwise a

--- a/dpnp/dpnp_iface_statistics.py
+++ b/dpnp/dpnp_iface_statistics.py
@@ -1082,8 +1082,6 @@ def max(a, axis=None, out=None, keepdims=False, initial=None, where=True):
     :obj:`dpnp.min` : Return the minimum of an array.
     :obj:`dpnp.maximum` : Element-wise maximum of two arrays, propagates NaNs.
     :obj:`dpnp.fmax` : Element-wise maximum of two arrays, ignores NaNs.
-    :obj:`dpnp.amax` : The maximum value of an array along a given axis,
-                       propagates NaNs.
     :obj:`dpnp.nanmax` : The maximum value of an array along a given axis,
                          ignores NaNs.
 
@@ -1359,8 +1357,6 @@ def min(a, axis=None, out=None, keepdims=False, initial=None, where=True):
     :obj:`dpnp.max` : Return the maximum of an array.
     :obj:`dpnp.minimum` : Element-wise minimum of two arrays, propagates NaNs.
     :obj:`dpnp.fmin` : Element-wise minimum of two arrays, ignores NaNs.
-    :obj:`dpnp.amin` : The minimum value of an array along a given axis,
-                       propagates NaNs.
     :obj:`dpnp.nanmin` : The minimum value of an array along a given axis,
                          ignores NaNs.
 

--- a/dpnp/dpnp_utils/dpnp_utils_pad.py
+++ b/dpnp/dpnp_utils/dpnp_utils_pad.py
@@ -248,10 +248,10 @@ def _get_stats(padded, axis, width_pair, length_pair, stat_func):
         right_length = max_length
 
     if (left_length == 0 or right_length == 0) and stat_func in [
-        dpnp.amax,
-        dpnp.amin,
+        dpnp.max,
+        dpnp.min,
     ]:
-        # amax and amin can't operate on an empty array,
+        # max and min can't operate on an empty array,
         # raise a more descriptive warning here instead of the default one
         raise ValueError("stat_length of 0 yields no value for padding")
 
@@ -740,8 +740,8 @@ def dpnp_pad(array, pad_width, mode="constant", **kwargs):
             return _pad_simple(array, pad_width, 0)[0]
 
     stat_functions = {
-        "maximum": dpnp.amax,
-        "minimum": dpnp.amin,
+        "maximum": dpnp.max,
+        "minimum": dpnp.min,
         "mean": dpnp.mean,
         "median": dpnp.median,
     }


### PR DESCRIPTION
The pointing docstrings and internal usage at the alias pages forces readers to click through a second time to reach the real
`max`/`min` documentation; referencing the canonical names directly avoids that indirection.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [x] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
