### PR TITLE
Fix abort on empty boolean-mask advanced indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ This release is compatible with NumPy 2.5.
 * Fixed `dpnp.interp` returning `nan` when querying at an exact knot point whose adjacent `fp` value is `inf` [#2986](https://github.com/IntelPython/dpnp/pull/2986)
 * Fixed missing strides validation in `dpnp.tensor.usm_ndarray` constructor when allocating new memory [#2927](https://github.com/IntelPython/dpnp/pull/2927)
 * Fixed `dpnp.bincount` raising a `ValueError` on an empty input array instead of returning an empty `intp` array [#3018](https://github.com/IntelPython/dpnp/pull/3018)
+* Fixed a crash in boolean-mask advanced indexing (`dpnp.ndarray` get/set item) when the selection is empty (e.g. a scalar `False` index that injects a length-0 axis) [#3019](https://github.com/IntelPython/dpnp/pull/3019)
 
 ### Security
 

--- a/dpnp/tensor/libtensor/source/boolean_advanced_indexing.cpp
+++ b/dpnp/tensor/libtensor/source/boolean_advanced_indexing.cpp
@@ -217,6 +217,11 @@ std::pair<sycl::event, sycl::event>
         throw py::value_error("Inconsistent array dimensions");
     }
 
+    if (ortho_nelems == 0 || masked_src_nelems == 0) {
+        // nothing to do
+        return std::make_pair(sycl::event(), sycl::event());
+    }
+
     dpnp::tensor::validation::AmpleMemory::throw_if_not_ample(
         dst, ortho_nelems * masked_dst_nelems);
 
@@ -540,6 +545,11 @@ std::pair<sycl::event, sycl::event>
     if (!same_ortho_dims ||
         (masked_dst_nelems != static_cast<std::size_t>(cumsum_sz))) {
         throw py::value_error("Inconsistent array dimensions");
+    }
+
+    if (ortho_nelems == 0 || masked_dst_nelems == 0) {
+        // nothing to do
+        return std::make_pair(sycl::event(), sycl::event());
     }
 
     dpnp::tensor::validation::AmpleMemory::throw_if_not_ample(


### PR DESCRIPTION
Boolean-mask advanced indexing (`dpnp.ndarray.__getitem__`/`__setitem__`) aborted when the selection was empty. For example:

```python
import dpnp
a = dpnp.zeros((2, 3, 4))
a[False, [True, False]] = 1   # scalar `False` injects a length-0 axis
```

`py_place` and `py_extract` compute the orthogonal and masked element counts and dispatch to the strided masked place/extract kernels without checking for zero. When the boolean index produces an empty selection — e.g. a leading scalar `False` that injects a length-0 axis — `ortho_nelems` becomes `0`, and the some-slices kernel builds `sycl::nd_range<2>` with `GlobalSize[0] == 0` and a non-zero local size.

That is a degenerate launch. It is a silent no-op on a SYCL runtime built with `NDEBUG`, so it goes unnoticed with the released oneAPI runtime. On an assertions-enabled SYCL runtime it aborts, because `adjustNDRangePerKernel` asserts `NDR.LocalSize[0] == 0` whenever `GlobalSize[0]` is `0`:

```
Assertion `NDR.LocalSize[0] == 0' failed.
  .../sycl/source/detail/scheduler/commands.cpp
  void sycl::_V1::detail::adjustNDRangePerKernel(...)
```

This PR proposes to return early with empty events when the orthogonal or masked element count is zero, before any kernel is submitted, in both `py_place` and `py_extract`. An empty selection is a no-op, so this is semantically correct and mirrors the existing `cumsum_sz == 0` guard in the same file.

Note, the issue was identified when building with the nightly LLVM SYCL compiler and [running](https://github.com/antonwolfy/dpnp/actions/runs/31576568012/job/94049919151) dpnp tests.
And the test is [passing](https://github.com/antonwolfy/dpnp/actions/runs/31585418522/job/94078011200) with the fix:
> dpnp/tests/third_party/cupy/core_tests/test_ndarray_adv_indexing.py::TestArrayAdvancedIndexingSetitemScalarValue::test_adv_setitem[42] PASSED [ 77%]

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
