### PR TITLE
Fix malformed :obj: cross-reference roles in docstrings

### DIFF
--- a/dpnp/dpnp_iface_histograms.py
+++ b/dpnp/dpnp_iface_histograms.py
@@ -574,7 +574,7 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
     :obj:`dpnp.digitize` : Return the indices of the bins to which each value
                            in input array belongs.
     :obj:`dpnp.histogram_bin_edges` : Return only the edges of the bins used
-                                      by the obj:`dpnp.histogram` function.
+                                      by the :obj:`dpnp.histogram` function.
 
     Examples
     --------

--- a/dpnp/dpnp_iface_sorting.py
+++ b/dpnp/dpnp_iface_sorting.py
@@ -156,7 +156,7 @@ def argsort(
     :obj:`dpnp.sort` : Return a sorted copy of an array.
     :obj:`dpnp.lexsort` : Indirect stable sort with multiple keys.
     :obj:`dpnp.argpartition` : Indirect partial sort.
-    :obj:`dpnp.take_along_axis` : Apply ``index_array`` from obj:`dpnp.argsort`
+    :obj:`dpnp.take_along_axis` : Apply ``index_array`` from :obj:`dpnp.argsort`
                                   to an array as if by calling sort.
 
     Examples


### PR DESCRIPTION
Two `See Also` entries used `obj:` instead of `:obj:` (missing the leading colon), so Sphinx did not recognize the cross-reference role and rendered it as literal `obj:` text in the API docs:

- `dpnp.argsort` — the `dpnp.take_along_axis` entry rendered as "…from obj: dpnp.argsort…"
- `dpnp.histogram` — the `dpnp.histogram_bin_edges` entry rendered as "…by the obj:dpnp.histogram function"

Adding the missing colon makes both render as proper cross-reference links. This is a docstring-only change with no functional impact.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [x] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
