### PR TITLE
Relax float16 tolerance in cupy trigonometric binary tests

### DIFF
--- a/dpnp/tests/third_party/cupy/math_tests/test_trigonometric.py
+++ b/dpnp/tests/third_party/cupy/math_tests/test_trigonometric.py
@@ -18,7 +18,10 @@ class TestTrigonometric(unittest.TestCase):
         return getattr(xp, name)(a)
 
     @testing.for_all_dtypes(no_complex=True)
-    @testing.numpy_cupy_allclose(atol=1e-5, type_check=has_support_aspect64())
+    @testing.numpy_cupy_allclose(
+        atol={numpy.float16: 1e-3, "default": 1e-5},
+        type_check=has_support_aspect64(),
+    )
     def check_binary(self, name, xp, dtype):
         a = testing.shaped_arange((2, 3), xp, dtype)
         b = testing.shaped_reverse_arange((2, 3), xp, dtype)


### PR DESCRIPTION
The GitHub workflow might fail on `third_party/cupy/math_tests/test_trigonometric.py::TestTrigonometric::test_arctan2`:
```
Mismatched elements: 1 / 6 (16.7%)
 [0, 1]: 0.38037109375 (ACTUAL, dpnp), 0.380615234375 (DESIRED, numpy)
Max absolute difference: 0.0002441
```

This is the `float16` (`"e"` dtype) parametrization of `check_binary("arctan2")`, which asserts with a flat `atol=1e-5`. That tolerance is tighter than the resolution of float16 — one ULP near 0.38 is ~2.4e-4.

This PR proposes to use a float16-aware tolerance. for `check_binary`.
This mirrors the pattern already used by `check_unary_unit` in the same file, and leaves the default `1e-5` tolerance unchanged for all higher-precision dtypes.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
