### PR TITLE
Release GIL around blocking oneMKL calls in BLAS/LAPACK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ This release is compatible with NumPy 2.5.
 * Fixed missing strides validation in `dpnp.tensor.usm_ndarray` constructor when allocating new memory [#2927](https://github.com/IntelPython/dpnp/pull/2927)
 * Fixed `dpnp.bincount` raising a `ValueError` on an empty input array instead of returning an empty `intp` array [#3018](https://github.com/IntelPython/dpnp/pull/3018)
 * Fixed `dpnp.tensor.top_k` aborting for `k=0` by returning empty result arrays without launching a zero-sized kernel [#3022](https://github.com/IntelPython/dpnp/pull/3022)
+* Released the GIL before the remaining blocking OneMKL BLAS and LAPACK calls to prevent host tasks contention, completing the work started in [#2850](https://github.com/IntelPython/dpnp/pull/2850) [#3027](https://github.com/IntelPython/dpnp/pull/3027)
 
 ### Security
 

--- a/dpnp/backend/extensions/blas/dot.hpp
+++ b/dpnp/backend/extensions/blas/dot.hpp
@@ -65,7 +65,6 @@ static sycl::event dot_impl(sycl::queue &exec_q,
         // to the same queue in OneMKL
         py::gil_scoped_release lock{};
 
-
         dot_event = mkl_blas::column_major::dot(exec_q,
                                                 n, // size of the input vectors
                                                 x, // Pointer to vector x.

--- a/dpnp/backend/extensions/blas/dot.hpp
+++ b/dpnp/backend/extensions/blas/dot.hpp
@@ -30,12 +30,15 @@
 
 #include <stdexcept>
 
+#include <pybind11/pybind11.h>
+
 #include "dot_common.hpp"
 
 namespace dpnp::extensions::blas
 {
 namespace mkl_blas = oneapi::mkl::blas;
 namespace type_utils = dpnp::tensor::type_utils;
+namespace py = pybind11;
 
 template <typename T>
 static sycl::event dot_impl(sycl::queue &exec_q,
@@ -58,6 +61,11 @@ static sycl::event dot_impl(sycl::queue &exec_q,
 
     sycl::event dot_event;
     try {
+        // Release GIL to avoid serialization of host task submissions
+        // to the same queue in OneMKL
+        py::gil_scoped_release lock{};
+
+
         dot_event = mkl_blas::column_major::dot(exec_q,
                                                 n, // size of the input vectors
                                                 x, // Pointer to vector x.

--- a/dpnp/backend/extensions/blas/dotc.hpp
+++ b/dpnp/backend/extensions/blas/dotc.hpp
@@ -65,7 +65,6 @@ static sycl::event dotc_impl(sycl::queue &exec_q,
         // to the same queue in OneMKL
         py::gil_scoped_release lock{};
 
-
         dotc_event =
             mkl_blas::column_major::dotc(exec_q,
                                          n,    // size of the input vectors

--- a/dpnp/backend/extensions/blas/dotc.hpp
+++ b/dpnp/backend/extensions/blas/dotc.hpp
@@ -30,12 +30,15 @@
 
 #include <stdexcept>
 
+#include <pybind11/pybind11.h>
+
 #include "dot_common.hpp"
 
 namespace dpnp::extensions::blas
 {
 namespace mkl_blas = oneapi::mkl::blas;
 namespace type_utils = dpnp::tensor::type_utils;
+namespace py = pybind11;
 
 template <typename T>
 static sycl::event dotc_impl(sycl::queue &exec_q,
@@ -58,6 +61,11 @@ static sycl::event dotc_impl(sycl::queue &exec_q,
 
     sycl::event dotc_event;
     try {
+        // Release GIL to avoid serialization of host task submissions
+        // to the same queue in OneMKL
+        py::gil_scoped_release lock{};
+
+
         dotc_event =
             mkl_blas::column_major::dotc(exec_q,
                                          n,    // size of the input vectors

--- a/dpnp/backend/extensions/blas/dotu.hpp
+++ b/dpnp/backend/extensions/blas/dotu.hpp
@@ -65,7 +65,6 @@ static sycl::event dotu_impl(sycl::queue &exec_q,
         // to the same queue in OneMKL
         py::gil_scoped_release lock{};
 
-
         dotu_event =
             mkl_blas::column_major::dotu(exec_q,
                                          n,    // size of the input vectors

--- a/dpnp/backend/extensions/blas/dotu.hpp
+++ b/dpnp/backend/extensions/blas/dotu.hpp
@@ -30,12 +30,15 @@
 
 #include <stdexcept>
 
+#include <pybind11/pybind11.h>
+
 #include "dot_common.hpp"
 
 namespace dpnp::extensions::blas
 {
 namespace mkl_blas = oneapi::mkl::blas;
 namespace type_utils = dpnp::tensor::type_utils;
+namespace py = pybind11;
 
 template <typename T>
 static sycl::event dotu_impl(sycl::queue &exec_q,
@@ -58,6 +61,11 @@ static sycl::event dotu_impl(sycl::queue &exec_q,
 
     sycl::event dotu_event;
     try {
+        // Release GIL to avoid serialization of host task submissions
+        // to the same queue in OneMKL
+        py::gil_scoped_release lock{};
+
+
         dotu_event =
             mkl_blas::column_major::dotu(exec_q,
                                          n,    // size of the input vectors

--- a/dpnp/backend/extensions/blas/gemm.cpp
+++ b/dpnp/backend/extensions/blas/gemm.cpp
@@ -117,7 +117,6 @@ static sycl::event gemm_impl(sycl::queue &exec_q,
         // to the same queue in OneMKL
         py::gil_scoped_release lock{};
 
-
         gemm_event = gemm_func(
             exec_q,
             transA, // Defines the transpose operation for matrix A:

--- a/dpnp/backend/extensions/blas/gemm.cpp
+++ b/dpnp/backend/extensions/blas/gemm.cpp
@@ -113,6 +113,11 @@ static sycl::event gemm_impl(sycl::queue &exec_q,
                                                     c, ldc, deps);
             }
         };
+        // Release GIL to avoid serialization of host task submissions
+        // to the same queue in OneMKL
+        py::gil_scoped_release lock{};
+
+
         gemm_event = gemm_func(
             exec_q,
             transA, // Defines the transpose operation for matrix A:

--- a/dpnp/backend/extensions/blas/gemm_batch.cpp
+++ b/dpnp/backend/extensions/blas/gemm_batch.cpp
@@ -125,6 +125,11 @@ static sycl::event gemm_batch_impl(sycl::queue &exec_q,
                     strideb, beta, c, ldc, stridec, batch_size, deps);
             }
         };
+        // Release GIL to avoid serialization of host task submissions
+        // to the same queue in OneMKL
+        py::gil_scoped_release lock{};
+
+
         gemm_batch_event = gemm_batch_func(
             exec_q,
             transA,     // Defines the transpose operation for matrix A:

--- a/dpnp/backend/extensions/blas/gemm_batch.cpp
+++ b/dpnp/backend/extensions/blas/gemm_batch.cpp
@@ -129,7 +129,6 @@ static sycl::event gemm_batch_impl(sycl::queue &exec_q,
         // to the same queue in OneMKL
         py::gil_scoped_release lock{};
 
-
         gemm_batch_event = gemm_batch_func(
             exec_q,
             transA,     // Defines the transpose operation for matrix A:

--- a/dpnp/backend/extensions/lapack/geqrf.cpp
+++ b/dpnp/backend/extensions/lapack/geqrf.cpp
@@ -86,6 +86,10 @@ static sycl::event geqrf_impl(sycl::queue &exec_q,
 
     sycl::event geqrf_event;
     try {
+        // Release GIL to avoid serialization of host task submissions
+        // to the same queue in OneMKL
+        py::gil_scoped_release lock{};
+
         scratchpad = sycl::malloc_device<T>(scratchpad_size, exec_q);
 
         geqrf_event = mkl_lapack::geqrf(

--- a/dpnp/backend/extensions/lapack/geqrf_batch.cpp
+++ b/dpnp/backend/extensions/lapack/geqrf_batch.cpp
@@ -94,6 +94,10 @@ static sycl::event geqrf_batch_impl(sycl::queue &exec_q,
 
     sycl::event geqrf_batch_event;
     try {
+        // Release GIL to avoid serialization of host task submissions
+        // to the same queue in OneMKL
+        py::gil_scoped_release lock{};
+
         scratchpad = sycl::malloc_device<T>(scratchpad_size, exec_q);
 
         geqrf_batch_event = mkl_lapack::geqrf_batch(

--- a/dpnp/backend/extensions/lapack/gesv.cpp
+++ b/dpnp/backend/extensions/lapack/gesv.cpp
@@ -112,6 +112,10 @@ static sycl::event gesv_impl(sycl::queue &exec_q,
 #if defined(USE_ONEMATH)
     sycl::event getrf_event;
     try {
+        // Release GIL to avoid serialization of host task submissions
+        // to the same queue in OneMKL
+        py::gil_scoped_release lock{};
+
         getrf_event = mkl_lapack::getrf(
             exec_q,
             n,          // The order of the square matrix A (0 ≤ n).
@@ -169,6 +173,10 @@ static sycl::event gesv_impl(sycl::queue &exec_q,
     }
 #else
     try {
+        // Release GIL to avoid serialization of host task submissions
+        // to the same queue in OneMKL
+        py::gil_scoped_release lock{};
+
         comp_event = mkl_lapack::gesv(
             exec_q,
             n,    // The order of the square matrix A

--- a/dpnp/backend/extensions/lapack/gesvd.cpp
+++ b/dpnp/backend/extensions/lapack/gesvd.cpp
@@ -99,6 +99,10 @@ static sycl::event gesvd_impl(sycl::queue &exec_q,
 
     sycl::event gesvd_event;
     try {
+        // Release GIL to avoid serialization of host task submissions
+        // to the same queue in OneMKL
+        py::gil_scoped_release lock{};
+
         gesvd_event = mkl_lapack::gesvd(
             exec_q,
             jobu,  // Character specifying how to compute the matrix U:

--- a/dpnp/backend/extensions/lapack/getrf.cpp
+++ b/dpnp/backend/extensions/lapack/getrf.cpp
@@ -87,6 +87,10 @@ static sycl::event getrf_impl(sycl::queue &exec_q,
 
     sycl::event getrf_event;
     try {
+        // Release GIL to avoid serialization of host task submissions
+        // to the same queue in OneMKL
+        py::gil_scoped_release lock{};
+
         scratchpad = sycl::malloc_device<T>(scratchpad_size, exec_q);
 
         getrf_event = mkl_lapack::getrf(

--- a/dpnp/backend/extensions/lapack/getrf_batch.cpp
+++ b/dpnp/backend/extensions/lapack/getrf_batch.cpp
@@ -96,6 +96,10 @@ static sycl::event getrf_batch_impl(sycl::queue &exec_q,
 
     sycl::event getrf_batch_event;
     try {
+        // Release GIL to avoid serialization of host task submissions
+        // to the same queue in OneMKL
+        py::gil_scoped_release lock{};
+
         scratchpad = sycl::malloc_device<T>(scratchpad_size, exec_q);
 
         getrf_batch_event = mkl_lapack::getrf_batch(

--- a/dpnp/backend/extensions/lapack/heevd.cpp
+++ b/dpnp/backend/extensions/lapack/heevd.cpp
@@ -42,6 +42,7 @@
 
 namespace dpnp::extensions::lapack
 {
+namespace py = pybind11;
 namespace mkl_lapack = oneapi::mkl::lapack;
 namespace type_utils = dpnp::tensor::type_utils;
 
@@ -73,6 +74,10 @@ static sycl::event heevd_impl(sycl::queue &exec_q,
 
     sycl::event heevd_event;
     try {
+        // Release GIL to avoid serialization of host task submissions
+        // to the same queue in OneMKL
+        py::gil_scoped_release lock{};
+
         heevd_event = mkl_lapack::heevd(
             exec_q,
             jobz, // 'jobz == job::vec' means eigenvalues and eigenvectors are

--- a/dpnp/backend/extensions/lapack/orgqr_batch.cpp
+++ b/dpnp/backend/extensions/lapack/orgqr_batch.cpp
@@ -96,6 +96,10 @@ static sycl::event orgqr_batch_impl(sycl::queue &exec_q,
 
     sycl::event orgqr_batch_event;
     try {
+        // Release GIL to avoid serialization of host task submissions
+        // to the same queue in OneMKL
+        py::gil_scoped_release lock{};
+
         scratchpad = sycl::malloc_device<T>(scratchpad_size, exec_q);
 
         orgqr_batch_event = mkl_lapack::orgqr_batch(

--- a/dpnp/backend/extensions/lapack/potrf.cpp
+++ b/dpnp/backend/extensions/lapack/potrf.cpp
@@ -83,6 +83,10 @@ static sycl::event potrf_impl(sycl::queue &exec_q,
 
     sycl::event potrf_event;
     try {
+        // Release GIL to avoid serialization of host task submissions
+        // to the same queue in OneMKL
+        py::gil_scoped_release lock{};
+
         scratchpad = sycl::malloc_device<T>(scratchpad_size, exec_q);
 
         potrf_event = mkl_lapack::potrf(

--- a/dpnp/backend/extensions/lapack/potrf_batch.cpp
+++ b/dpnp/backend/extensions/lapack/potrf_batch.cpp
@@ -90,6 +90,10 @@ static sycl::event potrf_batch_impl(sycl::queue &exec_q,
 
     sycl::event potrf_batch_event;
     try {
+        // Release GIL to avoid serialization of host task submissions
+        // to the same queue in OneMKL
+        py::gil_scoped_release lock{};
+
         scratchpad = sycl::malloc_device<T>(scratchpad_size, exec_q);
 
         potrf_batch_event = mkl_lapack::potrf_batch(

--- a/dpnp/backend/extensions/lapack/syevd.cpp
+++ b/dpnp/backend/extensions/lapack/syevd.cpp
@@ -42,6 +42,7 @@
 
 namespace dpnp::extensions::lapack
 {
+namespace py = pybind11;
 namespace mkl_lapack = oneapi::mkl::lapack;
 namespace type_utils = dpnp::tensor::type_utils;
 
@@ -73,6 +74,10 @@ static sycl::event syevd_impl(sycl::queue &exec_q,
 
     sycl::event syevd_event;
     try {
+        // Release GIL to avoid serialization of host task submissions
+        // to the same queue in OneMKL
+        py::gil_scoped_release lock{};
+
         syevd_event = mkl_lapack::syevd(
             exec_q,
             jobz, // 'jobz == job::vec' means eigenvalues and eigenvectors are

--- a/dpnp/backend/extensions/lapack/ungqr.cpp
+++ b/dpnp/backend/extensions/lapack/ungqr.cpp
@@ -87,6 +87,10 @@ static sycl::event ungqr_impl(sycl::queue &exec_q,
 
     sycl::event ungqr_event;
     try {
+        // Release GIL to avoid serialization of host task submissions
+        // to the same queue in OneMKL
+        py::gil_scoped_release lock{};
+
         scratchpad = sycl::malloc_device<T>(scratchpad_size, exec_q);
 
         ungqr_event = mkl_lapack::ungqr(

--- a/dpnp/backend/extensions/lapack/ungqr_batch.cpp
+++ b/dpnp/backend/extensions/lapack/ungqr_batch.cpp
@@ -96,6 +96,10 @@ static sycl::event ungqr_batch_impl(sycl::queue &exec_q,
 
     sycl::event ungqr_batch_event;
     try {
+        // Release GIL to avoid serialization of host task submissions
+        // to the same queue in OneMKL
+        py::gil_scoped_release lock{};
+
         scratchpad = sycl::malloc_device<T>(scratchpad_size, exec_q);
 
         ungqr_batch_event = mkl_lapack::ungqr_batch(

--- a/dpnp/tests/test_blas_lapack_gil.py
+++ b/dpnp/tests/test_blas_lapack_gil.py
@@ -1,0 +1,176 @@
+"""Blocking oneMKL calls in the BLAS/LAPACK extensions must release the GIL.
+
+Routines such as ``potrf``, ``getrf``, ``syevd`` and ``gesv`` block the calling
+thread for the whole oneMKL call. Holding the GIL across that stalls every
+other Python thread, including the host tasks dpnp queues to manage object
+lifetimes, which reacquire the GIL. Five sibling files already wrap their call
+in ``py::gil_scoped_release`` (gh-2850 did this for ``orgqr``); these tests
+cover the rest.
+
+Progress of a competing thread is compared against ``SyclQueue.wait()``, which
+is ``nogil`` and therefore the best rate achievable on the machine.
+"""
+
+import sys
+import threading
+import time
+
+import dpctl
+import pytest
+
+import dpnp
+
+from .helper import has_support_aspect64, is_gpu_device
+
+# Large enough that every routine here actually blocks. Smaller sizes stop
+# discriminating: at n=512 cholesky returns asynchronously, and at n=1024
+# gesv blocks for only ~7 ms and passes even without the fix.
+_SIZE = 2048
+
+# A releasing call matches the nogil reference within a factor of ~2; a call
+# holding the GIL measures ~0.00-0.04 of it.
+_MIN_RATIO = 0.10
+
+_BACKLOG = 2  # queued matmuls, so the measured call has something to wait on
+
+
+class _Ticker:
+    """Counts how often a competing Python thread gets scheduled."""
+
+    def __enter__(self):
+        self.ticks = 0
+        self._stop = False
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+        return self
+
+    def _run(self):
+        while not self._stop:
+            self.ticks += 1
+            time.sleep(0)
+
+    def __exit__(self, *exc):
+        self._stop = True
+        self._thread.join(timeout=5)
+        return False
+
+
+@pytest.mark.skipif(not is_gpu_device(), reason="requires a GPU device")
+@pytest.mark.skipif(not has_support_aspect64(), reason="requires fp64 support")
+class TestBlockingCallsReleaseGil:
+    @pytest.fixture(autouse=True)
+    def _switch_interval(self):
+        # Stop CPython handing the GIL over on its own timer, so the
+        # measurement reflects the extension rather than the interpreter.
+        previous = sys.getswitchinterval()
+        sys.setswitchinterval(0.001)
+        yield
+        sys.setswitchinterval(previous)
+
+    @pytest.fixture
+    def mats(self):
+        spd = dpnp.eye(_SIZE, dtype="f8") * float(_SIZE)  # positive definite
+        return spd, dpnp.eye(_SIZE, dtype="f8") + 0.1
+
+    def _assert_releases_gil(self, name, spd, fn):
+        queue = spd.sycl_queue
+
+        def rate(ticker, func):
+            for _ in range(_BACKLOG):
+                dpnp.matmul(spd, spd)
+            ticker.ticks = 0
+            start = time.perf_counter()
+            func()
+            elapsed_ms = 1000 * (time.perf_counter() - start)
+            queue.wait()
+            return ticker.ticks / max(elapsed_ms, 1e-3)
+
+        fn()  # warm up JIT
+        queue.wait()
+
+        with _Ticker() as ticker:
+            measured = rate(ticker, fn)
+            reference = rate(ticker, queue.wait)
+
+        assert reference > 0, "reference measurement produced no ticks"
+        ratio = measured / reference
+        assert ratio >= _MIN_RATIO, (
+            f"{name} holds the GIL while blocking: {measured:.2f} ticks/ms vs "
+            f"{reference:.2f} for nogil queue.wait() (ratio {ratio:.3f}, need "
+            f">= {_MIN_RATIO}). The oneMKL call needs py::gil_scoped_release."
+        )
+
+    def test_potrf(self, mats):
+        spd, _ = mats
+        self._assert_releases_gil("potrf", spd, lambda: dpnp.linalg.cholesky(spd))
+
+    def test_getrf(self, mats):
+        spd, gen = mats
+        self._assert_releases_gil("getrf", spd, lambda: dpnp.linalg.det(gen))
+
+    def test_syevd(self, mats):
+        spd, _ = mats
+        self._assert_releases_gil("syevd", spd, lambda: dpnp.linalg.eigh(spd))
+
+    # No qr/geqrf case: dpnp.linalg.qr() also calls orgqr, already fixed in
+    # gh-2850, and that release alone keeps the competing thread running. The
+    # measurement would pass with or without geqrf's own release.
+
+    def test_gesv(self, mats):
+        spd, gen = mats
+        rhs = dpnp.ones(_SIZE, dtype="f8")
+        self._assert_releases_gil(
+            "gesv", spd, lambda: dpnp.linalg.solve(gen, rhs)
+        )
+
+
+@pytest.mark.skipif(not is_gpu_device(), reason="requires a GPU device")
+@pytest.mark.skipif(not has_support_aspect64(), reason="requires fp64 support")
+def test_multithreaded_linalg_overlaps():
+    """Two threads on two queues must run oneMKL work concurrently.
+
+    Holding the GIL across the blocking call serializes them, so a
+    multithreaded application gets no scaling from a second queue.
+    """
+    max_ratio = 0.85
+
+    queues = [
+        dpctl.SyclQueue(dpctl.SyclDevice("gpu"), property="in_order")
+        for _ in range(2)
+    ]
+    mats = [
+        dpnp.eye(_SIZE, dtype="f8", sycl_queue=q) * float(_SIZE) for q in queues
+    ]
+
+    def work(idx):
+        for _ in range(2):
+            dpnp.linalg.eigh(mats[idx])
+        queues[idx].wait()
+
+    for idx in range(2):  # warm up JIT
+        work(idx)
+
+    previous = sys.getswitchinterval()
+    sys.setswitchinterval(0.001)
+    try:
+        start = time.perf_counter()
+        work(0)
+        work(1)
+        serial = time.perf_counter() - start
+
+        start = time.perf_counter()
+        threads = [threading.Thread(target=work, args=(i,)) for i in range(2)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+        parallel = time.perf_counter() - start
+    finally:
+        sys.setswitchinterval(previous)
+
+    ratio = parallel / serial
+    assert ratio <= max_ratio, (
+        f"two threads running eigh did not overlap: {parallel * 1000:.1f} ms "
+        f"parallel vs {serial * 1000:.1f} ms serial (ratio {ratio:.3f}, need "
+        f"<= {max_ratio}). The oneMKL call is holding the GIL."
+    )

--- a/dpnp/tests/test_blas_lapack_gil.py
+++ b/dpnp/tests/test_blas_lapack_gil.py
@@ -94,6 +94,7 @@ class TestBlockingCallsReleaseGil:
             f">= {_MIN_RATIO}). The oneMKL call needs py::gil_scoped_release."
         )
 
+    @pytest.mark.slow
     def test_potrf(self, mats):
         spd, _ = mats
         self._assert_releases_gil(

--- a/dpnp/tests/test_blas_lapack_gil.py
+++ b/dpnp/tests/test_blas_lapack_gil.py
@@ -100,14 +100,17 @@ class TestBlockingCallsReleaseGil:
             "potrf", spd, lambda: dpnp.linalg.cholesky(spd)
         )
 
+    @pytest.mark.slow
     def test_getrf(self, mats):
         spd, gen = mats
         self._assert_releases_gil("getrf", spd, lambda: dpnp.linalg.det(gen))
 
+    @pytest.mark.slow
     def test_syevd(self, mats):
         spd, _ = mats
         self._assert_releases_gil("syevd", spd, lambda: dpnp.linalg.eigh(spd))
 
+    @pytest.mark.slow
     def test_gesv(self, mats):
         spd, gen = mats
         rhs = dpnp.ones(_SIZE, dtype="f8")
@@ -118,6 +121,7 @@ class TestBlockingCallsReleaseGil:
 
 # GPU only: on a CPU device oneMKL already saturates every core, so two threads
 # contend for the same hardware and the ratio stays ~1.0 either way.
+@pytest.mark.slow
 @pytest.mark.skipif(not is_gpu_device(), reason="requires a GPU device")
 @pytest.mark.skipif(not has_support_aspect64(), reason="requires fp64 support")
 def test_multithreaded_linalg_overlaps():

--- a/dpnp/tests/test_blas_lapack_gil.py
+++ b/dpnp/tests/test_blas_lapack_gil.py
@@ -1,12 +1,5 @@
 """Blocking oneMKL calls in the BLAS/LAPACK extensions must release the GIL.
 
-Routines such as ``potrf``, ``getrf``, ``syevd`` and ``gesv`` block the calling
-thread for the whole oneMKL call. Holding the GIL across that stalls every
-other Python thread, including the host tasks dpnp queues to manage object
-lifetimes, which reacquire the GIL. Five sibling files already wrap their call
-in ``py::gil_scoped_release`` (gh-2850 did this for ``orgqr``); these tests
-cover the rest.
-
 Progress of a competing thread is compared against ``SyclQueue.wait()``, which
 is ``nogil`` and therefore the best rate achievable on the machine.
 """
@@ -22,16 +15,15 @@ import dpnp
 
 from .helper import has_support_aspect64, is_gpu_device
 
-# Large enough that every routine here actually blocks. Smaller sizes stop
-# discriminating: at n=512 cholesky returns asynchronously, and at n=1024
-# gesv blocks for only ~7 ms and passes even without the fix.
+# Smaller sizes stop discriminating: the calls either stay asynchronous or
+# block too briefly for a stable measurement.
 _SIZE = 2048
 
-# A releasing call matches the nogil reference within a factor of ~2; a call
-# holding the GIL measures ~0.00-0.04 of it.
 _MIN_RATIO = 0.10
 
 _BACKLOG = 2  # queued matmuls, so the measured call has something to wait on
+
+_TRIALS = 5  # samples averaged per measurement
 
 
 class _Ticker:
@@ -55,13 +47,11 @@ class _Ticker:
         return False
 
 
-@pytest.mark.skipif(not is_gpu_device(), reason="requires a GPU device")
 @pytest.mark.skipif(not has_support_aspect64(), reason="requires fp64 support")
 class TestBlockingCallsReleaseGil:
     @pytest.fixture(autouse=True)
     def _switch_interval(self):
-        # Stop CPython handing the GIL over on its own timer, so the
-        # measurement reflects the extension rather than the interpreter.
+        # Stop CPython handing the GIL over on its own timer.
         previous = sys.getswitchinterval()
         sys.setswitchinterval(0.001)
         yield
@@ -69,21 +59,25 @@ class TestBlockingCallsReleaseGil:
 
     @pytest.fixture
     def mats(self):
-        spd = dpnp.eye(_SIZE, dtype="f8") * float(_SIZE)  # positive definite
+        spd = dpnp.eye(_SIZE, dtype="f8") * float(_SIZE)
         return spd, dpnp.eye(_SIZE, dtype="f8") + 0.1
 
     def _assert_releases_gil(self, name, spd, fn):
         queue = spd.sycl_queue
 
         def rate(ticker, func):
-            for _ in range(_BACKLOG):
-                dpnp.matmul(spd, spd)
-            ticker.ticks = 0
-            start = time.perf_counter()
-            func()
-            elapsed_ms = 1000 * (time.perf_counter() - start)
-            queue.wait()
-            return ticker.ticks / max(elapsed_ms, 1e-3)
+            total_ticks = 0
+            total_ms = 0.0
+            for _ in range(_TRIALS):
+                for _ in range(_BACKLOG):
+                    dpnp.matmul(spd, spd)
+                ticker.ticks = 0
+                start = time.perf_counter()
+                func()
+                total_ms += 1000 * (time.perf_counter() - start)
+                total_ticks += ticker.ticks
+                queue.wait()
+            return total_ticks / max(total_ms, 1e-3)
 
         fn()  # warm up JIT
         queue.wait()
@@ -102,7 +96,9 @@ class TestBlockingCallsReleaseGil:
 
     def test_potrf(self, mats):
         spd, _ = mats
-        self._assert_releases_gil("potrf", spd, lambda: dpnp.linalg.cholesky(spd))
+        self._assert_releases_gil(
+            "potrf", spd, lambda: dpnp.linalg.cholesky(spd)
+        )
 
     def test_getrf(self, mats):
         spd, gen = mats
@@ -112,10 +108,6 @@ class TestBlockingCallsReleaseGil:
         spd, _ = mats
         self._assert_releases_gil("syevd", spd, lambda: dpnp.linalg.eigh(spd))
 
-    # No qr/geqrf case: dpnp.linalg.qr() also calls orgqr, already fixed in
-    # gh-2850, and that release alone keeps the competing thread running. The
-    # measurement would pass with or without geqrf's own release.
-
     def test_gesv(self, mats):
         spd, gen = mats
         rhs = dpnp.ones(_SIZE, dtype="f8")
@@ -124,20 +116,16 @@ class TestBlockingCallsReleaseGil:
         )
 
 
+# GPU only: on a CPU device oneMKL already saturates every core, so two threads
+# contend for the same hardware and the ratio stays ~1.0 either way.
 @pytest.mark.skipif(not is_gpu_device(), reason="requires a GPU device")
 @pytest.mark.skipif(not has_support_aspect64(), reason="requires fp64 support")
 def test_multithreaded_linalg_overlaps():
-    """Two threads on two queues must run oneMKL work concurrently.
-
-    Holding the GIL across the blocking call serializes them, so a
-    multithreaded application gets no scaling from a second queue.
-    """
+    """Two threads on two queues must run oneMKL work concurrently."""
     max_ratio = 0.85
 
-    queues = [
-        dpctl.SyclQueue(dpctl.SyclDevice("gpu"), property="in_order")
-        for _ in range(2)
-    ]
+    device = dpctl.select_default_device()
+    queues = [dpctl.SyclQueue(device, property="in_order") for _ in range(2)]
     mats = [
         dpnp.eye(_SIZE, dtype="f8", sycl_queue=q) * float(_SIZE) for q in queues
     ]


### PR DESCRIPTION
potrf, getrf, geqrf, gesv, gesvd, heevd, syevd, ungqr and the BLAS dot/gemm family block the calling thread for the whole oneMKL call while holding the GIL. That stalls every other Python thread, including the host tasks dpnp queues to manage object lifetimes, which reacquire the GIL to drop references.

Completes the backport of #2850, which applied the same fix to orgqr.cpp; gesv_batch, gesvd_batch, heevd_batch and syevd_batch already had it.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
