### PR TITLE
Fix ValueError in dpnp.bincount for empty input arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ This release is compatible with NumPy 2.5.
 * Fixed `dpnp.interp` with an empty input array `x` to return an empty array with the correct dtype [#2985](https://github.com/IntelPython/dpnp/pull/2985)
 * Fixed `dpnp.interp` returning `nan` when querying at an exact knot point whose adjacent `fp` value is `inf` [#2986](https://github.com/IntelPython/dpnp/pull/2986)
 * Fixed missing strides validation in `dpnp.tensor.usm_ndarray` constructor when allocating new memory [#2927](https://github.com/IntelPython/dpnp/pull/2927)
+* Fixed `dpnp.bincount` raising a `ValueError` on an empty input array instead of returning an empty `intp` array [#3018](https://github.com/IntelPython/dpnp/pull/3018)
 
 ### Security
 

--- a/dpnp/dpnp_iface_histograms.py
+++ b/dpnp/dpnp_iface_histograms.py
@@ -374,6 +374,10 @@ def bincount(x, weights=None, minlength=0):
     queue = x.sycl_queue
     device = queue.sycl_device
 
+    if x.size == 0:
+        # NumPy returns intp dtype for empty input even when weights is given
+        return dpnp.zeros_like(x, shape=int(minlength), dtype=dpnp.intp)
+
     if weights is None:
         ntype = dpnp.dtype(dpnp.intp)
     else:

--- a/dpnp/tests/third_party/cupy/statistics_tests/test_histogram.py
+++ b/dpnp/tests/third_party/cupy/statistics_tests/test_histogram.py
@@ -339,6 +339,25 @@ class TestHistogram(unittest.TestCase):
             with pytest.raises((ValueError, TypeError)):
                 xp.bincount(x, minlength=-1)
 
+    @for_all_dtypes_bincount()
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
+    def test_bincount_empty(self, xp, dtype):
+        x = xp.array([], dtype=dtype)
+        return xp.bincount(x)
+
+    @for_all_dtypes_bincount()
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
+    def test_bincount_empty_with_minlength(self, xp, dtype):
+        x = xp.array([], dtype=dtype)
+        return xp.bincount(x, minlength=2)
+
+    @for_all_dtypes_combination_bincount(names=["x_type", "w_type"])
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
+    def test_bincount_empty_with_weight(self, xp, x_type, w_type):
+        x = xp.array([], dtype=x_type)
+        w = xp.array([], dtype=w_type)
+        return xp.bincount(x, weights=w, minlength=2)
+
 
 # This class compares CUB results against NumPy's
 @unittest.skipUnless(False, "The CUB routine is not enabled")

--- a/dpnp/tests/third_party/cupy/testing/_loops.py
+++ b/dpnp/tests/third_party/cupy/testing/_loops.py
@@ -991,6 +991,16 @@ def numpy_cupy_raises(
     return decorator
 
 
+def _dtype_supported_by_default_device(dtype):
+    """Skip dtypes the default device cannot represent natively."""
+    dtype = numpy.dtype(dtype).type
+    if dtype in (numpy.float64, numpy.complex128):
+        return has_support_aspect64()
+    if dtype == numpy.float16:
+        return select_default_device().has_aspect_fp16
+    return True
+
+
 def for_dtypes(dtypes, name="dtype", xfail_dtypes=None):
     """Decorator for parameterized dtype test.
 
@@ -1008,16 +1018,7 @@ def for_dtypes(dtypes, name="dtype", xfail_dtypes=None):
         @_wraps_partial(impl, name)
         def test_func(*args, **kw):
             for dtype in dtypes:
-                if (
-                    numpy.dtype(dtype).type in (numpy.float64, numpy.complex128)
-                    and not has_support_aspect64()
-                ):
-                    continue
-
-                if (
-                    numpy.dtype(dtype).type == numpy.float16
-                    and not select_default_device().has_aspect_fp16
-                ):
+                if not _dtype_supported_by_default_device(dtype):
                     continue
 
                 try:
@@ -1331,6 +1332,12 @@ def for_dtypes_combination(types, names=("dtype",), full=None):
         @_wraps_partial(impl, *names)
         def test_func(*args, **kw):
             for dtypes in combination:
+                if not all(
+                    _dtype_supported_by_default_device(dtype)
+                    for dtype in dtypes.values()
+                ):
+                    continue
+
                 kw_copy = kw.copy()
                 kw_copy.update(dtypes)
 


### PR DESCRIPTION
`dpnp.bincount` raised a `ValueError` when given an empty input array, while NumPy returns an empty (or zero-filled) array. This PR short-circuits the empty-input case so `dpnp.bincount` matches NumPy.

The Python layer determines the binning edges by reducing over the input with `dpnp.max`/`dpnp.min`. Those reductions have no identity for zero-size input, so an empty array failed before ever reaching the kernel:
```python
>>> import dpnp
>>> dpnp.bincount(dpnp.array([], dtype="i8"))
ValueError: reduction cannot be performed over zero-size axes
```

The C++ kernel already guards `sample.get_size() == 0`, but that code path is unreachable because the `max`/`min` reduction runs first.

The fix assumes to return early for empty input with an `intp` array of zeros of length `minlength`, before any reduction is performed.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
