### PR TITLE
Enable free-threaded Python for dpnp

### DIFF
--- a/.github/workflows/check-onemath.yaml
+++ b/.github/workflows/check-onemath.yaml
@@ -15,6 +15,7 @@ env:
   build-with-oneapi-env: 'environments/build_with_oneapi.yml'
   dpctl-pkg-env: 'environments/dpctl_pkg.yml'
   oneapi-pkgs-env: 'environments/oneapi_pkgs.yml'
+  python-pkg-env: 'environments/python.yml'
   test-pkg-env: 'environments/test.yml'
   test-env-name: 'test_onemath'
   rerun-tests-on-failure: 'true'
@@ -29,8 +30,18 @@ jobs:
       # Needed to cancel any previous runs that are not completed for a given workflow
       actions: write
 
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ['3.14']
+        python_spec: ['3.14.* *_cp314', '3.14.* *_cp314t']
+
     runs-on: 'ubuntu-latest'
     timeout-minutes: 5
+
+    env:
+      python-label: ${{ endsWith(matrix.python_spec, 't') && format('{0}t', matrix.python) || matrix.python }}
+      python-install-spec: "python ${{ matrix.python_spec || format('{0}.*', matrix.python) }}"
 
     steps:
       - name: Cancel Previous Runs
@@ -48,18 +59,29 @@ jobs:
         with:
           packages: conda-merge
 
+      - name: Build Python env file
+        run: |
+          cat > ${{ env.python-pkg-env }} <<EOF
+          name: Python interpreter to test with
+          channels:
+            - conda-forge
+          dependencies:
+            - ${{ env.python-install-spec }}
+          EOF
+
       - name: Merge conda env files
         run: |
           conda-merge ${{ env.dpctl-pkg-env }}         \
                       ${{ env.oneapi-pkgs-env }}       \
                       ${{ env.build-with-oneapi-env }} \
-                      ${{ env.test-pkg-env }} > ${{ env.environment-file }}
+                      ${{ env.test-pkg-env }}          \
+                      ${{ env.python-pkg-env }} > ${{ env.environment-file }}
           cat ${{ env.environment-file }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ env.environment-file-name }}
+          name: ${{ env.environment-file-name }}-${{ env.python-label }}
           path: ${{ env.environment-file }}
 
   test_by_tag:
@@ -71,6 +93,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ['3.14']
+        python_spec: ['3.14.* *_cp314', '3.14.* *_cp314t']
         os: [ubuntu-latest] # windows-2022 - no DFT support for Windows in oneMKL
 
     runs-on: ${{ matrix.os }}
@@ -79,6 +102,9 @@ jobs:
     defaults:
       run:
         shell: ${{ matrix.os == 'windows-2022' && 'cmd /C CALL {0}' || 'bash -el {0}' }}
+
+    env:
+      python-label: ${{ endsWith(matrix.python_spec, 't') && format('{0}t', matrix.python) || matrix.python }}
 
     steps:
       - name: Checkout DPNP repo
@@ -89,7 +115,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ env.environment-file-name }}
+          name: ${{ env.environment-file-name }}-${{ env.python-label }}
           path: ${{ env.environment-file-loc }}
 
       - name: Setup miniconda
@@ -100,7 +126,6 @@ jobs:
           miniforge-version: latest
           use-mamba: 'true'
           conda-remove-defaults: 'true'
-          python-version: ${{ matrix.python }}
           environment-file: ${{ env.environment-file }}
           activate-environment: ${{ env.test-env-name }}
 
@@ -111,7 +136,6 @@ jobs:
           miniforge-version: latest
           use-mamba: 'true'
           conda-remove-defaults: 'true'
-          python-version: ${{ matrix.python }}
           environment-file: ${{ env.environment-file }}
           activate-environment: ${{ env.test-env-name }}
 
@@ -188,6 +212,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ['3.14']
+        python_spec: ['3.14.* *_cp314', '3.14.* *_cp314t']
         os: [ubuntu-latest] # windows-2022 - no DFT support for Windows in oneMKL
 
     runs-on: ${{ matrix.os }}
@@ -199,6 +224,7 @@ jobs:
 
     env:
       onemkl-source-dir: '${{ github.workspace }}/onemkl/'
+      python-label: ${{ endsWith(matrix.python_spec, 't') && format('{0}t', matrix.python) || matrix.python }}
 
     steps:
       - name: Checkout DPNP repo
@@ -209,7 +235,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ env.environment-file-name }}
+          name: ${{ env.environment-file-name }}-${{ env.python-label }}
           path: ${{ env.environment-file-loc }}
 
       - name: Checkout oneMKL repo
@@ -232,7 +258,6 @@ jobs:
           miniforge-version: latest
           use-mamba: 'true'
           conda-remove-defaults: 'true'
-          python-version: ${{ matrix.python }}
           environment-file: ${{ env.environment-file }}
           activate-environment: ${{ env.test-env-name }}
 
@@ -243,7 +268,6 @@ jobs:
           miniforge-version: latest
           use-mamba: 'true'
           conda-remove-defaults: 'true'
-          python-version: ${{ matrix.python }}
           environment-file: ${{ env.environment-file }}
           activate-environment: ${{ env.test-env-name }}
 

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -29,8 +29,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-22.04, windows-2022]
+        python_spec: ['']
+        include:
+          - python: '3.14'
+            os: ubuntu-22.04
+            python_spec: '3.14.* *_cp314'
+          - python: '3.14'
+            os: windows-2022
+            python_spec: '3.14.* *_cp314'
+          - python: '3.14'
+            os: ubuntu-22.04
+            python_spec: '3.14.* *_cp314t'
+          - python: '3.14'
+            os: windows-2022
+            python_spec: '3.14.* *_cp314t'
 
     permissions:
       # Needed to cancel any previous runs that are not completed for a given workflow
@@ -46,6 +60,8 @@ jobs:
     env:
       build-conda-pkg-env: 'environments/build_conda_pkg.yml'
       build-env-name: 'build'
+      python-label: ${{ contains(matrix.python_spec, 'cp314t') && '3.14t' || matrix.python }}
+      python-conda-spec: ${{ matrix.python_spec || matrix.python }}
 
     steps:
       - name: Cancel Previous Runs
@@ -91,26 +107,26 @@ jobs:
       - name: Build conda package
         id: build_conda_pkg
         continue-on-error: true
-        run: conda-build --no-test --python ${{ matrix.python }} --numpy 2.0 ${{ env.channels-list }} conda-recipe
+        run: conda-build --no-test --python "${{ env.python-conda-spec }}" --numpy 2.0 ${{ env.channels-list }} conda-recipe
         env:
           MAX_BUILD_CMPL_MKL_VERSION: '2027.0a0'
 
       - name: ReBuild conda package
         if: steps.build_conda_pkg.outcome == 'failure'
-        run: conda-build --no-test --python ${{ matrix.python }} --numpy 2.0 ${{ env.channels-list }} conda-recipe
+        run: conda-build --no-test --python "${{ env.python-conda-spec }}" --numpy 2.0 ${{ env.channels-list }} conda-recipe
         env:
           MAX_BUILD_CMPL_MKL_VERSION: '2027.0a0'
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ env.package-name }} ${{ runner.os }} Python ${{ matrix.python }}
+          name: ${{ env.package-name }} ${{ runner.os }} Python ${{ env.python-label }}
           path: ${{ env.CONDA_BLD }}${{ env.package-name }}-*.conda
 
       - name: Upload wheels artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ env.package-name }} ${{ runner.os }} Wheels Python ${{ matrix.python }}
+          name: ${{ env.package-name }} ${{ runner.os }} Wheels Python ${{ env.python-label }}
           path: ${{ env.WHEELS_OUTPUT_FOLDER }}${{ env.package-name }}-*.whl
 
   test_linux:
@@ -128,8 +144,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest]
+        python_spec: ['']
+        include:
+          - python: '3.14'
+            os: ubuntu-latest
+            python_spec: '3.14.* *_cp314'
+          - python: '3.14'
+            os: ubuntu-latest
+            python_spec: '3.14.* *_cp314t'
 
     env:
       dpnp-repo-path: '${{ github.workspace }}/source/'
@@ -137,6 +161,9 @@ jobs:
       channel-path: '${{ github.workspace }}/channel/'
       pkg-path-in-channel: '${{ github.workspace }}/channel/linux-64/'
       ver-json-path: '${{ github.workspace }}/version.json'
+      python-label: ${{ contains(matrix.python_spec, 'cp314t') && '3.14t' || matrix.python }}
+      # mamba only takes a build string in a spec which spells out the package name
+      python-install-spec: "python ${{ matrix.python_spec || format('{0}.*', matrix.python) }}"
 
     steps:
       - name: Set Swap Space
@@ -153,7 +180,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ env.package-name }} ${{ runner.os }} Python ${{ matrix.python }}
+          name: ${{ env.package-name }} ${{ runner.os }} Python ${{ env.python-label }}
           path: ${{ env.pkg-path-in-channel }}
 
       - name: Setup miniconda
@@ -198,14 +225,14 @@ jobs:
         id: install_dpnp
         continue-on-error: true
         run: |
-          mamba install ${{ env.package-name }}=${{ env.PACKAGE_VERSION }} pytest pytest-xdist python=${{ matrix.python }} ${{ env.TEST_CHANNELS }}
+          mamba install ${{ env.package-name }}=${{ env.PACKAGE_VERSION }} pytest pytest-xdist "${{ env.python-install-spec }}" ${{ env.TEST_CHANNELS }}
         env:
           TEST_CHANNELS: '-c ${{ env.channel-path }} ${{ env.channels-list }}'
 
       - name: ReInstall dpnp
         if: steps.install_dpnp.outcome == 'failure'
         run: |
-          mamba install ${{ env.package-name }}=${{ env.PACKAGE_VERSION }} pytest pytest-xdist python=${{ matrix.python }} ${{ env.TEST_CHANNELS }}
+          mamba install ${{ env.package-name }}=${{ env.PACKAGE_VERSION }} pytest pytest-xdist "${{ env.python-install-spec }}" ${{ env.TEST_CHANNELS }}
         env:
           TEST_CHANNELS: '-c ${{ env.channel-path }} ${{ env.channels-list }}'
 
@@ -221,7 +248,7 @@ jobs:
         if: env.rerun-tests-on-failure != 'true'
         run: |
           export SKIP_TENSOR_TESTS=1
-          if [[ "${{ matrix.python }}" == "${{ env.python-ver-test-all-dtypes }}" ]]; then
+          if [[ "${{ env.python-label }}" == "${{ env.python-ver-test-all-dtypes }}" ]]; then
             export DPNP_TEST_ALL_INT_TYPES=1
             python -m pytest -ra --pyargs ${{ env.package-name }}.tests
           else
@@ -242,7 +269,7 @@ jobs:
             mamba activate ${{ env.test-env-name }}
             export SKIP_TENSOR_TESTS=1
 
-            if [[ "${{ matrix.python }}" == "${{ env.python-ver-test-all-dtypes }}" ]]; then
+            if [[ "${{ env.python-label }}" == "${{ env.python-ver-test-all-dtypes }}" ]]; then
               export DPNP_TEST_ALL_INT_TYPES=1
               python -m pytest -ra --pyargs ${{ env.package-name }}.tests
             else
@@ -282,8 +309,10 @@ jobs:
         shell: bash -el {0}
 
     strategy:
+      fail-fast: false
       matrix:
         python: ['3.14']
+        python_spec: ['3.14.* *_cp314', '3.14.* *_cp314t']
 
     env:
       dpnp-repo-path: '${{ github.workspace }}/source/'
@@ -292,6 +321,9 @@ jobs:
       pkg-path-in-channel: '${{ github.workspace }}/channel/linux-64/'
       ver-json-path: '${{ github.workspace }}/version.json'
       examples-env-name: 'examples_test'
+      python-label: ${{ contains(matrix.python_spec, 'cp314t') && '3.14t' || matrix.python }}
+      # mamba only takes a build string in a spec which spells out the package name
+      python-install-spec: "python ${{ matrix.python_spec || format('{0}.*', matrix.python) }}"
 
     steps:
       - name: Checkout DPNP repo
@@ -303,7 +335,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ env.package-name }} ${{ runner.os }} Python ${{ matrix.python }}
+          name: ${{ env.package-name }} ${{ runner.os }} Python ${{ env.python-label }}
           path: ${{ env.pkg-path-in-channel }}
 
       - name: Setup miniconda
@@ -345,14 +377,14 @@ jobs:
         id: install_dpnp
         continue-on-error: true
         run: |
-          mamba install ${{ env.package-name }}=${{ env.PACKAGE_VERSION }} python=${{ matrix.python }} ${{ env.TEST_CHANNELS }}
+          mamba install ${{ env.package-name }}=${{ env.PACKAGE_VERSION }} "${{ env.python-install-spec }}" ${{ env.TEST_CHANNELS }}
         env:
           TEST_CHANNELS: '-c ${{ env.channel-path }} ${{ env.channels-list }}'
 
       - name: ReInstall dpnp
         if: steps.install_dpnp.outcome == 'failure'
         run: |
-          mamba install ${{ env.package-name }}=${{ env.PACKAGE_VERSION }} python=${{ matrix.python }} ${{ env.TEST_CHANNELS }}
+          mamba install ${{ env.package-name }}=${{ env.PACKAGE_VERSION }} "${{ env.python-install-spec }}" ${{ env.TEST_CHANNELS }}
         env:
           TEST_CHANNELS: '-c ${{ env.channel-path }} ${{ env.channels-list }}'
 
@@ -391,8 +423,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python: ['3.10', '3.11', '3.12', '3.13']
         os: [windows-2022]
+        python_spec: ['']
+        include:
+          - python: '3.14'
+            os: windows-2022
+            python_spec: '3.14.* *_cp314'
+          - python: '3.14'
+            os: windows-2022
+            python_spec: '3.14.* *_cp314t'
 
     env:
       dpnp-repo-path: '${{ github.workspace }}\source'
@@ -400,6 +440,9 @@ jobs:
       channel-path: '${{ github.workspace }}\channel\'
       pkg-path-in-channel: '${{ github.workspace }}\channel\win-64\'
       ver-json-path: '${{ github.workspace }}\version.json'
+      python-label: ${{ contains(matrix.python_spec, 'cp314t') && '3.14t' || matrix.python }}
+      # mamba only takes a build string in a spec which spells out the package name
+      python-install-spec: "python ${{ matrix.python_spec || format('{0}.*', matrix.python) }}"
 
     steps:
       - name: Checkout DPNP repo
@@ -411,7 +454,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ env.package-name }} ${{ runner.os }} Python ${{ matrix.python }}
+          name: ${{ env.package-name }} ${{ runner.os }} Python ${{ env.python-label }}
           path: ${{ env.pkg-path-in-channel }}
 
       - name: Store a path to package archive
@@ -478,7 +521,7 @@ jobs:
       - name: Install dpnp
         run: |
           @echo on
-          mamba install ${{ env.package-name }}=${{ env.PACKAGE_VERSION }} pytest pytest-xdist python=${{ matrix.python }} ${{ env.TEST_CHANNELS }}
+          mamba install ${{ env.package-name }}=${{ env.PACKAGE_VERSION }} pytest pytest-xdist "${{ env.python-install-spec }}" ${{ env.TEST_CHANNELS }}
         env:
           TEST_CHANNELS: '-c ${{ env.channel-path }} ${{ env.channels-list }}'
           MAMBA_NO_LOW_SPEED_LIMIT: 1
@@ -512,7 +555,7 @@ jobs:
         shell: pwsh
         run: |
           $env:SKIP_TENSOR_TESTS=1
-          if (${{ matrix.python }} -eq ${{ env.python-ver-test-all-dtypes }}) {
+          if ("${{ env.python-label }}" -eq "${{ env.python-ver-test-all-dtypes }}") {
             $env:DPNP_TEST_ALL_INT_TYPES=1
             python -m pytest -ra --pyargs ${{ env.package-name }}.tests
           } else {
@@ -530,7 +573,7 @@ jobs:
           shell: pwsh
           command: |
             $env:SKIP_TENSOR_TESTS=1
-            if ( ${{ matrix.python }} -eq ${{ env.python-ver-test-all-dtypes }} ) {
+            if ( "${{ env.python-label }}" -eq "${{ env.python-ver-test-all-dtypes }}" ) {
               $env:DPNP_TEST_ALL_INT_TYPES=1
               python -m pytest -ra --pyargs ${{ env.package-name }}.tests
             } else {
@@ -563,8 +606,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, windows-2022]
+        python_spec: ['']
+        include:
+          - python: '3.14'
+            os: ubuntu-latest
+            python_spec: '3.14.* *_cp314'
+          - python: '3.14'
+            os: windows-2022
+            python_spec: '3.14.* *_cp314'
+          - python: '3.14'
+            os: ubuntu-latest
+            python_spec: '3.14.* *_cp314t'
+          - python: '3.14'
+            os: windows-2022
+            python_spec: '3.14.* *_cp314t'
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
@@ -576,6 +633,7 @@ jobs:
     env:
       upload-conda-pkg-env: 'environments/upload_cleanup_conda_pkg.yml'
       upload-env-name: 'upload'
+      python-label: ${{ contains(matrix.python_spec, 'cp314t') && '3.14t' || matrix.python }}
 
     if: |
       (github.repository == 'IntelPython/dpnp') &&
@@ -590,12 +648,12 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ env.package-name }} ${{ runner.os }} Python ${{ matrix.python }}
+          name: ${{ env.package-name }} ${{ runner.os }} Python ${{ env.python-label }}
 
       - name: Download wheels artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ env.package-name }} ${{ runner.os }} Wheels Python ${{ matrix.python }}
+          name: ${{ env.package-name }} ${{ runner.os }} Wheels Python ${{ env.python-label }}
 
       - name: Setup miniconda
         id: setup_miniconda

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -31,7 +31,6 @@ jobs:
       matrix:
         python: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-22.04, windows-2022]
-        python_spec: ['']
         include:
           - python: '3.14'
             os: ubuntu-22.04
@@ -60,7 +59,7 @@ jobs:
     env:
       build-conda-pkg-env: 'environments/build_conda_pkg.yml'
       build-env-name: 'build'
-      python-label: ${{ contains(matrix.python_spec, 'cp314t') && '3.14t' || matrix.python }}
+      python-label: ${{ endsWith(matrix.python_spec, 't') && format('{0}t', matrix.python) || matrix.python }}
       python-conda-spec: ${{ matrix.python_spec || matrix.python }}
 
     steps:
@@ -146,7 +145,6 @@ jobs:
       matrix:
         python: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest]
-        python_spec: ['']
         include:
           - python: '3.14'
             os: ubuntu-latest
@@ -161,8 +159,7 @@ jobs:
       channel-path: '${{ github.workspace }}/channel/'
       pkg-path-in-channel: '${{ github.workspace }}/channel/linux-64/'
       ver-json-path: '${{ github.workspace }}/version.json'
-      python-label: ${{ contains(matrix.python_spec, 'cp314t') && '3.14t' || matrix.python }}
-      # mamba only takes a build string in a spec which spells out the package name
+      python-label: ${{ endsWith(matrix.python_spec, 't') && format('{0}t', matrix.python) || matrix.python }}
       python-install-spec: "python ${{ matrix.python_spec || format('{0}.*', matrix.python) }}"
 
     steps:
@@ -321,8 +318,7 @@ jobs:
       pkg-path-in-channel: '${{ github.workspace }}/channel/linux-64/'
       ver-json-path: '${{ github.workspace }}/version.json'
       examples-env-name: 'examples_test'
-      python-label: ${{ contains(matrix.python_spec, 'cp314t') && '3.14t' || matrix.python }}
-      # mamba only takes a build string in a spec which spells out the package name
+      python-label: ${{ endsWith(matrix.python_spec, 't') && format('{0}t', matrix.python) || matrix.python }}
       python-install-spec: "python ${{ matrix.python_spec || format('{0}.*', matrix.python) }}"
 
     steps:
@@ -425,7 +421,6 @@ jobs:
       matrix:
         python: ['3.10', '3.11', '3.12', '3.13']
         os: [windows-2022]
-        python_spec: ['']
         include:
           - python: '3.14'
             os: windows-2022
@@ -440,8 +435,7 @@ jobs:
       channel-path: '${{ github.workspace }}\channel\'
       pkg-path-in-channel: '${{ github.workspace }}\channel\win-64\'
       ver-json-path: '${{ github.workspace }}\version.json'
-      python-label: ${{ contains(matrix.python_spec, 'cp314t') && '3.14t' || matrix.python }}
-      # mamba only takes a build string in a spec which spells out the package name
+      python-label: ${{ endsWith(matrix.python_spec, 't') && format('{0}t', matrix.python) || matrix.python }}
       python-install-spec: "python ${{ matrix.python_spec || format('{0}.*', matrix.python) }}"
 
     steps:
@@ -608,7 +602,6 @@ jobs:
       matrix:
         python: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, windows-2022]
-        python_spec: ['']
         include:
           - python: '3.14'
             os: ubuntu-latest
@@ -633,7 +626,7 @@ jobs:
     env:
       upload-conda-pkg-env: 'environments/upload_cleanup_conda_pkg.yml'
       upload-env-name: 'upload'
-      python-label: ${{ contains(matrix.python_spec, 'cp314t') && '3.14t' || matrix.python }}
+      python-label: ${{ endsWith(matrix.python_spec, 't') && format('{0}t', matrix.python) || matrix.python }}
 
     if: |
       (github.repository == 'IntelPython/dpnp') &&

--- a/.github/workflows/cron-run-tests.yaml
+++ b/.github/workflows/cron-run-tests.yaml
@@ -38,8 +38,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python: ['3.10', '3.11', '3.12', '3.13']
         runner: [ubuntu-22.04, ubuntu-24.04, windows-2022]
+        python_spec: ['']
+        include:
+          - python: '3.14'
+            runner: ubuntu-22.04
+            python_spec: '3.14.* *_cp314'
+          - python: '3.14'
+            runner: ubuntu-24.04
+            python_spec: '3.14.* *_cp314'
+          - python: '3.14'
+            runner: windows-2022
+            python_spec: '3.14.* *_cp314'
+          - python: '3.14'
+            runner: ubuntu-22.04
+            python_spec: '3.14.* *_cp314t'
+          - python: '3.14'
+            runner: ubuntu-24.04
+            python_spec: '3.14.* *_cp314t'
+          - python: '3.14'
+            runner: windows-2022
+            python_spec: '3.14.* *_cp314t'
+
+    env:
+      # mamba only takes a build string in a spec which spells out the package name
+      python-install-spec: "python ${{ matrix.python_spec || format('{0}.*', matrix.python) }}"
 
     steps:
       - name: Cancel Previous Runs
@@ -88,12 +112,12 @@ jobs:
         id: install_dpnp
         continue-on-error: true
         run: |
-          mamba install ${{ env.package-name }}=${{ steps.find_latest_tag.outputs.tag }} ${{ env.test-packages }} ${{ env.channels-list }}
+          mamba install ${{ env.package-name }}=${{ steps.find_latest_tag.outputs.tag }} ${{ env.test-packages }} "${{ env.python-install-spec }}" ${{ env.channels-list }}
 
       - name: ReInstall dpnp
         if: steps.install_dpnp.outcome == 'failure'
         run: |
-          mamba install ${{ env.package-name }}=${{ steps.find_latest_tag.outputs.tag }} ${{ env.test-packages }} ${{ env.channels-list }}
+          mamba install ${{ env.package-name }}=${{ steps.find_latest_tag.outputs.tag }} ${{ env.test-packages }} "${{ env.python-install-spec }}" ${{ env.channels-list }}
 
       - name: List installed packages
         run: mamba list

--- a/.github/workflows/cron-run-tests.yaml
+++ b/.github/workflows/cron-run-tests.yaml
@@ -40,7 +40,6 @@ jobs:
       matrix:
         python: ['3.10', '3.11', '3.12', '3.13']
         runner: [ubuntu-22.04, ubuntu-24.04, windows-2022]
-        python_spec: ['']
         include:
           - python: '3.14'
             runner: ubuntu-22.04
@@ -62,7 +61,6 @@ jobs:
             python_spec: '3.14.* *_cp314t'
 
     env:
-      # mamba only takes a build string in a spec which spells out the package name
       python-install-spec: "python ${{ matrix.python_spec || format('{0}.*', matrix.python) }}"
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This release is compatible with NumPy 2.5.
 * Added `dpnp-config.cmake` to make `find_package(Dpnp)` work out of the box, and an example which uses it [#2941](https://github.com/IntelPython/dpnp/pull/2941)
 * Added implementation of `dpnp.lib.stride_tricks.as_strided` [#2991](https://github.com/IntelPython/dpnp/pull/2991)
 * Added `dpnp.tensor.broadcast_shapes` to align with the 2025.12 version of the Python array API [#3009](https://github.com/IntelPython/dpnp/pull/3009)
+* Added support for free-threaded Python builds [gh-3026](https://github.com/IntelPython/dpnp/pull/3026)
 
 ### Changed
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -33,7 +33,6 @@ source:
 requirements:
     host:
       - python
-      - python-gil     # [py>=314]
       - pip >=25.0
       - pybind11 >=2.13.6
       {% for dep in py_build_deps %}
@@ -62,7 +61,6 @@ requirements:
       - {{ compiler('dpcpp') }} >={{ required_compiler_version }},<{{ max_compiler_and_mkl_version }}
     run:
       - python
-      - python-gil     # [py>=314]
       - {{ pin_compatible('dpctl', min_pin='x.x.x', max_pin=None) }}
       - {{ pin_compatible('dpcpp-cpp-rt', min_pin='x.x', max_pin='x') }}
       - {{ pin_compatible('intel-sycl-rt', min_pin='x.x', max_pin='x') }}

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     host:
       - python
       - pip >=25.0
-      - pybind11 >=2.13.6
+      - pybind11 >=3.0.2
       {% for dep in py_build_deps %}
       {% if dep.startswith('dpctl') %}
       - dpctl >={{ required_dpctl_version }}

--- a/dpnp/backend/extensions/blas/blas_py.cpp
+++ b/dpnp/backend/extensions/blas/blas_py.cpp
@@ -64,7 +64,7 @@ static dot_impl_fn_ptr_t dot_dispatch_vector[dpnp_td_ns::num_types];
 static dot_impl_fn_ptr_t dotc_dispatch_vector[dpnp_td_ns::num_types];
 static dot_impl_fn_ptr_t dotu_dispatch_vector[dpnp_td_ns::num_types];
 
-PYBIND11_MODULE(_blas_impl, m)
+PYBIND11_MODULE(_blas_impl, m, py::mod_gil_not_used())
 {
     init_dispatch_vectors_tables();
 

--- a/dpnp/backend/extensions/fft/fft_py.cpp
+++ b/dpnp/backend/extensions/fft/fft_py.cpp
@@ -68,7 +68,7 @@ void register_descriptor(py::module &m, const char *name)
         .def("commit", &DwT::commit);
 }
 
-PYBIND11_MODULE(_fft_impl, m)
+PYBIND11_MODULE(_fft_impl, m, py::mod_gil_not_used())
 {
     constexpr mkl_dft::domain complex_dom = mkl_dft::domain::COMPLEX;
     constexpr mkl_dft::domain real_dom = mkl_dft::domain::REAL;

--- a/dpnp/backend/extensions/indexing/indexing_py.cpp
+++ b/dpnp/backend/extensions/indexing/indexing_py.cpp
@@ -34,7 +34,7 @@
 
 #include "choose.hpp"
 
-PYBIND11_MODULE(_indexing_impl, m)
+PYBIND11_MODULE(_indexing_impl, m, py::mod_gil_not_used())
 {
     dpnp::extensions::indexing::init_choose(m);
 }

--- a/dpnp/backend/extensions/lapack/lapack_py.cpp
+++ b/dpnp/backend/extensions/lapack/lapack_py.cpp
@@ -78,7 +78,7 @@ void init_dispatch_tables(void)
     lapack_ext::init_gesvd_batch_dispatch_table();
 }
 
-PYBIND11_MODULE(_lapack_impl, m)
+PYBIND11_MODULE(_lapack_impl, m, py::mod_gil_not_used())
 {
     // Expose oneMKL transpose enum to Python
     py::enum_<oneapi::mkl::transpose>(m, "Transpose")

--- a/dpnp/backend/extensions/statistics/statistics_py.cpp
+++ b/dpnp/backend/extensions/statistics/statistics_py.cpp
@@ -37,7 +37,7 @@
 #include "histogramdd.hpp"
 #include "sliding_dot_product1d.hpp"
 
-PYBIND11_MODULE(_statistics_impl, m)
+PYBIND11_MODULE(_statistics_impl, m, py::mod_gil_not_used())
 {
     statistics::histogram::populate_bincount(m);
     statistics::histogram::populate_histogram(m);

--- a/dpnp/backend/extensions/ufunc/ufunc_py.cpp
+++ b/dpnp/backend/extensions/ufunc/ufunc_py.cpp
@@ -32,4 +32,7 @@
 
 namespace ufunc_ns = dpnp::extensions::ufunc;
 
-PYBIND11_MODULE(_ufunc_impl, m) { ufunc_ns::init_elementwise_functions(m); }
+PYBIND11_MODULE(_ufunc_impl, m, py::mod_gil_not_used())
+{
+    ufunc_ns::init_elementwise_functions(m);
+}

--- a/dpnp/backend/extensions/vm/vm_py.cpp
+++ b/dpnp/backend/extensions/vm/vm_py.cpp
@@ -82,7 +82,7 @@ namespace vm_ns = dpnp::extensions::vm;
 
 #include <pybind11/pybind11.h>
 
-PYBIND11_MODULE(_vm_impl, m)
+PYBIND11_MODULE(_vm_impl, m, py::mod_gil_not_used())
 {
 #if not defined(USE_ONEMATH)
     vm_ns::init_abs(m);

--- a/dpnp/backend/extensions/vm/vm_py.cpp
+++ b/dpnp/backend/extensions/vm/vm_py.cpp
@@ -82,6 +82,8 @@ namespace vm_ns = dpnp::extensions::vm;
 
 #include <pybind11/pybind11.h>
 
+namespace py = pybind11;
+
 PYBIND11_MODULE(_vm_impl, m, py::mod_gil_not_used())
 {
 #if not defined(USE_ONEMATH)

--- a/dpnp/backend/extensions/window/window_py.cpp
+++ b/dpnp/backend/extensions/window/window_py.cpp
@@ -73,7 +73,7 @@ static window_fn_ptr_t blackman_dispatch_vector[dpnp_td_ns::num_types];
 static window_fn_ptr_t hamming_dispatch_vector[dpnp_td_ns::num_types];
 static window_fn_ptr_t hanning_dispatch_vector[dpnp_td_ns::num_types];
 
-PYBIND11_MODULE(_window_impl, m)
+PYBIND11_MODULE(_window_impl, m, py::mod_gil_not_used())
 {
     using arrayT = dpnp::tensor::usm_ndarray;
     using event_vecT = std::vector<sycl::event>;

--- a/dpnp/backend/kernels/dpnp_krnl_random.cpp
+++ b/dpnp/backend/kernels/dpnp_krnl_random.cpp
@@ -30,6 +30,7 @@
 #include <cmath>
 #include <exception>
 #include <mkl_vsl.h>
+#include <mutex>
 #include <stdexcept>
 #include <vector>
 
@@ -45,12 +46,17 @@ namespace mkl_blas = oneapi::mkl::blas;
 namespace mkl_rng = oneapi::mkl::rng;
 namespace mkl_vm = oneapi::mkl::vm;
 
+static std::mutex rng_stream_mutex;
 /**
- * Use get/set functions to access/modify this variable
+ * Use get/set functions to access/modify this variable. Both require
+ * `rng_stream_mutex` to be held, and it must stay held for as long as the
+ * stream returned by the getter is in use, since the setter destroys the
+ * stream.
  */
 static VSLStreamStatePtr rng_stream = nullptr;
 
-static void set_rng_stream(size_t seed = 1)
+// only called with rng_stream_mutex held
+static void set_rng_stream_nolock(size_t seed = 1)
 {
     if (rng_stream) {
         vslDeleteStream(&rng_stream);
@@ -60,10 +66,11 @@ static void set_rng_stream(size_t seed = 1)
     vslNewStream(&rng_stream, VSL_BRNG_MT19937, seed);
 }
 
-static VSLStreamStatePtr get_rng_stream()
+// only called with rng_stream_mutex held
+static VSLStreamStatePtr get_rng_stream_nolock()
 {
     if (!rng_stream) {
-        set_rng_stream();
+        set_rng_stream_nolock();
     }
 
     return rng_stream;
@@ -73,7 +80,9 @@ void dpnp_rng_srand_c(size_t seed)
 {
     auto &be = backend_sycl::get();
     be.set_rng_engines_seed(seed);
-    set_rng_stream(seed);
+
+    std::lock_guard<std::mutex> lock(rng_stream_mutex);
+    set_rng_stream_nolock(seed);
 }
 
 template <typename _DistrType, typename _EngineType, typename _DataType>
@@ -1094,9 +1103,18 @@ DPCTLSyclEventRef
             DPNPC_ptr_adapter<_DataType> result_ptr(q_ref, result, size, true,
                                                     true);
             _DataType *result1 = result_ptr.get_ptr();
-            int errcode = viRngMultinomial(
-                VSL_RNG_METHOD_MULTINOMIAL_MULTPOISSON, get_rng_stream(), n,
-                result1, ntrial, p_size, p_data);
+
+            int errcode;
+            {
+                // the lock is held across the call, as the stream is mutated
+                // by the generation and may be destroyed by a concurrent
+                // reseeding
+                std::lock_guard<std::mutex> lock(rng_stream_mutex);
+                errcode =
+                    viRngMultinomial(VSL_RNG_METHOD_MULTINOMIAL_MULTPOISSON,
+                                     get_rng_stream_nolock(), n, result1,
+                                     ntrial, p_size, p_data);
+            }
             if (errcode != VSL_STATUS_OK) {
                 throw std::runtime_error(
                     "DPNP RNG Error: dpnp_rng_multinomial_c() failed.");

--- a/dpnp/backend/src/verbose.cpp
+++ b/dpnp/backend/src/verbose.cpp
@@ -29,33 +29,35 @@
 #include "verbose.hpp"
 #include <iostream>
 
-bool _is_verbose_mode = false;
-bool _is_verbose_mode_init = false;
+static bool read_verbose_mode()
+{
+    bool verbose = false;
+    char *env_var = nullptr;
+
+#ifdef _WIN32
+    size_t env_var_size = 0;
+    _dupenv_s(&env_var, &env_var_size, "DPNP_VERBOSE");
+#else
+    env_var = std::getenv("DPNP_VERBOSE");
+#endif
+
+    if (env_var && std::string(env_var) == "1") {
+        verbose = true;
+    }
+
+#ifdef _WIN32
+    if (env_var != nullptr)
+        free(env_var);
+#endif
+
+    return verbose;
+}
 
 bool is_verbose_mode()
 {
-    if (!_is_verbose_mode_init) {
-        _is_verbose_mode = false;
-        char *env_var = nullptr;
-
-#ifdef _WIN32
-        size_t env_var_size = 0;
-        _dupenv_s(&env_var, &env_var_size, "DPNP_VERBOSE");
-#else
-        env_var = std::getenv("DPNP_VERBOSE");
-#endif
-
-        if (env_var && std::string(env_var) == "1") {
-            _is_verbose_mode = true;
-        }
-        _is_verbose_mode_init = true;
-
-#ifdef _WIN32
-        if (env_var != nullptr)
-            free(env_var);
-#endif
-    }
-    return _is_verbose_mode;
+    // initialization of a function-local static is thread-safe
+    static const bool verbose = read_verbose_mode();
+    return verbose;
 }
 
 class barrierKernelClass;

--- a/dpnp/dpnp_algo/dpnp_algo.pyx
+++ b/dpnp/dpnp_algo/dpnp_algo.pyx
@@ -1,5 +1,6 @@
 # cython: language_level=3
 # cython: linetrace=True
+# cython: freethreading_compatible = True
 # -*- coding: utf-8 -*-
 # *****************************************************************************
 # Copyright (c) 2016, Intel Corporation

--- a/dpnp/dpnp_utils/dpnp_algo_utils.pyx
+++ b/dpnp/dpnp_utils/dpnp_algo_utils.pyx
@@ -1,5 +1,6 @@
 # cython: language_level=3
 # cython: linetrace=True
+# cython: freethreading_compatible = True
 # -*- coding: utf-8 -*-
 # *****************************************************************************
 # Copyright (c) 2016, Intel Corporation

--- a/dpnp/include/dpnp4pybind11.hpp
+++ b/dpnp/include/dpnp4pybind11.hpp
@@ -38,6 +38,7 @@
 #include "usm_ndarray_constants.h"
 
 #include <array>
+#include <atomic>
 #include <cassert>
 #include <cstddef> // for std::size_t for C++ linkage
 #include <cstdint>
@@ -123,8 +124,37 @@ public:
 
     static auto &get()
     {
-        static dpnp_capi api{};
-        return api;
+        static std::atomic<dpnp_capi *> global_capi{nullptr};
+        dpnp_capi *capi_ptr = global_capi.load(std::memory_order_acquire);
+
+        // fast path
+        if (capi_ptr) {
+            return *capi_ptr;
+        }
+
+        static std::mutex init_mtx;
+
+        // initialization requires calls into Python C-API, so initializing
+        // thread must hold the GIL, while other threads must not block on the
+        // mutex while holding the GIL, as this creates a deadlock
+        py::gil_scoped_release release;
+        std::lock_guard<std::mutex> lock(init_mtx);
+
+        // double check after acquiring lock
+        capi_ptr = global_capi.load(std::memory_order_relaxed);
+
+        if (!capi_ptr) {
+            // acquire gil to safely call into Python C API
+            py::gil_scoped_acquire acquire;
+
+            // initialize C-API singleton
+            // not freed, as it's kept until process termination
+            capi_ptr = new dpnp_capi();
+
+            global_capi.store(capi_ptr, std::memory_order_release);
+        }
+
+        return *capi_ptr;
     }
 
     py::object default_usm_ndarray_pyobj() { return *default_usm_ndarray_; }

--- a/dpnp/include/dpnp4pybind11.hpp
+++ b/dpnp/include/dpnp4pybind11.hpp
@@ -43,6 +43,7 @@
 #include <cstddef> // for std::size_t for C++ linkage
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <utility>
 #include <vector>

--- a/dpnp/random/dpnp_algo_random.pyx
+++ b/dpnp/random/dpnp_algo_random.pyx
@@ -39,6 +39,7 @@ and the rest of the library
 
 
 import numbers
+import threading
 
 import numpy
 
@@ -402,10 +403,12 @@ cdef class _Engine:
     cdef engine_struct* engine_base
     cdef c_dpctl.DPCTLSyclQueueRef q_ref
     cdef c_dpctl.SyclQueue q
+    cdef object lock
 
     def __cinit__(self, seed, sycl_queue):
         self.engine_base = NULL
         self.q_ref = NULL
+        self.lock = threading.Lock()
         if sycl_queue is None:
             raise ValueError("SyclQueue isn't defined")
 
@@ -486,17 +489,19 @@ cdef class _Engine:
             <fptr_dpnp_rng_normal_c_1out_t>
             kernel_data.ptr
         )
-        # call FPTR function
-        event_ref = func(
-            self.get_queue_ref(), result.get_data(),
-            loc, scale, result.size,
-            self.get_engine(), NULL,
-        )
+        # call FPTR function, keeping the lock until the submitted kernel is
+        # done, since it reads the engine state for as long as it runs
+        with self.lock:
+            event_ref = func(
+                self.get_queue_ref(), result.get_data(),
+                loc, scale, result.size,
+                self.get_engine(), NULL,
+            )
 
-        if event_ref != NULL:
-            with nogil:
-                c_dpctl.DPCTLEvent_WaitAndThrow(event_ref)
-            c_dpctl.DPCTLEvent_Delete(event_ref)
+            if event_ref != NULL:
+                with nogil:
+                    c_dpctl.DPCTLEvent_WaitAndThrow(event_ref)
+                c_dpctl.DPCTLEvent_Delete(event_ref)
         return result
 
     cpdef utils.dpnp_descriptor uniform(
@@ -539,17 +544,19 @@ cdef class _Engine:
             <fptr_dpnp_rng_uniform_c_1out_t>
             kernel_data.ptr
         )
-        # call FPTR function
-        event_ref = func(
-            self.get_queue_ref(), result.get_data(),
-            low, high, result.size,
-            self.get_engine(), NULL,
-        )
+        # call FPTR function, keeping the lock until the submitted kernel is
+        # done, since it reads the engine state for as long as it runs
+        with self.lock:
+            event_ref = func(
+                self.get_queue_ref(), result.get_data(),
+                low, high, result.size,
+                self.get_engine(), NULL,
+            )
 
-        if event_ref != NULL:
-            with nogil:
-                c_dpctl.DPCTLEvent_WaitAndThrow(event_ref)
-            c_dpctl.DPCTLEvent_Delete(event_ref)
+            if event_ref != NULL:
+                with nogil:
+                    c_dpctl.DPCTLEvent_WaitAndThrow(event_ref)
+                c_dpctl.DPCTLEvent_Delete(event_ref)
         return result
 
 

--- a/dpnp/random/dpnp_algo_random.pyx
+++ b/dpnp/random/dpnp_algo_random.pyx
@@ -1,5 +1,6 @@
 # cython: language_level=3
 # cython: linetrace=True
+# cython: freethreading_compatible = True
 # -*- coding: utf-8 -*-
 # *****************************************************************************
 # Copyright (c) 2016, Intel Corporation

--- a/dpnp/random/dpnp_iface_random.py
+++ b/dpnp/random/dpnp_iface_random.py
@@ -37,6 +37,7 @@ Set of functions to implement NumPy random module API
 """
 
 import operator
+import threading
 
 import numpy
 
@@ -47,26 +48,42 @@ from dpnp.dpnp_utils import *
 from .dpnp_algo_random import *
 from .dpnp_random_state import RandomState
 
+# lock the RNG calls for concurrent access
+_legacy_rng_lock = threading.RLock()
+
+
+def _legacy_rng(func, *args, **kwargs):
+    """Call a legacy ``dpnp_rng_*`` generator holding `_legacy_rng_lock`."""
+    with _legacy_rng_lock:
+        return func(*args, **kwargs)
+
+
+# Guards the `_dpnp_random_states` cache, so that concurrent callers asking
+# for the state of the same queue are guaranteed to get the same instance
+# back rather than each building one of their own.
+_random_states_lock = threading.RLock()
+
 
 def _get_random_state(device=None, sycl_queue=None):
     global _dpnp_random_states
 
-    if not isinstance(_dpnp_random_states, dict):
-        _dpnp_random_states = {}
     sycl_queue = dpnp.get_normalized_queue_device(
         device=device, sycl_queue=sycl_queue
     )
-    if sycl_queue not in _dpnp_random_states:
-        rs = RandomState(device=device, sycl_queue=sycl_queue)
-        if sycl_queue == rs.get_sycl_queue():
-            _dpnp_random_states[sycl_queue] = rs
-        else:
-            raise RuntimeError(
-                "Normalized SYCL queue {} mismatched with one returned by RandmoState {}".format(
-                    sycl_queue, rs.get_sycl_queue()
+    with _random_states_lock:
+        if not isinstance(_dpnp_random_states, dict):
+            _dpnp_random_states = {}
+        if sycl_queue not in _dpnp_random_states:
+            rs = RandomState(device=device, sycl_queue=sycl_queue)
+            if sycl_queue == rs.get_sycl_queue():
+                _dpnp_random_states[sycl_queue] = rs
+            else:
+                raise RuntimeError(
+                    "Normalized SYCL queue {} mismatched with one returned by RandmoState {}".format(
+                        sycl_queue, rs.get_sycl_queue()
+                    )
                 )
-            )
-    return _dpnp_random_states[sycl_queue]
+        return _dpnp_random_states[sycl_queue]
 
 
 def _is_type_supported(obj_type):
@@ -115,7 +132,7 @@ def beta(a, b, size=None):
         elif b <= 0:
             pass
         else:
-            return dpnp_rng_beta(a, b, size).get_pyobj()
+            return _legacy_rng(dpnp_rng_beta, a, b, size).get_pyobj()
 
     return call_origin(numpy.random.beta, a, b, size)
 
@@ -166,7 +183,7 @@ def binomial(n, p, size=None):
         elif n < 0:
             pass
         else:
-            return dpnp_rng_binomial(int(n), p, size).get_pyobj()
+            return _legacy_rng(dpnp_rng_binomial, int(n), p, size).get_pyobj()
 
     return call_origin(numpy.random.binomial, n, p, size)
 
@@ -221,7 +238,7 @@ def chisquare(df, size=None):
         else:
             # TODO:
             # float to int, safe
-            return dpnp_rng_chisquare(int(df), size).get_pyobj()
+            return _legacy_rng(dpnp_rng_chisquare, int(df), size).get_pyobj()
 
     return call_origin(numpy.random.chisquare, df, size)
 
@@ -292,7 +309,7 @@ def exponential(scale=1.0, size=None):
         elif scale < 0:
             pass
         else:
-            return dpnp_rng_exponential(scale, size).get_pyobj()
+            return _legacy_rng(dpnp_rng_exponential, scale, size).get_pyobj()
 
     return call_origin(numpy.random.exponential, scale, size)
 
@@ -333,7 +350,7 @@ def f(dfnum, dfden, size=None):
         elif dfden <= 0:
             pass
         else:
-            return dpnp_rng_f(dfnum, dfden, size).get_pyobj()
+            return _legacy_rng(dpnp_rng_f, dfnum, dfden, size).get_pyobj()
 
     return call_origin(numpy.random.f, dfnum, dfden, size)
 
@@ -376,7 +393,7 @@ def gamma(shape, scale=1.0, size=None):
         elif shape < 0:
             pass
         else:
-            return dpnp_rng_gamma(shape, scale, size).get_pyobj()
+            return _legacy_rng(dpnp_rng_gamma, shape, scale, size).get_pyobj()
 
     return call_origin(numpy.random.gamma, shape, scale, size)
 
@@ -415,7 +432,7 @@ def geometric(p, size=None):
         elif p > 1 or p <= 0:
             pass
         else:
-            return dpnp_rng_geometric(p, size).get_pyobj()
+            return _legacy_rng(dpnp_rng_geometric, p, size).get_pyobj()
 
     return call_origin(numpy.random.geometric, p, size)
 
@@ -456,7 +473,7 @@ def gumbel(loc=0.0, scale=1.0, size=None):
         elif scale < 0:
             pass
         else:
-            return dpnp_rng_gumbel(loc, scale, size).get_pyobj()
+            return _legacy_rng(dpnp_rng_gumbel, loc, scale, size).get_pyobj()
 
     return call_origin(numpy.random.gumbel, loc, scale, size)
 
@@ -512,7 +529,9 @@ def hypergeometric(ngood, nbad, nsample, size=None):
             _m = int(ngood)
             _l = int(ngood) + int(nbad)
             _s = int(nsample)
-            return dpnp_rng_hypergeometric(_l, _s, _m, size).get_pyobj()
+            return _legacy_rng(
+                dpnp_rng_hypergeometric, _l, _s, _m, size
+            ).get_pyobj()
 
     return call_origin(numpy.random.hypergeometric, ngood, nbad, nsample, size)
 
@@ -552,7 +571,7 @@ def laplace(loc=0.0, scale=1.0, size=None):
         elif scale < 0:
             pass
         else:
-            return dpnp_rng_laplace(loc, scale, size).get_pyobj()
+            return _legacy_rng(dpnp_rng_laplace, loc, scale, size).get_pyobj()
 
     return call_origin(numpy.random.laplace, loc, scale, size)
 
@@ -591,7 +610,9 @@ def logistic(loc=0.0, scale=1.0, size=None):
         elif scale < 0:
             pass
         else:
-            result = dpnp_rng_logistic(loc, scale, size).get_pyobj()
+            result = _legacy_rng(
+                dpnp_rng_logistic, loc, scale, size
+            ).get_pyobj()
             if size is None or size == 1:
                 return result[0]
             else:
@@ -637,7 +658,9 @@ def lognormal(mean=0.0, sigma=1.0, size=None):
         elif sigma < 0:
             pass
         else:
-            return dpnp_rng_lognormal(mean, sigma, size).get_pyobj()
+            return _legacy_rng(
+                dpnp_rng_lognormal, mean, sigma, size
+            ).get_pyobj()
 
     return call_origin(numpy.random.lognormal, mean, sigma, size)
 
@@ -707,7 +730,9 @@ def multinomial(n, pvals, size=None):
                 except Exception:
                     shape = tuple(size) + (d,)
 
-            return dpnp_rng_multinomial(int(n), pvals_desc, shape).get_pyobj()
+            return _legacy_rng(
+                dpnp_rng_multinomial, int(n), pvals_desc, shape
+            ).get_pyobj()
 
     return call_origin(numpy.random.multinomial, n, pvals, size)
 
@@ -759,8 +784,8 @@ def multivariate_normal(mean, cov, size=None, check_valid="warn", tol=1e-8):
         else:
             final_shape = list(shape[:])
             final_shape.append(mean_.shape[0])
-            return dpnp_rng_multivariate_normal(
-                mean_, cov_, final_shape
+            return _legacy_rng(
+                dpnp_rng_multivariate_normal, mean_, cov_, final_shape
             ).get_pyobj()
 
     return call_origin(
@@ -814,7 +839,9 @@ def negative_binomial(n, p, size=None):
         elif n <= 0:
             pass
         else:
-            return dpnp_rng_negative_binomial(n, p, size).get_pyobj()
+            return _legacy_rng(
+                dpnp_rng_negative_binomial, n, p, size
+            ).get_pyobj()
 
     return call_origin(numpy.random.negative_binomial, n, p, size)
 
@@ -910,7 +937,9 @@ def noncentral_chisquare(df, nonc, size=None):
         elif nonc < 0:
             pass
         else:
-            return dpnp_rng_noncentral_chisquare(df, nonc, size).get_pyobj()
+            return _legacy_rng(
+                dpnp_rng_noncentral_chisquare, df, nonc, size
+            ).get_pyobj()
 
     return call_origin(numpy.random.noncentral_chisquare, df, nonc, size)
 
@@ -965,7 +994,7 @@ def pareto(a, size=None):
         elif a <= 0:
             pass
         else:
-            return dpnp_rng_pareto(a, size).get_pyobj()
+            return _legacy_rng(dpnp_rng_pareto, a, size).get_pyobj()
 
     return call_origin(numpy.random.pareto, a, size)
 
@@ -1039,7 +1068,7 @@ def poisson(lam=1.0, size=None):
         elif lam < 0:
             pass
         else:
-            return dpnp_rng_poisson(lam, size).get_pyobj()
+            return _legacy_rng(dpnp_rng_poisson, lam, size).get_pyobj()
 
     return call_origin(numpy.random.poisson, lam, size)
 
@@ -1079,7 +1108,7 @@ def power(a, size=None):
         elif a <= 0:
             pass
         else:
-            return dpnp_rng_power(a, size).get_pyobj()
+            return _legacy_rng(dpnp_rng_power, a, size).get_pyobj()
 
     return call_origin(numpy.random.power, a, size)
 
@@ -1540,7 +1569,7 @@ def rayleigh(scale=1.0, size=None):
         elif scale < 0:
             pass
         else:
-            return dpnp_rng_rayleigh(scale, size).get_pyobj()
+            return _legacy_rng(dpnp_rng_rayleigh, scale, size).get_pyobj()
 
     return call_origin(numpy.random.rayleigh, scale, size)
 
@@ -1624,7 +1653,7 @@ def shuffle(x1):
         if not _is_type_supported(x1_desc.dtype):
             pass
         else:
-            dpnp_rng_shuffle(x1_desc).get_pyobj()
+            _legacy_rng(dpnp_rng_shuffle, x1_desc).get_pyobj()
             return
 
     call_origin(numpy.random.shuffle, x1, dpnp_inplace=True)
@@ -1664,9 +1693,10 @@ def seed(seed=None, device=None, sycl_queue=None):
     sycl_queue = dpnp.get_normalized_queue_device(
         device=device, sycl_queue=sycl_queue
     )
-    _dpnp_random_states[sycl_queue] = RandomState(
-        seed=seed, sycl_queue=sycl_queue
-    )
+    with _random_states_lock:
+        _dpnp_random_states[sycl_queue] = RandomState(
+            seed=seed, sycl_queue=sycl_queue
+        )
 
     if not use_origin_backend(seed):
         if dpnp.is_cuda_backend():  # pragma: no cover
@@ -1685,7 +1715,7 @@ def seed(seed=None, device=None, sycl_queue=None):
         else:
             # TODO:
             # migrate to a single approach with RandomState class
-            dpnp_rng_srand(seed)
+            _legacy_rng(dpnp_rng_srand, seed)
 
     # always reseed numpy engine also
     return call_origin(numpy.random.seed, seed, allow_fallback=True)
@@ -1718,7 +1748,7 @@ def standard_cauchy(size=None):
             raise NotImplementedError(
                 "Running on CUDA is currently not supported"
             )
-        return dpnp_rng_standard_cauchy(size).get_pyobj()
+        return _legacy_rng(dpnp_rng_standard_cauchy, size).get_pyobj()
 
     return call_origin(numpy.random.standard_cauchy, size)
 
@@ -1747,7 +1777,7 @@ def standard_exponential(size=None):
             raise NotImplementedError(
                 "Running on CUDA is currently not supported"
             )
-        return dpnp_rng_standard_exponential(size).get_pyobj()
+        return _legacy_rng(dpnp_rng_standard_exponential, size).get_pyobj()
 
     return call_origin(numpy.random.standard_exponential, size)
 
@@ -1787,7 +1817,7 @@ def standard_gamma(shape, size=None):
         elif shape < 0:
             pass
         else:
-            return dpnp_rng_standard_gamma(shape, size).get_pyobj()
+            return _legacy_rng(dpnp_rng_standard_gamma, shape, size).get_pyobj()
 
     return call_origin(numpy.random.standard_gamma, shape, size)
 
@@ -1876,7 +1906,7 @@ def standard_t(df, size=None):
         elif df <= 0:
             pass
         else:
-            return dpnp_rng_standard_t(df, size).get_pyobj()
+            return _legacy_rng(dpnp_rng_standard_t, df, size).get_pyobj()
 
     return call_origin(numpy.random.standard_t, df, size)
 
@@ -1925,7 +1955,9 @@ def triangular(left, mode, right, size=None):
         elif left == right:
             pass
         else:
-            return dpnp_rng_triangular(left, mode, right, size).get_pyobj()
+            return _legacy_rng(
+                dpnp_rng_triangular, left, mode, right, size
+            ).get_pyobj()
 
     return call_origin(numpy.random.triangular, left, mode, right, size)
 
@@ -2040,7 +2072,7 @@ def vonmises(mu, kappa, size=None):
         elif kappa < 0:
             pass
         else:
-            return dpnp_rng_vonmises(mu, kappa, size).get_pyobj()
+            return _legacy_rng(dpnp_rng_vonmises, mu, kappa, size).get_pyobj()
 
     return call_origin(numpy.random.vonmises, mu, kappa, size)
 
@@ -2081,7 +2113,7 @@ def wald(mean, scale, size=None):
         elif scale <= 0:
             pass
         else:
-            return dpnp_rng_wald(mean, scale, size).get_pyobj()
+            return _legacy_rng(dpnp_rng_wald, mean, scale, size).get_pyobj()
 
     return call_origin(numpy.random.wald, mean, scale, size)
 
@@ -2118,7 +2150,7 @@ def weibull(a, size=None):
         elif a < 0:
             pass
         else:
-            return dpnp_rng_weibull(a, size).get_pyobj()
+            return _legacy_rng(dpnp_rng_weibull, a, size).get_pyobj()
 
     return call_origin(numpy.random.weibull, a, size)
 
@@ -2155,7 +2187,7 @@ def zipf(a, size=None):
         elif a <= 1:
             pass
         else:
-            return dpnp_rng_zipf(a, size).get_pyobj()
+            return _legacy_rng(dpnp_rng_zipf, a, size).get_pyobj()
 
     return call_origin(numpy.random.zipf, a, size)
 

--- a/dpnp/random/dpnp_random_state.py
+++ b/dpnp/random/dpnp_random_state.py
@@ -36,6 +36,8 @@ Set of functions to implement NumPy random module API
 
 """
 
+import threading
+
 import numpy
 
 import dpnp
@@ -113,6 +115,10 @@ class RandomState:
         else:
             # MCG59 is assumed to provide a better performance on GPU than MT19937
             self._random_state = MCG59(self._seed, self._sycl_queue)
+
+        # guard for concurrent access under free-threaded builds
+        self._lock = threading.RLock()
+
         self._fallback_random_state = call_origin(
             numpy.random.RandomState, seed, allow_fallback=True
         )
@@ -275,13 +281,14 @@ class RandomState:
                     )
 
                 validate_usm_type(usm_type, allow_none=False)
-                return self._random_state.normal(
-                    loc=loc,
-                    scale=scale,
-                    size=size,
-                    dtype=dtype,
-                    usm_type=usm_type,
-                ).get_pyobj()
+                with self._lock:
+                    return self._random_state.normal(
+                        loc=loc,
+                        scale=scale,
+                        size=size,
+                        dtype=dtype,
+                        usm_type=usm_type,
+                    ).get_pyobj()
 
         return call_origin(
             self._fallback_random_state.normal,
@@ -654,13 +661,14 @@ class RandomState:
                 )
                 validate_usm_type(usm_type, allow_none=False)
 
-                return self._random_state.uniform(
-                    low=low,
-                    high=high,
-                    size=size,
-                    dtype=dtype,
-                    usm_type=usm_type,
-                ).get_pyobj()
+                with self._lock:
+                    return self._random_state.uniform(
+                        low=low,
+                        high=high,
+                        size=size,
+                        dtype=dtype,
+                        usm_type=usm_type,
+                    ).get_pyobj()
 
         return call_origin(
             self._fallback_random_state.uniform,

--- a/dpnp/random/dpnp_random_state.py
+++ b/dpnp/random/dpnp_random_state.py
@@ -36,8 +36,6 @@ Set of functions to implement NumPy random module API
 
 """
 
-import threading
-
 import numpy
 
 import dpnp
@@ -116,9 +114,6 @@ class RandomState:
             # MCG59 is assumed to provide a better performance on GPU than MT19937
             self._random_state = MCG59(self._seed, self._sycl_queue)
 
-        # guard for concurrent access under free-threaded builds
-        self._lock = threading.RLock()
-
         self._fallback_random_state = call_origin(
             numpy.random.RandomState, seed, allow_fallback=True
         )
@@ -179,6 +174,14 @@ class RandomState:
         -------
         out : object
             An object representing the internal state of the generator.
+
+        Notes
+        -----
+        Unlike :obj:`numpy.random.RandomState.get_state`, which returns a
+        snapshot of the state as plain data, this returns the live engine the
+        generator draws from. Generating from the returned engine advances the
+        state seen by this :class:`RandomState`, and does so safely if other
+        threads are drawing from it at the same time.
         """
         return self._random_state
 
@@ -281,14 +284,13 @@ class RandomState:
                     )
 
                 validate_usm_type(usm_type, allow_none=False)
-                with self._lock:
-                    return self._random_state.normal(
-                        loc=loc,
-                        scale=scale,
-                        size=size,
-                        dtype=dtype,
-                        usm_type=usm_type,
-                    ).get_pyobj()
+                return self._random_state.normal(
+                    loc=loc,
+                    scale=scale,
+                    size=size,
+                    dtype=dtype,
+                    usm_type=usm_type,
+                ).get_pyobj()
 
         return call_origin(
             self._fallback_random_state.normal,
@@ -661,14 +663,13 @@ class RandomState:
                 )
                 validate_usm_type(usm_type, allow_none=False)
 
-                with self._lock:
-                    return self._random_state.uniform(
-                        low=low,
-                        high=high,
-                        size=size,
-                        dtype=dtype,
-                        usm_type=usm_type,
-                    ).get_pyobj()
+                return self._random_state.uniform(
+                    low=low,
+                    high=high,
+                    size=size,
+                    dtype=dtype,
+                    usm_type=usm_type,
+                ).get_pyobj()
 
         return call_origin(
             self._fallback_random_state.uniform,

--- a/dpnp/tensor/_compute_follows_data.pyx
+++ b/dpnp/tensor/_compute_follows_data.pyx
@@ -29,6 +29,7 @@
 # distutils: language = c++
 # cython: language_level=3
 # cython: linetrace=True
+# cython: freethreading_compatible = True
 
 """Compute-follows-data utilities for execution queue and USM type management.
 

--- a/dpnp/tensor/_dlpack.pyx
+++ b/dpnp/tensor/_dlpack.pyx
@@ -29,6 +29,7 @@
 # distutils: language = c++
 # cython: language_level=3
 # cython: linetrace=True
+# cython: freethreading_compatible = True
 
 cdef extern from "numpy/npy_no_deprecated_api.h":
     pass

--- a/dpnp/tensor/_flags.pyx
+++ b/dpnp/tensor/_flags.pyx
@@ -29,6 +29,7 @@
 # distutils: language = c++
 # cython: language_level=3
 # cython: linetrace=True
+# cython: freethreading_compatible = True
 
 from libcpp cimport bool as cpp_bool
 

--- a/dpnp/tensor/_print.py
+++ b/dpnp/tensor/_print.py
@@ -29,6 +29,7 @@
 import contextlib
 import itertools
 import operator
+from contextvars import ContextVar
 
 import dpctl
 import numpy as np
@@ -39,7 +40,7 @@ import dpnp.tensor._tensor_impl as ti
 
 __doc__ = "Print functions for :class:`dpctl.tensor.usm_ndarray`."
 
-_print_options = {
+_default_print_options = {
     "linewidth": 75,
     "edgeitems": 3,
     "threshold": 1000,
@@ -50,6 +51,8 @@ _print_options = {
     "infstr": "inf",
     "sign": "-",
 }
+
+_print_options = ContextVar("print_options", default=_default_print_options)
 
 
 def _move_to_next_line(string, s, line_width, prefix):
@@ -75,9 +78,9 @@ def _options_dict(
 ):
     if numpy:
         numpy_options = np.get_printoptions()
-        options = {k: numpy_options[k] for k in _print_options.keys()}
+        options = {k: numpy_options[k] for k in _default_print_options.keys()}
     else:
-        options = _print_options.copy()
+        options = _print_options.get().copy()
 
     if suppress:
         options["suppress"] = True
@@ -116,6 +119,37 @@ def _options_dict(
         options["floatmode"] = floatmode
 
     return options
+
+
+def _set_print_options(
+    linewidth=None,
+    edgeitems=None,
+    threshold=None,
+    precision=None,
+    floatmode=None,
+    suppress=None,
+    nanstr=None,
+    infstr=None,
+    sign=None,
+    numpy=False,
+):
+    """
+    Setter for `print_options` that returns the ContextVar token to restore the
+    previous options without race conditions
+    """
+    options = _options_dict(
+        linewidth=linewidth,
+        edgeitems=edgeitems,
+        threshold=threshold,
+        precision=precision,
+        floatmode=floatmode,
+        suppress=suppress,
+        nanstr=nanstr,
+        infstr=infstr,
+        sign=sign,
+        numpy=numpy,
+    )
+    return _print_options.set(_print_options.get() | options)
 
 
 def set_print_options(
@@ -201,7 +235,7 @@ def set_print_options(
             will be used to initialize dpctl's print options.
             Default: "False"
     """
-    options = _options_dict(
+    _set_print_options(
         linewidth=linewidth,
         edgeitems=edgeitems,
         threshold=threshold,
@@ -213,7 +247,6 @@ def set_print_options(
         sign=sign,
         numpy=numpy,
     )
-    _print_options.update(options)
 
 
 def get_print_options():
@@ -237,7 +270,7 @@ def get_print_options():
         - "infstr" : str, default "inf"
         - "sign" : str, default "-"
     """
-    return _print_options.copy()
+    return _print_options.get().copy()
 
 
 @contextlib.contextmanager
@@ -248,12 +281,11 @@ def print_options(*args, **kwargs):
     Set print options for the scope of a `with` block.
     `as` yields dictionary of print options.
     """
-    options = dpt.get_print_options()
+    token = _set_print_options(*args, **kwargs)
     try:
-        dpt.set_print_options(*args, **kwargs)
-        yield dpt.get_print_options()
+        yield get_print_options()
     finally:
-        dpt.set_print_options(**options)
+        _print_options.reset(token)
 
 
 def _nd_corners(arr_in, edge_items):
@@ -462,7 +494,7 @@ def usm_ndarray_repr(
         raise TypeError(f"Expected dpnp.tensor.usm_ndarray, got {type(x)}")
 
     if line_width is None:
-        line_width = _print_options["linewidth"]
+        line_width = _print_options.get()["linewidth"]
 
     show_dtype = x.dtype not in [
         dpt.bool,

--- a/dpnp/tensor/_slicing.pyx
+++ b/dpnp/tensor/_slicing.pyx
@@ -29,6 +29,7 @@
 # distutils: language = c++
 # cython: language_level=3
 # cython: linetrace=True
+# cython: freethreading_compatible = True
 
 from operator import index
 from cpython.buffer cimport PyObject_CheckBuffer

--- a/dpnp/tensor/_stride_utils.pyx
+++ b/dpnp/tensor/_stride_utils.pyx
@@ -29,6 +29,7 @@
 # distutils: language = c++
 # cython: language_level=3
 # cython: linetrace=True
+# cython: freethreading_compatible = True
 
 from cpython.mem cimport PyMem_Free, PyMem_Malloc
 from cpython.ref cimport Py_INCREF

--- a/dpnp/tensor/_types.pyx
+++ b/dpnp/tensor/_types.pyx
@@ -29,6 +29,7 @@
 # distutils: language = c++
 # cython: language_level=3
 # cython: linetrace=True
+# cython: freethreading_compatible = True
 
 import numpy as np
 

--- a/dpnp/tensor/_usmarray.pyx
+++ b/dpnp/tensor/_usmarray.pyx
@@ -29,6 +29,7 @@
 # distutils: language = c++
 # cython: language_level=3
 # cython: linetrace=True
+# cython: freethreading_compatible = True
 
 import warnings
 

--- a/dpnp/tensor/libtensor/source/tensor_accumulation.cpp
+++ b/dpnp/tensor/libtensor/source/tensor_accumulation.cpp
@@ -37,7 +37,7 @@
 
 #include "accumulators/accumulators_common.hpp"
 
-PYBIND11_MODULE(_tensor_accumulation_impl, m)
+PYBIND11_MODULE(_tensor_accumulation_impl, m, py::mod_gil_not_used())
 {
     dpnp::tensor::py_internal::init_accumulator_functions(m);
 }

--- a/dpnp/tensor/libtensor/source/tensor_ctors.cpp
+++ b/dpnp/tensor/libtensor/source/tensor_ctors.cpp
@@ -175,7 +175,7 @@ void init_dispatch_vectors(void)
 
 } // namespace
 
-PYBIND11_MODULE(_tensor_impl, m)
+PYBIND11_MODULE(_tensor_impl, m, py::mod_gil_not_used())
 {
     init_dispatch_tables();
     init_dispatch_vectors();

--- a/dpnp/tensor/libtensor/source/tensor_elementwise.cpp
+++ b/dpnp/tensor/libtensor/source/tensor_elementwise.cpp
@@ -39,7 +39,7 @@
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(_tensor_elementwise_impl, m)
+PYBIND11_MODULE(_tensor_elementwise_impl, m, py::mod_gil_not_used())
 {
     dpnp::tensor::py_internal::init_elementwise_functions(m);
 }

--- a/dpnp/tensor/libtensor/source/tensor_linalg.cpp
+++ b/dpnp/tensor/libtensor/source/tensor_linalg.cpp
@@ -35,7 +35,7 @@
 #include "linalg_functions/dot.hpp"
 #include <pybind11/pybind11.h>
 
-PYBIND11_MODULE(_tensor_linalg_impl, m)
+PYBIND11_MODULE(_tensor_linalg_impl, m, py::mod_gil_not_used())
 {
     dpnp::tensor::py_internal::init_dot(m);
 }

--- a/dpnp/tensor/libtensor/source/tensor_reductions.cpp
+++ b/dpnp/tensor/libtensor/source/tensor_reductions.cpp
@@ -37,7 +37,7 @@
 
 #include "reductions/reduction_common.hpp"
 
-PYBIND11_MODULE(_tensor_reductions_impl, m)
+PYBIND11_MODULE(_tensor_reductions_impl, m, py::mod_gil_not_used())
 {
     dpnp::tensor::py_internal::init_reduction_functions(m);
 }

--- a/dpnp/tensor/libtensor/source/tensor_sorting.cpp
+++ b/dpnp/tensor/libtensor/source/tensor_sorting.cpp
@@ -43,7 +43,7 @@
 #include "sorting/searchsorted.hpp"
 #include "sorting/topk.hpp"
 
-PYBIND11_MODULE(_tensor_sorting_impl, m)
+PYBIND11_MODULE(_tensor_sorting_impl, m, py::mod_gil_not_used())
 {
     dpnp::tensor::py_internal::init_isin_functions(m);
     dpnp::tensor::py_internal::init_merge_sort_functions(m);

--- a/examples/pybind11/use_dpnp_array/CMakeLists.txt
+++ b/examples/pybind11/use_dpnp_array/CMakeLists.txt
@@ -49,7 +49,7 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(pybind11)
 
-find_package(Python REQUIRED COMPONENTS Development.Module)
+find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
 find_package(Dpctl REQUIRED)
 find_package(IntelSYCL REQUIRED)
 find_package(Dpnp REQUIRED)

--- a/examples/pybind11/use_dpnp_array/use_dpnp_array/_example.cpp
+++ b/examples/pybind11/use_dpnp_array/use_dpnp_array/_example.cpp
@@ -76,7 +76,7 @@ bool is_writable(const dpnp::tensor::usm_ndarray &arr)
     return arr.is_writable();
 }
 
-PYBIND11_MODULE(_use_dpnp_array, m)
+PYBIND11_MODULE(_use_dpnp_array, m, py::mod_gil_not_used())
 {
     m.def("get_ndim", &get_ndim);
     m.def("get_shape", &get_shape);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Free Threading :: 2 - Beta",
   "Topic :: Software Development",
   "Topic :: Scientific/Engineering",
   "Operating System :: Microsoft :: Windows",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
   # TODO: keep in sync with [project.dependencies]
   "build>=1.2.2",
   "cmake>=3.31.6",
-  "cython>=3.0.12",
+  "cython>=3.1.0",
   # WARNING: use only dpctl version available on PyPi
   "dpctl>=0.20.0",
   "ninja>=1.11.1; platform_system!='Windows'",


### PR DESCRIPTION
This PR removes `python-gil` as a dependency for dpnp and enables free-threaded builds, which are now run in public CI as part of the conda-package workflow.

Changes were made in particular to `dpnp_capi` aligning with similar changes in dpctl, print options which now align with NumPy's `ContextVar` approach, dpnp verbosity mode, and `dpnp.random` module, which has introduced locks for some state

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
