### PR TITLE
Fix dpnp.insert ignoring out-of-bounds negative indices in multi-element obj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ This release is compatible with NumPy 2.5.
 * Fixed `dpnp.ndarray.view` ignoring the USM element offset of a sliced array, which also caused `dpnp.einsum` to silently return wrong results for a single sliced operand with no summed index [#3037](https://github.com/IntelPython/dpnp/pull/3037)
 * Fixed `dpnp.all` and `dpnp.any` aborting when reducing over an empty axis (e.g. an array with a zero-length dimension) [#3021](https://github.com/IntelPython/dpnp/pull/3021)
 * Released the GIL before the blocking OneMKL DFT calls in the FFT extension [#3040](https://github.com/IntelPython/dpnp/pull/3040)
+* Fixed `dpnp.insert` silently ignoring out-of-bounds negative indices in a multi-element `obj`, so a mix of in-bounds and out-of-bounds indices now consistently raises `IndexError` [#3041](https://github.com/IntelPython/dpnp/pull/3041)
 
 ### Security
 

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -254,6 +254,15 @@ def _insert_array_indices(parameters, indices, values, obj):
         # Can safely cast the empty list to intp
         indices = indices.astype(dpnp.intp)
 
+    if indices.size > 0:
+        min_idx = int(indices.min())
+        max_idx = int(indices.max())
+        if min_idx < -n or max_idx > n:
+            oob = min_idx if min_idx < -n else max_idx
+            raise IndexError(
+                f"index {oob} is out of bounds for axis {axis} with size {n}"
+            )
+
     indices[indices < 0] += n
 
     numnew = len(indices)

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -259,6 +259,10 @@ def _check_index_bounds(obj, indices, n, axis):
         min_idx, max_idx = dpnp.stack([indices.min(), indices.max()]).asnumpy()
     else:
         host_obj = numpy.asarray(obj)
+        if host_obj.dtype == dpnp.bool:
+            # a boolean mask selects positions, which (for an oversized mask)
+            # can fall out of bounds, so validate the flatnonzero result
+            host_obj = numpy.flatnonzero(host_obj)
         min_idx, max_idx = host_obj.min(), host_obj.max()
 
     min_idx, max_idx = int(min_idx), int(max_idx)

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -240,6 +240,35 @@ def _calc_parameters(a, axis, obj, values=None):
     )
 
 
+def _check_index_bounds(obj, indices, n, axis):
+    """
+    Raise ``IndexError`` if any index in `obj` is out of bounds for `axis`.
+
+    Mirrors the size-1 path in ``_insert_singleton_index``: when `obj` lives on
+    the host (a Python sequence/scalar or NumPy array) the bounds are validated
+    with NumPy, avoiding a device sync entirely. A slice cannot be out of bounds
+    (``obj.indices(n)`` is clamped to ``[0, n]``), so it is skipped. Only a
+    device array `obj` needs a single host transfer to read its extremes.
+
+    """
+
+    if isinstance(obj, slice) or indices.size == 0:
+        return
+
+    if dpnp.is_supported_array_type(obj):
+        min_idx, max_idx = dpnp.stack([indices.min(), indices.max()]).asnumpy()
+    else:
+        host_obj = numpy.asarray(obj)
+        min_idx, max_idx = host_obj.min(), host_obj.max()
+
+    min_idx, max_idx = int(min_idx), int(max_idx)
+    if min_idx < -n or max_idx > n:
+        oob = min_idx if min_idx < -n else max_idx
+        raise IndexError(
+            f"index {oob} is out of bounds for axis {axis} with size {n}"
+        )
+
+
 def _insert_array_indices(parameters, indices, values, obj):
     """
     Utility function for ``dpnp.insert`` when indices is an array with
@@ -253,15 +282,6 @@ def _insert_array_indices(parameters, indices, values, obj):
     if indices.size == 0 and not is_array:
         # Can safely cast the empty list to intp
         indices = indices.astype(dpnp.intp)
-
-    if indices.size > 0:
-        min_idx = int(indices.min())
-        max_idx = int(indices.max())
-        if min_idx < -n or max_idx > n:
-            oob = min_idx if min_idx < -n else max_idx
-            raise IndexError(
-                f"index {oob} is out of bounds for axis {axis} with size {n}"
-            )
 
     indices[indices < 0] += n
 
@@ -2531,8 +2551,10 @@ def insert(arr, obj, values, axis=None):
             )
 
     if indices.size == 1:
+        # the size-1 path validates the bounds itself while reading the index
         return _insert_singleton_index(params, indices, values, obj)
 
+    _check_index_bounds(obj, indices, params.n, params.axis)
     return _insert_array_indices(params, indices, values, obj)
 
 

--- a/dpnp/dpnp_iface_manipulation.py
+++ b/dpnp/dpnp_iface_manipulation.py
@@ -2464,6 +2464,13 @@ def insert(arr, obj, values, axis=None):
         does not occur in-place: a new array is returned. If
         `axis` is ``None``, `out` is a flattened array.
 
+    Warnings
+    --------
+    This function might synchronize in order to validate that the indices are
+    within bounds. This may harm performance in some applications. To avoid
+    synchronization, pass `obj` as a Python scalar or sequence, or as a NumPy
+    array.
+
     See Also
     --------
     :obj:`dpnp.append` : Append elements at the end of an array.

--- a/dpnp/tests/test_manipulation.py
+++ b/dpnp/tests/test_manipulation.py
@@ -815,7 +815,7 @@ class TestInsert:
         with pytest.raises(TypeError):
             dpnp.insert(a, [], 2, axis="nonsense")
 
-    @testing.with_requires("numpy>=2.5.3")
+    @testing.with_requires("numpy>=2.6")
     @pytest.mark.parametrize("xp", [numpy, dpnp])
     @pytest.mark.parametrize(
         "idx, values",

--- a/dpnp/tests/test_manipulation.py
+++ b/dpnp/tests/test_manipulation.py
@@ -815,11 +815,18 @@ class TestInsert:
         with pytest.raises(TypeError):
             dpnp.insert(a, [], 2, axis="nonsense")
 
-    @pytest.mark.parametrize("idx", [4, -4])
-    def test_index_out_of_bounds(self, idx):
+    @pytest.mark.parametrize(
+        "idx, values",
+        [
+            ([4], [3, 4]),
+            ([-4], [3, 4]),
+            ([-6, 0], [9, 8]),
+        ],
+    )
+    def test_index_out_of_bounds(self, idx, values):
         a = dpnp.array([0, 1, 2])
         with pytest.raises(IndexError, match="out of bounds"):
-            dpnp.insert(a, [idx], [3, 4])
+            dpnp.insert(a, idx, values)
 
 
 # array_split has more comprehensive test of splitting.

--- a/dpnp/tests/test_manipulation.py
+++ b/dpnp/tests/test_manipulation.py
@@ -842,6 +842,20 @@ class TestInsert:
         with pytest.raises(IndexError, match="out of bounds"):
             xp.insert(a, [5, 0], 9, axis=axis)
 
+    @pytest.mark.parametrize(
+        "obj",
+        [
+            [True, False, False, False, True],
+            numpy.array([True, False, False, False, True]),
+            dpnp.array([True, False, False, False, True]),
+        ],
+        ids=["list", "numpy", "dpnp"],
+    )
+    def test_bool_mask_out_of_bounds(self, obj):
+        a = dpnp.array([0, 1, 2])
+        with pytest.raises(IndexError, match="out of bounds"):
+            dpnp.insert(a, obj, 9)
+
 
 # array_split has more comprehensive test of splitting.
 # only do simple test on hsplit, vsplit, and dsplit

--- a/dpnp/tests/test_manipulation.py
+++ b/dpnp/tests/test_manipulation.py
@@ -815,18 +815,32 @@ class TestInsert:
         with pytest.raises(TypeError):
             dpnp.insert(a, [], 2, axis="nonsense")
 
+    @testing.with_requires("numpy>=2.5.3")
+    @pytest.mark.parametrize("xp", [numpy, dpnp])
     @pytest.mark.parametrize(
         "idx, values",
         [
+            # single-element obj -> singleton path
             ([4], [3, 4]),
             ([-4], [3, 4]),
+            # multi-element obj -> array path
             ([-6, 0], [9, 8]),
+            ([0, 6], [9, 8]),
+            ([4, 4], [3, 4]),
+            ([-4, -5], [3, 4]),
         ],
     )
-    def test_index_out_of_bounds(self, idx, values):
-        a = dpnp.array([0, 1, 2])
+    def test_index_out_of_bounds(self, xp, idx, values):
+        a = xp.array([0, 1, 2])
         with pytest.raises(IndexError, match="out of bounds"):
-            dpnp.insert(a, idx, values)
+            xp.insert(a, idx, values)
+
+    @pytest.mark.parametrize("xp", [numpy, dpnp])
+    @pytest.mark.parametrize("axis", [0, 1])
+    def test_index_out_of_bounds_ndim(self, xp, axis):
+        a = xp.ones((3, 3))
+        with pytest.raises(IndexError, match="out of bounds"):
+            xp.insert(a, [5, 0], 9, axis=axis)
 
 
 # array_split has more comprehensive test of splitting.


### PR DESCRIPTION
`dpnp.insert` has two index paths: the singleton path (`_insert_singleton_index`) already validated bounds, but the multi-element array path (`_insert_array_indices`) normalized negative indices with `indices[indices < 0] += n` without any bounds check. As a result, an out-of-bounds negative index mixed with in-bounds ones — e.g. `dpnp.insert([0, 1, 2], [-6, 0], [9, 8])` — silently produced a wrong result instead of raising.

This PR adds the same bounds validation NumPy introduced: if any index is `< -n` or `> n`, `IndexError` is raised with the standard `index {i} is out of bounds for axis {axis} with size {n}` message. In-bounds and out-of-bounds indices mixed in a single call now consistently raise.


- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
