### PR TITLE
Remove obsolete LIB/INCLUDE workaround from Windows conda build script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This release is compatible with NumPy 2.5.
 * Removed support for arrays of 2-dimensional vectors in `dpnp.cross`, which now requires (arrays of) 3-dimensional vectors and raises `ValueError` otherwise [#2950](https://github.com/IntelPython/dpnp/pull/2950)
 * Removed `dpnp.row_stack` in favor of `dpnp.vstack` [#2956](https://github.com/IntelPython/dpnp/pull/2956)
 * Removed all references to the unimplemented `dpnp.ndarray.resize` method from the documentation [#2989](https://github.com/IntelPython/dpnp/pull/2989)
+* Removed an obsolete oneAPI 2021.x workaround from the Windows conda build script that manually prepended `BUILD_PREFIX` paths onto the `LIB` and `INCLUDE` [#3013](https://github.com/IntelPython/dpnp/pull/3013)
 
 ### Fixed
 

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -1,7 +1,3 @@
-REM A workaround for activate-dpcpp.bat issue to be addressed in 2021.4
-set "LIB=%BUILD_PREFIX%\Library\lib;%BUILD_PREFIX%\compiler\lib;%LIB%"
-set "INCLUDE=%BUILD_PREFIX%\include;%INCLUDE%"
-
 "%PYTHON%" setup.py clean --all
 
 set "MKLROOT=%PREFIX%/Library"


### PR DESCRIPTION
Removes a stale workaround from `conda-recipe/bld.bat` that manually prepended `BUILD_PREFIX` paths onto the Windows `LIB` and `INCLUDE` environment variables.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
