### PR TITLE
Skip OpenSSF Scorecard workflow on forks

### DIFF
--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -24,6 +24,8 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
+    # disable the workflow to be run in forks
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
The OpenSSF Scorecard workflow fails on forks with `validating options: only default branch is supported`, because Scorecard only runs against a repository's default branch and forks typically push to / have a different default branch than the upstream repo.

This PR adds a job-level guard so the analysis job is skipped in forks and only runs on the upstream repository.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
