### PR TITLE
Clean up dead code guarded by outdated oneMKL and DPC++ version checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This release is compatible with NumPy 2.5.
 * Updated Python Array API specification version supported to `2025.12` [#2899](https://github.com/IntelPython/dpnp/pull/2899)
 * Replaced references to the `dpnp.amax`/`dpnp.amin` aliases with the canonical `dpnp.max`/`dpnp.min` in docstrings and code internally [#2990](https://github.com/IntelPython/dpnp/pull/2990)
 * Aligned the signature of `dpnp.tensor.expand_dims` with the Python array API by making `axis` a required argument [#2988](https://github.com/IntelPython/dpnp/pull/2988)
+* Removed dead code branches guarded by outdated oneMKL and DPC++ compiler version checks [#2999](https://github.com/IntelPython/dpnp/pull/2999)
 
 ### Deprecated
 

--- a/dpnp/backend/extensions/fft/common.hpp
+++ b/dpnp/backend/extensions/fft/common.hpp
@@ -112,12 +112,13 @@ public:
         const typename valT::value_type dim = get_dim();
 
         valT fwd_strides(dim + 1);
-#if INTEL_MKL_VERSION >= 20250000
-        descr_.get_value(mkl_dft::config_param::FWD_STRIDES, &fwd_strides);
-#else
+#if defined(USE_ONEMATH)
+        // oneMath uses a C-style variadic API that expects a raw pointer
         descr_.get_value(mkl_dft::config_param::FWD_STRIDES,
                          fwd_strides.data());
-#endif // INTEL_MKL_VERSION
+#else
+        descr_.get_value(mkl_dft::config_param::FWD_STRIDES, &fwd_strides);
+#endif // USE_ONEMATH
         return fwd_strides;
     }
 
@@ -130,11 +131,12 @@ public:
             throw py::value_error(
                 "Strides length does not match descriptor's dimension");
         }
-#if INTEL_MKL_VERSION >= 20250000
-        descr_.set_value(mkl_dft::config_param::FWD_STRIDES, strides);
-#else
+#if defined(USE_ONEMATH)
+        // oneMath uses a C-style variadic API that expects a raw pointer
         descr_.set_value(mkl_dft::config_param::FWD_STRIDES, strides.data());
-#endif // INTEL_MKL_VERSION
+#else
+        descr_.set_value(mkl_dft::config_param::FWD_STRIDES, strides);
+#endif // USE_ONEMATH
     }
 
     // config_param::BWD_STRIDES
@@ -144,12 +146,13 @@ public:
         const typename valT::value_type dim = get_dim();
 
         valT bwd_strides(dim + 1);
-#if INTEL_MKL_VERSION >= 20250000
-        descr_.get_value(mkl_dft::config_param::BWD_STRIDES, &bwd_strides);
-#else
+#if defined(USE_ONEMATH)
+        // oneMath uses a C-style variadic API that expects a raw pointer
         descr_.get_value(mkl_dft::config_param::BWD_STRIDES,
                          bwd_strides.data());
-#endif // INTEL_MKL_VERSION
+#else
+        descr_.get_value(mkl_dft::config_param::BWD_STRIDES, &bwd_strides);
+#endif // USE_ONEMATH
         return bwd_strides;
     }
 
@@ -162,11 +165,12 @@ public:
             throw py::value_error(
                 "Strides length does not match descriptor's dimension");
         }
-#if INTEL_MKL_VERSION >= 20250000
-        descr_.set_value(mkl_dft::config_param::BWD_STRIDES, strides);
-#else
+#if defined(USE_ONEMATH)
+        // oneMath uses a C-style variadic API that expects a raw pointer
         descr_.set_value(mkl_dft::config_param::BWD_STRIDES, strides.data());
-#endif // INTEL_MKL_VERSION
+#else
+        descr_.set_value(mkl_dft::config_param::BWD_STRIDES, strides);
+#endif // USE_ONEMATH
     }
 
     // config_param::FWD_DISTANCE
@@ -204,32 +208,17 @@ public:
     // config_param::PLACEMENT
     bool get_in_place()
     {
-#if defined(USE_ONEMATH) || INTEL_MKL_VERSION >= 20250000
         mkl_dft::config_value placement;
         descr_.get_value(mkl_dft::config_param::PLACEMENT, &placement);
         return (placement == mkl_dft::config_value::INPLACE);
-#else
-        // TODO: remove branch when MKLD-10506 is implemented
-        DFTI_CONFIG_VALUE placement;
-        descr_.get_value(mkl_dft::config_param::PLACEMENT, &placement);
-        return (placement == DFTI_CONFIG_VALUE::DFTI_INPLACE);
-#endif // USE_ONEMATH or INTEL_MKL_VERSION
     }
 
     void set_in_place(const bool &in_place_request)
     {
-#if defined(USE_ONEMATH) || INTEL_MKL_VERSION >= 20250000
         descr_.set_value(mkl_dft::config_param::PLACEMENT,
                          (in_place_request)
                              ? mkl_dft::config_value::INPLACE
                              : mkl_dft::config_value::NOT_INPLACE);
-#else
-        // TODO: remove branch when MKLD-10506 is implemented
-        descr_.set_value(mkl_dft::config_param::PLACEMENT,
-                         (in_place_request)
-                             ? DFTI_CONFIG_VALUE::DFTI_INPLACE
-                             : DFTI_CONFIG_VALUE::DFTI_NOT_INPLACE);
-#endif // USE_ONEMATH or INTEL_MKL_VERSION
     }
 
     // config_param::PRECISION
@@ -244,16 +233,9 @@ public:
     // config_param::COMMIT_STATUS
     bool is_committed()
     {
-#if defined(USE_ONEMATH) || INTEL_MKL_VERSION >= 20250000
         mkl_dft::config_value committed;
         descr_.get_value(mkl_dft::config_param::COMMIT_STATUS, &committed);
         return (committed == mkl_dft::config_value::COMMITTED);
-#else
-        // TODO: remove branch when MKLD-10506 is implemented
-        DFTI_CONFIG_VALUE committed;
-        descr_.get_value(mkl_dft::config_param::COMMIT_STATUS, &committed);
-        return (committed == DFTI_CONFIG_VALUE::DFTI_COMMITTED);
-#endif // USE_ONEMATH or INTEL_MKL_VERSION
     }
 
 private:

--- a/dpnp/backend/extensions/vm/common.hpp
+++ b/dpnp/backend/extensions/vm/common.hpp
@@ -46,19 +46,6 @@
 #include "utils/memory_overlap.hpp"
 #include "utils/type_dispatch.hpp"
 
-/**
- * Version of Intel MKL at which transition to OneMKL release 2023.2.0 occurs.
- *
- * @note with OneMKL=2023.1.0 the call of oneapi::mkl::vm::div() was dead
- * locked inside ~usm_wrapper_to_host()->{...; q_->wait_and_throw(); ...}
- */
-#ifndef __INTEL_MKL_2023_2_0_VERSION_REQUIRED
-#define __INTEL_MKL_2023_2_0_VERSION_REQUIRED 20230002L
-#endif
-
-static_assert(INTEL_MKL_VERSION >= __INTEL_MKL_2023_2_0_VERSION_REQUIRED,
-              "OneMKL does not meet minimum version requirement");
-
 namespace ext_ns = ext::common;
 namespace py = pybind11;
 namespace td_ns = dpnp::tensor::type_dispatch;

--- a/dpnp/backend/kernels/dpnp_krnl_random.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_random.cpp
@@ -41,9 +41,6 @@
 #include "dpnpc_memory_adapter.hpp"
 #include "queue_sycl.hpp"
 
-static_assert(INTEL_MKL_VERSION >= __INTEL_MKL_2023_0_0_VERSION_REQUIRED,
-              "OneMKL does not meet minimum version requirement");
-
 namespace mkl_blas = oneapi::mkl::blas;
 namespace mkl_rng = oneapi::mkl::rng;
 namespace mkl_vm = oneapi::mkl::vm;

--- a/dpnp/backend/kernels/elementwise_functions/i0.hpp
+++ b/dpnp/backend/kernels/elementwise_functions/i0.hpp
@@ -31,14 +31,6 @@
 #include <sycl/sycl.hpp>
 
 /**
- * Version of SYCL DPC++ 2025.1 compiler where an issue with
- * sycl::ext::intel::math::cyl_bessel_i0(x) is fully resolved.
- */
-#ifndef __SYCL_COMPILER_BESSEL_I0_SUPPORT
-#define __SYCL_COMPILER_BESSEL_I0_SUPPORT 20241208L
-#endif
-
-/**
  * Include <sycl/ext/intel/math.hpp> only when targeting to Intel devices.
  * This header relies on intel-specific types like _iml_half_internal,
  * which are not suppose to work with other targets (e.g., CUDA, AMD).
@@ -47,15 +39,13 @@
 #define __SYCL_EXT_INTEL_MATH_SUPPORT
 #endif
 
-#if defined(__SYCL_EXT_INTEL_MATH_SUPPORT) &&                                  \
-    (__SYCL_COMPILER_VERSION >= __SYCL_COMPILER_BESSEL_I0_SUPPORT)
+#if defined(__SYCL_EXT_INTEL_MATH_SUPPORT)
 #include <sycl/ext/intel/math.hpp>
 #endif
 
 namespace dpnp::kernels::i0
 {
-#if defined(__SYCL_EXT_INTEL_MATH_SUPPORT) &&                                  \
-    (__SYCL_COMPILER_VERSION >= __SYCL_COMPILER_BESSEL_I0_SUPPORT)
+#if defined(__SYCL_EXT_INTEL_MATH_SUPPORT)
 using sycl::ext::intel::math::cyl_bessel_i0;
 
 #else

--- a/dpnp/backend/src/dpnp_utils.hpp
+++ b/dpnp/backend/src/dpnp_utils.hpp
@@ -42,13 +42,6 @@
 #include <dpnp_iface_fptr.hpp>
 
 /**
- * Version of Intel MKL at which transition to OneMKL release 2023.0.0 occurs.
- */
-#ifndef __INTEL_MKL_2023_0_0_VERSION_REQUIRED
-#define __INTEL_MKL_2023_0_0_VERSION_REQUIRED 20230000
-#endif
-
-/**
  * @defgroup BACKEND_UTILS Backend C++ library utilities
  * @{
  * This section describes utilities used in Backend API.


### PR DESCRIPTION
Since the build and runtime minimum was raised to **oneMKL / DPC++ compiler 2026.0** (`conda-recipe/meta.yaml`), several preprocessor and version guards now select a fixed branch on every supported configuration. This PR removes the resulting dead code and replaces version comparisons with the condition they actually encode.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
