### PR TITLE
Release transient SYCL queues at the end of each test file to avoid OOM on low-memory GPUs

### DIFF
--- a/dpnp/tests/conftest.py
+++ b/dpnp/tests/conftest.py
@@ -31,6 +31,7 @@ import sys
 import warnings
 
 import dpctl
+import dpctl.utils as dpu
 import numpy
 import pytest
 
@@ -184,6 +185,27 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "slow" in item.keywords:
                 item.add_marker(skip_slow)
+
+
+def pytest_runtest_teardown(item, nextitem):
+    """
+    Release transient SYCL queues at the end of each test file.
+
+    Every distinct ``SyclQueue`` a test creates is retained forever as a key in
+    dpctl's ``SequentialOrderManager`` (keyed by queue identity), which pins its
+    host-task events and the backing USM memory for the whole session. Over a
+    full run this accumulates hundreds of queues and steadily drains device
+    memory. Draining and dropping them at each file boundary keeps the footprint
+    flat without paying the cost after every individual test.
+    """
+    # Only act on the last test of the current file (``nextitem`` is None at the
+    # very end of the session, or points at the first test of the next file).
+    if nextitem is not None and item.path == nextitem.path:
+        return
+    try:
+        dpu.SequentialOrderManager.clear()
+    except Exception as e:  # never let cleanup break the run
+        warnings.warn(f"Failed to clear SequentialOrderManager: {e}")
 
 
 @pytest.fixture


### PR DESCRIPTION
Running the full test suite in a single process steadily drains device memory and can end in a `RuntimeError: ... UR_RESULT_ERROR_OUT_OF_RESOURCES` (seen intermittently on a low-memory iGPU, where the kernel logs `VM worker error: -12` / `exec queue reset detected`).

Root cause: every distinct `dpctl.SyclQueue` a test creates is retained **for the whole session** as a key in dpctl's `SequentialOrderManager` (the map is keyed by queue identity and only ever grows). Each retained entry holds a host-task event that pins the backing USM allocation, so the memory is never released. Over a full run the map accumulates ~300 queues
and free device memory bleeds from several GB down to ~1 GB, occasionally crossing the device limit.

This is amplified on integrated GPUs, where "device memory" is system RAM, so the leaked USM competes directly with the host and the container's memory budget.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
