### PR TITLE
Fix project name capitalization (Numpy -> NumPy)

### DIFF
--- a/dpnp/tensor/_ctors.py
+++ b/dpnp/tensor/_ctors.py
@@ -121,7 +121,7 @@ def _asarray_from_numpy_ndarray(
     copy_q = normalize_queue_device(sycl_queue=None, device=sycl_queue)
     if ary.dtype.char not in "?bBhHiIlLqQefdFD":
         raise TypeError(
-            f"Numpy array of data type {ary.dtype} is not supported. "
+            f"NumPy array of data type {ary.dtype} is not supported. "
             "Please convert the input to an array with numeric data type."
         )
     if dtype is None:

--- a/dpnp/tensor/_print.py
+++ b/dpnp/tensor/_print.py
@@ -231,7 +231,7 @@ def set_print_options(
             `"-"`, `"+"`, or `" "`.
             Default: `"-"`.
         numpy (bool, optional): If `True,` then before other specified print
-            options are set, a dictionary of Numpy's print options
+            options are set, a dictionary of NumPy's print options
             will be used to initialize dpctl's print options.
             Default: "False"
     """
@@ -412,7 +412,7 @@ def usm_ndarray_str(
             Default: `"-"`.
         numpy (bool, optional):
             If `True,` then before other specified print
-            options are set, a dictionary of Numpy's print options
+            options are set, a dictionary of NumPy's print options
             will be used to initialize dpctl's print options.
             Default: "False"
         separator (str, optional):

--- a/dpnp/tests/helper.py
+++ b/dpnp/tests/helper.py
@@ -466,7 +466,7 @@ def is_intel_numpy():
     Return True if Intel NumPy is used during testing.
 
     The check is based on MKL backend name stored in Build Dependencies, where
-    in case of Intel Numpy there "mkl" is expected at the beginning of the name
+    in case of Intel NumPy there "mkl" is expected at the beginning of the name
     for both BLAS and LAPACK (the full name is "mkl-dynamic-ilp64-iomp").
 
     """

--- a/dpnp/tests/tensor/test_tensor_asarray.py
+++ b/dpnp/tests/tensor/test_tensor_asarray.py
@@ -187,7 +187,7 @@ def test_asarray_input_validation():
         # buffer to usm_ndarray requires a copy
         dpt.asarray(memoryview(np.arange(5)), copy=False)
     with pytest.raises(ValueError):
-        # Numpy array to usm_ndarray requires a copy
+        # NumPy array to usm_ndarray requires a copy
         dpt.asarray(np.arange(5), copy=False)
     with pytest.raises(ValueError):
         # Python sequence to usm_ndarray requires a copy

--- a/dpnp/tests/test_fft.py
+++ b/dpnp/tests/test_fft.py
@@ -500,21 +500,21 @@ class TestFftn:
         a = dpnp.array(3, dtype=dtype)  # 0-D input
 
         # axes is None
-        # For 0-D array, stock Numpy and dpnp return input array
+        # For 0-D array, stock NumPy and dpnp return input array
         # while Intel NumPy return a complex zero
         result = dpnp.fft.fftn(a)
         expected = a.asnumpy()
         assert_dtype_allclose(result, expected)
 
         # axes=()
-        # For 0-D array with axes=(), stock Numpy and dpnp return input array
+        # For 0-D array with axes=(), stock NumPy and dpnp return input array
         # Intel NumPy does not support empty axes and raises an Error
         result = dpnp.fft.fftn(a, axes=())
         expected = a.asnumpy()
         assert_dtype_allclose(result, expected)
 
         # axes=(0,)
-        # For 0-D array with non-empty axes, stock Numpy and dpnp raise
+        # For 0-D array with non-empty axes, stock NumPy and dpnp raise
         # IndexError, while Intel NumPy raises ZeroDivisionError
         assert_raises(IndexError, dpnp.fft.fftn, a, axes=(0,))
 
@@ -522,7 +522,7 @@ class TestFftn:
     def test_empty_axes(self, dtype):
         a = dpnp.ones((2, 3, 4), dtype=dtype)
 
-        # For axes=(), stock Numpy and dpnp return input array
+        # For axes=(), stock NumPy and dpnp return input array
         # Intel NumPy does not support empty axes and raises an Error
         result = dpnp.fft.fftn(a, axes=())
         expected = a.asnumpy()

--- a/dpnp/tests/test_linalg.py
+++ b/dpnp/tests/test_linalg.py
@@ -1823,7 +1823,7 @@ class TestLstsq:
 
         result = dpnp.linalg.lstsq(a_dp, b_dp)
         # if rcond is not set, FutureWarning is given.
-        # By default Numpy uses None for calculations
+        # By default NumPy uses None for calculations
         expected = numpy.linalg.lstsq(a_np, b_np, rcond=None)
 
         for param_dp, param_np in zip(result, expected):
@@ -1838,7 +1838,7 @@ class TestLstsq:
         b_dp = dpnp.array(b_np)
 
         # if rcond is not set, FutureWarning is given.
-        # By default Numpy uses None for calculations
+        # By default NumPy uses None for calculations
         expected = numpy.linalg.lstsq(a_np, b_np, rcond=None)
         result = dpnp.linalg.lstsq(a_dp, b_dp)
 
@@ -1859,7 +1859,7 @@ class TestLstsq:
 
         result = dpnp.linalg.lstsq(a_dp, b_dp)
         # if rcond is not set, FutureWarning is given.
-        # By default Numpy uses None for calculations
+        # By default NumPy uses None for calculations
         expected = numpy.linalg.lstsq(a_np, b_np, rcond=None)
 
         for param_dp, param_np in zip(result, expected):


### PR DESCRIPTION
Corrects inconsistent capitalization of the NumPy project name ("Numpy" → "NumPy") across the codebase. The most notable occurrence is in a user-facing `TypeError` message in `dpnp/tensor/_ctors.py`; the rest are docstrings and test comments. No functional change.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
