### PR TITLE
ci: drop Python 3.10/3.11 and pin Ubuntu runners to ubuntu-latest

### DIFF
--- a/.github/workflows/conda-build-test.yml
+++ b/.github/workflows/conda-build-test.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.10', '3.11', '3.12', '3.13']
+        python: ['3.12', '3.13']
         include:
           - python: '3.14'
             python_spec: '3.14.* *_cp314'
@@ -124,7 +124,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.10', '3.11', '3.12', '3.13']
+        python: ['3.12', '3.13']
         include:
           - python: '3.14'
             python_spec: '3.14.* *_cp314'

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -29,17 +29,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.10', '3.11', '3.12', '3.13']
-        os: [ubuntu-22.04, windows-2022]
+        python: ['3.12', '3.13']
+        os: [ubuntu-latest, windows-2022]
         include:
           - python: '3.14'
-            os: ubuntu-22.04
+            os: ubuntu-latest
             python_spec: '3.14.* *_cp314'
           - python: '3.14'
             os: windows-2022
             python_spec: '3.14.* *_cp314'
           - python: '3.14'
-            os: ubuntu-22.04
+            os: ubuntu-latest
             python_spec: '3.14.* *_cp314t'
           - python: '3.14'
             os: windows-2022
@@ -143,7 +143,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.10', '3.11', '3.12', '3.13']
+        python: ['3.12', '3.13']
         os: [ubuntu-latest]
         include:
           - python: '3.14'
@@ -419,7 +419,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.10', '3.11', '3.12', '3.13']
+        python: ['3.12', '3.13']
         os: [windows-2022]
         include:
           - python: '3.14'
@@ -600,7 +600,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.10', '3.11', '3.12', '3.13']
+        python: ['3.12', '3.13']
         os: [ubuntu-latest, windows-2022]
         include:
           - python: '3.14'

--- a/.github/workflows/cron-run-tests.yaml
+++ b/.github/workflows/cron-run-tests.yaml
@@ -38,23 +38,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.10', '3.11', '3.12', '3.13']
-        runner: [ubuntu-22.04, ubuntu-24.04, windows-2022]
+        python: ['3.12', '3.13']
+        runner: [ubuntu-latest, windows-2022]
         include:
           - python: '3.14'
-            runner: ubuntu-22.04
-            python_spec: '3.14.* *_cp314'
-          - python: '3.14'
-            runner: ubuntu-24.04
+            runner: ubuntu-latest
             python_spec: '3.14.* *_cp314'
           - python: '3.14'
             runner: windows-2022
             python_spec: '3.14.* *_cp314'
           - python: '3.14'
-            runner: ubuntu-22.04
-            python_spec: '3.14.* *_cp314t'
-          - python: '3.14'
-            runner: ubuntu-24.04
+            runner: ubuntu-latest
             python_spec: '3.14.* *_cp314t'
           - python: '3.14'
             runner: windows-2022


### PR DESCRIPTION
Trims the GitHub Actions test matrices to reduce load on GitHub-hosted runners. Full coverage across the dropped configurations continues to run in internal CI (Jenkins), so no use case loses testing overall.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
