### PR TITLE
Add proper exception handling for nested lists in `dpnp.repeat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ This release is compatible with NumPy 2.5.
 * Fixed missing strides validation in `dpnp.tensor.usm_ndarray` constructor when allocating new memory [#2927](https://github.com/IntelPython/dpnp/pull/2927)
 * Fixed `dpnp.bincount` raising a `ValueError` on an empty input array instead of returning an empty `intp` array [#3018](https://github.com/IntelPython/dpnp/pull/3018)
 * Fixed `dpnp.tensor.top_k` aborting for `k=0` by returning empty result arrays without launching a zero-sized kernel [#3022](https://github.com/IntelPython/dpnp/pull/3022)
+* Fixed `dpnp.repeat` raising an unclear `TypeError` for a nested sequence of `repeats` [#3024](https://github.com/IntelPython/dpnp/issues/3024)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ This release is compatible with NumPy 2.5.
 * Fixed missing strides validation in `dpnp.tensor.usm_ndarray` constructor when allocating new memory [#2927](https://github.com/IntelPython/dpnp/pull/2927)
 * Fixed `dpnp.bincount` raising a `ValueError` on an empty input array instead of returning an empty `intp` array [#3018](https://github.com/IntelPython/dpnp/pull/3018)
 * Fixed `dpnp.tensor.top_k` aborting for `k=0` by returning empty result arrays without launching a zero-sized kernel [#3022](https://github.com/IntelPython/dpnp/pull/3022)
-* Fixed `dpnp.repeat` raising an unclear `TypeError` for a nested sequence of `repeats` [#3024](https://github.com/IntelPython/dpnp/issues/3024)
+* Fixed `dpnp.repeat` raising an unclear `TypeError` for a nested sequence of `repeats` [#3024](https://github.com/IntelPython/dpnp/pull/3024)
 
 ### Security
 

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -2800,14 +2800,15 @@ def repeat(a, repeats, axis=None):
 
     Parameters
     ----------
-    x : {dpnp.ndarray, usm_ndarray}
+    a : {dpnp.ndarray, usm_ndarray}
         Input array.
     repeats : {int, tuple, list, range, dpnp.ndarray, usm_ndarray}
         The number of repetitions for each element. `repeats` is broadcasted to
         fit the shape of the given axis.
         If `repeats` is an array, it must have an integer data type.
         Otherwise, `repeats` must be a Python integer or sequence of Python
-        integers (i.e., a tuple, list, or range).
+        integers (i.e., a tuple, list, or range). A sequence must be 0- or
+        1-dimensional.
     axis : {None, int}, optional
         The axis along which to repeat values. By default, use the flattened
         input array, and return a flat output array.

--- a/dpnp/tensor/_manipulation_functions.py
+++ b/dpnp/tensor/_manipulation_functions.py
@@ -663,21 +663,25 @@ def repeat(x, repeats, /, *, axis=None):
         usm_type = x.usm_type
         exec_q = x.sycl_queue
 
-        len_reps = len(repeats)
-        if len_reps == 1:
-            repeats = repeats[0]
+        repeats = dpt.asarray(
+            repeats, dtype=dpt.int64, usm_type=usm_type, sycl_queue=exec_q
+        )
+        if repeats.ndim > 1:
+            raise ValueError(
+                "`repeats` sequence must be 0- or 1-dimensional, got "
+                f"{repeats.ndim} dimensions"
+            )
+        if repeats.size == 1:
+            scalar = True
+            repeats = int(repeats[0])
             if repeats < 0:
                 raise ValueError("`repeats` elements must be positive")
-            scalar = True
         else:
-            if len_reps != axis_size:
+            if repeats.size != axis_size:
                 raise ValueError(
                     "`repeats` sequence must have the same length as the "
                     "repeated axis"
                 )
-            repeats = dpt.asarray(
-                repeats, dtype=dpt.int64, usm_type=usm_type, sycl_queue=exec_q
-            )
             if not dpt.all(repeats >= 0):
                 raise ValueError("`repeats` elements must be positive")
     else:

--- a/dpnp/tensor/_manipulation_functions.py
+++ b/dpnp/tensor/_manipulation_functions.py
@@ -576,7 +576,8 @@ def repeat(x, repeats, /, *, axis=None):
 
             If `repeats` is an array, it must have an integer data type.
             Otherwise, `repeats` must be a Python integer or sequence of
-            Python integers (i.e., a tuple, list, or range).
+            Python integers (i.e., a tuple, list, or range). A sequence must
+            be 0- or 1-dimensional.
 
         axis (Optional[int]):
             The axis along which to repeat values. If `axis` is `None`, the

--- a/dpnp/tensor/_manipulation_functions.py
+++ b/dpnp/tensor/_manipulation_functions.py
@@ -663,9 +663,8 @@ def repeat(x, repeats, /, *, axis=None):
         usm_type = x.usm_type
         exec_q = x.sycl_queue
 
-        repeats = dpt.asarray(
-            repeats, dtype=dpt.int64, usm_type=usm_type, sycl_queue=exec_q
-        )
+        # inspect the sequence on the host to preserve the scalar fast path
+        repeats = np.asarray(repeats)
         if repeats.ndim > 1:
             raise ValueError(
                 "`repeats` sequence must be 0- or 1-dimensional, got "
@@ -682,6 +681,9 @@ def repeat(x, repeats, /, *, axis=None):
                     "`repeats` sequence must have the same length as the "
                     "repeated axis"
                 )
+            repeats = dpt.asarray(
+                repeats, dtype=dpt.int64, usm_type=usm_type, sycl_queue=exec_q
+            )
             if not dpt.all(repeats >= 0):
                 raise ValueError("`repeats` elements must be positive")
     else:

--- a/dpnp/tests/tensor/test_usm_ndarray_manipulation.py
+++ b/dpnp/tests/tensor/test_usm_ndarray_manipulation.py
@@ -1464,6 +1464,12 @@ def test_repeat_arg_validation():
     with pytest.raises(ValueError):
         dpt.repeat(x, dpt.ones((1, 1), dtype="i8"))
 
+    # repeats nested sequence must be 0d or 1d
+    with pytest.raises(ValueError, match="0- or 1-dimensional"):
+        dpt.repeat(x, [[4]])
+    with pytest.raises(ValueError, match="0- or 1-dimensional"):
+        dpt.repeat(x, [[1, 2, 3, 4, 5]])
+
     # repeats must be castable to i8
     with pytest.raises(TypeError):
         dpt.repeat(x, dpt.asarray(2.0, dtype="f4"))

--- a/dpnp/tests/tensor/test_usm_ndarray_manipulation.py
+++ b/dpnp/tests/tensor/test_usm_ndarray_manipulation.py
@@ -1469,6 +1469,8 @@ def test_repeat_arg_validation():
         dpt.repeat(x, [[4]])
     with pytest.raises(ValueError, match="0- or 1-dimensional"):
         dpt.repeat(x, [[1, 2, 3, 4, 5]])
+    with pytest.raises(ValueError, match="0- or 1-dimensional"):
+        dpt.repeat(x, [[1], [2], [3], [4], [5]])
 
     # repeats must be castable to i8
     with pytest.raises(TypeError):

--- a/dpnp/tests/third_party/cupy/manipulation_tests/test_tiling.py
+++ b/dpnp/tests/third_party/cupy/manipulation_tests/test_tiling.py
@@ -293,9 +293,8 @@ class TestRepeatNdarrayErrors:
             with pytest.raises(ValueError):
                 xp.repeat(xp.arange(6), xp.array([[1, 2, 3, 4, 5, 6]]))
 
-    @pytest.mark.skip("different message for nested lists")
     def test_ndim_gt1_list_rejected(self):
-        with pytest.raises(ValueError, match=r"too deep"):
+        with pytest.raises(ValueError, match=r"0- or 1-dimensional"):
             cupy.repeat(cupy.arange(6), [[1, 2, 3, 4, 5, 6]])
 
     def test_bad_axis(self):

--- a/dpnp/tests/third_party/cupy/manipulation_tests/test_tiling.py
+++ b/dpnp/tests/third_party/cupy/manipulation_tests/test_tiling.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import unittest
 
 import numpy
@@ -29,11 +31,7 @@ class TestRepeat(unittest.TestCase):
     {"repeats": [2], "axis": None},
     {"repeats": [2], "axis": 1},
 )
-class TestRepeatListBroadcast(unittest.TestCase):
-    """Test for `repeats` argument using single element list.
-
-    This feature is only supported in NumPy 1.10 or later.
-    """
+class TestRepeatListBroadcast:
 
     @testing.numpy_cupy_array_equal()
     def test_array_repeat(self, xp):
@@ -48,7 +46,7 @@ class TestRepeatListBroadcast(unittest.TestCase):
     {"repeats": [1, 2, 3, 4], "axis": None},
     {"repeats": [1, 2, 3, 4], "axis": 0},
 )
-class TestRepeat1D(unittest.TestCase):
+class TestRepeat1D:
 
     @testing.numpy_cupy_array_equal()
     def test_array_repeat(self, xp):
@@ -60,8 +58,7 @@ class TestRepeat1D(unittest.TestCase):
     {"repeats": [2], "axis": None},
     {"repeats": [2], "axis": 0},
 )
-class TestRepeat1DListBroadcast(unittest.TestCase):
-    """See comment in TestRepeatListBroadcast class."""
+class TestRepeat1DListBroadcast:
 
     @testing.numpy_cupy_array_equal()
     def test_array_repeat(self, xp):
@@ -77,7 +74,7 @@ class TestRepeat1DListBroadcast(unittest.TestCase):
     {"repeats": 2, "axis": -4},
     {"repeats": 2, "axis": 3},
 )
-class TestRepeatFailure(unittest.TestCase):
+class TestRepeatFailure:
 
     def test_repeat_failure(self):
         for xp in (numpy, cupy):
@@ -191,38 +188,6 @@ class TestRepeatNdarrayNonContiguous:
         return xp.repeat(x, xp.array([0, 1, 2, 1, 0]))
 
 
-class TestRepeatNdarrayDtypeEdges:
-
-    @testing.numpy_cupy_array_equal()
-    def test_bool_perelement(self, xp):
-        return xp.repeat(xp.arange(3), xp.array([True, False, True]))
-
-    @testing.numpy_cupy_array_equal()
-    def test_bool_broadcast(self, xp):
-        return xp.repeat(
-            testing.shaped_arange((3, 4), xp), xp.array([True]), axis=0
-        )
-
-    @testing.numpy_cupy_array_equal()
-    def test_uint32_accepted(self, xp):
-        return xp.repeat(
-            xp.arange(4), xp.array([1, 2, 3, 4], dtype=numpy.uint32)
-        )
-
-
-class TestRepeatNdarrayLarge:
-
-    @testing.numpy_cupy_array_equal()
-    def test_large_single(self, xp):
-        return xp.repeat(
-            testing.shaped_arange((3,), xp), xp.array([0, 100000, 0])
-        )
-
-    @testing.numpy_cupy_array_equal()
-    def test_large_broadcast(self, xp):
-        return xp.repeat(testing.shaped_arange((3,), xp), xp.array([50000]))
-
-
 class TestRepeatScalarEquivalence:
     """All scalar-like repeats inputs produce identical results."""
 
@@ -307,6 +272,38 @@ class TestRepeatNdarrayErrors:
         a = cupy.arange(4)
         reps = cupy.array([1, 2, 0, 3])
         testing.assert_array_equal(a.repeat(reps), cupy.repeat(a, reps))
+
+
+class TestRepeatNdarrayDtypeEdges:
+
+    @testing.numpy_cupy_array_equal()
+    def test_bool_perelement(self, xp):
+        return xp.repeat(xp.arange(3), xp.array([True, False, True]))
+
+    @testing.numpy_cupy_array_equal()
+    def test_bool_broadcast(self, xp):
+        return xp.repeat(
+            testing.shaped_arange((3, 4), xp), xp.array([True]), axis=0
+        )
+
+    @testing.numpy_cupy_array_equal()
+    def test_uint32_accepted(self, xp):
+        return xp.repeat(
+            xp.arange(4), xp.array([1, 2, 3, 4], dtype=numpy.uint32)
+        )
+
+
+class TestRepeatNdarrayLarge:
+
+    @testing.numpy_cupy_array_equal()
+    def test_large_single(self, xp):
+        return xp.repeat(
+            testing.shaped_arange((3,), xp), xp.array([0, 100000, 0])
+        )
+
+    @testing.numpy_cupy_array_equal()
+    def test_large_broadcast(self, xp):
+        return xp.repeat(testing.shaped_arange((3,), xp), xp.array([50000]))
 
 
 @testing.parameterize(


### PR DESCRIPTION
This PR fixes #2972.

Passing a nested sequence as `repeats` to `dpnp.repeat` (e.g. `np.repeat(x, [[4]])`) raised an unclear `TypeError` instead of a meaningful error:

```python
>>> import dpnp as np
>>> x = np.array([3])
>>> np.repeat(x, [[4]])
TypeError: '<' not supported between instances of 'list' and 'int'
```

The sequence branch of `dpnp.tensor.repeat` special-cased a length-1 sequence by taking `repeats[0]` and comparing it to `0`, which fails when that element is itself a list. It also had no dimensionality guard, so a multi-element nested sequence could slip through as a 2-D array — unlike the `usm_ndarray` branch, which already rejects `ndim > 1`.

The fix converts the sequence to an array up front and rejects a dimensionality greater than 1, aligning with NumPy, which raises a `ValueError` in this case:

```python
>>> np.repeat(x, [[4]])
ValueError: `repeats` sequence must be 0- or 1-dimensional, got 2 dimensions
```

The scalar fast path (`_repeat_by_scalar`) is preserved for the size-1 case.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
