### PR TITLE
Fix row corruption in batched multi-level cumulative scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ This release is compatible with NumPy 2.5.
 * Fixed `dpnp.insert` silently ignoring out-of-bounds negative indices in a multi-element `obj`, so a mix of in-bounds and out-of-bounds indices now consistently raises `IndexError` [#3041](https://github.com/IntelPython/dpnp/pull/3041)
 * Fixed a per-call `sycl::queue` leak in `usm_ndarray::get_queue()`/`get_device()` [#3042](https://github.com/IntelPython/dpnp/pull/3042)
 * Fixed `dpnp.linspace` returning `nan` for equal infinite endpoints [#3043](https://github.com/IntelPython/dpnp/pull/3043)
+* Fixed `dpnp.cumsum`, `dpnp.cumprod`, and their `nan`/`cumulative_*` variants (including `dpnp.tensor.cumulative_sum`/`cumulative_prod`) silently returning incorrect results when accumulating along a axis of an array with more than one row [#3063](https://github.com/IntelPython/dpnp/pull/3063)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@ This release is compatible with NumPy 2.5.
 * Fixed `dpnp.insert` silently ignoring out-of-bounds negative indices in a multi-element `obj`, so a mix of in-bounds and out-of-bounds indices now consistently raises `IndexError` [#3041](https://github.com/IntelPython/dpnp/pull/3041)
 * Fixed a per-call `sycl::queue` leak in `usm_ndarray::get_queue()`/`get_device()` [#3042](https://github.com/IntelPython/dpnp/pull/3042)
 * Fixed `dpnp.linspace` returning `nan` for equal infinite endpoints [#3043](https://github.com/IntelPython/dpnp/pull/3043)
-* Fixed `dpnp.cumsum`, `dpnp.cumprod`, and their `nan`/`cumulative_*` variants (including `dpnp.tensor.cumulative_sum`/`cumulative_prod`) silently returning incorrect results when accumulating along a axis of an array with more than one row [#3063](https://github.com/IntelPython/dpnp/pull/3063)
+* Fixed `dpnp.cumsum`, `dpnp.cumprod`, and their `nan`/`cumulative_*` variants (including `dpnp.tensor.cumulative_sum`/`cumulative_prod`) silently returning incorrect results when accumulating along an axis of an array with more than one row [#3063](https://github.com/IntelPython/dpnp/pull/3063)
 
 ### Security
 

--- a/dpnp/tensor/libtensor/include/kernels/accumulators.hpp
+++ b/dpnp/tensor/libtensor/include/kernels/accumulators.hpp
@@ -920,10 +920,12 @@ sycl::event update_local_chunks(sycl::queue &exec_q,
                                 sycl::event dependent_event)
 {
     static constexpr NoOpIndexer out_indexer{};
-    static constexpr NoOpIndexer iter_out_indexer{};
+    // src rows stride by src_size; NoOp iter offset only ok for iter_nelems==1
+    const Strided1DIndexer iter_out_indexer{/* size */ iter_nelems,
+                                            /* step */ src_size};
 
     return final_update_local_chunks<UpdateKernelName, outputT, n_wi,
-                                     NoOpIndexer, NoOpIndexer, ScanOpT>(
+                                     Strided1DIndexer, NoOpIndexer, ScanOpT>(
         exec_q, iter_nelems, src, src_size, local_scans, chunk_size,
         local_stride, iter_out_indexer, out_indexer, dependent_event);
 }

--- a/dpnp/tests/tensor/test_tensor_accumulation.py
+++ b/dpnp/tests/tensor/test_tensor_accumulation.py
@@ -128,8 +128,8 @@ def test_strided_cumsum_axis_sint(dt):
 
 @pytest.mark.parametrize("func", ["cumulative_sum", "cumulative_prod"])
 def test_batched_multilevel_scan(func):
-    # axis > chunk_size**2 (chunk_size <= 2048) needs >=3 scan levels; with >1
-    # batch row the intermediate update mis-strided rows. 5e6 forces that path.
+    # Regression test for gh-3063: multi-row scan over an axis needing >=3
+    # levels (axis > chunk_size**2, chunk_size <= 2048) mis-strided rows.
     get_queue_or_skip()
     n0, n1 = 3, 5_000_000
     x = dpt.ones((n0, n1), dtype="i1")

--- a/dpnp/tests/tensor/test_tensor_accumulation.py
+++ b/dpnp/tests/tensor/test_tensor_accumulation.py
@@ -126,6 +126,23 @@ def test_strided_cumsum_axis_sint(dt):
     assert dpt.all(res == dpt.expand_dims(expected, axis=1))
 
 
+@pytest.mark.parametrize("func", ["cumulative_sum", "cumulative_prod"])
+def test_batched_multilevel_scan(func):
+    # axis > chunk_size**2 (chunk_size <= 2048) needs >=3 scan levels; with >1
+    # batch row the intermediate update mis-strided rows. 5e6 forces that path.
+    get_queue_or_skip()
+    n0, n1 = 3, 5_000_000
+    x = dpt.ones((n0, n1), dtype="i1")
+
+    if func == "cumulative_prod":
+        x[:, 0] = 2  # leading 2 then ones -> cumprod is 2 everywhere
+        res = dpt.cumulative_prod(x, axis=1, dtype="i4")
+        assert dpt.all(res == 2)
+    else:
+        res = dpt.cumulative_sum(x, axis=1, dtype="i4")
+        assert dpt.all(res == dpt.arange(1, n1 + 1, dtype="i4"))
+
+
 def test_accumulate_scalar():
     get_queue_or_skip()
 


### PR DESCRIPTION
## Summary

`dpnp.cumsum`, `dpnp.cumprod`, and their `nan`/`cumulative_*` variants (including `dpnp.tensor.cumulative_sum`/`cumulative_prod`) could silently return incorrect results when accumulating along an axis of a multi-row array, with no error raised. The corruption is triggered when the accumulation axis is long enough to require three or more reduction levels in the internal block-scan (axis length greater than `chunk_size ** 2`, where `chunk_size = wg_size * n_wi`, i.e. roughly a million elements on GPU and about four million on CPU) and the array has more than one batch row. The elementwise total is conserved but redistributed across rows.

## Root cause

In the batched scan driver `inclusive_scan_iter` (`accumulators.hpp`), the intermediate block-scan fixup `update_local_chunks` passed a `NoOpIndexer` for the per-row (iter) offset into the `src` buffer. The intermediate block-scan buffers, however, are laid out strided per row with a stride of `src_size`. The `local_scans` read already used the correct `iter_gid * local_stride` offset, but the `src` write offset was unstrided, so rows overwrote each other. This cancels out only when `iter_nelems == 1` (a single row) or when fewer than three levels are needed, which is why the bug went unnoticed.

## Fix

Give `update_local_chunks` a `Strided1DIndexer{iter_nelems, src_size}` for the row offset instead of the `NoOpIndexer` (the within-row `out_indexer` stays `NoOp`, since the level buffers are contiguous within a row).


- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
