### PR TITLE
Fix `OverflowError` in comparison functions and divide for out-of-range integer scalars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ This release is compatible with NumPy 2.5.
 * Fixed `dpnp.interp` with an empty input array `x` to return an empty array with the correct dtype [#2985](https://github.com/IntelPython/dpnp/pull/2985)
 * Fixed `dpnp.interp` returning `nan` when querying at an exact knot point whose adjacent `fp` value is `inf` [#2986](https://github.com/IntelPython/dpnp/pull/2986)
 * Fixed missing strides validation in `dpnp.tensor.usm_ndarray` constructor when allocating new memory [#2927](https://github.com/IntelPython/dpnp/pull/2927)
+* Fixed comparison functions (`dpnp.equal`, `dpnp.not_equal`, `dpnp.less`, `dpnp.less_equal`, `dpnp.greater`, `dpnp.greater_equal`) and `dpnp.divide` raising `OverflowError` when comparing an integer array against a Python integer scalar outside the array dtype's range [#3017](https://github.com/IntelPython/dpnp/pull/3017)
 
 ### Security
 

--- a/dpnp/dpnp_iface_logic.py
+++ b/dpnp/dpnp_iface_logic.py
@@ -50,6 +50,7 @@ import dpnp
 import dpnp.backend.extensions.ufunc._ufunc_impl as ufi
 import dpnp.tensor as dpt
 import dpnp.tensor._tensor_elementwise_impl as ti
+from dpnp.tensor._type_utils import _resolve_weak_types_all_py_ints
 
 from .dpnp_algo.dpnp_elementwise_common import DPNPBinaryFunc, DPNPUnaryFunc
 from .dpnp_array import dpnp_array
@@ -661,6 +662,7 @@ equal = DPNPBinaryFunc(
     ti._equal_result_type,
     ti._equal,
     _EQUAL_DOCSTRING,
+    weak_type_resolver=_resolve_weak_types_all_py_ints,
 )
 
 
@@ -737,6 +739,7 @@ greater = DPNPBinaryFunc(
     ti._greater_result_type,
     ti._greater,
     _GREATER_DOCSTRING,
+    weak_type_resolver=_resolve_weak_types_all_py_ints,
 )
 
 
@@ -814,6 +817,7 @@ greater_equal = DPNPBinaryFunc(
     ti._greater_equal_result_type,
     ti._greater_equal,
     _GREATER_EQUAL_DOCSTRING,
+    weak_type_resolver=_resolve_weak_types_all_py_ints,
 )
 
 
@@ -1750,6 +1754,7 @@ less = DPNPBinaryFunc(
     ti._less_result_type,
     ti._less,
     _LESS_DOCSTRING,
+    weak_type_resolver=_resolve_weak_types_all_py_ints,
 )
 
 
@@ -1826,6 +1831,7 @@ less_equal = DPNPBinaryFunc(
     ti._less_equal_result_type,
     ti._less_equal,
     _LESS_EQUAL_DOCSTRING,
+    weak_type_resolver=_resolve_weak_types_all_py_ints,
 )
 
 
@@ -2198,4 +2204,5 @@ not_equal = DPNPBinaryFunc(
     ti._not_equal_result_type,
     ti._not_equal,
     _NOT_EQUAL_DOCSTRING,
+    weak_type_resolver=_resolve_weak_types_all_py_ints,
 )

--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -1526,6 +1526,7 @@ divide = DPNPBinaryFunc(
     mkl_impl_fn="_div",
     binary_inplace_fn=ti._divide_inplace,
     acceptance_fn=dtu._acceptance_fn_divide,
+    weak_type_resolver=dtu._resolve_weak_types_all_py_ints,
 )
 
 

--- a/dpnp/tests/third_party/cupy/logic_tests/test_comparison.py
+++ b/dpnp/tests/third_party/cupy/logic_tests/test_comparison.py
@@ -77,7 +77,6 @@ class TestComparisonOperator:
         b = 3
         return [op(a, b) for op in self.operators]
 
-    @pytest.mark.skip("SAT-8549")
     @pytest.mark.parametrize(
         "dtype", [numpy.int8, numpy.int64, numpy.uint8, numpy.uint64]
     )
@@ -108,7 +107,7 @@ class TestComparisonOperator:
         b = scalar
         return [op(a, b), op(b, a)]
 
-    @pytest.mark.skip("SAT-8549")
+    @pytest.mark.skip("dpnp follows NumPy")
     @pytest.mark.parametrize(
         "scalar,safe_scalar",
         [(2**63, 2), (2**63 + 100, 2), (-(2**63), -1)],


### PR DESCRIPTION
Comparison ufuncs (`dpnp.equal`, `dpnp.not_equal`, `dpnp.less`, `dpnp.less_equal`, `dpnp.greater`, `dpnp.greater_equal`) and `dpnp.divide` raised `OverflowError` when an integer array was compared with (or divided by) a Python `int` scalar outside the array dtype's range. NumPy handles these cases and returns a well-defined result, so this was a parity gap.

For example:
```python
import dpnp
dpnp.less(dpnp.array([0, 1, 2**63, 2**64 - 1], dtype="u8"), -1)
# Out: OverflowError: Python integer -1 out of bounds for uint64

dpnp.divide(dpnp.array([0, 2, 2**63], dtype="u8"), -1)
# Out: OverflowError: Python integer -1 out of bounds for uint64
```

NumPy instead evaluates the comparison against the true value of the scalar (`-1` is less than any `uint64`, so the result is all-`False`) and returns floating-point results for the division.

These functions used the default weak-type resolver `_resolve_weak_types`, which forces a Python integer scalar into the other operand's dtype before dispatch. When the scalar does not fit that dtype (a negative value against an unsigned array, or a value larger than the signed range), the coercion overflows and raises.

This PR:
- Pass `weak_type_resolver=_resolve_weak_types_all_py_ints` to the six comparison ufuncs in `dpnp_iface_logic.py`.
- Pass the same resolver to `dpnp.divide` in `dpnp_iface_mathematical.py` (also covers `dpnp.true_divide`).
- Un-skip test `test_binary_array_pyscalar_int`, which now passes

`dpnp.floor_divide` is intentionally left unchanged: NumPy itself raises `OverflowError` for out-of-range integer scalars there, and dpnp already matches that behavior.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
