### PR TITLE
Add ndmax keyword to dpnp.array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This release is compatible with NumPy 2.5.
 * Added `dpnp.tensor.broadcast_shapes` to align with the 2025.12 version of the Python array API [#3009](https://github.com/IntelPython/dpnp/pull/3009)
 * Added support for free-threaded Python builds [gh-3026](https://github.com/IntelPython/dpnp/pull/3026)
 * Added `dpnp.broadcast` class implementation [#2901](https://github.com/IntelPython/dpnp/pull/2901)
+* Added the `ndmax` keyword to `dpnp.array` for compatibility with NumPy [#3044](https://github.com/IntelPython/dpnp/pull/3044)
 
 ### Changed
 

--- a/dpnp/dpnp_iface.py
+++ b/dpnp/dpnp_iface.py
@@ -196,6 +196,7 @@ def as_usm_ndarray(a, dtype=None, device=None, usm_type=None, sycl_queue=None):
 
 def check_limitations(
     subok=False,
+    ndmax=0,
     like=None,
     initial=None,
     where=True,
@@ -207,6 +208,7 @@ def check_limitations(
 
     Parameter `subok` for array creation functions is only supported with
     default value ``False``.
+    Parameter `ndmax` is only supported with default value ``0``.
     Parameter `like` is only supported with default value ``None``.
     Parameter `initial` is only supported with default value ``None``.
     Parameter `where` is only supported with default value ``True``.
@@ -230,6 +232,11 @@ def check_limitations(
         raise NotImplementedError(
             "Keyword argument `subok` is supported only with "
             f"default value ``False``, but got {subok}."
+        )
+    if ndmax != 0:
+        raise NotImplementedError(
+            "Keyword argument `ndmax` is supported only with "
+            f"default value ``0``, but got {ndmax}."
         )
     if initial is not None:
         raise NotImplementedError(

--- a/dpnp/dpnp_iface_arraycreation.py
+++ b/dpnp/dpnp_iface_arraycreation.py
@@ -261,6 +261,7 @@ def array(
     order="K",
     subok=False,
     ndmin=0,
+    ndmax=0,
     like=None,
     device=None,
     usm_type=None,
@@ -329,6 +330,7 @@ def array(
     Limitations
     -----------
     Parameter `subok` is supported only with default value ``False``.
+    Parameter `ndmax` is supported only with default value ``0``.
     Parameter `like` is supported only with default value ``None``.
     Otherwise, the function raises ``NotImplementedError`` exception.
 
@@ -396,7 +398,7 @@ def array(
 
     """
 
-    dpnp.check_limitations(subok=subok, like=like)
+    dpnp.check_limitations(subok=subok, ndmax=ndmax, like=like)
     if not isinstance(ndmin, (int, dpnp.integer)):
         raise TypeError(f"`ndmin` should be an integer, got {type(ndmin)}")
 

--- a/dpnp/tests/test_arraycreation.py
+++ b/dpnp/tests/test_arraycreation.py
@@ -55,6 +55,16 @@ class TestArray:
         assert a.flags.f_contiguous == ia.flags.f_contiguous
         assert_array_equal(ia, a)
 
+    def test_ndmax_default(self):
+        x = [[1, 2, 3], [4, 5, 6]]
+        a = numpy.array(x, ndmax=0)
+        ia = dpnp.array(x, ndmax=0)
+        assert_array_equal(ia, a)
+
+    @pytest.mark.parametrize("ndmax", [1, 2, 3])
+    def test_ndmax_unsupported(self, ndmax):
+        assert_raises(NotImplementedError, dpnp.array, [[1, 2, 3]], ndmax=ndmax)
+
     def test_error(self):
         x = numpy.ones((3, 4))
         assert_raises(TypeError, dpnp.array, x, ndmin=3.0)

--- a/dpnp/tests/test_arraycreation.py
+++ b/dpnp/tests/test_arraycreation.py
@@ -55,9 +55,13 @@ class TestArray:
         assert a.flags.f_contiguous == ia.flags.f_contiguous
         assert_array_equal(ia, a)
 
+    @testing.with_requires("numpy>=2.4")
     def test_ndmax_default(self):
+        # dpnp supports only the default `ndmax=0`, treating it as a no-op;
+        # the NumPy no-op is `ndmax >= ndim` (an explicit `ndmax=0` caps the
+        # result at zero dimensions and raises)
         x = [[1, 2, 3], [4, 5, 6]]
-        a = numpy.array(x, ndmax=0)
+        a = numpy.array(x, ndmax=numpy.ndim(x))
         ia = dpnp.array(x, ndmax=0)
         assert_array_equal(ia, a)
 


### PR DESCRIPTION
NumPy 2.4.0 added a new `ndmax` keyword to `numpy.array`. This PR aligns `dpnp.array` with that signature.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [x] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
