### PR TITLE
Link `dpnp_backend_c` against only the MKL SYCL domains it uses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This release is compatible with NumPy 2.5.
 * Replaced the deprecated `nd_item::barrier()` member calls in the `accumulators` and `gemm` kernels with the SYCL 2020 `sycl::group_barrier()` free function [#3006](https://github.com/IntelPython/dpnp/pull/3006)
 * Changed `dpnp.broadcast_arrays` and `dpnp.tensor.broadcast_arrays` to return a tuple instead of a list, aligning with the 2025.12 Python array API spec [#2944](https://github.com/IntelPython/dpnp/pull/2944)
 * Bumped the default minimum required DPC++ compiler version to `2026.1.1` and migrated to the OpenCL ICD loader from the conda-forge `ocl-icd-system` (Linux) and `khronos-opencl-icd-loader` (Windows) packages [#2905](https://github.com/IntelPython/dpnp/pull/2905)
+* Linked the `dpnp_backend_c` library against only the MKL SYCL domains it uses (`BLAS`, `RNG`, `VM`) [#3012](https://github.com/IntelPython/dpnp/pull/3012)
 
 ### Deprecated
 

--- a/dpnp/backend/CMakeLists.txt
+++ b/dpnp/backend/CMakeLists.txt
@@ -76,7 +76,12 @@ if(DPNP_GENERATE_COVERAGE)
     target_link_options(${_trgt} PRIVATE -fprofile-instr-generate -fcoverage-mapping)
 endif()
 
-target_link_libraries(${_trgt} PUBLIC MKL::MKL_SYCL)
+# Link only the MKL SYCL domains actually used by the backend sources
+# (BLAS: mkl_blas::scal; RNG: engines/distributions; VM: vector math ops)
+target_link_libraries(
+    ${_trgt}
+    PUBLIC MKL::MKL_SYCL::BLAS MKL::MKL_SYCL::RNG MKL::MKL_SYCL::VM
+)
 target_link_libraries(${_trgt} PUBLIC oneDPL)
 
 if(UNIX)


### PR DESCRIPTION
`dpnp_backend_c` linked the `MKL::MKL_SYCL` umbrella target, whose link interface pulls in *every* MKL SYCL domain. This target is defined by MKL's `MKLConfig.cmake`, so the exact DLL set it drags in depends on the MKL build, not on dpnp.

This PR links the backend against only the MKL SYCL domains its sources use:
* **BLAS** — `oneapi::mkl::blas::scal`
* **RNG** — `oneapi::mkl::rng` engines/distributions and the VSL C API
* **VM** — `oneapi::mkl::vm` vector math (`div`, `sqr`, `add`, `powx`, `sqrt`, …)

`dft`, `lapack`, `sparse`, `stats`, and `data_fitting` are not referenced by any source compiled into `dpnp_backend_c`, so they are dropped from its link interface.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
