### PR TITLE
Reuse reduction/dot buffer as sqrt output in linalg.norm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ This release is compatible with NumPy 2.5.
 * Linked the `dpnp_backend_c` library against only the MKL SYCL domains it uses (`BLAS`, `RNG`, `VM`) [#3012](https://github.com/IntelPython/dpnp/pull/3012)
 * `dpnp` uses pybind11 3.1.0 [#3015](https://github.com/IntelPython/dpnp/pull/3015)
 * Reworked the ASV benchmarks and added end-to-end workload benchmarks derived from dpBench [#2996](https://github.com/IntelPython/dpnp/pull/2996)
+* Reduced allocations in `dpnp.linalg.norm` by reusing the reduction result as the `sqrt` output buffer in the 2-norm and Frobenius-norm branches [#3062](https://github.com/IntelPython/dpnp/pull/3062)
 
 ### Deprecated
 

--- a/dpnp/linalg/dpnp_utils_linalg.py
+++ b/dpnp/linalg/dpnp_utils_linalg.py
@@ -1162,8 +1162,8 @@ def _norm_int_axis(x, ord, axis, keepdims):
         return dpnp.abs(x).sum(axis=axis, keepdims=keepdims)
     if ord is None or ord == 2:
         # special case for speedup
-        s = (dpnp.conj(x) * x).real
-        return dpnp.sqrt(dpnp.sum(s, axis=axis, keepdims=keepdims))
+        s = dpnp.sum((dpnp.conj(x) * x).real, axis=axis, keepdims=keepdims)
+        return dpnp.sqrt(s, out=s)
     if isinstance(ord, (int, float)):
         absx = dpnp.abs(x)
         absx **= ord
@@ -1215,7 +1215,8 @@ def _norm_tuple_axis(x, ord, row_axis, col_axis, keepdims):
             row_axis -= 1
         ret = dpnp.abs(x).sum(axis=col_axis).min(axis=row_axis)
     elif ord in [None, "fro", "f"]:
-        ret = dpnp.sqrt(dpnp.sum((dpnp.conj(x) * x).real, axis=axis))
+        ret = dpnp.sum((dpnp.conj(x) * x).real, axis=axis)
+        ret = dpnp.sqrt(ret, out=ret)
     elif ord == "nuc":
         ret = _multi_svd_norm(x, row_axis, col_axis, dpnp.sum)
     else:
@@ -2360,7 +2361,7 @@ def dpnp_norm(x, ord=None, axis=None, keepdims=False):
                 sqnorm = dpnp.dot(x_real, x_real) + dpnp.dot(x_imag, x_imag)
             else:
                 sqnorm = dpnp.dot(x, x)
-            ret = dpnp.sqrt(sqnorm)
+            ret = dpnp.sqrt(sqnorm, out=sqnorm)
             if keepdims:
                 ret = ret.reshape((1,) * ndim)
             return ret


### PR DESCRIPTION
In the `dpnp.linalg.norm` implementation, the 2-norm and Frobenius-norm branches computed `sqrt(sum(...))` (or `sqrt(dot(...))` on the `axis=None` fast path) allocating a fresh array for the `sqrt` output on top of the array already produced by the reduction.

These branches now capture the reduction (or dot) result and pass it back as `out=` to `dpnp.sqrt`, so the intermediate buffer is reused as the output instead of allocating a new one. The reused buffer is a private, unaliased array in every case, and its dtype matches the `sqrt` output, so the in-place write is safe. On the `axis=None` fast path the reused buffer is a scalar, so the change there is for consistency.

This is an allocation saving only; it does not change results or reduce the number of kernel launches.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
