### PR TITLE
Skip einsum test_out_0d for NumPy older than 2.4.5

### DIFF
--- a/dpnp/tests/test_linalg.py
+++ b/dpnp/tests/test_linalg.py
@@ -601,6 +601,7 @@ class TestEinsum:
         expected = numpy.einsum("ii->i", a.asnumpy())
         assert_dtype_allclose(result, expected)
 
+    @testing.with_requires("numpy>=2.4.5")
     def test_out_0d(self):
         a = numpy.ones(7, dtype=int)
         out = numpy.array(0, dtype=a.dtype)


### PR DESCRIPTION
This guards `TestEinsum.test_out_0d` with `@testing.with_requires("numpy>=2.4.5")`.

The test compares `dpnp.einsum` against a reference `numpy.einsum` call that uses a 0-d `out` array with `optimize="optimal"`. That reference behavior only matches on NumPy 2.4.5 and newer, so the test is skipped on older NumPy versions to avoid spurious failures.

The test was introduced in #2987.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
