### PR TITLE
Revert OneAPI 2025.3 pinning in coverage workflow

### DIFF
--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -46,18 +46,16 @@ jobs:
           echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
           sudo apt update
 
-      # Pinned to OneAPI 2025.3 due to known 2026.0 DPC++ compiler issue with Segfault during the sycl-post-link
-      # TODO: renmove once CMPLRLLVM-75178 is resolved and released
-      - name: Install Intel OneAPI
+      - name: Install latest Intel OneAPI
         if: env.oneapi-pkgs-env == ''
         run: |
-          sudo apt install hwloc                                   \
-                           intel-oneapi-mkl-2025.3                 \
-                           intel-oneapi-umf-1.0                    \
-                           intel-oneapi-mkl-devel-2025.3           \
-                           intel-oneapi-tbb-devel-2022.3           \
-                           intel-oneapi-libdpstd-devel-2022.10     \
-                           intel-oneapi-compiler-dpcpp-cpp-2025.3
+          sudo apt install hwloc                           \
+                           intel-oneapi-mkl                \
+                           intel-oneapi-umf                \
+                           intel-oneapi-mkl-devel          \
+                           intel-oneapi-tbb-devel          \
+                           intel-oneapi-libdpstd-devel     \
+                           intel-oneapi-compiler-dpcpp-cpp
 
       - name: Checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -109,14 +107,10 @@ jobs:
       # with a newer version of the DPC++ compiler).
       # Installing dpctl via the pip manager has no such limitation, as the package has no
       # run dependency on the DPC++ RT pip package, so this is why the step is necessary here.
-      # - name: Install dpctl
-      #   if: env.oneapi-pkgs-env == ''
-      #   run: |
-      #     pip install -r ${{ env.dpctl-pkg-txt }}
-      # TODO: renmove pinning once CMPLRLLVM-75178 is resolved and released
       - name: Install dpctl
+        if: env.oneapi-pkgs-env == ''
         run: |
-          pip install dpctl>=0.23.0dev0 --index-url https://pypi.anaconda.org/dppy/label/coverage/simple
+          pip install -r ${{ env.dpctl-pkg-txt }}
 
       - name: Conda info
         run: |


### PR DESCRIPTION
This reverts the changes from #2887, which pinned Intel OneAPI to 2025.3 in the `generate_coverage` workflow.

#2887 introduced the pinning to work around a known 2026.0 DPC++ compiler issue (CMPLRLLVM-75178) causing a segfault during `sycl-post-link`. With OneAPI 2026.1 now released, the pinning is no longer needed.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
