### PR TITLE
Remove obsolete array API skip for test_dunder_dlpack

### DIFF
--- a/.github/workflows/array-api-skips.txt
+++ b/.github/workflows/array-api-skips.txt
@@ -1,7 +1,4 @@
 # array API tests to be skipped
 
-# data-apis/array-api-tests/issues/456
-array_api_tests/test_dlpack.py::test_dunder_dlpack
-
 # data-apis/array-api/issues/1006
 array_api_tests/test_special_cases.py::test_unary[tanh(real(x_i) is +infinity and isfinite(imag(x_i)) and imag(x_i) > 0) -> 1 + 0j]


### PR DESCRIPTION
The array API conformance job skipped `test_dlpack.py::test_dunder_dlpack` as a workaround for a bug in the test itself (tracked in [array-api-tests#457](https://github.com/data-apis/array-api-tests/pull/457)): the test pinned the requested `dl_device` to `kDLCPU` while drawing `copy` from `{True, False, None}`, so on a SYCL device (reported as `kDLOneAPI`) the `copy=False` case forced a cross-device transfer and the spec-mandated `BufferError` was counted as a failure.

The upstream test has since been fixed to tolerate `BufferError` only when `copy is False` and the requested device differs from the array's own `__dlpack_device__()` — behavior dpnp already implements correctly by delegating to dpctl. The conformance job checks out the array-api-tests default branch without pinning a ref, so the fix is already picked up on new runs and the skip is now dead weight.

This change removes only that entry. The remaining `tanh` special-case skip is unrelated (an open array-api spec issue) and is left in place.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?