### PR TITLE
Fix hanging coverage workflow

### DIFF
--- a/dpnp/CMakeLists.txt
+++ b/dpnp/CMakeLists.txt
@@ -42,7 +42,12 @@ function(build_dpnp_cython_ext _trgt _src _dest)
     endif()
 
     if(DPNP_GENERATE_COVERAGE)
-        target_compile_definitions(${_trgt} PRIVATE CYTHON_TRACE=1 CYTHON_TRACE_NOGIL=1)
+        # Pass CYTHON_USE_SYS_MONITORING=0 to force Cython's legacy (settrace-based)
+        # line tracing instead of the sys.monitoring path
+        target_compile_definitions(
+            ${_trgt}
+            PRIVATE CYTHON_TRACE=1 CYTHON_TRACE_NOGIL=1 CYTHON_USE_SYS_MONITORING=0
+        )
         target_compile_options(${_trgt} PRIVATE "-fno-sycl-use-footer")
     endif()
 
@@ -110,7 +115,13 @@ function(build_dpnp_tensor_ext _trgt _src _dest)
     endif()
     target_link_libraries(${_trgt} PRIVATE Python::NumPy)
     if(DPNP_GENERATE_COVERAGE)
-        target_compile_definitions(${_trgt} PRIVATE CYTHON_TRACE=1 CYTHON_TRACE_NOGIL=1)
+        # Pass CYTHON_USE_SYS_MONITORING=0 to force Cython's legacy (settrace-based)
+        # line tracing instead of the sys.monitoring path
+        # See https://github.com/cython/cython/issues/6658.
+        target_compile_definitions(
+            ${_trgt}
+            PRIVATE CYTHON_TRACE=1 CYTHON_TRACE_NOGIL=1 CYTHON_USE_SYS_MONITORING=0
+        )
         if(BUILD_DPNP_TENSOR_SYCL)
             target_compile_options(${_trgt} PRIVATE -fno-sycl-use-footer)
         endif()


### PR DESCRIPTION
The GutHub coverage workflow started hanging right after the coverage environment was bumped from Python 3.12 to 3.14 (#2922).

This PR fixes the hang by compiling the coverage build with `CYTHON_USE_SYS_MONITORING=0`, forcing Cython to use its legacy `settrace`-based line tracing instead of the `sys.monitoring` path that becomes the default on Python 3.13+.

### Root cause

Coverage builds compile every Cython extension with line tracing (`CYTHON_TRACE=1 CYTHON_TRACE_NOGIL=1` + `# cython: linetrace=True`). On Python 3.13+, Cython gates its tracing implementation on `CYTHON_USE_SYS_MONITORING` (`PY_VERSION_HEX >= 0x030d00B1`) and emits `sys.monitoring` hooks directly into the compiled `.so`.

Those hooks fire exception/unwind events (`PyMonitoring_FireRaiseEvent`, `PyMonitoring_FirePyUnwindEvent`, ...) **without preserving the in-flight exception** — unlike the legacy path (`__Pyx_call_line_trace_func`), which brackets the trace call with `PyErr_Fetch`/`PyErr_Restore`. When an exception propagates out of an instrumented `.pyx` frame, this corrupts the interpreter's error state: the correct exception is turned into a `SystemError` ("returned a result with an exception set"), and the process
then hangs.

This is an upstream Cython bug: https://github.com/cython/cython/issues/6658 (open, same failure mode — Cython + coverage + Python 3.13 `sys.monitoring` → `SystemError` and hang).

The first test to trigger this is `test_dlpack.py::TestDLPack::test_invaid_stream`, which does `assert_raises(TypeError, x.__dlpack__, stream=<invalid>)`. The `TypeError` is raised in the instrumented `dpnp/tensor/_usmarray.pyx` (`_validate_and_use_stream`) and unwinds out through `usm_ndarray.__dlpack__`, hitting the corruption.

#### Why not just rely on `core = "ctrace"`?

PR #2922 added `core = "ctrace"` in `pyproject.toml` to keep **coverage.py** off the `sysmon` measurement core (needed for the `Cython.Coverage` plugin). That is still required and unchanged. But it only controls coverage.py's own tracer — the corruption here comes from **Cython's compiled-in** `sys.monitoring` instrumentation, which is gated purely on the Python version and independent of coverage.py's core choice.
`CYTHON_USE_SYS_MONITORING=0` addresses that side; the two settings are complementary.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
