### PR TITLE
Fix abort in `top_k` for k=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ This release is compatible with NumPy 2.5.
 * Fixed `dpnp.interp` returning `nan` when querying at an exact knot point whose adjacent `fp` value is `inf` [#2986](https://github.com/IntelPython/dpnp/pull/2986)
 * Fixed missing strides validation in `dpnp.tensor.usm_ndarray` constructor when allocating new memory [#2927](https://github.com/IntelPython/dpnp/pull/2927)
 * Fixed `dpnp.bincount` raising a `ValueError` on an empty input array instead of returning an empty `intp` array [#3018](https://github.com/IntelPython/dpnp/pull/3018)
+* Fixed `dpnp.tensor.top_k` aborting for `k=0` by returning empty result arrays without launching a zero-sized kernel [#3022](https://github.com/IntelPython/dpnp/pull/3022)
 
 ### Security
 

--- a/dpnp/tensor/libtensor/source/sorting/topk.cpp
+++ b/dpnp/tensor/libtensor/source/sorting/topk.cpp
@@ -219,7 +219,7 @@ std::pair<sycl::event, sycl::event>
     dpnp::tensor::validation::CheckWritable::throw_if_not_writable(vals);
     dpnp::tensor::validation::CheckWritable::throw_if_not_writable(inds);
 
-    if ((iter_nelems == 0) || (axis_nelems == 0)) {
+    if ((iter_nelems == 0) || (axis_nelems == 0) || (k == 0)) {
         // Nothing to do
         return std::make_pair(sycl::event(), sycl::event());
     }


### PR DESCRIPTION
`dpnp.tensor.top_k(x, 0)` might aborted the process on an assertions-enabled SYCL runtime:

```python
import dpnp.tensor as dpt
dpt.top_k(dpt.arange(12).reshape(3, 4), 0)   # k = 0
```

`k == 0` is a valid request whose result is empty, and it passes validation (`k < 0` is rejected, `k > size` is rejected, but `k == 0` is allowed). `py_topk` then dispatched to the kernel, whose output-writing step (`write_out_impl`) builds an `nd_range` from `nelems = iter_nelems * k`. A zero-sized `nd_range` is a silent no-op on runtimes built with `NDEBUG`, but aborts on an assertions-enabled SYCL runtime.

The existing guard covered `iter_nelems == 0` and `axis_nelems == 0`, but not `k == 0`.

This PR proposes to extend the early-return guard in `py_topk` to also cover `k == 0`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
