### PR TITLE
Improve dpnp.trapezoid docstring wording and line wrapping

### DIFF
--- a/dpnp/dpnp_iface_mathematical.py
+++ b/dpnp/dpnp_iface_mathematical.py
@@ -5019,9 +5019,9 @@ def trapezoid(y, x=None, dx=1.0, axis=-1):
 
     Integrate `y` (`x`) along each 1d slice on the given axis, compute
     :math:`\int y(x) dx`.
-    When `x` is specified, this integrates along the parametric curve,
-    computing :math:`\int_t y(t) dt =
-    \int_t y(t) \left.\frac{dx}{dt}\right|_{x=x(t)} dt`.
+    When `x` is specified, this integrates along the parametric curve :math:`C`
+    given by :math:`(x(t), y(t))`, computing the line integral
+    :math:`\int_C y \, dx = \int y(t) \frac{dx}{dt} \, dt`.
 
     For full documentation refer to :obj:`numpy.trapezoid`.
 
@@ -5046,9 +5046,9 @@ def trapezoid(y, x=None, dx=1.0, axis=-1):
     Returns
     -------
     out : dpnp.ndarray
-        Definite integral of `y` = n-dimensional array as approximated along
-        a single axis by the trapezoidal rule. The result is an `n`-1
-        dimensional array.
+        Definite integral of `y` = n-dimensional array as approximated along a
+        single axis by the trapezoidal rule. The result is an `n`-1 dimensional
+        array.
 
     See Also
     --------


### PR DESCRIPTION
This PR refines the docstring of `dpnp.trapezoid` and corrects the description of the parametric-curve case. The previous wording described the computation with a change-of-variable formula that was misleading; it now identifies the parametric curve explicitly and characterizes the result as a line integral.

The change is documentation-only: no behavior, signature, or keyword change.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [x] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
