### PR TITLE
Fix `dpnp.ndarray.flat` indexing edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ This release is compatible with NumPy 2.5.
 * Fixed `astype` casting an out-of-range floating point value to a signed narrow integer type saturating to the destination min/max instead of wrapping like NumPy, generalizing the earlier unsigned-only fix [#3033](https://github.com/IntelPython/dpnp/pull/3033)
 * Fixed `dpnp.insert` silently ignoring out-of-bounds negative indices in a multi-element `obj`, so a mix of in-bounds and out-of-bounds indices now consistently raises `IndexError` [#3041](https://github.com/IntelPython/dpnp/pull/3041)
 * Fixed a per-call `sycl::queue` leak in `usm_ndarray::get_queue()`/`get_device()` [#3042](https://github.com/IntelPython/dpnp/pull/3042)
+* Fixed `dpnp.ndarray.flat` indexing edge cases, adding support for slices, ellipsis, and integer/boolean array indices [#3045](https://github.com/IntelPython/dpnp/pull/3045)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,7 @@ This release is compatible with NumPy 2.5.
 * Fixed `dpnp.cumsum`, `dpnp.cumprod`, and their `nan`/`cumulative_*` variants (including `dpnp.tensor.cumulative_sum`/`cumulative_prod`) silently returning incorrect results when accumulating along an axis of an array with more than one row [#3063](https://github.com/IntelPython/dpnp/pull/3063)
 * Fixed `dpnp.einsum` returning a result whose memory layout differs from NumPy for the default `order="K"`, and ignoring `out` and `order` for a contraction over a size-0 dimension [#3058](https://github.com/IntelPython/dpnp/pull/3058)
 * Fixed operations on a boolean array whose bytes are not `0x00`/`0x01` [#3055](https://github.com/IntelPython/dpnp/pull/3055)
-* Fixed `dpnp.ndarray.flat` indexing edge cases, adding support for slices, ellipsis, and integer/boolean array indices [#3045](https://github.com/IntelPython/dpnp/pull/3045)
+* Fixed `dpnp.ndarray.flat` indexing and assignment edge cases, adding support for slices, ellipsis, and integer/boolean array indices [#3045](https://github.com/IntelPython/dpnp/pull/3045)
 
 ### Security
 

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -1337,6 +1337,8 @@ class dpnp_array:
         This is a :obj:`dpnp.flatiter` instance, which acts similarly to, but
         is not a subclass of, Python's built-in iterator object.
 
+        For full documentation refer to :obj:`numpy.ndarray.flat`.
+
         See Also
         --------
         :obj:`dpnp.flatiter` : Flat iterator object to iterate over arrays.

--- a/dpnp/dpnp_array.py
+++ b/dpnp/dpnp_array.py
@@ -1332,9 +1332,35 @@ class dpnp_array:
     @property
     def flat(self):
         """
-        Return a flat iterator, or set a flattened version of self to value.
+        A 1-D iterator over the array.
 
-        """  # noqa: D200
+        This is a :obj:`dpnp.flatiter` instance, which acts similarly to, but
+        is not a subclass of, Python's built-in iterator object.
+
+        See Also
+        --------
+        :obj:`dpnp.flatiter` : Flat iterator object to iterate over arrays.
+        :obj:`dpnp.ndarray.flatten` : Return a flattened copy of the array.
+
+        Examples
+        --------
+        >>> import dpnp as np
+        >>> x = np.arange(1, 7).reshape(2, 3)
+        >>> x
+        array([[1, 2, 3],
+               [4, 5, 6]])
+        >>> x.flat[3]
+        array(4)
+        >>> x.T.flat[3]
+        array(5)
+
+        An assignment example:
+
+        >>> x.flat[[1, 4]] = 1; x
+        array([[1, 1, 3],
+               [4, 1, 6]])
+
+        """
 
         return dpnp.flatiter(self)
 
@@ -1367,7 +1393,7 @@ class dpnp_array:
         See Also
         --------
         :obj:`dpnp.ravel` : Return a flattened array.
-        :obj:`dpnp.flat` : A 1-D flat iterator over the array.
+        :obj:`dpnp.ndarray.flat` : A 1-D flat iterator over the array.
 
         Examples
         --------

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -182,9 +182,12 @@ class flatiter:
             idx = flat_index[key]
 
         if not dpnp.isscalar(val):
-            val = dpnp.asarray(
-                val, sycl_queue=exec_q, usm_type=usm_type
-            ).ravel()
+            val = dpnp.asarray(val, sycl_queue=exec_q, usm_type=usm_type)
+            if idx.ndim == 0 and val.ndim != 0:
+                # a scalar index targets a single item, reject an array value
+                raise ValueError("Error setting single item of array.")
+
+            val = val.ravel()
             n = idx.size
             if 0 < val.size != n:
                 # cycles the values over the selection

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -78,6 +78,14 @@ class flatiter:
         self._i = 0
 
     @staticmethod
+    def _unwrap_tuple(key):
+        # a flat iterator is 1-D, so a single-element index tuple is equivalent
+        # to its element (e.g. `flat[(idx,)]` behaves like `flat[idx]`)
+        if isinstance(key, tuple) and len(key) == 1:
+            return key[0]
+        return key
+
+    @staticmethod
     def _reject_newaxis(key):
         # newaxis (None) is valid for array indexing but not for flat indexing
         if key is None or (
@@ -119,6 +127,7 @@ class flatiter:
         return dpnp.reshape(self._arr, -1)
 
     def __getitem__(self, key):
+        key = self._unwrap_tuple(key)
         self._reject_newaxis(key)
         self._check_bounds(key)
 
@@ -126,6 +135,7 @@ class flatiter:
         return self._flatten()[key].copy()
 
     def __setitem__(self, key, val):
+        key = self._unwrap_tuple(key)
         self._reject_newaxis(key)
         self._check_bounds(key)
 

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -82,24 +82,6 @@ class flatiter:
         self._size = a.size
         self._i = 0
 
-    @staticmethod
-    def _unwrap_tuple(key):
-        # a flat iterator is 1-D, so a single-element index tuple is equivalent
-        # to its element (e.g. `flat[(idx,)]` behaves like `flat[idx]`)
-        if isinstance(key, tuple) and len(key) == 1:
-            return key[0]
-        return key
-
-    @staticmethod
-    def _reject_invalid_key(key):
-        # newaxis (None) and multi-element tuples (a flat iterator is 1-D and
-        # takes a single index) are not valid, unlike regular array indexing
-        if key is None or (isinstance(key, tuple) and len(key) > 1):
-            raise IndexError(
-                "only integers, slices (`:`), ellipsis (`...`) and integer "
-                "or boolean arrays are valid indices"
-            )
-
     def _check_bounds(self, key):
         # fancy int indices wrap instead of raising, so check them vs NumPy
         if key is Ellipsis or isinstance(key, (slice, bool, tuple)):
@@ -131,22 +113,26 @@ class flatiter:
         if lo < -size:
             raise IndexError(f"index {lo} is out of bounds for size {size}")
 
-    def _flatten(self):
-        # C-order flat view (copy if non-contiguous)
-        return dpnp.reshape(self._arr, -1)
+    def _normalize_key(self, key):
+        # 1-D iterator: unwrap a 1-elem tuple; reject None and longer tuples
+        if isinstance(key, tuple) and len(key) == 1:
+            key = key[0]
+        if key is None or (isinstance(key, tuple) and len(key) > 1):
+            raise IndexError(
+                "only integers, slices (`:`), ellipsis (`...`) and integer "
+                "or boolean arrays are valid indices"
+            )
+        self._check_bounds(key)
+        return key
 
     def __getitem__(self, key):
-        key = self._unwrap_tuple(key)
-        self._reject_invalid_key(key)
-        self._check_bounds(key)
+        key = self._normalize_key(key)
 
         # flat always yields a copy, never a view
-        return self._flatten()[key].copy()
+        return dpnp.reshape(self._arr, -1)[key].copy()
 
     def __setitem__(self, key, val):
-        key = self._unwrap_tuple(key)
-        self._reject_invalid_key(key)
-        self._check_bounds(key)
+        key = self._normalize_key(key)
 
         if isinstance(key, tuple) and len(key) == 0:
             # NumPy rejects arr.flat[()] = val

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -34,57 +34,89 @@ import dpnp
 class flatiter:
     """Flat iterator object to iterate over arrays."""
 
-    def __init__(self, X):
-        if type(X) is not dpnp.ndarray:
+    def __init__(self, a):
+        if type(a) is not dpnp.ndarray:
             raise TypeError(
-                "Argument must be of type dpnp.ndarray, got {}".format(type(X))
+                "Argument must be of type dpnp.ndarray, got {}".format(type(a))
             )
-        self.arr_ = X
-        self.size_ = X.size
-        self.i_ = 0
+        self._arr = a
+        self._size = a.size
+        self._i = 0
 
-    def _multiindex(self, i):
-        nd = self.arr_.ndim
-        if nd == 0:
-            if i == 0:
-                return ()
-            raise KeyError
-        elif nd == 1:
-            return (i,)
-        sh = self.arr_.shape
-        i_ = i
-        multi_index = [0] * nd
-        for k in reversed(range(1, nd)):
-            si = sh[k]
-            q = i_ // si
-            multi_index[k] = i_ - q * si
-            i_ = q
-        multi_index[0] = i_
-        return tuple(multi_index)
+    @staticmethod
+    def _reject_newaxis(key):
+        # newaxis (None) is valid for array indexing but not for flat indexing
+        if key is None or (
+            isinstance(key, tuple) and any(k is None for k in key)
+        ):
+            raise IndexError(
+                "only integers, slices (`:`), ellipsis (`...`) and integer "
+                "or boolean arrays are valid indices"
+            )
+
+    def _check_bounds(self, key):
+        # fancy int indices wrap instead of raising, so check them vs NumPy
+        if key is Ellipsis or isinstance(key, (slice, bool, tuple)):
+            return
+
+        if isinstance(key, int) or (
+            callable(getattr(key, "__index__", None))
+            and not hasattr(key, "ndim")
+        ):
+            return  # scalar int: regular indexing checks it
+
+        try:
+            idx = dpnp.asarray(key, sycl_queue=self._arr.sycl_queue)
+        except Exception:
+            return  # let regular indexing raise
+
+        if idx.dtype.kind not in "iu" or idx.size == 0:
+            return
+
+        size = self._size
+        hi, lo = int(dpnp.max(idx)), int(dpnp.min(idx))
+        if hi >= size:
+            raise IndexError(f"index {hi} is out of bounds for size {size}")
+        if lo < -size:
+            raise IndexError(f"index {lo} is out of bounds for size {size}")
+
+    def _flatten(self):
+        # C-order flat view (copy if non-contiguous)
+        return dpnp.reshape(self._arr, -1)
 
     def __getitem__(self, key):
-        idx = getattr(key, "__index__", None)
-        if not callable(idx):
-            raise TypeError(key)
-        i = idx()
-        mi = self._multiindex(i)
-        return self.arr_.__getitem__(mi)
+        self._reject_newaxis(key)
+        self._check_bounds(key)
+
+        # flat always yields a copy, never a view
+        return self._flatten()[key].copy()
 
     def __setitem__(self, key, val):
-        idx = getattr(key, "__index__", None)
-        if not callable(idx):
-            raise TypeError(key)
-        i = idx()
-        mi = self._multiindex(i)
-        return self.arr_.__setitem__(mi, val)
+        self._reject_newaxis(key)
+        self._check_bounds(key)
+
+        if isinstance(key, tuple) and len(key) == 0:
+            # NumPy rejects arr.flat[()] = val
+            raise IndexError(
+                "Assigning to a flat iterator with a 0-D index is not "
+                "supported"
+            )
+
+        # resolve key to flat positions, reusing regular indexing to validate
+        arr = self._arr
+        flat_index = dpnp.arange(
+            arr.size, sycl_queue=arr.sycl_queue, usm_type=arr.usm_type
+        )
+        positions = dpnp.reshape(flat_index[key], -1)
+        dpnp.put(arr, positions, val)
 
     def __iter__(self):
         return self
 
     def __next__(self):
-        if self.i_ < self.size_:
-            val = self.__getitem__(self.i_)
-            self.i_ = self.i_ + 1
+        if self._i < self._size:
+            val = self.__getitem__(self._i)
+            self._i = self._i + 1
             return val
         else:
             raise StopIteration

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -35,9 +35,9 @@ class flatiter:
     """Flat iterator object to iterate over arrays."""
 
     def __init__(self, a):
-        if type(a) is not dpnp.ndarray:
+        if not isinstance(a, dpnp.ndarray):
             raise TypeError(
-                "Argument must be of type dpnp.ndarray, got {}".format(type(a))
+                f"An array must be of type dpnp.ndarray, but got {type(a)}"
             )
         self._arr = a
         self._size = a.size

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -28,7 +28,12 @@
 
 """Implementation of flatiter."""
 
+import numpy
+
 import dpnp
+import dpnp.tensor as dpt
+
+from .dpnp_array import dpnp_array
 
 
 class flatiter:
@@ -107,16 +112,21 @@ class flatiter:
         ):
             return  # scalar int: regular indexing checks it
 
-        try:
-            idx = dpnp.asarray(key, sycl_queue=self._arr.sycl_queue)
-        except Exception:
-            return  # let regular indexing raise
+        if isinstance(key, dpnp_array):
+            idx = key
+        elif isinstance(key, dpt.usm_ndarray):
+            idx = dpnp_array._create_from_usm_ndarray(key)
+        else:
+            try:
+                idx = numpy.asarray(key)
+            except Exception:
+                return  # let regular indexing raise
 
-        if idx.dtype.kind not in "iu" or idx.size == 0:
+        if not dpnp.issubdtype(idx.dtype, dpnp.integer) or idx.size == 0:
             return
 
         size = self._size
-        hi, lo = int(dpnp.max(idx)), int(dpnp.min(idx))
+        hi, lo = int(idx.max()), int(idx.min())
         if hi >= size:
             raise IndexError(f"index {hi} is out of bounds for size {size}")
         if lo < -size:

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -91,11 +91,10 @@ class flatiter:
         return key
 
     @staticmethod
-    def _reject_newaxis(key):
-        # newaxis (None) is valid for array indexing but not for flat indexing
-        if key is None or (
-            isinstance(key, tuple) and any(k is None for k in key)
-        ):
+    def _reject_invalid_key(key):
+        # newaxis (None) and multi-element tuples (a flat iterator is 1-D and
+        # takes a single index) are not valid, unlike regular array indexing
+        if key is None or (isinstance(key, tuple) and len(key) > 1):
             raise IndexError(
                 "only integers, slices (`:`), ellipsis (`...`) and integer "
                 "or boolean arrays are valid indices"
@@ -138,7 +137,7 @@ class flatiter:
 
     def __getitem__(self, key):
         key = self._unwrap_tuple(key)
-        self._reject_newaxis(key)
+        self._reject_invalid_key(key)
         self._check_bounds(key)
 
         # flat always yields a copy, never a view
@@ -146,7 +145,7 @@ class flatiter:
 
     def __setitem__(self, key, val):
         key = self._unwrap_tuple(key)
-        self._reject_newaxis(key)
+        self._reject_invalid_key(key)
         self._check_bounds(key)
 
         if isinstance(key, tuple) and len(key) == 0:

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -32,7 +32,41 @@ import dpnp
 
 
 class flatiter:
-    """Flat iterator object to iterate over arrays."""
+    """
+    Flat iterator object to iterate over arrays.
+
+    A flat iterator is returned by :obj:`dpnp.ndarray.flat` for any array. It
+    allows iterating over the array as if it were a 1-D array, either in a
+    for-loop or by calling its ``next`` method.
+
+    Iteration is done in row-major, C-style order (the last index varying the
+    fastest). The iterator can also be indexed using basic slicing or advanced
+    indexing.
+
+    For full documentation refer to :obj:`numpy.flatiter`.
+
+    See Also
+    --------
+    :obj:`dpnp.ndarray.flat` : Return a flat iterator over an array.
+    :obj:`dpnp.ndarray.flatten` : Return a flattened copy of an array.
+
+    Examples
+    --------
+    >>> import dpnp as np
+    >>> x = np.arange(6).reshape(2, 3)
+    >>> for item in x.flat:
+    ...     print(item)
+    0
+    1
+    2
+    3
+    4
+    5
+
+    >>> x.flat[2:4]
+    array([2, 3])
+
+    """
 
     def __init__(self, a):
         if not isinstance(a, dpnp.ndarray):

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -118,7 +118,7 @@ class flatiter:
         else:
             try:
                 idx = numpy.asarray(key)
-            except Exception:
+            except (TypeError, ValueError):
                 return  # let regular indexing raise
 
         if not dpnp.issubdtype(idx.dtype, dpnp.integer) or idx.size == 0:

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -141,8 +141,25 @@ class flatiter:
         usm_type = a.usm_type
 
         # resolve key to flat positions, reusing regular indexing to validate
-        flat_index = dpnp.arange(a.size, sycl_queue=exec_q, usm_type=usm_type)
-        idx = flat_index[key]
+        if isinstance(key, int) and not isinstance(key, bool):
+            # fast path for a scalar index: avoid building a full index array
+            pos = key + a.size if key < 0 else key
+            if not 0 <= pos < a.size:
+                raise IndexError(
+                    f"index {key} is out of bounds for size {a.size}"
+                )
+            idx = dpnp.asarray(pos, sycl_queue=exec_q, usm_type=usm_type)
+        elif isinstance(key, slice):
+            # slice fast path: build only the selected positions
+            start, stop, step = key.indices(a.size)
+            idx = dpnp.arange(
+                start, stop, step, sycl_queue=exec_q, usm_type=usm_type
+            )
+        else:
+            flat_index = dpnp.arange(
+                a.size, sycl_queue=exec_q, usm_type=usm_type
+            )
+            idx = flat_index[key]
 
         if not dpnp.isscalar(val):
             val = dpnp.asarray(

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -82,16 +82,20 @@ class flatiter:
         self._size = a.size
         self._i = 0
 
-    def _check_bounds(self, key):
-        # fancy int indices wrap instead of raising, so check them vs NumPy
-        if key is Ellipsis or isinstance(key, (slice, bool, tuple)):
+    def _validate_key(self, key):
+        # Ellipsis/slice/tuple need no validation here
+        if key is Ellipsis or isinstance(key, (slice, tuple)):
             return
 
-        if isinstance(key, int) or (
-            callable(getattr(key, "__index__", None))
-            and not hasattr(key, "ndim")
+        # a genuine scalar int (not bool): regular indexing checks it
+        if not isinstance(key, bool) and (
+            isinstance(key, int)
+            or (
+                callable(getattr(key, "__index__", None))
+                and not hasattr(key, "ndim")
+            )
         ):
-            return  # scalar int: regular indexing checks it
+            return
 
         if isinstance(key, dpnp_array):
             idx = key
@@ -103,9 +107,16 @@ class flatiter:
             except (TypeError, ValueError):
                 return  # let regular indexing raise
 
+        if dpnp.issubdtype(idx.dtype, dpnp.bool):
+            # only a boolean ndarray mask is valid; reject bool scalars/lists
+            if idx.ndim > 0 and not isinstance(key, (bool, list, tuple)):
+                return
+            raise IndexError("boolean indices for iterators are not supported")
+
         if not dpnp.issubdtype(idx.dtype, dpnp.integer) or idx.size == 0:
             return
 
+        # fancy int indices wrap instead of raising, so bounds-check
         size = self._size
         hi, lo = int(idx.max()), int(idx.min())
         if hi >= size:
@@ -122,7 +133,7 @@ class flatiter:
                 "only integers, slices (`:`), ellipsis (`...`) and integer "
                 "or boolean arrays are valid indices"
             )
-        self._check_bounds(key)
+        self._validate_key(key)
         return key
 
     def __getitem__(self, key):
@@ -145,7 +156,7 @@ class flatiter:
         exec_q = a.sycl_queue
         usm_type = a.usm_type
 
-        # resolve key to flat positions, reusing regular indexing to validate
+        # resolve key to flat positions
         if isinstance(key, int) and not isinstance(key, bool):
             # fast path for a scalar index: avoid building a full index array
             pos = key + a.size if key < 0 else key

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -102,13 +102,27 @@ class flatiter:
                 "supported"
             )
 
+        a = self._arr
+        exec_q = a.sycl_queue
+        usm_type = a.usm_type
+
         # resolve key to flat positions, reusing regular indexing to validate
-        arr = self._arr
-        flat_index = dpnp.arange(
-            arr.size, sycl_queue=arr.sycl_queue, usm_type=arr.usm_type
-        )
-        positions = dpnp.reshape(flat_index[key], -1)
-        dpnp.put(arr, positions, val)
+        flat_index = dpnp.arange(a.size, sycl_queue=exec_q, usm_type=usm_type)
+        idx = flat_index[key]
+
+        if not dpnp.isscalar(val):
+            val = dpnp.asarray(
+                val, sycl_queue=exec_q, usm_type=usm_type
+            ).ravel()
+            n = idx.size
+            if 0 < val.size != n:
+                # cycles the values over the selection
+                val = val[
+                    dpnp.arange(n, sycl_queue=exec_q, usm_type=usm_type)
+                    % val.size
+                ]
+
+        dpnp.put(a, idx, val)
 
     def __iter__(self):
         return self

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -74,7 +74,7 @@ class flatiter:
     """
 
     def __init__(self, a):
-        if not isinstance(a, dpnp.ndarray):
+        if not isinstance(a, dpnp_array):
             raise TypeError(
                 f"An array must be of type dpnp.ndarray, but got {type(a)}"
             )

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -106,8 +106,14 @@ class flatiter:
                 return  # let regular indexing raise
 
         if dpnp.issubdtype(idx.dtype, dpnp.bool):
-            # only a boolean ndarray mask is valid; reject bool scalars/lists
-            if idx.ndim > 0 and not isinstance(key, list):
+            if idx.ndim > 1:
+                raise IndexError(
+                    "too many indices for flat iterator: flat iterator is "
+                    f"1-dimensional, but {idx.ndim} were indexed"
+                )
+
+            # only a 1-D boolean ndarray mask is valid; reject scalars/lists
+            if idx.ndim == 1 and not isinstance(key, list):
                 # an empty mask selects nothing; otherwise sizes must match
                 if idx.size not in (0, self._size):
                     raise IndexError(

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -83,9 +83,16 @@ class flatiter:
         self._i = 0
 
     def _validate_key(self, key):
+        """
+        Validate `key` as a flat iterator index.
+
+        Return the array of flat positions for an integer-array key, or
+        ``None`` when the caller has to resolve the positions itself.
+
+        """
         # Ellipsis/slice/tuple need no validation here
         if key is Ellipsis or isinstance(key, (slice, tuple)):
-            return
+            return None
 
         # a genuine scalar int (not bool, not an array): bounds-checked later
         if (
@@ -93,7 +100,7 @@ class flatiter:
             and callable(getattr(key, "__index__", None))
             and not hasattr(key, "ndim")
         ):
-            return
+            return None
 
         if isinstance(key, dpnp_array):
             idx = key
@@ -103,7 +110,7 @@ class flatiter:
             try:
                 idx = numpy.asarray(key)
             except (TypeError, ValueError):
-                return  # let regular indexing raise
+                return None  # let regular indexing raise
 
         if dpnp.issubdtype(idx.dtype, dpnp.bool):
             if idx.ndim > 1:
@@ -121,11 +128,11 @@ class flatiter:
                         f"axis 0; size of axis is {self._size} but size of "
                         f"corresponding boolean axis is {idx.size}"
                     )
-                return
+                return None
             raise IndexError("boolean indices for iterators are not supported")
 
         if not dpnp.issubdtype(idx.dtype, dpnp.integer) or idx.size == 0:
-            return
+            return None
 
         # fancy int indices wrap instead of raising, so bounds-check
         size = self._size
@@ -134,9 +141,11 @@ class flatiter:
             raise IndexError(f"index {hi} is out of bounds for size {size}")
         if lo < -size:
             raise IndexError(f"index {lo} is out of bounds for size {size}")
+        return idx
 
-    def _normalize_key(self, key):
-        # 1-D iterator: unwrap a 1-elem tuple; reject None and longer tuples
+    def _prepare_key(self, key):
+        # normalize a 1-D iterator index (unwrap a 1-elem tuple; reject None
+        # and longer tuples) and return it with the validated positions or None
         if isinstance(key, tuple) and len(key) == 1:
             key = key[0]
         if key is None or (isinstance(key, tuple) and len(key) > 1):
@@ -144,8 +153,7 @@ class flatiter:
                 "only integers, slices (`:`), ellipsis (`...`) and integer "
                 "or boolean arrays are valid indices"
             )
-        self._validate_key(key)
-        return key
+        return key, self._validate_key(key)
 
     def _scalar_pos(self, key):
         # normalize a scalar flat index (wrap negatives) and bounds-check it
@@ -167,11 +175,11 @@ class flatiter:
         )
 
     def __getitem__(self, key):
-        key = self._normalize_key(key)
+        key, _ = self._prepare_key(key)
 
         if isinstance(key, int):
             # scalar fast path: index directly instead of flattening the array
-            # (a bool key was already rejected in _normalize_key)
+            # (a bool key was already rejected in _prepare_key)
             pos = self._scalar_pos(key)
             return self._arr[numpy.unravel_index(pos, self._arr.shape)].copy()
 
@@ -184,7 +192,7 @@ class flatiter:
         return res
 
     def __setitem__(self, key, val):
-        key = self._normalize_key(key)
+        key, idx = self._prepare_key(key)
 
         if isinstance(key, tuple) and len(key) == 0:
             # NumPy rejects arr.flat[()] = val
@@ -197,10 +205,11 @@ class flatiter:
         exec_q = a.sycl_queue
         usm_type = a.usm_type
 
-        # resolve key to flat positions
+        # resolve key to flat positions; an integer-array key is already
+        # validated (idx), and dpnp.put resolves its negative positions
         if isinstance(key, int):
             # scalar fast path: avoid building a full index array
-            # (a bool key was already rejected in _normalize_key)
+            # (a bool key was already rejected in _prepare_key)
             pos = self._scalar_pos(key)
             idx = dpnp.asarray(pos, sycl_queue=exec_q, usm_type=usm_type)
         elif isinstance(key, slice):
@@ -213,7 +222,9 @@ class flatiter:
             # boolean mask fast path
             mask = self._as_dpnp_array(key)
             idx = dpnp.nonzero(mask)[0]
-        else:
+        elif idx is None:
+            # ellipsis, empty tuple or an unrecognized key: let regular
+            # indexing resolve the positions and raise on an invalid key
             flat_index = dpnp.arange(
                 a.size, sycl_queue=exec_q, usm_type=usm_type
             )

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -142,16 +142,21 @@ class flatiter:
         self._validate_key(key)
         return key
 
+    def _scalar_pos(self, key):
+        # normalize a scalar flat index (wrap negatives) and bounds-check it
+        pos = key + self._size if key < 0 else key
+        if not 0 <= pos < self._size:
+            raise IndexError(
+                f"index {key} is out of bounds for size {self._size}"
+            )
+        return pos
+
     def __getitem__(self, key):
         key = self._normalize_key(key)
 
         if isinstance(key, int) and not isinstance(key, bool):
             # scalar fast path: index directly instead of flattening the array
-            pos = key + self._size if key < 0 else key
-            if not 0 <= pos < self._size:
-                raise IndexError(
-                    f"index {key} is out of bounds for size {self._size}"
-                )
+            pos = self._scalar_pos(key)
             return self._arr[numpy.unravel_index(pos, self._arr.shape)].copy()
 
         # flat always yields a copy, never a view
@@ -173,12 +178,8 @@ class flatiter:
 
         # resolve key to flat positions
         if isinstance(key, int) and not isinstance(key, bool):
-            # fast path for a scalar index: avoid building a full index array
-            pos = key + a.size if key < 0 else key
-            if not 0 <= pos < a.size:
-                raise IndexError(
-                    f"index {key} is out of bounds for size {a.size}"
-                )
+            # scalar fast path: avoid building a full index array
+            pos = self._scalar_pos(key)
             idx = dpnp.asarray(pos, sycl_queue=exec_q, usm_type=usm_type)
         elif isinstance(key, slice):
             # slice fast path: build only the selected positions
@@ -187,9 +188,9 @@ class flatiter:
                 start, stop, step, sycl_queue=exec_q, usm_type=usm_type
             )
         elif hasattr(key, "dtype") and dpnp.issubdtype(key.dtype, dpnp.bool):
-            # use a fast path for boolean mask
-            pos = dpnp.asarray(key, sycl_queue=exec_q, usm_type=usm_type)
-            idx = dpnp.nonzero(pos)[0]
+            # boolean mask fast path
+            mask = dpnp.asarray(key, sycl_queue=exec_q, usm_type=usm_type)
+            idx = dpnp.nonzero(mask)[0]
         else:
             flat_index = dpnp.arange(
                 a.size, sycl_queue=exec_q, usm_type=usm_type
@@ -204,7 +205,7 @@ class flatiter:
 
             val = val.ravel()
             n = idx.size
-            if 0 < val.size != n:
+            if val.size and val.size != n:
                 # cycles the values over the selection
                 val = val[
                     dpnp.arange(n, sycl_queue=exec_q, usm_type=usm_type)

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -87,8 +87,7 @@ class flatiter:
         if key is Ellipsis or isinstance(key, (slice, tuple)):
             return
 
-        # a genuine scalar int (not bool, not an array): regular indexing
-        # checks it
+        # a genuine scalar int (not bool, not an array): bounds-checked later
         if (
             not isinstance(key, bool)
             and callable(getattr(key, "__index__", None))

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -164,8 +164,12 @@ class flatiter:
             pos = self._scalar_pos(key)
             return self._arr[numpy.unravel_index(pos, self._arr.shape)].copy()
 
-        # flat always yields a copy, never a view
-        return dpnp.reshape(self._arr, -1)[key].copy()
+        res = dpnp.reshape(self._arr, -1)[key]
+        # copy only a basic-index view, when shares the source allocation
+        # pylint: disable=protected-access
+        if res.get_array()._pointer == self._arr.get_array()._pointer:
+            res = res.copy()
+        return res
 
     def __setitem__(self, key, val):
         key = self._normalize_key(key)

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -165,9 +165,13 @@ class flatiter:
             return self._arr[numpy.unravel_index(pos, self._arr.shape)].copy()
 
         res = dpnp.reshape(self._arr, -1)[key]
-        # copy only a basic-index view, when shares the source allocation
+        # advanced indexing is already fresh; copy only a basic-index view,
+        # i.e. when res shares the source allocation. Compare the allocation
+        # base `usm_data._pointer` (offset-independent), not the array-level
+        # `_pointer` which is adjusted to the first element.
         # pylint: disable=protected-access
-        if res.get_array()._pointer == self._arr.get_array()._pointer:
+        src = self._arr.get_array().usm_data._pointer
+        if res.get_array().usm_data._pointer == src:
             res = res.copy()
         return res
 

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -214,7 +214,7 @@ class flatiter:
             idx = dpnp.asarray(pos, sycl_queue=exec_q, usm_type=usm_type)
         elif isinstance(key, slice):
             # slice fast path: build only the selected positions
-            start, stop, step = key.indices(a.size)
+            start, stop, step = key.indices(self._size)
             idx = dpnp.arange(
                 start, stop, step, sycl_queue=exec_q, usm_type=usm_type
             )
@@ -226,7 +226,7 @@ class flatiter:
             # ellipsis, empty tuple or an unrecognized key: let regular
             # indexing resolve the positions and raise on an invalid key
             flat_index = dpnp.arange(
-                a.size, sycl_queue=exec_q, usm_type=usm_type
+                self._size, sycl_queue=exec_q, usm_type=usm_type
             )
             idx = flat_index[key]
 

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -109,7 +109,8 @@ class flatiter:
         if dpnp.issubdtype(idx.dtype, dpnp.bool):
             # only a boolean ndarray mask is valid; reject bool scalars/lists
             if idx.ndim > 0 and not isinstance(key, list):
-                if idx.size != self._size:
+                # an empty mask selects nothing; otherwise sizes must match
+                if idx.size not in (0, self._size):
                     raise IndexError(
                         "boolean index did not match indexed array along "
                         f"axis 0; size of axis is {self._size} but size of "

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -156,12 +156,12 @@ class flatiter:
             )
         return pos
 
-    def _asarray_cfd(self, x):
-        # compute-follows-data: keep a device array on its own queue so a
-        # downstream op raises on a queue mismatch, and only place a host
-        # input on the iterator's queue
-        if dpnp.is_supported_array_type(x):
-            return dpnp.asarray(x)
+    def _as_dpnp_array(self, x):
+        # coerce to a dpnp array without overriding a device array's queue
+        if isinstance(x, dpnp_array):
+            return x
+        if isinstance(x, dpt.usm_ndarray):
+            return dpnp_array._create_from_usm_ndarray(x)
         return dpnp.asarray(
             x, sycl_queue=self._arr.sycl_queue, usm_type=self._arr.usm_type
         )
@@ -209,7 +209,7 @@ class flatiter:
             )
         elif hasattr(key, "dtype") and dpnp.issubdtype(key.dtype, dpnp.bool):
             # boolean mask fast path
-            mask = self._asarray_cfd(key)
+            mask = self._as_dpnp_array(key)
             idx = dpnp.nonzero(mask)[0]
         else:
             flat_index = dpnp.arange(
@@ -218,7 +218,7 @@ class flatiter:
             idx = flat_index[key]
 
         if not dpnp.isscalar(val):
-            val = self._asarray_cfd(val)
+            val = self._as_dpnp_array(val)
             if idx.ndim == 0 and val.ndim != 0:
                 # a scalar index targets a single item, reject an array value
                 raise ValueError("Error setting single item of array.")

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -124,9 +124,9 @@ class flatiter:
                 # an empty mask selects nothing; otherwise sizes must match
                 if idx.size not in (0, self._size):
                     raise IndexError(
-                        "boolean index did not match indexed array along "
-                        f"axis 0; size of axis is {self._size} but size of "
-                        f"corresponding boolean axis is {idx.size}"
+                        "boolean index did not match indexed flat iterator "
+                        f"along axis 0; size of axis is {self._size} but size "
+                        f"of corresponding boolean axis is {idx.size}"
                     )
                 return None
             raise IndexError("boolean indices for iterators are not supported")

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -175,10 +175,7 @@ class flatiter:
             return self._arr[numpy.unravel_index(pos, self._arr.shape)].copy()
 
         res = dpnp.reshape(self._arr, -1)[key]
-        # advanced indexing is already fresh; copy only a basic-index view,
-        # i.e. when res shares the source allocation. Compare the allocation
-        # base `usm_data._pointer` (offset-independent), not the array-level
-        # `_pointer` which is adjusted to the first element.
+        # basic indexing may alias the source, copy if shares the source buffer
         # pylint: disable=protected-access
         src = self._arr.get_array().usm_data._pointer
         if res.get_array().usm_data._pointer == src:

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -156,6 +156,16 @@ class flatiter:
             )
         return pos
 
+    def _asarray_cfd(self, x):
+        # compute-follows-data: keep a device array on its own queue so a
+        # downstream op raises on a queue mismatch, and only place a host
+        # input on the iterator's queue
+        if dpnp.is_supported_array_type(x):
+            return dpnp.asarray(x)
+        return dpnp.asarray(
+            x, sycl_queue=self._arr.sycl_queue, usm_type=self._arr.usm_type
+        )
+
     def __getitem__(self, key):
         key = self._normalize_key(key)
 
@@ -202,7 +212,7 @@ class flatiter:
             )
         elif hasattr(key, "dtype") and dpnp.issubdtype(key.dtype, dpnp.bool):
             # boolean mask fast path
-            mask = dpnp.asarray(key, sycl_queue=exec_q, usm_type=usm_type)
+            mask = self._asarray_cfd(key)
             idx = dpnp.nonzero(mask)[0]
         else:
             flat_index = dpnp.arange(
@@ -211,7 +221,7 @@ class flatiter:
             idx = flat_index[key]
 
         if not dpnp.isscalar(val):
-            val = dpnp.asarray(val, sycl_queue=exec_q, usm_type=usm_type)
+            val = self._asarray_cfd(val)
             if idx.ndim == 0 and val.ndim != 0:
                 # a scalar index targets a single item, reject an array value
                 raise ValueError("Error setting single item of array.")

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -87,13 +87,12 @@ class flatiter:
         if key is Ellipsis or isinstance(key, (slice, tuple)):
             return
 
-        # a genuine scalar int (not bool): regular indexing checks it
-        if not isinstance(key, bool) and (
-            isinstance(key, int)
-            or (
-                callable(getattr(key, "__index__", None))
-                and not hasattr(key, "ndim")
-            )
+        # a genuine scalar int (not bool, not an array): regular indexing
+        # checks it
+        if (
+            not isinstance(key, bool)
+            and callable(getattr(key, "__index__", None))
+            and not hasattr(key, "ndim")
         ):
             return
 
@@ -109,7 +108,13 @@ class flatiter:
 
         if dpnp.issubdtype(idx.dtype, dpnp.bool):
             # only a boolean ndarray mask is valid; reject bool scalars/lists
-            if idx.ndim > 0 and not isinstance(key, (bool, list, tuple)):
+            if idx.ndim > 0 and not isinstance(key, list):
+                if idx.size != self._size:
+                    raise IndexError(
+                        "boolean index did not match indexed array along "
+                        f"axis 0; size of axis is {self._size} but size of "
+                        f"corresponding boolean axis is {idx.size}"
+                    )
                 return
             raise IndexError("boolean indices for iterators are not supported")
 
@@ -138,6 +143,15 @@ class flatiter:
 
     def __getitem__(self, key):
         key = self._normalize_key(key)
+
+        if isinstance(key, int) and not isinstance(key, bool):
+            # scalar fast path: index directly instead of flattening the array
+            pos = key + self._size if key < 0 else key
+            if not 0 <= pos < self._size:
+                raise IndexError(
+                    f"index {key} is out of bounds for size {self._size}"
+                )
+            return self._arr[numpy.unravel_index(pos, self._arr.shape)].copy()
 
         # flat always yields a copy, never a view
         return dpnp.reshape(self._arr, -1)[key].copy()
@@ -171,6 +185,10 @@ class flatiter:
             idx = dpnp.arange(
                 start, stop, step, sycl_queue=exec_q, usm_type=usm_type
             )
+        elif hasattr(key, "dtype") and dpnp.issubdtype(key.dtype, dpnp.bool):
+            # use a fast path for boolean mask
+            pos = dpnp.asarray(key, sycl_queue=exec_q, usm_type=usm_type)
+            idx = dpnp.nonzero(pos)[0]
         else:
             flat_index = dpnp.arange(
                 a.size, sycl_queue=exec_q, usm_type=usm_type

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -169,8 +169,9 @@ class flatiter:
     def __getitem__(self, key):
         key = self._normalize_key(key)
 
-        if isinstance(key, int) and not isinstance(key, bool):
+        if isinstance(key, int):
             # scalar fast path: index directly instead of flattening the array
+            # (a bool key was already rejected in _normalize_key)
             pos = self._scalar_pos(key)
             return self._arr[numpy.unravel_index(pos, self._arr.shape)].copy()
 
@@ -197,8 +198,9 @@ class flatiter:
         usm_type = a.usm_type
 
         # resolve key to flat positions
-        if isinstance(key, int) and not isinstance(key, bool):
+        if isinstance(key, int):
             # scalar fast path: avoid building a full index array
+            # (a bool key was already rejected in _normalize_key)
             pos = self._scalar_pos(key)
             idx = dpnp.asarray(pos, sycl_queue=exec_q, usm_type=usm_type)
         elif isinstance(key, slice):

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -252,8 +252,8 @@ class flatiter:
 
     def __next__(self):
         if self._i < self._size:
-            val = self.__getitem__(self._i)
-            self._i = self._i + 1
+            val = self[self._i]
+            self._i += 1
             return val
         else:
             raise StopIteration

--- a/dpnp/dpnp_flatiter.py
+++ b/dpnp/dpnp_flatiter.py
@@ -225,8 +225,8 @@ class flatiter:
 
             val = val.ravel()
             n = idx.size
-            if val.size and val.size != n:
-                # cycles the values over the selection
+            if val.size not in (0, 1, n):
+                # put broadcasts size-0/1 values; otherwise cycle over selection
                 val = val[
                     dpnp.arange(n, sycl_queue=exec_q, usm_type=usm_type)
                     % val.size

--- a/dpnp/tests/test_flat.py
+++ b/dpnp/tests/test_flat.py
@@ -63,11 +63,20 @@ class TestFlatiter:
             slice(1, 4),
             slice(None),
             slice(None, None, 2),
+            slice(None, None, -1),
             [0, 2, 4],
             [-1, -2],
             Ellipsis,
         ],
-        ids=["slice", "full_slice", "step_slice", "list", "neg_list", "..."],
+        ids=[
+            "slice",
+            "full_slice",
+            "step_slice",
+            "neg_step_slice",
+            "list",
+            "neg_list",
+            "...",
+        ],
     )
     def test_flat_getitem_index_types(self, key):
         a = np.arange(1, 7).reshape(2, 3)

--- a/dpnp/tests/test_flat.py
+++ b/dpnp/tests/test_flat.py
@@ -117,6 +117,32 @@ class TestFlatiter:
         with pytest.raises(IndexError, match="out of bounds"):
             a.flat[index] = 0
 
+    @pytest.mark.parametrize("xp", [dpnp, np])
+    def test_flat_setitem_single_item_array_value(self, xp):
+        for index in (0, xp.array(0), np.int64(0)):
+            a = xp.arange(1, 7)
+            with pytest.raises(ValueError, match="single item"):
+                a.flat[index] = [1, 2, 3]
+
+    def test_flat_setitem_single_item_scalar_value(self):
+        a = np.arange(1, 7)
+        ia = dpnp.array(a)
+
+        a.flat[0] = 9
+        a.flat[np.array(1)] = np.asarray(8)
+
+        ia.flat[0] = 9
+        ia.flat[dpnp.array(1)] = dpnp.asarray(8)
+        assert_array_equal(ia, a)
+
+    def test_flat_setitem_length_one_slice_cycles(self):
+        a = np.arange(1, 7)
+        ia = dpnp.array(a)
+
+        a.flat[0:1] = [10, 20, 30]
+        ia.flat[0:1] = [10, 20, 30]
+        assert_array_equal(ia, a)
+
     def test_flat_index_array(self):
         a = np.arange(1, 7).reshape(2, 3)
         ia = dpnp.array(a)

--- a/dpnp/tests/test_flat.py
+++ b/dpnp/tests/test_flat.py
@@ -124,6 +124,21 @@ class TestFlatiter:
         # int array index
         assert_array_equal(ia.flat[dpnp.array([0, 3, 5])], a.flat[[0, 3, 5]])
 
+    def test_flat_usm_ndarray_index(self):
+        a = np.arange(1, 7)
+        ia = dpnp.array(a)
+
+        # a usm_ndarray index is validated and used like a dpnp array
+        usm_key = dpnp.array([0, 2, 4]).get_array()
+        assert_array_equal(ia.flat[usm_key], a.flat[[0, 2, 4]])
+        with pytest.raises(IndexError, match="out of bounds"):
+            _ = ia.flat[dpnp.array([100]).get_array()]
+
+    @pytest.mark.parametrize("xp", [dpnp, np])
+    def test_flat_empty_index(self, xp):
+        a = xp.arange(1, 7)
+        assert_array_equal(a.flat[xp.array([], dtype=xp.intp)], a.flat[[]])
+
     def test_flat_single_element_tuple(self):
         a = np.arange(1, 7)
         ia = dpnp.array(a)

--- a/dpnp/tests/test_flat.py
+++ b/dpnp/tests/test_flat.py
@@ -26,7 +26,9 @@ class TestFlatiter:
     def test_flat_iteration(self):
         a = np.array([[1, 2], [3, 4]])
         ia = dpnp.array(a)
-        for ival, val in zip(ia.flat, a.flat):
+        result = list(ia.flat)
+        assert len(result) == a.size
+        for ival, val in zip(result, a.flat):
             assert ival == val
 
     def test_init_error(self):
@@ -181,6 +183,7 @@ class TestFlatiter:
         with pytest.raises(ValueError):
             _ = a.flat[[[1, 2], [3]]]
 
+    @testing.with_requires("numpy>=2.4")
     def test_flat_single_element_tuple(self):
         a = np.arange(1, 7)
         ia = dpnp.array(a)
@@ -205,6 +208,7 @@ class TestFlatiter:
         with pytest.raises(IndexError):
             a.flat[key] = 0
 
+    @testing.with_requires("numpy>=2.4")
     @pytest.mark.parametrize("xp", [dpnp, np])
     def test_flat_tuple_array_out_of_bounds(self, xp):
         a = xp.array([1, 2, 3])

--- a/dpnp/tests/test_flat.py
+++ b/dpnp/tests/test_flat.py
@@ -175,6 +175,12 @@ class TestFlatiter:
         a = xp.arange(1, 7)
         assert_array_equal(a.flat[xp.array([], dtype=xp.intp)], a.flat[[]])
 
+    @pytest.mark.parametrize("xp", [dpnp, np])
+    def test_flat_ragged_index(self, xp):
+        a = xp.arange(6)
+        with pytest.raises(ValueError):
+            _ = a.flat[[[1, 2], [3]]]
+
     def test_flat_single_element_tuple(self):
         a = np.arange(1, 7)
         ia = dpnp.array(a)

--- a/dpnp/tests/test_flat.py
+++ b/dpnp/tests/test_flat.py
@@ -117,6 +117,7 @@ class TestFlatiter:
         with pytest.raises(IndexError, match="out of bounds"):
             a.flat[index] = 0
 
+    @testing.with_requires("numpy>=2.4")
     @pytest.mark.parametrize("xp", [dpnp, np])
     def test_flat_setitem_single_item_array_value(self, xp):
         for index in (0, xp.array(0), np.int64(0)):
@@ -185,7 +186,6 @@ class TestFlatiter:
         with pytest.raises(IndexError, match="out of bounds"):
             a.flat[idx] = 0
 
-    @testing.with_requires("numpy>=2.4")
     def test_flat_bool_mask(self):
         a = np.arange(1, 7).reshape(2, 3)
         ia = dpnp.array(a)
@@ -242,7 +242,6 @@ class TestFlatiter:
         with pytest.raises(IndexError, match="0-D index is not supported"):
             a.flat[()] = 0
 
-    @testing.with_requires("numpy>=2.4")
     @pytest.mark.parametrize("xp", [dpnp, np])
     @pytest.mark.parametrize("key", [[100], [-100]], ids=["oob", "neg_oob"])
     def test_flat_array_out_of_bounds(self, xp, key):

--- a/dpnp/tests/test_flat.py
+++ b/dpnp/tests/test_flat.py
@@ -76,8 +76,24 @@ class TestFlatiter:
 
     @pytest.mark.parametrize(
         "key",
-        [slice(1, 4), slice(None), [0, 2, 4], [-1, -2], Ellipsis],
-        ids=["slice", "full_slice", "list", "neg_list", "..."],
+        [
+            slice(1, 4),
+            slice(None),
+            slice(None, None, 2),
+            slice(None, None, -1),
+            [0, 2, 4],
+            [-1, -2],
+            Ellipsis,
+        ],
+        ids=[
+            "slice",
+            "full_slice",
+            "step_slice",
+            "neg_step_slice",
+            "list",
+            "neg_list",
+            "...",
+        ],
     )
     def test_flat_setitem_index_types(self, key):
         a = np.arange(1, 7).reshape(2, 3)
@@ -85,6 +101,21 @@ class TestFlatiter:
         a.flat[key] = 0
         ia.flat[key] = 0
         assert_array_equal(ia, a)
+
+    @pytest.mark.parametrize("index", [0, 5, -1, -6])
+    def test_flat_setitem_scalar(self, index):
+        a = np.arange(1, 7)
+        ia = dpnp.array(a)
+        a.flat[index] = 99
+        ia.flat[index] = 99
+        assert_array_equal(ia, a)
+
+    @pytest.mark.parametrize("xp", [dpnp, np])
+    @pytest.mark.parametrize("index", [6, -7], ids=["oob", "neg_oob"])
+    def test_flat_setitem_scalar_out_of_bounds(self, xp, index):
+        a = xp.arange(1, 7)
+        with pytest.raises(IndexError, match="out of bounds"):
+            a.flat[index] = 0
 
     def test_flat_index_array(self):
         a = np.arange(1, 7).reshape(2, 3)

--- a/dpnp/tests/test_flat.py
+++ b/dpnp/tests/test_flat.py
@@ -1,8 +1,10 @@
 import numpy as np
 import pytest
-from numpy.testing import assert_array_equal, assert_raises
+from numpy.testing import assert_array_equal
 
 import dpnp
+
+from .third_party.cupy import testing
 
 
 class TestFlatiter:
@@ -16,37 +18,144 @@ class TestFlatiter:
         ids=["1D array", "2D array", "2D.T array"],
     )
     def test_flat_getitem(self, a, index):
-        a_dp = dpnp.array(a)
-        result = a_dp.flat[index]
+        ia = dpnp.array(a)
+        result = ia.flat[index]
         expected = a.flat[index]
         assert_array_equal(expected, result)
 
     def test_flat_iteration(self):
         a = np.array([[1, 2], [3, 4]])
-        a_dp = dpnp.array(a)
-        for dp_val, np_val in zip(a_dp.flat, a.flat):
-            assert dp_val == np_val
+        ia = dpnp.array(a)
+        for ival, val in zip(ia.flat, a.flat):
+            assert ival == val
 
     def test_init_error(self):
-        assert_raises(TypeError, dpnp.flatiter, [1, 2, 3])
+        with pytest.raises(TypeError, match="must be of type dpnp.ndarray"):
+            dpnp.flatiter([1, 2, 3])
 
-    def test_flat_key_error(self):
-        a_dp = dpnp.array(42)
-        with pytest.raises(KeyError):
-            _ = a_dp.flat[1]
+    @pytest.mark.parametrize("xp", [dpnp, np])
+    def test_flat_key_error(self, xp):
+        a = xp.array(42)
+        with pytest.raises(IndexError):
+            _ = a.flat[1]
 
-    def test_flat_invalid_key(self):
-        a_dp = dpnp.array([1, 2, 3])
-        flat = dpnp.flatiter(a_dp)
+    @pytest.mark.parametrize("xp", [dpnp, np])
+    def test_flat_invalid_key(self, xp):
+        flat = xp.array([1, 2, 3]).flat
+
         # check __getitem__
-        with pytest.raises(TypeError):
+        with pytest.raises(IndexError):
             _ = flat["invalid"]
+
         # check __setitem__
-        with pytest.raises(TypeError):
+        with pytest.raises(IndexError):
             flat["invalid"] = 42
 
-    def test_flat_out_of_bounds(self):
-        a_dp = dpnp.array([1, 2, 3])
-        flat = dpnp.flatiter(a_dp)
+    @pytest.mark.parametrize("xp", [dpnp, np])
+    def test_flat_out_of_bounds(self, xp):
+        flat = xp.array([1, 2, 3]).flat
         with pytest.raises(IndexError):
             _ = flat[10]
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            slice(1, 4),
+            slice(None),
+            slice(None, None, 2),
+            [0, 2, 4],
+            [-1, -2],
+            Ellipsis,
+        ],
+        ids=["slice", "full_slice", "step_slice", "list", "neg_list", "..."],
+    )
+    def test_flat_getitem_index_types(self, key):
+        a = np.arange(1, 7).reshape(2, 3)
+        ia = dpnp.array(a)
+        assert_array_equal(ia.flat[key], a.flat[key])
+
+    @pytest.mark.parametrize(
+        "key",
+        [slice(1, 4), slice(None), [0, 2, 4], [-1, -2], Ellipsis],
+        ids=["slice", "full_slice", "list", "neg_list", "..."],
+    )
+    def test_flat_setitem_index_types(self, key):
+        a = np.arange(1, 7).reshape(2, 3)
+        ia = dpnp.array(a)
+        a.flat[key] = 0
+        ia.flat[key] = 0
+        assert_array_equal(ia, a)
+
+    def test_flat_index_array(self):
+        a = np.arange(1, 7).reshape(2, 3)
+        ia = dpnp.array(a)
+
+        # int array index
+        assert_array_equal(ia.flat[dpnp.array([0, 3, 5])], a.flat[[0, 3, 5]])
+
+    @testing.with_requires("numpy>=2.4")
+    def test_flat_bool_mask(self):
+        a = np.arange(1, 7).reshape(2, 3)
+        ia = dpnp.array(a)
+        mask = np.array([True, False] * 3)
+
+        # getitem via bool array
+        assert_array_equal(ia.flat[dpnp.array(mask)], a.flat[mask])
+
+        # setitem via bool array
+        a.flat[mask] = -1
+        ia.flat[dpnp.array(mask)] = -1
+        assert_array_equal(ia, a)
+
+    def test_flat_non_contiguous(self):
+        # C-order traversal + write-back for non-contiguous arrays
+        a = np.arange(1, 7).reshape(2, 3).T
+        ia = dpnp.array(np.arange(1, 7).reshape(2, 3)).T
+        assert_array_equal(ia.flat[1:5], a.flat[1:5])
+        a.flat[1:5] = 0
+        ia.flat[1:5] = 0
+        assert_array_equal(ia, a)
+
+    @pytest.mark.parametrize("xp", [dpnp, np])
+    def test_flat_getitem_returns_copy(self, xp):
+        # flat yields copies, not views
+        a = xp.arange(10)
+        s = a.flat[1:4]
+        s[0] = 999
+        assert a[1] != 999
+
+    def test_flat_scalar_getitem_returns_copy(self):
+        # dpnp returns a 0-d array copy (NumPy returns an immutable scalar)
+        ia = dpnp.arange(10)
+        x = ia.flat[3]
+        x[...] = 777
+        assert ia[3] != 777
+
+    @testing.with_requires("numpy>=2.4")
+    @pytest.mark.parametrize("xp", [dpnp, np])
+    def test_flat_newaxis(self, xp):
+        a = xp.array([1, 2, 3])
+        with pytest.raises(IndexError, match="are valid indices"):
+            _ = a.flat[None]
+        with pytest.raises(IndexError, match="are valid indices"):
+            a.flat[None] = 0
+
+    @testing.with_requires("numpy>=2.4")
+    @pytest.mark.parametrize("xp", [dpnp, np])
+    def test_flat_empty_tuple(self, xp):
+        a = xp.arange(1, 7).reshape(2, 3)
+        # getitem with () returns the whole flattened array
+        assert_array_equal(a.flat[()], xp.arange(1, 7))
+        # setitem with a 0-d index is unsupported
+        with pytest.raises(IndexError, match="0-D index is not supported"):
+            a.flat[()] = 0
+
+    @testing.with_requires("numpy>=2.4")
+    @pytest.mark.parametrize("xp", [dpnp, np])
+    @pytest.mark.parametrize("key", [[100], [-100]], ids=["oob", "neg_oob"])
+    def test_flat_array_out_of_bounds(self, xp, key):
+        a = xp.array([1, 2, 3])
+        with pytest.raises(IndexError, match="out of bounds for size"):
+            _ = a.flat[key]
+        with pytest.raises(IndexError, match="out of bounds for size"):
+            a.flat[key] = 0

--- a/dpnp/tests/test_flat.py
+++ b/dpnp/tests/test_flat.py
@@ -187,6 +187,19 @@ class TestFlatiter:
         )
 
     @pytest.mark.parametrize("xp", [dpnp, np])
+    @pytest.mark.parametrize(
+        "key",
+        [(Ellipsis, 2), (2, Ellipsis), (Ellipsis, slice(1, 3)), (1, 2)],
+        ids=["ell_int", "int_ell", "ell_slice", "int_int"],
+    )
+    def test_flat_multi_element_tuple(self, xp, key):
+        a = xp.arange(6)
+        with pytest.raises(IndexError):
+            _ = a.flat[key]
+        with pytest.raises(IndexError):
+            a.flat[key] = 0
+
+    @pytest.mark.parametrize("xp", [dpnp, np])
     def test_flat_tuple_array_out_of_bounds(self, xp):
         a = xp.array([1, 2, 3])
         idx = (xp.array([5]),)

--- a/dpnp/tests/test_flat.py
+++ b/dpnp/tests/test_flat.py
@@ -124,6 +124,26 @@ class TestFlatiter:
         # int array index
         assert_array_equal(ia.flat[dpnp.array([0, 3, 5])], a.flat[[0, 3, 5]])
 
+    def test_flat_single_element_tuple(self):
+        a = np.arange(1, 7)
+        ia = dpnp.array(a)
+
+        # a 1-element index tuple is equivalent to the bare index
+        assert_array_equal(ia.flat[(0,)], a.flat[(0,)])
+        assert_array_equal(ia.flat[(slice(1, 4),)], a.flat[(slice(1, 4),)])
+        assert_array_equal(
+            ia.flat[(dpnp.array([0, 2]),)], a.flat[(np.array([0, 2]),)]
+        )
+
+    @pytest.mark.parametrize("xp", [dpnp, np])
+    def test_flat_tuple_array_out_of_bounds(self, xp):
+        a = xp.array([1, 2, 3])
+        idx = (xp.array([5]),)
+        with pytest.raises(IndexError, match="out of bounds"):
+            _ = a.flat[idx]
+        with pytest.raises(IndexError, match="out of bounds"):
+            a.flat[idx] = 0
+
     @testing.with_requires("numpy>=2.4")
     def test_flat_bool_mask(self):
         a = np.arange(1, 7).reshape(2, 3)

--- a/dpnp/tests/test_flat.py
+++ b/dpnp/tests/test_flat.py
@@ -183,7 +183,6 @@ class TestFlatiter:
         with pytest.raises(ValueError):
             _ = a.flat[[[1, 2], [3]]]
 
-    @testing.with_requires("numpy>=2.4")
     def test_flat_single_element_tuple(self):
         a = np.arange(1, 7)
         ia = dpnp.array(a)
@@ -208,7 +207,6 @@ class TestFlatiter:
         with pytest.raises(IndexError):
             a.flat[key] = 0
 
-    @testing.with_requires("numpy>=2.4")
     @pytest.mark.parametrize("xp", [dpnp, np])
     def test_flat_tuple_array_out_of_bounds(self, xp):
         a = xp.array([1, 2, 3])

--- a/dpnp/tests/test_flat.py
+++ b/dpnp/tests/test_flat.py
@@ -227,6 +227,26 @@ class TestFlatiter:
         ia.flat[dpnp.array(mask)] = -1
         assert_array_equal(ia, a)
 
+    @testing.with_requires("numpy>=2.4")
+    @pytest.mark.parametrize("xp", [dpnp, np])
+    def test_flat_boolean_list_index(self, xp):
+        a = xp.arange(6)
+        mask = [True, False, True, False, True, False]
+        with pytest.raises(IndexError):
+            _ = a.flat[mask]
+        with pytest.raises(IndexError):
+            a.flat[mask] = 0
+
+    @pytest.mark.parametrize("index", [True, False])
+    def test_flat_boolean_scalar_index(self, index):
+        a = dpnp.arange(6)
+        with pytest.raises(IndexError):
+            _ = a.flat[index]
+        with pytest.raises(IndexError):
+            a.flat[index] = 9
+        with pytest.raises(IndexError):
+            _ = a.flat[dpnp.array(index)]
+
     def test_flat_non_contiguous(self):
         # C-order traversal + write-back for non-contiguous arrays
         a = np.arange(1, 7).reshape(2, 3).T

--- a/dpnp/tests/test_flat.py
+++ b/dpnp/tests/test_flat.py
@@ -150,22 +150,6 @@ class TestFlatiter:
         ia.flat[dpnp.array(1)] = dpnp.asarray(8)
         assert_array_equal(ia, a)
 
-    def test_flat_setitem_different_queue(self):
-        # compute-follows-data: a value or mask on another queue must raise
-        # rather than being silently migrated (like assignment and dpnp.put)
-        import dpctl
-
-        from dpnp.exceptions import ExecutionPlacementError
-
-        ia = dpnp.arange(6)
-        q = dpctl.SyclQueue(ia.sycl_device)
-        v = dpnp.array([7, 8], sycl_queue=q)
-        m = dpnp.array([True, False] * 3, sycl_queue=q)
-        with pytest.raises(ExecutionPlacementError):
-            ia.flat[0:2] = v
-        with pytest.raises(ExecutionPlacementError):
-            ia.flat[m] = -1
-
     def test_flat_setitem_length_one_slice_cycles(self):
         a = np.arange(1, 7)
         ia = dpnp.array(a)

--- a/dpnp/tests/test_flat.py
+++ b/dpnp/tests/test_flat.py
@@ -150,6 +150,14 @@ class TestFlatiter:
         ia.flat[dpnp.array(1)] = dpnp.asarray(8)
         assert_array_equal(ia, a)
 
+    @pytest.mark.parametrize("value", [[8], np.array(8)], ids=["size1", "0d"])
+    def test_flat_setitem_single_value_broadcasts(self, value):
+        a = np.arange(6)
+        ia = dpnp.array(a)
+        a.flat[1:5] = value
+        ia.flat[1:5] = value
+        assert_array_equal(ia, a)
+
     def test_flat_setitem_length_one_slice_cycles(self):
         a = np.arange(1, 7)
         ia = dpnp.array(a)

--- a/dpnp/tests/test_flat.py
+++ b/dpnp/tests/test_flat.py
@@ -273,9 +273,9 @@ class TestFlatiter:
     def test_flat_bool_mask_wrong_size(self, xp):
         a = xp.arange(6)
         mask = xp.array([True, False, True])
-        with pytest.raises(IndexError):
+        with pytest.raises(IndexError, match="indexed flat iterator"):
             _ = a.flat[mask]
-        with pytest.raises(IndexError):
+        with pytest.raises(IndexError, match="indexed flat iterator"):
             a.flat[mask] = 0
 
     @testing.with_requires("numpy>=2.4")

--- a/dpnp/tests/test_flat.py
+++ b/dpnp/tests/test_flat.py
@@ -300,12 +300,14 @@ class TestFlatiter:
         assert_array_equal(ia, a)
 
     @pytest.mark.parametrize("xp", [dpnp, np])
-    def test_flat_getitem_returns_copy(self, xp):
-        # flat yields copies, not views
-        a = xp.arange(10)
+    @pytest.mark.parametrize("contiguous", [True, False], ids=["C", "non-C"])
+    def test_flat_getitem_returns_copy(self, xp, contiguous):
+        # flat yields copies, not view
+        a = xp.arange(10) if contiguous else xp.arange(20)[::2]
+        orig = a[1].copy()
         s = a.flat[1:4]
         s[0] = 999
-        assert a[1] != 999
+        assert a[1] == orig
 
     def test_flat_scalar_getitem_returns_copy(self):
         # dpnp returns a 0-d array copy (NumPy returns an immutable scalar)

--- a/dpnp/tests/test_flat.py
+++ b/dpnp/tests/test_flat.py
@@ -262,6 +262,16 @@ class TestFlatiter:
 
     @testing.with_requires("numpy>=2.4")
     @pytest.mark.parametrize("xp", [dpnp, np])
+    def test_flat_bool_mask_ndim(self, xp):
+        a = xp.arange(6).reshape(2, 3)
+        mask = xp.array([[True, False, True], [False, True, False]])
+        with pytest.raises(IndexError):
+            _ = a.flat[mask]
+        with pytest.raises(IndexError):
+            a.flat[mask] = -1
+
+    @testing.with_requires("numpy>=2.4")
+    @pytest.mark.parametrize("xp", [dpnp, np])
     def test_flat_boolean_list_index(self, xp):
         a = xp.arange(6)
         mask = [True, False, True, False, True, False]

--- a/dpnp/tests/test_flat.py
+++ b/dpnp/tests/test_flat.py
@@ -166,6 +166,22 @@ class TestFlatiter:
         ia.flat[0:1] = [10, 20, 30]
         assert_array_equal(ia, a)
 
+    def test_flat_setitem_cycles(self):
+        # a value shorter than the selection is cycled to fill it
+        a = np.arange(6)
+        ia = dpnp.array(a)
+        a.flat[0:6] = [1, 2, 3]
+        ia.flat[0:6] = [1, 2, 3]
+        assert_array_equal(ia, a)
+
+    def test_flat_setitem_empty_selection(self):
+        # an in-bounds empty selection with an empty value is a no-op
+        a = np.arange(6)
+        ia = dpnp.array(a)
+        a.flat[0:0] = []
+        ia.flat[0:0] = []
+        assert_array_equal(ia, a)
+
     def test_flat_index_array(self):
         a = np.arange(1, 7).reshape(2, 3)
         ia = dpnp.array(a)
@@ -204,6 +220,16 @@ class TestFlatiter:
         with pytest.raises(ValueError):
             _ = a.flat[[[1, 2], [3]]]
 
+    @pytest.mark.parametrize("xp", [dpnp, np])
+    def test_flat_float_array_index(self, xp):
+        # a non-integer, non-boolean array index is rejected
+        a = xp.arange(6)
+        key = xp.asarray([0.0, 1.0])
+        with pytest.raises(IndexError):
+            _ = a.flat[key]
+        with pytest.raises(IndexError):
+            a.flat[key] = 0
+
     def test_flat_single_element_tuple(self):
         a = np.arange(1, 7)
         ia = dpnp.array(a)
@@ -214,6 +240,13 @@ class TestFlatiter:
         assert_array_equal(
             ia.flat[(dpnp.array([0, 2]),)], a.flat[(np.array([0, 2]),)]
         )
+
+        # setitem unwraps the 1-element tuple too
+        a.flat[(slice(1, 4),)] = 0
+        ia.flat[(slice(1, 4),)] = 0
+        a.flat[(np.array([0, 2]),)] = 9
+        ia.flat[(dpnp.array([0, 2]),)] = 9
+        assert_array_equal(ia, a)
 
     @pytest.mark.parametrize("xp", [dpnp, np])
     @pytest.mark.parametrize(

--- a/dpnp/tests/test_flat.py
+++ b/dpnp/tests/test_flat.py
@@ -331,3 +331,10 @@ class TestFlatiter:
             _ = a.flat[key]
         with pytest.raises(IndexError, match="out of bounds for size"):
             a.flat[key] = 0
+
+    @pytest.mark.parametrize("key", [[1, 9], [-9, 0]], ids=["oob", "neg_oob"])
+    def test_flat_setitem_out_of_bounds_empty_value(self, key):
+        # dpnp validates the index even for an empty value (NumPy no-ops here)
+        ia = dpnp.arange(6)
+        with pytest.raises(IndexError, match="out of bounds for size"):
+            ia.flat[key] = []

--- a/dpnp/tests/test_flat.py
+++ b/dpnp/tests/test_flat.py
@@ -3,6 +3,7 @@ import pytest
 from numpy.testing import assert_array_equal
 
 import dpnp
+import dpnp.tensor as dpt
 
 from .third_party.cupy import testing
 
@@ -14,8 +15,10 @@ class TestFlatiter:
             (np.array([1, 0, 2, -3, -1, 2, 21, -9]), 0),
             (np.arange(1, 7).reshape(2, 3), 3),
             (np.arange(1, 7).reshape(2, 3).T, 3),
+            (np.arange(1, 7), -1),
+            (np.arange(1, 7).reshape(2, 3).T, -2),
         ],
-        ids=["1D array", "2D array", "2D.T array"],
+        ids=["1D array", "2D array", "2D.T array", "1D neg", "2D.T neg"],
     )
     def test_flat_getitem(self, a, index):
         ia = dpnp.array(a)
@@ -216,18 +219,34 @@ class TestFlatiter:
         with pytest.raises(IndexError, match="out of bounds"):
             a.flat[idx] = 0
 
-    def test_flat_bool_mask(self):
+    @pytest.mark.parametrize("mask_type", ["dpnp", "numpy", "usm"])
+    def test_flat_bool_mask(self, mask_type):
         a = np.arange(1, 7).reshape(2, 3)
         ia = dpnp.array(a)
         mask = np.array([True, False] * 3)
+        if mask_type == "dpnp":
+            key = dpnp.array(mask)
+        elif mask_type == "numpy":
+            key = mask
+        else:
+            key = dpt.asarray(mask)
 
-        # getitem via bool array
-        assert_array_equal(ia.flat[dpnp.array(mask)], a.flat[mask])
+        # getitem via bool mask
+        assert_array_equal(ia.flat[key], a.flat[mask])
 
-        # setitem via bool array
+        # setitem via bool mask
         a.flat[mask] = -1
-        ia.flat[dpnp.array(mask)] = -1
+        ia.flat[key] = -1
         assert_array_equal(ia, a)
+
+    @pytest.mark.parametrize("xp", [dpnp, np])
+    def test_flat_bool_mask_wrong_size(self, xp):
+        a = xp.arange(6)
+        mask = xp.array([True, False, True])
+        with pytest.raises(IndexError):
+            _ = a.flat[mask]
+        with pytest.raises(IndexError):
+            a.flat[mask] = 0
 
     @testing.with_requires("numpy>=2.4")
     @pytest.mark.parametrize("xp", [dpnp, np])

--- a/dpnp/tests/test_flat.py
+++ b/dpnp/tests/test_flat.py
@@ -173,6 +173,16 @@ class TestFlatiter:
         # int array index
         assert_array_equal(ia.flat[dpnp.array([0, 3, 5])], a.flat[[0, 3, 5]])
 
+    @pytest.mark.parametrize(
+        "key", [[0, 3, 5], [-1, -2, 3]], ids=["pos", "neg"]
+    )
+    def test_flat_setitem_int_array_value(self, key):
+        a = np.arange(1, 7)
+        ia = dpnp.array(a)
+        a.flat[key] = [10, 20, 30]
+        ia.flat[dpnp.array(key)] = dpnp.array([10, 20, 30])
+        assert_array_equal(ia, a)
+
     def test_flat_usm_ndarray_index(self):
         a = np.arange(1, 7)
         ia = dpnp.array(a)

--- a/dpnp/tests/test_flat.py
+++ b/dpnp/tests/test_flat.py
@@ -150,6 +150,22 @@ class TestFlatiter:
         ia.flat[dpnp.array(1)] = dpnp.asarray(8)
         assert_array_equal(ia, a)
 
+    def test_flat_setitem_different_queue(self):
+        # compute-follows-data: a value or mask on another queue must raise
+        # rather than being silently migrated (like assignment and dpnp.put)
+        import dpctl
+
+        from dpnp.exceptions import ExecutionPlacementError
+
+        ia = dpnp.arange(6)
+        q = dpctl.SyclQueue(ia.sycl_device)
+        v = dpnp.array([7, 8], sycl_queue=q)
+        m = dpnp.array([True, False] * 3, sycl_queue=q)
+        with pytest.raises(ExecutionPlacementError):
+            ia.flat[0:2] = v
+        with pytest.raises(ExecutionPlacementError):
+            ia.flat[m] = -1
+
     def test_flat_setitem_length_one_slice_cycles(self):
         a = np.arange(1, 7)
         ia = dpnp.array(a)

--- a/dpnp/tests/test_flat.py
+++ b/dpnp/tests/test_flat.py
@@ -239,6 +239,7 @@ class TestFlatiter:
         ia.flat[key] = -1
         assert_array_equal(ia, a)
 
+    @testing.with_requires("numpy>=2.4")
     @pytest.mark.parametrize("xp", [dpnp, np])
     def test_flat_bool_mask_wrong_size(self, xp):
         a = xp.arange(6)

--- a/dpnp/tests/test_flat.py
+++ b/dpnp/tests/test_flat.py
@@ -239,6 +239,17 @@ class TestFlatiter:
         ia.flat[key] = -1
         assert_array_equal(ia, a)
 
+    def test_flat_bool_mask_empty(self):
+        a = np.arange(6)
+        ia = dpnp.array(a)
+        mask = np.array([], dtype=bool)
+
+        assert_array_equal(ia.flat[dpnp.array(mask)], a.flat[mask])
+
+        a.flat[mask] = 9
+        ia.flat[dpnp.array(mask)] = 9
+        assert_array_equal(ia, a)
+
     @testing.with_requires("numpy>=2.4")
     @pytest.mark.parametrize("xp", [dpnp, np])
     def test_flat_bool_mask_wrong_size(self, xp):

--- a/dpnp/tests/test_sycl_queue.py
+++ b/dpnp/tests/test_sycl_queue.py
@@ -687,8 +687,9 @@ def test_flat(device):
     assert_sycl_queue_equal(x.flat[1:4].sycl_queue, x.sycl_queue)
     assert_sycl_queue_equal(x.flat[y].sycl_queue, x.sycl_queue)
 
-    # setitem keeps the array on its queue
+    # setitem keeps the array on its queue (array-index and slice paths)
     x.flat[y] = dpnp.arange(3, device=device)
+    x.flat[1:4] = dpnp.arange(3, device=device)
     assert_sycl_queue_equal(x.flat[y].sycl_queue, x.sycl_queue)
 
 

--- a/dpnp/tests/test_sycl_queue.py
+++ b/dpnp/tests/test_sycl_queue.py
@@ -678,6 +678,32 @@ def test_2in_1out_diff_queue_but_equal_context(func, device):
         getattr(dpnp, func)(x1, x2)
 
 
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
+def test_flat(device):
+    x = dpnp.arange(6, device=device)
+    y = dpnp.array([0, 2, 4], device=device)
+
+    # getitem keeps the result on the input's queue
+    assert_sycl_queue_equal(x.flat[1:4].sycl_queue, x.sycl_queue)
+    assert_sycl_queue_equal(x.flat[y].sycl_queue, x.sycl_queue)
+
+    # setitem keeps the array on its queue
+    x.flat[y] = dpnp.arange(3, device=device)
+    assert_sycl_queue_equal(x.flat[y].sycl_queue, x.sycl_queue)
+
+
+@pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
+def test_flat_setitem_diff_queue(device):
+    a = dpnp.arange(6, device=device)
+    q = dpctl.SyclQueue(device)
+    v = dpnp.arange(2, sycl_queue=q)
+    m = dpnp.array([True, False] * 3, sycl_queue=q)
+    with assert_raises((ValueError, ExecutionPlacementError)):
+        a.flat[0:2] = v
+    with assert_raises((ValueError, ExecutionPlacementError)):
+        a.flat[m] = -1
+
+
 @pytest.mark.parametrize("op", ["bitwise_count", "bitwise_not"])
 @pytest.mark.parametrize("device", valid_dev, ids=dev_ids)
 def test_bitwise_op_1in(op, device):

--- a/dpnp/tests/test_usm_type.py
+++ b/dpnp/tests/test_usm_type.py
@@ -988,6 +988,24 @@ def test_take(func, usm_type_x, usm_type_ind):
     assert z.usm_type == dpt.get_coerced_usm_type([usm_type_x, usm_type_ind])
 
 
+@pytest.mark.parametrize("usm_type_x", list_of_usm_types)
+@pytest.mark.parametrize("usm_type_y", list_of_usm_types)
+def test_flat(usm_type_x, usm_type_y):
+    x = dpnp.arange(6, usm_type=usm_type_x)
+    y = dpnp.array([0, 2, 4], usm_type=usm_type_y)
+
+    # a basic-index (slice) result keeps the array's usm type
+    assert x.flat[1:4].usm_type == usm_type_x
+
+    # an advanced-index (array) result coerces the usm types
+    z = x.flat[y]
+    assert z.usm_type == dpt.get_coerced_usm_type([usm_type_x, usm_type_y])
+
+    # setitem updates the array in place, keeping its usm type
+    x.flat[y] = dpnp.arange(3, usm_type=usm_type_y)
+    assert x.usm_type == usm_type_x
+
+
 @pytest.mark.parametrize(
     "data, ind, axis",
     [

--- a/dpnp/tests/third_party/cupy/indexing_tests/test_iterate.py
+++ b/dpnp/tests/third_party/cupy/indexing_tests/test_iterate.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import unittest
 import warnings
 
@@ -58,17 +60,17 @@ class TestFlatiter(unittest.TestCase):
 
 
 @testing.parameterize(
-    # {"shape": (2, 3, 4), "index": Ellipsis},
+    {"shape": (2, 3, 4), "index": Ellipsis},
     {"shape": (2, 3, 4), "index": 0},
     {"shape": (2, 3, 4), "index": 10},
-    # {"shape": (2, 3, 4), "index": slice(None)},
-    # {"shape": (2, 3, 4), "index": slice(None, 10)},
-    # {"shape": (2, 3, 4), "index": slice(None, None, 2)},
-    # {"shape": (2, 3, 4), "index": slice(None, None, -1)},
-    # {"shape": (2, 3, 4), "index": slice(10, None, -1)},
-    # {"shape": (2, 3, 4), "index": slice(10, None, -2)},
-    # {"shape": (), "index": slice(None)},
-    # {"shape": (10,), "index": slice(None)},
+    {"shape": (2, 3, 4), "index": slice(None)},
+    {"shape": (2, 3, 4), "index": slice(None, 10)},
+    {"shape": (2, 3, 4), "index": slice(None, None, 2)},
+    {"shape": (2, 3, 4), "index": slice(None, None, -1)},
+    {"shape": (2, 3, 4), "index": slice(10, None, -1)},
+    {"shape": (2, 3, 4), "index": slice(10, None, -2)},
+    {"shape": (), "index": slice(None)},
+    {"shape": (10,), "index": slice(None)},
 )
 class TestFlatiterSubscript(unittest.TestCase):
 
@@ -125,12 +127,13 @@ class TestFlatiterSubscript(unittest.TestCase):
 
 @testing.parameterize(
     {"shape": (2, 3, 4), "index": None},
-    {"shape": (2, 3, 4), "index": (0,)},
-    {"shape": (2, 3, 4), "index": True},
-    {"shape": (2, 3, 4), "index": cupy.array([0])},
-    {"shape": (2, 3, 4), "index": [0]},
+    # the indices below are valid for flat iterators since NumPy 2.4
+    # (numpy-gh-28590) and no longer raise an IndexError:
+    # {"shape": (2, 3, 4), "index": (0,)},
+    # {"shape": (2, 3, 4), "index": True},
+    # {"shape": (2, 3, 4), "index": cupy.array([0])},
+    # {"shape": (2, 3, 4), "index": [0]},
 )
-@pytest.mark.skip("no exception raised")
 class TestFlatiterSubscriptIndexError(unittest.TestCase):
 
     @testing.for_all_dtypes()

--- a/dpnp/tests/third_party/cupy/indexing_tests/test_iterate.py
+++ b/dpnp/tests/third_party/cupy/indexing_tests/test_iterate.py
@@ -130,7 +130,7 @@ class TestFlatiterSubscript(unittest.TestCase):
     # the indices below are valid for flat iterators since NumPy 2.4
     # (numpy-gh-28590) and no longer raise an IndexError:
     # {"shape": (2, 3, 4), "index": (0,)},
-    # {"shape": (2, 3, 4), "index": True},
+    {"shape": (2, 3, 4), "index": True},
     # {"shape": (2, 3, 4), "index": cupy.array([0])},
     # {"shape": (2, 3, 4), "index": [0]},
 )


### PR DESCRIPTION
This PR reworks `dpnp.flatiter` (`dpnp.ndarray.flat`) indexing so it aligns with NumPy's flat-iterator semantics, which were tightened in NumPy 2.4.

Previously `dpnp.ndarray.flat` accepted only a single integer index and raised `TypeError` for everything else. Indexing now delegates to regular array indexing of the flattened array, so it supports the full set of flat index types and matches NumPy's error behavior.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?