### PR TITLE
ci: add zizmor security scanning for GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
+    cooldown:
+      default-days: 7
     rebase-strategy: "disabled"
     labels: ["autoupdate"]
     groups:
@@ -17,6 +19,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
+    cooldown:
+      default-days: 7
     rebase-strategy: "disabled"
     labels: ["autoupdate"]
     groups:
@@ -29,6 +33,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
+    cooldown:
+      default-days: 7
     rebase-strategy: "disabled"
     labels: ["autoupdate"]
     groups:
@@ -40,6 +46,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
+    cooldown:
+      default-days: 7
     rebase-strategy: "disabled"
     labels: ["autoupdate"]
     groups:

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -238,7 +238,7 @@ jobs:
         if: env.GH_EVENT_PR_OPEN == 'true' && steps.check_fork.outputs.is_fork == 'false'
         env:
           PR_NUM: ${{ github.event.number }}
-        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59 # v3.12.0.8.3.12.0
+        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59 # v3.12.0
         with:
           message-id: url_to_docs
           message: |
@@ -282,7 +282,7 @@ jobs:
           git push tokened_docs gh-pages
 
       - name: Modify the comment with URL to official documentation
-        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59 # v3.12.0.8.3.12.0
+        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59 # v3.12.0
         with:
           message-id: url_to_docs
           find: |

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -96,6 +96,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Install conda-merge tool
@@ -265,6 +266,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Remove docs [PR closed]

--- a/.github/workflows/bump-sycl-deps.yml
+++ b/.github/workflows/bump-sycl-deps.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Find latest intel/llvm driver release tag
         id: driver

--- a/.github/workflows/check-onemath.yaml
+++ b/.github/workflows/check-onemath.yaml
@@ -53,6 +53,7 @@ jobs:
       - name: Checkout DPNP repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Install conda-merge tool
@@ -111,6 +112,7 @@ jobs:
       - name: Checkout DPNP repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Download artifact
@@ -231,6 +233,7 @@ jobs:
       - name: Checkout DPNP repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Download artifact
@@ -242,6 +245,7 @@ jobs:
       - name: Checkout oneMKL repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           repository: 'oneapi-src/oneMKL'
           ref: 'develop'
           path: ${{ env.onemkl-source-dir }}

--- a/.github/workflows/check-onemath.yaml
+++ b/.github/workflows/check-onemath.yaml
@@ -6,7 +6,8 @@ on:
       - master
   pull_request:
 
-permissions: read-all
+permissions:
+  contents: read
 
 env:
   environment-file: 'environments/environment.yml'

--- a/.github/workflows/conda-build-test.yml
+++ b/.github/workflows/conda-build-test.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Checkout DPNP repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup miniconda
@@ -150,6 +151,7 @@ jobs:
       - name: Checkout DPNP repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: ${{ env.fetch-depth }}
           path: ${{ env.dpnp-repo-path }}
 

--- a/.github/workflows/conda-build-test.yml
+++ b/.github/workflows/conda-build-test.yml
@@ -92,17 +92,33 @@ jobs:
         run: conda list
 
       - name: Store conda paths as envs
+        env:
+          CONDA_SUBDIR: ${{ inputs.conda-subdir }}
         run: |
-          echo "CONDA_BLD=$CONDA_PREFIX/conda-bld/${{ inputs.conda-subdir }}/" | tr "\\\\" '/' >> "$GITHUB_ENV"
+          echo "CONDA_BLD=$CONDA_PREFIX/conda-bld/$CONDA_SUBDIR/" | tr "\\\\" '/' >> "$GITHUB_ENV"
 
       - name: Build conda package
         id: build_conda_pkg
         continue-on-error: true
-        run: conda-build --no-test --python "${{ env.python-conda-spec }}" --numpy 2.0 ${{ inputs.channels-list }} ${{ inputs.recipe-dir }}
+        env:
+          PYTHON_CONDA_SPEC: ${{ env.python-conda-spec }}
+          CHANNELS_LIST: ${{ inputs.channels-list }}
+          RECIPE_DIR: ${{ inputs.recipe-dir }}
+        run: |
+          # CHANNELS_LIST must stay unquoted to split into separate CLI args
+          # shellcheck disable=SC2086
+          conda-build --no-test --python "$PYTHON_CONDA_SPEC" --numpy 2.0 $CHANNELS_LIST "$RECIPE_DIR"
 
       - name: ReBuild conda package
         if: steps.build_conda_pkg.outcome == 'failure'
-        run: conda-build --no-test --python "${{ env.python-conda-spec }}" --numpy 2.0 ${{ inputs.channels-list }} ${{ inputs.recipe-dir }}
+        env:
+          PYTHON_CONDA_SPEC: ${{ env.python-conda-spec }}
+          CHANNELS_LIST: ${{ inputs.channels-list }}
+          RECIPE_DIR: ${{ inputs.recipe-dir }}
+        run: |
+          # CHANNELS_LIST must stay unquoted to split into separate CLI args
+          # shellcheck disable=SC2086
+          conda-build --no-test --python "$PYTHON_CONDA_SPEC" --numpy 2.0 $CHANNELS_LIST "$RECIPE_DIR"
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/conda-build-test.yml
+++ b/.github/workflows/conda-build-test.yml
@@ -20,7 +20,8 @@ on:
         required: true
         type: string
 
-permissions: read-all
+permissions:
+  contents: read
 
 env:
   package-name: dpnp

--- a/.github/workflows/conda-package-cf.yml
+++ b/.github/workflows/conda-package-cf.yml
@@ -6,7 +6,8 @@ on:
       - master
   pull_request:
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -6,7 +6,8 @@ on:
       - master
   pull_request:
 
-permissions: read-all
+permissions:
+  contents: read
 
 env:
   package-name: dpnp

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Checkout DPNP repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup miniconda
@@ -172,6 +173,7 @@ jobs:
       - name: Checkout DPNP repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: ${{ env.fetch-depth }}
           path: ${{ env.dpnp-repo-path }}
 
@@ -326,6 +328,7 @@ jobs:
       - name: Checkout DPNP repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: ${{ env.fetch-depth }}
           path: ${{ env.dpnp-repo-path }}
 
@@ -443,6 +446,7 @@ jobs:
       - name: Checkout DPNP repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: ${{ env.fetch-depth }}
           path: ${{ env.dpnp-repo-path }}
 
@@ -637,6 +641,7 @@ jobs:
       - name: Checkout DPNP repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: ${{ env.fetch-depth }}
 
       - name: Download artifact
@@ -721,6 +726,7 @@ jobs:
       - name: Checkout DPNP repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: ${{ env.fetch-depth }}
           path: ${{ env.dpnp-repo-path }}
 
@@ -794,6 +800,7 @@ jobs:
       - name: Clone array API tests repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           repository: 'data-apis/array-api-tests'
           path: ${{ env.array-api-tests-path }}
           fetch-depth: ${{ env.fetch-depth }}
@@ -877,6 +884,7 @@ jobs:
       - name: Checkout DPNP repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: ${{ env.fetch-depth }}
 
       - name: Setup miniconda
@@ -903,6 +911,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           repository: IntelPython/devops-tools
           fetch-depth: ${{ env.fetch-depth }}
 

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -851,7 +851,7 @@ jobs:
 
       - name: Post result to PR
         if: ${{ github.event.pull_request && !github.event.pull_request.head.repo.fork }}
-        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59 # v3.12.0.8.3.12.0
+        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59 # v3.12.0
         with:
           message-id: array_api_results
           message: |

--- a/.github/workflows/cron-run-tests.yaml
+++ b/.github/workflows/cron-run-tests.yaml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Find the latest tag
         id: find_latest_tag
-        uses: oprypin/find-latest-tag@6957ac556fa6d349727ecabfcaaf9f8e5ee37124 # 1.1.3
+        uses: oprypin/find-latest-tag@6957ac556fa6d349727ecabfcaaf9f8e5ee37124 # v1.1.3
         with:
           repository: IntelPython/dpnp
           releases-only: false

--- a/.github/workflows/generate_coverage.yaml
+++ b/.github/workflows/generate_coverage.yaml
@@ -60,6 +60,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Install conda-merge tool

--- a/.github/workflows/os-llvm-sycl-build.yml
+++ b/.github/workflows/os-llvm-sycl-build.yml
@@ -106,11 +106,13 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Checkout dpctl repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           repository: IntelPython/dpctl
           fetch-depth: 0
           path: ${{ env.dpctl-repo-path }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Checkout DPNP repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           # use commit hash to make "no-commit-to-branch" check passing
           ref: ${{ github.sha }}
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3
         with:
+          # Low/informational template-injection notes come from internally-defined
+          # values (no external input), so they are reported as annotations but do not gate CI
+          min-severity: medium
           advanced-security: false
           annotations: true
           inputs: .github/

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,36 @@
+name: Security scan of GitHub Actions workflows (zizmor)
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Scan GitHub Actions workflows
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      contents: read # needed to clone the repo
+
+    steps:
+      - name: Checkout DPNP repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3
+        with:
+          advanced-security: false
+          annotations: true
+          inputs: .github/


### PR DESCRIPTION
Adds a CI job that runs the [zizmor](https://docs.zizmor.sh) static analyzer over the workflow files under `.github/`.

`zizmor` audits GitHub Actions workflows for supply-chain and privilege-escalation weaknesses — unpinned action references, credential persistence through the checkout token, template injection via `${{ ... }}` expansion in `run:` blocks, and overly broad `GITHUB_TOKEN` permissions.

This is a CI/configuration-only change; no library code, tests, or documentation are affected.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
