### PR TITLE
Work around missing OpenCL headers in Intel Windows conda package

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -36,6 +36,7 @@ requirements:
       - mkl-devel-dpcpp >={{ required_compiler_and_mkl_version }},<{{ max_compiler_and_mkl_version }}
       - onedpl-devel
       - tbb-devel
+      - opencl-headers >=2025.06.13 # [win]
     build:
       - {{ compiler('cxx') }}
       - {{ stdlib('c') }}


### PR DESCRIPTION
## Summary

The Windows conda build currently fails while compiling the C++/SYCL backend:

```
%PREFIX%\Library\include\sycl\detail\cl.h(22,10): fatal error: 'CL/cl.h' file not found
   22 | #include <CL/cl.h>
```

This is **not** a dpnp source issue — it is an Intel oneAPI packaging regression. This PR adds a workaround so the Windows build succeeds again.

## Root cause

Starting with Intel oneAPI **2026.1.1**, the `intel-sycl-rt` conda package no longer bundles the OpenCL headers (`CL/cl.h` and the rest of `include/CL/*.h`), even though the SYCL headers still `#include <CL/cl.h>`. This change was done by the packaging team to avoid conda `ClobberWarnings` against conda-forge's `opencl-headers`/`ocl-icd`.

The fix was applied **asymmetrically** across platforms:

| `intel-sycl-rt` | Ships `CL/cl.h`? | `opencl-headers` dependency? | dpnp build |
|---|---|---|---|
| Linux `2026.1.1-intel_325` | ❌ removed | ✅ `depends: opencl-headers >=2025.06.13` | ✅ passes |
| Windows `2026.1.1-intel_327` | ❌ removed | ❌ **none** | ❌ fails |

So on Linux the header is still pulled in transitively via the new `opencl-headers` dependency, while on Windows nothing provides `CL/cl.h` and the backend fails to compile.

## Change

Add `opencl-headers` as a host dependency on Windows only:

```yaml
- opencl-headers  # [win]
```

conda-forge's `opencl-headers` installs `CL/cl.h` to `%PREFIX%\Library\include\CL\cl.h`, which is already on the compiler include path (`-external:I%PREFIX%\Library\include`), so no build-script change is needed. Linux is left untouched since it already gets the header transitively.

## Follow-up

This is a workaround. The proper fix is upstream: the Windows `intel-sycl-rt` package should gain the same `opencl-headers` run dependency that the Linux package received. Once that ships, this workaround can be removed.
